### PR TITLE
Improve `RepositoryMetaResultProcessor` resiliency

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessor.java
@@ -1,40 +1,108 @@
 package org.dependencytrack.event.kafka.processor;
 
 import alpine.common.logging.Logger;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.tasks.repositories.MetaModel;
+import org.postgresql.util.PSQLState;
 
+import javax.jdo.JDODataStoreException;
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+import javax.jdo.Transaction;
+import java.sql.SQLException;
 import java.util.Date;
 import java.util.UUID;
 
+/**
+ * A {@link Processor} responsible for processing result of component repository meta analyses.
+ */
 public class RepositoryMetaResultProcessor implements Processor<UUID, MetaModel, Void, Void> {
 
     private static final Logger LOGGER = Logger.getLogger(RepositoryMetaResultProcessor.class);
 
     @Override
     public void process(final Record<UUID, MetaModel> record) {
-        final MetaModel result = record.value();
-
-        LOGGER.info("Received repository meta analysis result");
-        LOGGER.info(" - Component: " + result.getComponent());
-        if (result.getLatestVersion() != null) {
-            LOGGER.info(" - Latest version: " + result.getLatestVersion());
+        if (record.value().getLatestVersion() != null) {
             try (final var qm = new QueryManager()) {
-                final var metaComponent = new RepositoryMetaComponent();
-                metaComponent.setRepositoryType(RepositoryType.resolve(result.getComponent().getPurl()));
-                metaComponent.setNamespace(result.getComponent().getPurl().getNamespace());
-                metaComponent.setName(result.getComponent().getPurl().getName());
-                metaComponent.setPublished(result.getPublishedTimestamp());
-                metaComponent.setLatestVersion(result.getLatestVersion());
-                metaComponent.setLastCheck(new Date());
-                qm.synchronizeRepositoryMetaComponent(metaComponent);
+                synchronizeRepositoryMetaComponent(qm.getPersistenceManager(), record);
+            } catch (Exception e) {
+                LOGGER.error("An unexpected error occurred while processing record %s".formatted(record), e);
             }
-        } else {
-            LOGGER.info(" - No meta information");
+        }
+    }
+
+    private void synchronizeRepositoryMetaComponent(final PersistenceManager pm, final Record<UUID, MetaModel> record) {
+        final MetaModel metaModel = record.value();
+        if (metaModel.getComponent() == null || metaModel.getComponent().getPurl() == null) {
+            LOGGER.warn("""
+                    Received repository meta information without component or PURL details,\s
+                    will not be able to correlate; Dropping
+                    """);
+            return;
+        }
+
+        // It is possible that the same meta info is reported for multiple components in parallel,
+        // causing unique constraint violations when attempting to insert into the REPOSITORY_META_COMPONENT table.
+        // In such cases, we can get away with simply retrying to SELECT+UPDATE or INSERT again. We'll attempt
+        // up to 3 times before giving up.
+        for (int i = 0; i < 3; i++) {
+            final Transaction trx = pm.currentTransaction();
+            try {
+                trx.begin();
+
+                final Query<RepositoryMetaComponent> query = pm.newQuery(RepositoryMetaComponent.class);
+                query.setFilter("repositoryType == :repositoryType && namespace == :namespace && name == :name");
+                query.setParameters(
+                        RepositoryType.resolve(metaModel.getComponent().getPurl()),
+                        metaModel.getComponent().getPurl().getNamespace(),
+                        metaModel.getComponent().getPurl().getName()
+                );
+                RepositoryMetaComponent persistentRepoMetaComponent = query.executeUnique();
+                if (persistentRepoMetaComponent == null) {
+                    persistentRepoMetaComponent = new RepositoryMetaComponent();
+                }
+
+                if (persistentRepoMetaComponent.getLastCheck() != null
+                        && persistentRepoMetaComponent.getLastCheck().after(new Date(record.timestamp()))) {
+                    LOGGER.warn("""
+                            Received repository meta information for %s that is older\s
+                            than what's already in the database; Discarding
+                            """.formatted(metaModel.getComponent()));
+                    return;
+                }
+
+                persistentRepoMetaComponent.setRepositoryType(RepositoryType.resolve(metaModel.getComponent().getPurl()));
+                persistentRepoMetaComponent.setNamespace(metaModel.getComponent().getPurl().getNamespace());
+                persistentRepoMetaComponent.setName(metaModel.getComponent().getPurl().getName());
+                persistentRepoMetaComponent.setLatestVersion(metaModel.getLatestVersion());
+                persistentRepoMetaComponent.setPublished(metaModel.getPublishedTimestamp());
+                persistentRepoMetaComponent.setLastCheck(new Date(record.timestamp()));
+                pm.makePersistent(persistentRepoMetaComponent);
+
+                trx.commit();
+            } catch (JDODataStoreException e) {
+                // TODO: DataNucleus doesn't map constraint violation exceptions very well,
+                // so we have to depend on the exception of the underlying JDBC driver to
+                // tell us what happened. We currently only handle PostgreSQL, but we'll have
+                // to do the same for at least H2 and MSSQL.
+                if (ExceptionUtils.getRootCause(e) instanceof final SQLException se
+                        && PSQLState.UNIQUE_VIOLATION.getState().equals(se.getSQLState())) {
+                    continue; // Retry
+                }
+
+                throw e;
+            } finally {
+                if (trx.isActive()) {
+                    trx.rollback();
+                }
+            }
+
+            return;
         }
     }
 

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -67,6 +67,8 @@ public class VulnerabilityScanResultProcessor extends ContextualProcessor<UUID, 
                 final Vulnerability persistentVuln = persistVulnerability(pm, vuln);
                 addVulnerability(pm, componentUuid, persistentVuln);
             }
+        } catch (Exception e) {
+            LOGGER.error("An unexpected error occurred while processing record %s".formatted(record), e);
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -27,7 +27,6 @@ import org.cyclonedx.parsers.Parser;
 import org.dependencytrack.event.BomUploadEvent;
 import org.dependencytrack.event.ComponentRepositoryMetaAnalysisEvent;
 import org.dependencytrack.event.ComponentVulnerabilityAnalysisEvent;
-import org.dependencytrack.event.RepositoryMetaEvent;
 import org.dependencytrack.event.kafka.KafkaEventDispatcher;
 import org.dependencytrack.model.Bom;
 import org.dependencytrack.model.Classifier;
@@ -168,7 +167,6 @@ public class BomUploadProcessingTask implements Subscriber {
 //                    vae.onSuccess(new NewVulnerableDependencyAnalysisEvent(newComponents));
 //                }
 //                Event.dispatch(vae);
-                Event.dispatch(new RepositoryMetaEvent(detachedFlattenedComponent));
                 LOGGER.info("Processed " + flattenedComponents.size() + " components and " + flattenedServices.size() + " services uploaded to project " + event.getProjectUuid());
                 content = "A " + bomFormat.getFormatShortName() + " BOM was processed";
                 //subject = new BomConsumedOrProcessed(detachedProject, Base64.getEncoder().encodeToString(bomBytes), bomFormat, bomSpecVersion);

--- a/src/test/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessorTest.java
@@ -1,0 +1,160 @@
+package org.dependencytrack.event.kafka.processor;
+
+import org.apache.kafka.common.serialization.UUIDDeserializer;
+import org.apache.kafka.common.serialization.UUIDSerializer;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.test.TestRecord;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.kafka.serialization.JacksonDeserializer;
+import org.dependencytrack.event.kafka.serialization.JacksonSerializer;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.RepositoryMetaComponent;
+import org.dependencytrack.model.RepositoryType;
+import org.dependencytrack.tasks.repositories.MetaModel;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RepositoryMetaResultProcessorTest extends PersistenceCapableTest {
+
+    private TopologyTestDriver testDriver;
+    private TestInputTopic<UUID, MetaModel> inputTopic;
+
+    @Before
+    public void setUp() {
+        final var topology = new Topology();
+        topology.addSource("sourceProcessor",
+                new UUIDDeserializer(), new JacksonDeserializer<>(MetaModel.class), "input-topic");
+        topology.addProcessor("metaResultProcessor",
+                RepositoryMetaResultProcessor::new, "sourceProcessor");
+
+        testDriver = new TopologyTestDriver(topology);
+        inputTopic = testDriver.createInputTopic("input-topic",
+                new UUIDSerializer(), new JacksonSerializer<>());
+    }
+
+    @After
+    public void tearDown() {
+        if (testDriver != null) {
+            testDriver.close();
+        }
+    }
+
+    @Test
+    public void processNewMetaModelTest() {
+        final var testStartTime = new Date();
+
+        final var component = new Component();
+        component.setUuid(UUID.randomUUID());
+        component.setPurl("pkg:maven/foo/bar@1.2.3");
+
+        final var metaModel = new MetaModel(component);
+        metaModel.setLatestVersion("1.2.4");
+        metaModel.setPublishedTimestamp(new Date());
+
+        inputTopic.pipeInput(component.getUuid(), metaModel);
+
+        final RepositoryMetaComponent metaComponent =
+                qm.getRepositoryMetaComponent(RepositoryType.MAVEN, "foo", "bar");
+        assertThat(metaComponent).isNotNull();
+        assertThat(metaComponent.getRepositoryType()).isEqualTo(RepositoryType.MAVEN);
+        assertThat(metaComponent.getNamespace()).isEqualTo("foo");
+        assertThat(metaComponent.getName()).isEqualTo("bar");
+        assertThat(metaComponent.getLatestVersion()).isEqualTo("1.2.4");
+        assertThat(metaComponent.getPublished()).isEqualTo(metaModel.getPublishedTimestamp());
+        assertThat(metaComponent.getLastCheck()).isAfterOrEqualTo(testStartTime);
+    }
+
+    @Test
+    public void processWithoutComponentDetailsTest() {
+        final var component = new Component();
+        component.setUuid(UUID.randomUUID());
+
+        final var metaModel = new MetaModel(component);
+        metaModel.setLatestVersion("1.2.4");
+        metaModel.setPublishedTimestamp(new Date());
+
+        inputTopic.pipeInput(component.getUuid(), metaModel);
+
+        final RepositoryMetaComponent metaComponent =
+                qm.getRepositoryMetaComponent(RepositoryType.MAVEN, "foo", "bar");
+        assertThat(metaComponent).isNull();
+    }
+
+    @Test
+    public void processUpdateExistingMetaModelTest() {
+        final var testStartTime = new Date();
+
+        final var metaComponent = new RepositoryMetaComponent();
+        metaComponent.setRepositoryType(RepositoryType.MAVEN);
+        metaComponent.setNamespace("foo");
+        metaComponent.setName("bar");
+        metaComponent.setLatestVersion("1.0.0");
+        metaComponent.setPublished(Date.from(Instant.now().minus(Duration.ofDays(1))));
+        metaComponent.setLastCheck(Date.from(Instant.now().minus(Duration.ofMinutes(5))));
+        qm.persist(metaComponent);
+
+        final var component = new Component();
+        component.setUuid(UUID.randomUUID());
+        component.setPurl("pkg:maven/foo/bar@1.2.3");
+
+        final var metaModel = new MetaModel(component);
+        metaModel.setLatestVersion("1.2.4");
+        metaModel.setPublishedTimestamp(new Date());
+
+        inputTopic.pipeInput(component.getUuid(), metaModel);
+
+        qm.getPersistenceManager().refresh(metaComponent);
+        assertThat(metaComponent).isNotNull();
+        assertThat(metaComponent.getRepositoryType()).isEqualTo(RepositoryType.MAVEN);
+        assertThat(metaComponent.getNamespace()).isEqualTo("foo");
+        assertThat(metaComponent.getName()).isEqualTo("bar");
+        assertThat(metaComponent.getLatestVersion()).isEqualTo("1.2.4");
+        assertThat(metaComponent.getPublished()).isEqualTo(metaModel.getPublishedTimestamp());
+        assertThat(metaComponent.getLastCheck()).isAfterOrEqualTo(testStartTime);
+    }
+
+    @Test
+    public void processUpdateOutOfOrderMetaModelTest() {
+        final var testStartTime = new Date();
+
+        final var metaComponent = new RepositoryMetaComponent();
+        metaComponent.setRepositoryType(RepositoryType.MAVEN);
+        metaComponent.setNamespace("foo");
+        metaComponent.setName("bar");
+        metaComponent.setLatestVersion("1.2.5");
+        metaComponent.setPublished(Date.from(Instant.now().minus(Duration.ofDays(1))));
+        metaComponent.setLastCheck(Date.from(Instant.now().minusSeconds(5)));
+        qm.persist(metaComponent);
+
+        final var component = new Component();
+        component.setUuid(UUID.randomUUID());
+        component.setPurl("pkg:maven/foo/bar@1.2.3");
+
+        final var metaModel = new MetaModel(component);
+        metaModel.setLatestVersion("1.2.4");
+        metaModel.setPublishedTimestamp(new Date());
+
+        // Pipe in a record that was produced 10 seconds ago, 5 seconds before metaComponent's lastCheck.
+        inputTopic.pipeInput(new TestRecord<>(component.getUuid(), metaModel, Instant.now().minusSeconds(10)));
+
+        qm.getPersistenceManager().refresh(metaComponent);
+        assertThat(metaComponent).isNotNull();
+        assertThat(metaComponent.getRepositoryType()).isEqualTo(RepositoryType.MAVEN);
+        assertThat(metaComponent.getNamespace()).isEqualTo("foo");
+        assertThat(metaComponent.getName()).isEqualTo("bar");
+        assertThat(metaComponent.getLatestVersion()).isEqualTo("1.2.5"); // Must not have been updated
+        assertThat(metaComponent.getPublished()).isNotEqualTo(metaModel.getPublishedTimestamp()); // Must not have been updated
+        assertThat(metaComponent.getLastCheck()).isBefore(testStartTime); // Must not have been updated
+    }
+
+}


### PR DESCRIPTION
### Description

Similar to `VulnerabilityScanResultProcessor`, it will now try to resolve unique constraint violation errors automatically by simply retrying. Other unexpected exceptions are now catched and logged, as unhandled exceptions would cause the Kafka Streams thread to shutdown.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
