### PR TITLE
Add basic health check servlet based on MicroProfile Health

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <lib.kafka-junit.version>3.3.0</lib.kafka-junit.version>
         <lib.kafka-streams.version>3.4.0</lib.kafka-streams.version>
         <lib.lucene.version>8.11.2</lib.lucene.version>
+        <lib.microprofile-health-api.version>3.1</lib.microprofile-health-api.version>
         <lib.packageurl.version>1.4.1</lib.packageurl.version>
         <lib.pebble.version>3.2.0</lib.pebble.version>
         <lib.protobuf-java.version>3.22.2</lib.protobuf-java.version>
@@ -175,7 +176,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.13.4</version>
+            <version>2.14.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>2.14.2</version>
         </dependency>
         <!-- OWASP Risk Rating calculator -->
         <dependency>
@@ -213,6 +219,12 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20230227</version>
+        </dependency>
+        <!-- MicroProfile Health -->
+        <dependency>
+            <groupId>org.eclipse.microprofile.health</groupId>
+            <artifactId>microprofile-health-api</artifactId>
+            <version>${lib.microprofile-health-api.version}</version>
         </dependency>
         <!-- Package URL -->
         <dependency>

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaStreamsInitializer.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaStreamsInitializer.java
@@ -61,6 +61,10 @@ public class KafkaStreamsInitializer implements ServletContextListener {
         }
     }
 
+    public static KafkaStreams getKafkaStreams() {
+        return STREAMS;
+    }
+
     static Properties getDefaultProperties() {
         final var properties = new Properties();
         properties.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, Config.getInstance().getProperty(ConfigKey.KAFKA_BOOTSTRAP_SERVERS));

--- a/src/main/java/org/dependencytrack/health/DatabaseHealthCheck.java
+++ b/src/main/java/org/dependencytrack/health/DatabaseHealthCheck.java
@@ -1,0 +1,66 @@
+package org.dependencytrack.health;
+
+import alpine.server.persistence.PersistenceManagerFactory;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.datanucleus.store.connection.ConnectionManagerImpl;
+import org.datanucleus.store.rdbms.ConnectionFactoryImpl;
+import org.datanucleus.store.rdbms.RDBMSStoreManager;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+import javax.jdo.PersistenceManager;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * A {@link HealthCheck} for database connections.
+ */
+class DatabaseHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        final var responseBuilder = HealthCheckResponse.named("database");
+
+        try (final PersistenceManager pm = PersistenceManagerFactory.createPersistenceManager()) {
+            if (pm.getPersistenceManagerFactory() instanceof final JDOPersistenceManagerFactory pmf
+                    && pmf.getNucleusContext().getStoreManager() instanceof final RDBMSStoreManager storeManager
+                    && storeManager.getConnectionManager() instanceof final ConnectionManagerImpl connectionManager) {
+                final HealthCheckResponse.Status primaryStatus = checkConnectionFactory(FieldUtils.readField(connectionManager, "primaryConnectionFactory", true));
+                final HealthCheckResponse.Status secondaryStatus = checkConnectionFactory(FieldUtils.readField(connectionManager, "secondaryConnectionFactory", true));
+
+                if (primaryStatus == HealthCheckResponse.Status.UP && secondaryStatus == HealthCheckResponse.Status.UP) {
+                    responseBuilder.up();
+                } else {
+                    responseBuilder.down();
+                }
+
+                responseBuilder
+                        .withData("primaryConnectionFactory", primaryStatus.name())
+                        .withData("secondaryConnectionFactory", secondaryStatus.name());
+            }
+        } catch (Exception e) {
+            responseBuilder.down()
+                    .withData("exception_message", e.getMessage());
+        }
+
+        return responseBuilder.build();
+    }
+
+    private HealthCheckResponse.Status checkConnectionFactory(final Object connectionFactory) throws Exception {
+        if (connectionFactory instanceof final ConnectionFactoryImpl connectionFactoryImpl) {
+            final Object dataSource = FieldUtils.readField(connectionFactoryImpl, "dataSource", true);
+            if (dataSource instanceof final HikariDataSource hikariDataSource) {
+                try (final Connection connection = hikariDataSource.getConnection()) {
+                    return HealthCheckResponse.Status.UP;
+                } catch (SQLException e) {
+                    return HealthCheckResponse.Status.DOWN;
+                }
+            }
+        }
+
+        return HealthCheckResponse.Status.DOWN;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/health/HealthCheckResponseBuilder.java
+++ b/src/main/java/org/dependencytrack/health/HealthCheckResponseBuilder.java
@@ -1,0 +1,80 @@
+package org.dependencytrack.health;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.function.Predicate.not;
+
+/**
+ * Implementation of the MicroProfile {@link org.eclipse.microprofile.health.HealthCheckResponseBuilder} SPI.
+ * <p>
+ * This code has been copied from the SmallRye Health project.
+ *
+ * @see <a href="https://github.com/smallrye/smallrye-health/blob/main/implementation/src/main/java/io/smallrye/health/ResponseBuilder.java">SmallRye ResponseBuilder</a>
+ */
+public class HealthCheckResponseBuilder extends org.eclipse.microprofile.health.HealthCheckResponseBuilder {
+
+    private String name;
+
+    private HealthCheckResponse.Status status = HealthCheckResponse.Status.DOWN;
+
+    private final Map<String, Object> data = new LinkedHashMap<>();
+
+    @Override
+    public HealthCheckResponseBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public HealthCheckResponseBuilder withData(String key, String value) {
+        this.data.put(key, value);
+        return this;
+    }
+
+    @Override
+    public HealthCheckResponseBuilder withData(String key, long value) {
+        this.data.put(key, value);
+        return this;
+    }
+
+    @Override
+    public HealthCheckResponseBuilder withData(String key, boolean value) {
+        this.data.put(key, value);
+        return this;
+    }
+
+    @Override
+    public HealthCheckResponseBuilder up() {
+        this.status = HealthCheckResponse.Status.UP;
+        return this;
+    }
+
+    @Override
+    public HealthCheckResponseBuilder down() {
+        this.status = HealthCheckResponse.Status.DOWN;
+        return this;
+    }
+
+    @Override
+    public HealthCheckResponseBuilder status(boolean up) {
+        if (up) {
+            return up();
+        }
+
+        return down();
+    }
+
+    @Override
+    public HealthCheckResponse build() {
+        if (null == this.name || this.name.trim().length() == 0) {
+            throw new IllegalArgumentException("Health Check contains an invalid name. Can not be null or empty.");
+        }
+
+        return new HealthCheckResponse(this.name, this.status, Optional.of(data).filter(not(Map::isEmpty)));
+    }
+
+}

--- a/src/main/java/org/dependencytrack/health/HealthCheckResponseProvider.java
+++ b/src/main/java/org/dependencytrack/health/HealthCheckResponseProvider.java
@@ -1,0 +1,12 @@
+package org.dependencytrack.health;
+
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+
+public class HealthCheckResponseProvider implements org.eclipse.microprofile.health.spi.HealthCheckResponseProvider {
+
+    @Override
+    public HealthCheckResponseBuilder createResponseBuilder() {
+        return new org.dependencytrack.health.HealthCheckResponseBuilder();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/health/HealthCheckServlet.java
+++ b/src/main/java/org/dependencytrack/health/HealthCheckServlet.java
@@ -1,0 +1,67 @@
+package org.dependencytrack.health;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.apache.http.HttpHeaders;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.List;
+
+public class HealthCheckServlet extends HttpServlet {
+
+    private List<HealthCheck> healthChecks;
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void init() {
+        healthChecks = List.of(
+                new DatabaseHealthCheck(),
+                new KafkaStreamsHealthCheck()
+        );
+
+        objectMapper = new ObjectMapper()
+                // HealthCheckResponse#data is of type Optional.
+                // We need this module to correctly serialize Optional values.
+                // https://github.com/FasterXML/jackson-modules-java8/tree/2.15/datatypes
+                .registerModule(new Jdk8Module());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        final List<HealthCheckResponse> checkResponses = healthChecks.stream()
+                .map(HealthCheck::call)
+                .toList();
+
+        // The overall UP status is determined by logical conjunction of all check statuses.
+        // https://download.eclipse.org/microprofile/microprofile-health-2.1/microprofile-health-spec.html#_policies_to_determine_the_overall_status
+        final HealthCheckResponse.Status overallStatus = checkResponses.stream()
+                .map(HealthCheckResponse::getStatus)
+                .filter(HealthCheckResponse.Status.DOWN::equals)
+                .findFirst()
+                .orElse(HealthCheckResponse.Status.UP);
+
+        final JsonNode responseJson = JsonNodeFactory.instance.objectNode()
+                .put("status", overallStatus.name())
+                .putPOJO("checks", checkResponses);
+
+        // https://download.eclipse.org/microprofile/microprofile-health-2.1/microprofile-health-spec.html#_response_codes_and_status_mappings
+        if (overallStatus == HealthCheckResponse.Status.UP) {
+            resp.setStatus(200);
+        } else {
+            resp.setStatus(503);
+        }
+
+        final String responseStr = objectMapper.writeValueAsString(responseJson);
+        resp.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        resp.getWriter().write(responseStr);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/health/KafkaStreamsHealthCheck.java
+++ b/src/main/java/org/dependencytrack/health/KafkaStreamsHealthCheck.java
@@ -1,0 +1,38 @@
+package org.dependencytrack.health;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.dependencytrack.event.kafka.KafkaStreamsInitializer;
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+/**
+ * A {@link HealthCheck} for Kafka Streams.
+ * <p>
+ * This code has been copied and slightly modified from Quarkus' Kafka Streams extension.
+ *
+ * @see <a href="https://github.com/quarkusio/quarkus/blob/2.16.5.Final/extensions/kafka-streams/runtime/src/main/java/io/quarkus/kafka/streams/runtime/health/KafkaStreamsStateHealthCheck.java">Quarkus Kafka Streams Health Check</a>
+ */
+class KafkaStreamsHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        final var responseBuilder = HealthCheckResponse.named("kafka-streams");
+
+        final KafkaStreams kafkaStreams = KafkaStreamsInitializer.getKafkaStreams();
+        if (kafkaStreams == null) {
+            return responseBuilder.down().build();
+        }
+
+        try {
+            final KafkaStreams.State state = kafkaStreams.state();
+            responseBuilder.status(state.isRunningOrRebalancing())
+                    .withData("state", state.name());
+        } catch (Exception e) {
+            responseBuilder.down()
+                    .withData("exception_message", e.getMessage());
+        }
+
+        return responseBuilder.build();
+    }
+
+}

--- a/src/main/resources/META-INF/services/org.eclipse.microprofile.health.spi.HealthCheckResponseProvider
+++ b/src/main/resources/META-INF/services/org.eclipse.microprofile.health.spi.HealthCheckResponseProvider
@@ -1,0 +1,1 @@
+org.dependencytrack.health.HealthCheckResponseProvider

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -62,7 +62,7 @@
         <filter-class>alpine.server.filters.WhitelistUrlFilter</filter-class>
         <init-param>
             <param-name>allowUrls</param-name>
-            <param-value>/index.html,/css,/fonts,/img,/js,/static,/favicon.ico,/api,/metrics,/mirror,/.well-known</param-value>
+            <param-value>/index.html,/css,/fonts,/img,/js,/static,/favicon.ico,/api,/metrics,/mirror,/.well-known,/health</param-value>
         </init-param>
         <init-param>
             <param-name>forwardTo</param-name>
@@ -70,7 +70,7 @@
         </init-param>
         <init-param>
             <param-name>forwardExcludes</param-name>
-            <param-value>/api,/metrics,/mirror</param-value>
+            <param-value>/api,/metrics,/mirror,/health</param-value>
         </init-param>
     </filter>
     <filter-mapping>
@@ -142,6 +142,16 @@
     <servlet-mapping>
         <servlet-name>Metrics</servlet-name>
         <url-pattern>/metrics</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>Health</servlet-name>
+        <servlet-class>org.dependencytrack.health.HealthCheckServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>Health</servlet-name>
+        <url-pattern>/health</url-pattern>
     </servlet-mapping>
 
     <error-page>


### PR DESCRIPTION
### Description

This PR adds a basic health check servlet that implements the [MicroProfile Health](https://download.eclipse.org/microprofile/microprofile-health-2.1/microprofile-health-spec.html) spec, which is also what [SmallRye Health](https://quarkus.io/guides/smallrye-health) is using.

This PR includes health checks for the database (can connections be acquired?) and Kafka Streams.

Example response of the `/health` endpoint:

```
{
    "status": "UP",
    "checks": [
        {
            "name": "database",
            "status": "UP",
            "data": {
                "primaryConnectionFactory": "UP",
                "secondaryConnectionFactory": "UP"
            }
        },
        {
            "name": "kafka-streams",
            "status": "UP",
            "data": {
                "state": "REBALANCING"
            }
        }
    ]
}
```

As defined by the MicroProfile Health spec, the endpoint will return status code `200` when all checks have the status `UP`, and status code `500` when *any* check has the status `DOWN`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
