### PR TITLE
Issue-343 : add configurable prefix to kafka topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -423,6 +423,11 @@
             <version>${lib.testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-core</artifactId>
+            <version>2.13.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaTopic.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaTopic.java
@@ -1,5 +1,8 @@
 package org.dependencytrack.event.kafka;
 
+import io.smallrye.config.SmallRyeConfig;
+import org.eclipse.microprofile.config.ConfigProvider;
+
 public enum KafkaTopic {
 
     NOTIFICATION_ANALYZER("dtrack.notification.analyzer"),
@@ -33,7 +36,12 @@ public enum KafkaTopic {
     }
 
     public String getName() {
-        return name;
+        var prefix = "";
+        SmallRyeConfig config = ConfigProvider.getConfig().unwrap(SmallRyeConfig.class);
+        var prefixConfig = config.getConfigValue("api.topic.prefix");
+        if (prefixConfig.getValue() != null)
+            prefix = prefixConfig.getValue();
+        return prefix + name;
     }
 
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -427,3 +427,6 @@ kafka.auto.offset.reset=earliest
 
 # Optional
 kafka.num.stream.threads=3
+
+# Optional
+api.topic.prefix=

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaTopicTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaTopicTest.java
@@ -1,0 +1,15 @@
+package org.dependencytrack.event.kafka;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class KafkaTopicTest {
+
+    @Test
+    public void testKafkaTopicConfig() {
+        assertEquals("dtrack.vulnerability.mirror.osv", KafkaTopic.MIRROR_OSV.getName());
+        System.setProperty("api.topic.prefix", "customPrefix.");
+        assertEquals("customPrefix.dtrack.vulnerability.mirror.osv", KafkaTopic.MIRROR_OSV.getName());
+    }
+}


### PR DESCRIPTION
### Description

Use custom prefixes (optional) for Kafka topics.

### Addressed Issue

Issue: https://github.com/DependencyTrack/hyades/issues/343

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
