### PR TITLE
Project count on delete

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventDispatcher.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventDispatcher.java
@@ -14,6 +14,7 @@ import org.dependencytrack.event.ComponentRepositoryMetaAnalysisEvent;
 import org.dependencytrack.event.ComponentVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.NistMirrorEvent;
 import org.dependencytrack.event.OsvMirrorEvent;
+import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.event.kafka.dto.Component;
 import org.dependencytrack.notification.NotificationGroup;
 import org.hyades.proto.vulnanalysis.v1.ScanCommand;
@@ -91,6 +92,8 @@ public class KafkaEventDispatcher {
             return dispatchInternal(KafkaTopics.COMPONENT_METRICS, componentMetricsUpdateEvent.uuid().toString(), componentMetricsUpdateEvent.dependencyMetrics(), null);
         } else if (event instanceof NistMirrorEvent) {
             return dispatchInternal(KafkaTopics.MIRROR_NVD, UUID.randomUUID().toString(), "", null);
+        } else if (event instanceof final ProjectMetricsUpdateEvent projectMetricsUpdateEvent) {
+            return dispatchInternal(KafkaTopics.PROJECT_METRICS, projectMetricsUpdateEvent.getUuid().toString(), null, null);
         }
 
         throw new IllegalArgumentException("Cannot publish event of type " + event.getClass().getName() + " to Kafka");

--- a/src/main/java/org/dependencytrack/event/kafka/processor/ProjectMetricsProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/ProjectMetricsProcessor.java
@@ -17,6 +17,10 @@ public class ProjectMetricsProcessor implements Processor<String, ProjectMetrics
 
     @Override
     public void process(Record<String, ProjectMetrics> record) {
+        //do nothing for tombstone event which has been dispatched by hyades api server
+        if(record.value() == null) {
+            return;
+        }
         UUID uuid = UUID.fromString(record.key());
         Counters counters = new Counters();
         try (final QueryManager qm = new QueryManager()) {

--- a/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
@@ -102,6 +102,7 @@ public class ProjectMetricsUpdateTask implements Subscriber {
                 final long lastId = components.get(components.size() - 1).getId();
                 components = fetchNextComponentsPage(pm, project, lastId);
             }
+            new KafkaEventDispatcher().dispatch(new ProjectMetricsUpdateEvent(project.getUuid()));
         }
     }
 

--- a/src/test/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTaskTest.java
@@ -216,6 +216,10 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
                 },
                 record -> {
                     assertThat(record.value() == null);
+                },
+                //tombstone for project
+                record -> {
+                    assertThat(record.value() == null);
                 }
         );
     }


### PR DESCRIPTION
### Description

Added tombstone event when Project is deleted. This event will be received by metrics service and it will remove the project from aggregation.

### Addressed Issue

fixes issue https://github.com/DependencyTrack/hyades/issues/359


### Additional Details

Tombstone is required to be sent when project is deleted otherwise metrics service will still keep that project which will misalign the count of projects on UI

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [~] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [~] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [~] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
