### PR TITLE
Make better use of producer batching when dispatching events to Kafka

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEvent.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEvent.java
@@ -1,0 +1,8 @@
+package org.dependencytrack.event.kafka;
+
+import org.dependencytrack.event.kafka.KafkaTopics.Topic;
+
+import java.util.Map;
+
+record KafkaEvent<K, V>(Topic<K, V> topic, K key, V value, Map<String, String> headers) {
+}

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
@@ -1,0 +1,93 @@
+package org.dependencytrack.event.kafka;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.event.ComponentRepositoryMetaAnalysisEvent;
+import org.dependencytrack.event.ComponentVulnerabilityAnalysisEvent;
+import org.dependencytrack.event.kafka.KafkaTopics.Topic;
+import org.dependencytrack.parser.hyades.NotificationModelConverter;
+import org.hyades.proto.notification.v1.Notification;
+import org.hyades.proto.repometaanalysis.v1.AnalysisCommand;
+import org.hyades.proto.vulnanalysis.v1.ScanCommand;
+import org.hyades.proto.vulnanalysis.v1.ScanKey;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Utility class to convert {@link alpine.event.framework.Event}s and {@link alpine.notification.Notification}s
+ * to {@link KafkaEvent}s.
+ */
+final class KafkaEventConverter {
+
+    private KafkaEventConverter() {
+    }
+
+    static KafkaEvent<ScanKey, ScanCommand> convert(final ComponentVulnerabilityAnalysisEvent event) {
+        final var componentBuilder = org.hyades.proto.vulnanalysis.v1.Component.newBuilder()
+                .setUuid(event.component().getUuid().toString())
+                .setInternal(event.component().isInternal());
+        Optional.ofNullable(event.component().getCpe()).ifPresent(componentBuilder::setCpe);
+        Optional.ofNullable(event.component().getPurl()).map(PackageURL::canonicalize).ifPresent(componentBuilder::setPurl);
+        Optional.ofNullable(event.component().getSwidTagId()).ifPresent(componentBuilder::setSwidTagId);
+
+        final var scanKey = ScanKey.newBuilder()
+                .setScanToken(event.token().toString())
+                .setComponentUuid(event.component().getUuid().toString())
+                .build();
+
+        final var scanCommand = ScanCommand.newBuilder()
+                .setComponent(componentBuilder)
+                .build();
+
+        return new KafkaEvent<>(
+                KafkaTopics.VULN_ANALYSIS_COMMAND,
+                scanKey, scanCommand,
+                Map.of(KafkaEventHeaders.VULN_ANALYSIS_LEVEL, event.level().name())
+        );
+    }
+
+    static KafkaEvent<String, AnalysisCommand> convert(final ComponentRepositoryMetaAnalysisEvent event) {
+        if (event.component() == null || event.component().getPurl() == null) {
+            return null;
+        }
+
+        final String purl = event.component().getPurl().canonicalize();
+        final var analysisCommand = AnalysisCommand.newBuilder()
+                .setComponent(org.hyades.proto.repometaanalysis.v1.Component.newBuilder()
+                        .setPurl(event.component().getPurl().canonicalize())
+                        .setInternal(event.component().isInternal()))
+                .build();
+
+        return new KafkaEvent<>(KafkaTopics.REPO_META_ANALYSIS_COMMAND, purl, analysisCommand, null);
+    }
+
+    static KafkaEvent<String, Notification> convert(final alpine.notification.Notification alpineNotification) {
+        final Notification notification = NotificationModelConverter.convert(alpineNotification);
+
+        final Topic<String, Notification> topic = switch (notification.getGroup()) {
+            case GROUP_CONFIGURATION -> KafkaTopics.NOTIFICATION_CONFIGURATION;
+            case GROUP_DATASOURCE_MIRRORING -> KafkaTopics.NOTIFICATION_DATASOURCE_MIRRORING;
+            case GROUP_REPOSITORY -> KafkaTopics.NOTIFICATION_REPOSITORY;
+            case GROUP_INTEGRATION -> KafkaTopics.NOTIFICATION_INTEGRATION;
+            case GROUP_ANALYZER -> KafkaTopics.NOTIFICATION_ANALYZER;
+            case GROUP_BOM_CONSUMED -> KafkaTopics.NOTIFICATION_BOM_CONSUMED;
+            case GROUP_BOM_PROCESSED -> KafkaTopics.NOTIFICATION_BOM_PROCESSED;
+            case GROUP_FILE_SYSTEM -> KafkaTopics.NOTIFICATION_FILE_SYSTEM;
+            case GROUP_INDEXING_SERVICE -> KafkaTopics.NOTIFICATION_INDEXING_SERVICE;
+            case GROUP_NEW_VULNERABILITY -> KafkaTopics.NOTIFICATION_NEW_VULNERABILITY;
+            case GROUP_NEW_VULNERABLE_DEPENDENCY -> KafkaTopics.NOTIFICATION_NEW_VULNERABLE_DEPENDENCY;
+            case GROUP_POLICY_VIOLATION -> KafkaTopics.NOTIFICATION_POLICY_VIOLATION;
+            case GROUP_PROJECT_AUDIT_CHANGE -> KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE;
+            case GROUP_PROJECT_CREATED -> KafkaTopics.NOTIFICATION_PROJECT_CREATED;
+            case GROUP_VEX_CONSUMED -> KafkaTopics.NOTIFICATION_VEX_CONSUMED;
+            case GROUP_VEX_PROCESSED -> KafkaTopics.NOTIFICATION_VEX_PROCESSED;
+            default -> null;
+        };
+        if (topic == null) {
+            return null;
+        }
+
+        return new KafkaEvent<>(topic, null, notification, null);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -302,8 +302,8 @@ public class ComponentResource extends AlpineResource {
             component.setNotes(StringUtils.trimToNull(jsonComponent.getNotes()));
 
             component = qm.createComponent(component, true);
-            kafkaEventDispatcher.dispatch(new ComponentRepositoryMetaAnalysisEvent(component));
-            kafkaEventDispatcher.dispatch(new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS));
+            kafkaEventDispatcher.dispatchBlocking(new ComponentRepositoryMetaAnalysisEvent(component));
+            kafkaEventDispatcher.dispatchBlocking(new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS));
             return Response.status(Response.Status.CREATED).entity(component).build();
         }
     }
@@ -386,8 +386,8 @@ public class ComponentResource extends AlpineResource {
                 component.setNotes(StringUtils.trimToNull(jsonComponent.getNotes()));
 
                 component = qm.updateComponent(component, true);
-                kafkaEventDispatcher.dispatch(new ComponentRepositoryMetaAnalysisEvent(component));
-                kafkaEventDispatcher.dispatch(new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS));
+                kafkaEventDispatcher.dispatchBlocking(new ComponentRepositoryMetaAnalysisEvent(component));
+                kafkaEventDispatcher.dispatchBlocking(new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS));
                 return Response.ok(component).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the component could not be found.").build();

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -155,8 +155,9 @@ public class BomUploadProcessingTask implements Subscriber {
                 // the vulnerability analysis hasn't taken place yet).
                 qm.createVulnerabilityScan(event.getChainIdentifier().toString(), flattenedComponents.size());
                 for (final Component component : flattenedComponents) {
-                    kafkaEventDispatcher.dispatch(new ComponentVulnerabilityAnalysisEvent(event.getChainIdentifier(),
-                            component, VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS));
+                    kafkaEventDispatcher.dispatchAsync(new ComponentVulnerabilityAnalysisEvent(
+                            event.getChainIdentifier(), component, VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS));
+                    kafkaEventDispatcher.dispatchAsync(new ComponentRepositoryMetaAnalysisEvent(component));
                 }
                 LOGGER.info("Processed " + flattenedComponents.size() + " components and " + flattenedServices.size() + " services uploaded to project " + event.getProjectUuid());
                 content = "A " + bomFormat.getFormatShortName() + " BOM was processed";
@@ -187,7 +188,6 @@ public class BomUploadProcessingTask implements Subscriber {
         if (isNew) {
             newComponents.add(qm.detach(Component.class, component.getId()));
         }
-        kafkaEventDispatcher.dispatch(new ComponentRepositoryMetaAnalysisEvent(component));
         if (component.getChildren() != null) {
             for (final Component child : component.getChildren()) {
                 processComponent(qm, child, flattenedComponents, newComponents);

--- a/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/NistMirrorTask.java
@@ -31,7 +31,7 @@ public class NistMirrorTask implements LoggableSubscriber {
         if (e instanceof NistMirrorEvent && this.isEnabled) {
             final long start = System.currentTimeMillis();
             LOGGER.info("Starting NIST mirroring task");
-            new KafkaEventDispatcher().dispatch(new NistMirrorEvent());
+            new KafkaEventDispatcher().dispatchBlocking(new NistMirrorEvent());
             final long end = System.currentTimeMillis();
             LOGGER.info("NIST mirroring complete. Time spent (total): " + (end - start) + "ms");
             Event.dispatch(new EpssMirrorEvent());

--- a/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
+++ b/src/main/java/org/dependencytrack/tasks/OsvDownloadTask.java
@@ -50,7 +50,7 @@ public class OsvDownloadTask implements LoggableSubscriber {
         if (e instanceof OsvMirrorEvent) {
             if (this.ecosystems != null && !this.ecosystems.isEmpty()) {
                 for (String ecosystem : this.ecosystems) {
-                    new KafkaEventDispatcher().dispatch(new OsvMirrorEvent(ecosystem));
+                    new KafkaEventDispatcher().dispatchBlocking(new OsvMirrorEvent(ecosystem));
                 }
             }
             else {

--- a/src/main/java/org/dependencytrack/tasks/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/RepositoryMetaAnalyzerTask.java
@@ -84,7 +84,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
             List<Component> components = fetchNextComponentsPage(pm, project, null);
             while (!components.isEmpty()) {
                 for (final var component : components) {
-                    kafkaEventDispatcher.dispatch(new ComponentRepositoryMetaAnalysisEvent(pm.detachCopy(component)));
+                    kafkaEventDispatcher.dispatchAsync(new ComponentRepositoryMetaAnalysisEvent(pm.detachCopy(component)));
                 }
 
                 final long lastId = components.get(components.size() - 1).getId();
@@ -105,7 +105,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
             List<Component> components = fetchNextComponentsPage(pm, null, null);
             while (!components.isEmpty()) {
                 for (final var component : components) {
-                    kafkaEventDispatcher.dispatch(new ComponentRepositoryMetaAnalysisEvent(pm.detachCopy(component)));
+                    kafkaEventDispatcher.dispatchAsync(new ComponentRepositoryMetaAnalysisEvent(pm.detachCopy(component)));
                 }
 
                 final long lastId = components.get(components.size() - 1).getId();

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -85,7 +85,7 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             List<Component> components = fetchNextComponentsPage(pm, project, null);
             while (!components.isEmpty()) {
                 for (final var component : components) {
-                    eventDispatcher.dispatch(new ComponentVulnerabilityAnalysisEvent(scanToken,
+                    eventDispatcher.dispatchAsync(new ComponentVulnerabilityAnalysisEvent(scanToken,
                             pm.detachCopy(component), VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS));
                 }
 
@@ -107,7 +107,7 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             List<Component> components = fetchNextComponentsPage(pm, null, null);
             while (!components.isEmpty()) {
                 for (final var component : components) {
-                    eventDispatcher.dispatch(new ComponentVulnerabilityAnalysisEvent(scanToken,
+                    eventDispatcher.dispatchAsync(new ComponentVulnerabilityAnalysisEvent(scanToken,
                             pm.detachCopy(component), VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS));
                 }
 

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -613,6 +613,6 @@ public final class NotificationUtil {
     }
 
     private static void sendNotificationToKafka(Notification notification){
-        new KafkaEventDispatcher().dispatchNotification(notification);
+        new KafkaEventDispatcher().dispatchAsync(notification);
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -88,8 +88,8 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         assertThat(kafkaMockProducer.history()).satisfiesExactly(
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM_CONSUMED.name()),
-                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
+                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM_PROCESSED.name())
         );
 


### PR DESCRIPTION
### Description

`KafkaProducer` is batching records behind the scenes before sending them to the broker. If we wait for broker acknowledgement for every single event we sent, we never really allow batches to fill up, causing unnecessary blocking in our code, and more network round trips between producer and broker.

https://kafka.apache.org/34/javadoc/org/apache/kafka/clients/producer/KafkaProducer.html#send(org.apache.kafka.clients.producer.ProducerRecord,org.apache.kafka.clients.producer.Callback)

By dispatching events asynchronously, batches are more likely to fill up before being submitted. This is especially beneficial when dispatching lots of events in a short period of time, for example after BOM uploads, or for vulnerability analysis of the entire portfolio.

If we enable snappy compression for the producer, it will be more effective because it applies to batches, not individual events.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
