### PR TITLE
Track vulnerability scan completion for manually triggered reanalysis

### DIFF
--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -38,15 +38,16 @@ import org.dependencytrack.tasks.KennaSecurityUploadTask;
 import org.dependencytrack.tasks.NewVulnerableDependencyAnalysisTask;
 import org.dependencytrack.tasks.NistMirrorTask;
 import org.dependencytrack.tasks.OsvDownloadTask;
+import org.dependencytrack.tasks.RepositoryMetaAnalyzerTask;
 import org.dependencytrack.tasks.TaskScheduler;
 import org.dependencytrack.tasks.VexUploadProcessingTask;
 import org.dependencytrack.tasks.VulnDbSyncTask;
 import org.dependencytrack.tasks.VulnerabilityAnalysisTask;
+import org.dependencytrack.tasks.VulnerabilityScanCleanupTask;
 import org.dependencytrack.tasks.metrics.ComponentMetricsUpdateTask;
 import org.dependencytrack.tasks.metrics.PortfolioMetricsUpdateTask;
 import org.dependencytrack.tasks.metrics.ProjectMetricsUpdateTask;
 import org.dependencytrack.tasks.metrics.VulnerabilityMetricsUpdateTask;
-import org.dependencytrack.tasks.RepositoryMetaAnalyzerTask;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -99,6 +100,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(ClearComponentAnalysisCacheEvent.class, ClearComponentAnalysisCacheTask.class);
         EVENT_SERVICE.subscribe(CallbackEvent.class, CallbackTask.class);
         EVENT_SERVICE.subscribe(NewVulnerableDependencyAnalysisEvent.class, NewVulnerableDependencyAnalysisTask.class);
+        EVENT_SERVICE.subscribe(VulnerabilityScanCleanupEvent.class, VulnerabilityScanCleanupTask.class);
 
         EVENT_SERVICE_ST.subscribe(IndexEvent.class, IndexTask.class);
         EVENT_SERVICE_ST.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
@@ -134,6 +136,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.unsubscribe(InternalComponentIdentificationTask.class);
         EVENT_SERVICE.unsubscribe(CallbackTask.class);
         EVENT_SERVICE.unsubscribe(NewVulnerableDependencyAnalysisTask.class);
+        EVENT_SERVICE.unsubscribe(VulnerabilityScanCleanupTask.class);
         EVENT_SERVICE.shutdown();
 
         EVENT_SERVICE_ST.unsubscribe(IndexTask.class);

--- a/src/main/java/org/dependencytrack/event/VulnerabilityScanCleanupEvent.java
+++ b/src/main/java/org/dependencytrack/event/VulnerabilityScanCleanupEvent.java
@@ -1,0 +1,13 @@
+package org.dependencytrack.event;
+
+import alpine.event.framework.Event;
+import org.dependencytrack.model.VulnerabilityScan;
+
+/**
+ * Defines an {@link Event} that is triggered to clean up {@link VulnerabilityScan}s
+ * that have not been updated for a certain amount of time.
+ *
+ * @since 5.0.0
+ */
+public record VulnerabilityScanCleanupEvent() implements Event {
+}

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -42,6 +42,7 @@ import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
+import org.dependencytrack.model.VulnerabilityScan;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentificationUtil;
 
@@ -303,7 +304,9 @@ public class ComponentResource extends AlpineResource {
 
             component = qm.createComponent(component, true);
             kafkaEventDispatcher.dispatchBlocking(new ComponentRepositoryMetaAnalysisEvent(component));
-            kafkaEventDispatcher.dispatchBlocking(new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS));
+            final var vulnAnalysisEvent = new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS);
+            qm.createVulnerabilityScan(VulnerabilityScan.TargetType.COMPONENT, component.getUuid(), vulnAnalysisEvent.token().toString(), 1);
+            kafkaEventDispatcher.dispatchBlocking(vulnAnalysisEvent);
             return Response.status(Response.Status.CREATED).entity(component).build();
         }
     }
@@ -387,7 +390,9 @@ public class ComponentResource extends AlpineResource {
 
                 component = qm.updateComponent(component, true);
                 kafkaEventDispatcher.dispatchBlocking(new ComponentRepositoryMetaAnalysisEvent(component));
-                kafkaEventDispatcher.dispatchBlocking(new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS));
+                final var vulnAnalysisEvent = new ComponentVulnerabilityAnalysisEvent(UUID.randomUUID(), component, VulnerabilityAnalysisLevel.MANUAL_ANALYSIS);
+                qm.createVulnerabilityScan(VulnerabilityScan.TargetType.COMPONENT, component.getUuid(), vulnAnalysisEvent.token().toString(), 1);
+                kafkaEventDispatcher.dispatchBlocking(vulnAnalysisEvent);
                 return Response.ok(component).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The UUID of the component could not be found.").build();

--- a/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
+++ b/src/main/java/org/dependencytrack/tasks/TaskScheduler.java
@@ -38,8 +38,11 @@ import org.dependencytrack.event.PortfolioRepositoryMetaAnalysisEvent;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.VulnDbSyncEvent;
 import org.dependencytrack.event.VulnerabilityMetricsUpdateEvent;
+import org.dependencytrack.event.VulnerabilityScanCleanupEvent;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
+
+import java.time.Duration;
 
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.DEFECTDOJO_SYNC_CADENCE;
@@ -109,6 +112,8 @@ public final class TaskScheduler extends AlpineTaskScheduler {
 
             // Creates a new event that executes every 72 hours (259200000) by default after an initial 10 second (10000) delay
             scheduleEvent(new ClearComponentAnalysisCacheEvent(), 10000, getCadenceConfigPropertyValueInMilliseconds(qm, TASK_SCHEDULER_COMPONENT_ANALYSIS_CACHE_CLEAR_CADENCE));
+
+            scheduleEvent(new VulnerabilityScanCleanupEvent(), Duration.ofSeconds(30).toMillis(), Duration.ofDays(6).toMillis());
         }
 
         // Configurable tasks

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -28,6 +28,7 @@ import org.dependencytrack.event.kafka.KafkaEventDispatcher;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
+import org.dependencytrack.model.VulnerabilityScan;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.jdo.PersistenceManager;
@@ -35,6 +36,8 @@ import javax.jdo.Query;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+
+import static java.lang.Math.toIntExact;
 
 /**
  * A {@link Subscriber} to {@link ProjectVulnerabilityAnalysisEvent} and {@link PortfolioVulnerabilityAnalysisEvent}
@@ -82,6 +85,13 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             final PersistenceManager pm = qm.getPersistenceManager();
             pm.getFetchPlan().setGroup(Component.FetchGroup.VULNERABILITY_ANALYSIS.name());
 
+            final long componentCount = getComponentCount(pm, project);
+            if (componentCount == 0) {
+                LOGGER.info("Project %s does not have any components; Skipping".formatted(projectUuid));
+                return;
+            }
+
+            qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, projectUuid, scanToken.toString(), toIntExact(componentCount));
             List<Component> components = fetchNextComponentsPage(pm, project, null);
             while (!components.isEmpty()) {
                 for (final var component : components) {
@@ -137,6 +147,15 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             query.setOrdering("id DESC");
             query.setRange(0, 500);
             return List.copyOf(query.executeList());
+        }
+    }
+
+    private long getComponentCount(final PersistenceManager pm, final Project project) throws Exception {
+        try (final Query<Component> query = pm.newQuery(Component.class)) {
+            query.setFilter("project == :project");
+            query.setParameters(project);
+            query.setResult("count(this)");
+            return query.executeResultUnique(Long.class);
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityScanCleanupTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityScanCleanupTask.java
@@ -1,0 +1,50 @@
+package org.dependencytrack.tasks;
+
+import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
+import org.dependencytrack.event.VulnerabilityScanCleanupEvent;
+import org.dependencytrack.model.VulnerabilityScan;
+import org.dependencytrack.persistence.QueryManager;
+
+import javax.jdo.Query;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+/**
+ * A {@link Subscriber} task that deletes {@link VulnerabilityScan}s from the database
+ * that have not been updated for over a day.
+ * <p>
+ * The purpose of this task is to prevent {@link VulnerabilityScan}s to increase in numbers indefinitely.
+ *
+ * @since 5.0.0
+ */
+public class VulnerabilityScanCleanupTask implements Subscriber {
+
+    private static final Logger LOGGER = Logger.getLogger(VulnerabilityScanCleanupTask.class);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void inform(final Event event) {
+        if (event instanceof VulnerabilityScanCleanupEvent) {
+            final Instant threshold = Instant.now().minus(1, ChronoUnit.DAYS);
+            LOGGER.info("Cleaning up vulnerability scans that received no update since %s".formatted(threshold));
+
+            try (final var qm = new QueryManager();
+                 final Query<?> query = qm.getPersistenceManager().newQuery("""
+                         DELETE FROM org.dependencytrack.model.VulnerabilityScan
+                         WHERE this.updatedAt < :threshold
+                         """)) {
+                query.setParameters(Date.from(threshold));
+                final long numDeleted = query.executeResultUnique(Long.class);
+                LOGGER.info("Deleted %d vulnerability scans".formatted(numDeleted));
+            } catch (Exception e) {
+                LOGGER.error("Cleaning up vulnerability scans failed", e);
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
@@ -5,6 +5,7 @@ import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.ProjectVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.VulnerabilityScan;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -101,7 +102,18 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
         componentC.setPurl("pkg:maven/acme/acme-lib-c@3.0.1?foo=bar");
         qm.persist(componentC);
 
-        new VulnerabilityAnalysisTask().inform(new ProjectVulnerabilityAnalysisEvent(project.getUuid()));
+        final var event = new ProjectVulnerabilityAnalysisEvent(project.getUuid());
+        new VulnerabilityAnalysisTask().inform(event);
+
+        final VulnerabilityScan scan = qm.getVulnerabilityScan(event.getChainIdentifier().toString());
+        assertThat(scan).isNotNull();
+        assertThat(scan.getTargetType()).isEqualTo(VulnerabilityScan.TargetType.PROJECT);
+        assertThat(scan.getTargetIdentifier()).isEqualTo(project.getUuid());
+        assertThat(scan.getExpectedResults()).isEqualTo(3);
+        assertThat(scan.getReceivedResults()).isEqualTo(0);
+        assertThat(scan.getStatus()).isEqualTo(VulnerabilityScan.Status.IN_PROGRESS);
+        assertThat(scan.getStartedAt()).isNotNull();
+        assertThat(scan.getUpdatedAt()).isNotNull();
 
         assertThat(kafkaMockProducer.history()).satisfiesExactly(
                 record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
@@ -132,6 +144,22 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
                     assertThat(command.getComponent().hasSwidTagId()).isFalse();
                     assertThat(command.getComponent().getInternal()).isFalse();
                 }
+        );
+    }
+
+    @Test
+    public void testProjectVulnerabilityAnalysisWithNoComponents() {
+        final var project = qm.createProject("acme-app-a", null, "1.0.0", null, null, null, true, false);
+
+        final var event = new ProjectVulnerabilityAnalysisEvent(project.getUuid());
+        new VulnerabilityAnalysisTask().inform(event);
+
+        final VulnerabilityScan scan = qm.getVulnerabilityScan(event.getChainIdentifier().toString());
+        assertThat(scan).isNull();
+
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(
+                record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name())
+                // Project does not have any components so nothing should've been submitted for analysis
         );
     }
 

--- a/src/test/java/org/dependencytrack/tasks/VulnerabilityScanCleanupTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/VulnerabilityScanCleanupTaskTest.java
@@ -1,0 +1,32 @@
+package org.dependencytrack.tasks;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.VulnerabilityScanCleanupEvent;
+import org.dependencytrack.model.VulnerabilityScan;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class VulnerabilityScanCleanupTaskTest extends PersistenceCapableTest {
+
+    @Test
+    public void testInform() {
+        qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, UUID.randomUUID(), "token-123", 5);
+        final var scanB = qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, UUID.randomUUID(), "token-xyz", 1);
+        qm.runInTransaction(() -> scanB.setUpdatedAt(Date.from(Instant.now().minus(25, ChronoUnit.HOURS))));
+        final var scanC = qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, UUID.randomUUID(), "token-1y3", 3);
+        qm.runInTransaction(() -> scanC.setUpdatedAt(Date.from(Instant.now().minus(13, ChronoUnit.HOURS))));
+
+        new VulnerabilityScanCleanupTask().inform(new VulnerabilityScanCleanupEvent());
+
+        assertThat(qm.getVulnerabilityScan("token-123")).isNotNull();
+        assertThat(qm.getVulnerabilityScan("token-xyz")).isNull();
+        assertThat(qm.getVulnerabilityScan("token-1y3")).isNotNull();
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes vulnerability scans for projects that were triggered manually to not be tracked for completion.

As a result, policy evaluation and metrics recalculation was not happening.

### Addressed Issue

Fixes https://github.com/DependencyTrack/hyades/issues/505

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
