### PR TITLE
Redundant notifications for existing policy violations

### DIFF
--- a/src/main/java/org/dependencytrack/policy/PolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/PolicyEngine.java
@@ -109,6 +109,7 @@ public class PolicyEngine {
 
     private List<PolicyViolation> evaluate(final QueryManager qm, final List<Policy> policies, Component component) {
         final List<PolicyViolation> policyViolations = new ArrayList<>();
+        final List<PolicyViolation> existingPolicyViolations = qm.detach(qm.getAllPolicyViolations(component));
         for (Policy policy : policies) {
             if (policy.isGlobal() || isPolicyAssignedToProject(policy, component.getProject())
                     || isPolicyAssignedToProjectTag(policy, component.getProject())) {
@@ -134,7 +135,9 @@ public class PolicyEngine {
         }
         qm.reconcilePolicyViolations(component, policyViolations);
         for (final PolicyViolation pv : qm.getAllPolicyViolations(component)) {
-            NotificationUtil.analyzeNotificationCriteria(qm, pv);
+            if (existingPolicyViolations.stream().noneMatch(existingViolation -> existingViolation.getId() == pv.getId())) {
+                NotificationUtil.analyzeNotificationCriteria(qm, pv);
+            }
         }
         return policyViolations;
     }


### PR DESCRIPTION
### Description

During policy evaluation, we currently do not check whether a violation existed before, and instead blindly dispatch a POLICY_VIOLATION notification for every identified violation.

This causes redundant notifications being sent, every time the policy evaluation is executed.

A POLICY_VIOLATION notification should only be sent for newly identified violations, not for existing ones.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/374 -> BugFix for 'Redundant notifications being sent for existing policy violation'

### Checklist

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
