### PR TITLE
Issue-389 : add finding attribution mapping

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -5,7 +5,9 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.kafka.streams.processor.api.ContextualFixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.FindingAttribution;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.parser.hyades.ModelConverter;
 import org.dependencytrack.persistence.QueryManager;
@@ -144,11 +146,14 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         final Transaction trx = pm.currentTransaction();
         try {
             trx.begin();
-            final Query<Component> query = pm.newQuery(Component.class);
+            Query<Component> query = pm.newQuery(Component.class);
             query.setFilter("uuid == :uuid");
             query.setParameters(componentUuid);
-            final Component component = query.executeUnique();
+            Component component = query.executeUnique();
             component.addVulnerability(vuln);
+            component = pm.makePersistent(component);
+            var finding = new FindingAttribution(component, vuln, AnalyzerIdentity.INTERNAL_ANALYZER, null, null);
+            pm.makePersistent(finding);
             trx.commit();
         } finally {
             if (trx.isActive()) {

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -14,6 +14,7 @@ import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerde;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
 import org.hyades.proto.vuln.v1.Source;
@@ -25,6 +26,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -182,6 +184,15 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                 vuln -> {
                     assertThat(vuln.getVulnId()).isEqualTo("SONATYPE-002");
                     assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.OSSINDEX.name());
+                }
+        );
+        final List<Finding> findings = qm.getFindings(project, false);
+        assertThat(findings).satisfiesExactlyInAnyOrder(
+                finding -> {
+                    assertThat(finding.getVulnerability().get("vulnId")).isEqualTo("INT-001");
+                },
+                finding -> {
+                    assertThat(finding.getVulnerability().get("vulnId")).isEqualTo("SONATYPE-002");
                 }
         );
     }


### PR DESCRIPTION
### Description

Currently this version of dependency track does not show the vulnerabilities in the audit vulnerabilities tab as seen in the vanilla dependency track. This feature needs to be available for assisting developers.

### Addressed Issue

Issue: https://github.com/DependencyTrack/hyades/issues/389

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
