### PR TITLE
Improve mapping of risk ratings from reported vulns to internal model

### DIFF
--- a/src/test/java/org/dependencytrack/parser/hyades/ModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/hyades/ModelConverterTest.java
@@ -37,15 +37,15 @@ public class ModelConverterTest extends PersistenceCapableTest {
                 .setTitle("Foo Bar")
                 .setDescription("Foo Bar Baz Qux Quux")
                 .addRatings(Rating.newBuilder()
-                        .setMethod(ScoreMethod.SCORE_METHOD_CVSSV31)
-                        .setSource(Source.SOURCE_NVD)
-                        .setVector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H")
-                        .setScore(10.0))
-                .addRatings(Rating.newBuilder()
                         .setMethod(ScoreMethod.SCORE_METHOD_CVSSV2)
                         .setSource(Source.SOURCE_NVD)
                         .setVector("(AV:N/AC:M/Au:N/C:C/I:C/A:C)")
                         .setScore(9.3))
+                .addRatings(Rating.newBuilder()
+                        .setMethod(ScoreMethod.SCORE_METHOD_CVSSV31)
+                        .setSource(Source.SOURCE_NVD)
+                        .setVector("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H")
+                        .setScore(10.0))
                 .addRatings(Rating.newBuilder()
                         .setMethod(ScoreMethod.SCORE_METHOD_CVSSV3)
                         .setSource(Source.SOURCE_SNYK)
@@ -70,7 +70,7 @@ public class ModelConverterTest extends PersistenceCapableTest {
         assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.NVD.name());
         assertThat(vuln.getTitle()).isEqualTo("Foo Bar");
         assertThat(vuln.getDescription()).isEqualTo("Foo Bar Baz Qux Quux");
-        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H");
+        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H");
         assertThat(vuln.getCvssV3BaseScore()).isEqualTo(BigDecimal.valueOf(10.0));
         assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:N/AC:M/Au:N/C:C/I:C/A:C)");
         assertThat(vuln.getCvssV2BaseScore()).isEqualTo(BigDecimal.valueOf(9.3));

--- a/src/test/java/org/dependencytrack/parser/hyades/ModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/hyades/ModelConverterTest.java
@@ -11,13 +11,17 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.sql.Time;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV2;
 import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV3;
 import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_CVSSV31;
+import static org.hyades.proto.vuln.v1.ScoreMethod.SCORE_METHOD_OWASP;
+import static org.hyades.proto.vuln.v1.Source.SOURCE_GITHUB;
 import static org.hyades.proto.vuln.v1.Source.SOURCE_NVD;
+import static org.hyades.proto.vuln.v1.Source.SOURCE_OSSINDEX;
 import static org.hyades.proto.vuln.v1.Source.SOURCE_SNYK;
 import static org.hyades.proto.vuln.v1.Source.SOURCE_UNKNOWN;
 
@@ -35,13 +39,6 @@ public class ModelConverterTest extends PersistenceCapableTest {
 
     @Test
     public void testConvert() {
-        // Create a vulnerability that was reported by Snyk.
-        // It is a CVE, with the authoritative source being the NVD.
-        // Snyk provides multiple risk ratings, including the "official" ones
-        // from the NVD, but also its own, custom ones.
-        //
-        // In this case, because the NVD is the authoritative source,
-        // we choose to use the NVD's risk ratings over Snyk's.
         final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
                 .setId("CVE-2021-44228")
                 .setSource(SOURCE_NVD)
@@ -61,6 +58,8 @@ public class ModelConverterTest extends PersistenceCapableTest {
                         .setMethod(SCORE_METHOD_CVSSV3)
                         .setSource(SOURCE_SNYK)
                         .setVector("snykVector"))
+                .setCreated(Timestamp.newBuilder()
+                        .setSeconds(1639098000)) // 2021-12-10
                 .setPublished(Timestamp.newBuilder()
                         .setSeconds(1639098000)) // 2021-12-10
                 .setUpdated(Timestamp.newBuilder()
@@ -85,7 +84,7 @@ public class ModelConverterTest extends PersistenceCapableTest {
         assertThat(vuln.getCvssV3BaseScore()).isEqualTo(BigDecimal.valueOf(10.0));
         assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:N/AC:M/Au:N/C:C/I:C/A:C)");
         assertThat(vuln.getCvssV2BaseScore()).isEqualTo(BigDecimal.valueOf(9.3));
-        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getCreated()).isInSameDayAs("2021-12-10");
         assertThat(vuln.getPublished()).isInSameDayAs("2021-12-10");
         assertThat(vuln.getUpdated()).isInSameDayAs("2023-02-06");
         assertThat(vuln.getReferences()).isEqualToIgnoringWhitespace("""
@@ -102,10 +101,7 @@ public class ModelConverterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testConvert2() {
-        // Create a vulnerability that was reported by Snyk.
-        // It has a SNYK identifier, with the authoritative source being Snyk itself.
-        // In this case, Snyk's own risk rating is used.
+    public void testConvertWithRatingFromSnykAsAuthoritativeSource() {
         final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
                 .setId("SNYK-PYTHON-DJANGO-2968205")
                 .setSource(SOURCE_SNYK)
@@ -138,6 +134,188 @@ public class ModelConverterTest extends PersistenceCapableTest {
         assertThat(vuln.getCvssV2BaseScore()).isNull();
         assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
         assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+    }
+
+    @Test
+    public void testConvertWithRatingsWithoutVector() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("SNYK-PYTHON-DJANGO-2968205")
+                .setSource(SOURCE_SNYK)
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV31)
+                        .setSource(SOURCE_UNKNOWN)
+                        .setScore(8.8))
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV31)
+                        .setSource(SOURCE_UNKNOWN)
+                        .setVector("CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:H/A:L")
+                        .setScore(7))
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV31)
+                        .setSource(SOURCE_UNKNOWN)
+                        .setScore(8.8))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("SNYK-PYTHON-DJANGO-2968205");
+        assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.SNYK.name());
+        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:H/A:L");
+        assertThat(vuln.getCvssV3BaseScore()).isEqualTo("7.0");
+        assertThat(vuln.getCvssV3ImpactSubScore()).isEqualTo("4.7");
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isEqualTo("2.2");
+    }
+
+    @Test
+    public void testConvertWithNoRatings() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("Foo")
+                .setSource(SOURCE_OSSINDEX)
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+    }
+
+    @Test
+    public void testConvertWithOnlyThirdPartyRatings() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("SONATYPE-001")
+                .setSource(SOURCE_OSSINDEX)
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV2)
+                        .setSource(SOURCE_NVD)
+                        .setVector("(AV:N/AC:M/Au:N/C:C/I:C/A:C)"))
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_OWASP)
+                        .setSource(SOURCE_GITHUB)
+                        .setVector("SL:1/M:4/O:4/S:9/ED:7/EE:3/A:4/ID:3/LC:9/LI:1/LAV:5/LAC:1/FD:3/RD:4/NC:7/PV:9"))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2Vector()).isEqualTo("(AV:N/AC:M/Au:N/C:C/I:C/A:C)");
+        assertThat(vuln.getCvssV2BaseScore()).isEqualTo(BigDecimal.valueOf(9.3));
+        assertThat(vuln.getCvssV2ImpactSubScore()).isEqualTo("10.0");
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isEqualTo("8.6");
+        assertThat(vuln.getOwaspRRVector()).isEqualTo("SL:1/M:4/O:4/S:9/ED:7/EE:3/A:4/ID:3/LC:9/LI:1/LAV:5/LAC:1/FD:3/RD:4/NC:7/PV:9");
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isEqualTo("5.75");
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isEqualTo("4.375");
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isEqualTo("4.0");
+    }
+
+    @Test
+    public void testConvertWithRatingWithoutMethod() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("SONATYPE-001")
+                .setSource(SOURCE_OSSINDEX)
+                .addRatings(Rating.newBuilder()
+                        .setSource(SOURCE_NVD)
+                        .setVector("(AV:N/AC:M/Au:N/C:C/I:C/A:C)"))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+    }
+
+    @Test
+    public void testConvertWithInvalidCVSSv31() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("CVE-001")
+                .setSource(SOURCE_NVD)
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV31)
+                        .setSource(SOURCE_NVD)
+                        .setVector("invalid"))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-001");
+        assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.NVD.name());
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+    }
+
+    @Test
+    public void testConvertWithInvalidCVSSv3() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("CVE-001")
+                .setSource(SOURCE_NVD)
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV3)
+                        .setSource(SOURCE_NVD)
+                        .setVector("invalid"))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-001");
+        assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.NVD.name());
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+    }
+
+    @Test
+    public void testConvertWithInvalidCVSSv2() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("CVE-001")
+                .setSource(SOURCE_NVD)
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV2)
+                        .setSource(SOURCE_NVD)
+                        .setVector("invalid"))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-001");
+        assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.NVD.name());
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+    }
+
+    @Test
+    public void testConvertWithInvalidOWASPRR() {
+        final var hyadesVuln = org.hyades.proto.vuln.v1.Vulnerability.newBuilder()
+                .setId("CVE-001")
+                .setSource(SOURCE_NVD)
+                .addRatings(Rating.newBuilder()
+                        .setMethod(SCORE_METHOD_OWASP)
+                        .setSource(SOURCE_NVD)
+                        .setVector("invalid"))
+                .build();
+
+        final Vulnerability vuln = ModelConverter.convert(hyadesVuln);
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-001");
+        assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.NVD.name());
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Handle multiple reported risk scores more intelligently by sorting them first, and then applying them one-by-one.

The sorting is currently implemented such that:

* Ratings from the authoritative source of the vulnerability are preferred
* Ratings that have a scoring method set are preferred over those that don't
* Ratings that have a vector string are preferred over those that don't
* Certain methods are preferred over others. The current priority is:
  1. CVSSv3.1
  2. CVSSv3
  3. CVSSv2
  4. OWASP RR
  5. Others

Practically, this means for example:

* When OSS Index reports a CVE, risk ratings from the NVD will be used over those provided by OSS Index
* When Snyk reports a `SNYK-XXX` vulnerability, risk ratings from Snyk will be used over those provided by the NVD

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
