### PR TITLE
Extend bom upload api parameters

### DIFF
--- a/docs/_docs/usage/cicd.md
+++ b/docs/_docs/usage/cicd.md
@@ -73,3 +73,16 @@ curl -X "POST" "http://dtrack.example.com/api/v1/bom" \
      -F "projectVersion=xxxx" \
      -F "bom=@target/bom.xml"
 ```
+You can also create a project as a child to some other project if you add `parentUUID` or `parentName` parameters.
+
+ ```bash
+ curl -X "POST" "http://dtrack.example.com/api/v1/bom" \
+      -H 'Content-Type: multipart/form-data' \
+      -H "X-Api-Key: xxxxxxx" \
+      -F "autoCreate=true" \
+      -F "projectName=xxxx" \
+      -F "projectVersion=xxxx.SNAPSHOT" \
+      -F "parentName=xxxx" \
+      -F "parentVersion=xxxx" \
+      -F "bom=@target/bom.xml"
+ ```

--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -227,7 +227,29 @@ public class BomResource extends AlpineResource {
                 Project project = qm.getProject(request.getProjectName(), request.getProjectVersion());
                 if (project == null && request.isAutoCreate()) {
                     if (hasPermission(Permissions.Constants.PORTFOLIO_MANAGEMENT) || hasPermission(Permissions.Constants.PROJECT_CREATION_UPLOAD)) {
-                        project = qm.createProject(StringUtils.trimToNull(request.getProjectName()), null, StringUtils.trimToNull(request.getProjectVersion()), null, null, null, true, true);
+                        Project parent = null;
+                        if (request.getParentUUID() != null || request.getParentName() != null) {
+                            if (request.getParentUUID() != null) {
+                                failOnValidationError(validator.validateProperty(request, "parentUUID"));
+                                parent = qm.getObjectByUuid(Project.class, request.getParentUUID());
+                            } else {
+                                failOnValidationError(
+                                        validator.validateProperty(request, "parentName"),
+                                        validator.validateProperty(request, "parentVersion")
+                                );
+                                final String trimmedParentName = StringUtils.trimToNull(request.getParentName());
+                                final String trimmedParentVersion = StringUtils.trimToNull(request.getParentVersion());
+                                parent = qm.getProject(trimmedParentName, trimmedParentVersion);
+                            }
+
+                            if (parent == null) { // if parent project is specified but not found
+                                return Response.status(Response.Status.NOT_FOUND).entity("The parent component could not be found.").build();
+                            } else if (! qm.hasAccess(super.getPrincipal(), parent)) {
+                                return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified parent project is forbidden").build();
+                            }
+                        }
+
+                        project = qm.createProject(StringUtils.trimToNull(request.getProjectName()), null, StringUtils.trimToNull(request.getProjectVersion()), null, parent, null, true, true);
                         Principal principal = getPrincipal();
                         qm.updateNewProjectACL(project, principal);
                     } else {
@@ -253,6 +275,9 @@ public class BomResource extends AlpineResource {
                               @DefaultValue("false") @FormDataParam("autoCreate") boolean autoCreate,
                               @FormDataParam("projectName") String projectName,
                               @FormDataParam("projectVersion") String projectVersion,
+                              @FormDataParam("parentName") String parentName,
+                              @FormDataParam("parentVersion") String parentVersion,
+                              @FormDataParam("parentUUID") String parentUUID,
                               final FormDataMultiPart multiPart) {
 
         final List<FormDataBodyPart> artifactParts = multiPart.getFields("bom");
@@ -268,7 +293,24 @@ public class BomResource extends AlpineResource {
                 Project project = qm.getProject(trimmedProjectName, trimmedProjectVersion);
                 if (project == null && autoCreate) {
                     if (hasPermission(Permissions.Constants.PORTFOLIO_MANAGEMENT) || hasPermission(Permissions.Constants.PROJECT_CREATION_UPLOAD)) {
-                        project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, null, null, null, true, true);
+                        Project parent = null;
+                        if (parentUUID != null || parentName != null) {
+                            if (parentUUID != null) {
+
+                                parent = qm.getObjectByUuid(Project.class, parentUUID);
+                            } else {
+                                final String trimmedParentName = StringUtils.trimToNull(parentName);
+                                final String trimmedParentVersion = StringUtils.trimToNull(parentVersion);
+                                parent = qm.getProject(trimmedParentName, trimmedParentVersion);
+                            }
+
+                            if (parent == null) { // if parent project is specified but not found
+                                return Response.status(Response.Status.NOT_FOUND).entity("The parent component could not be found.").build();
+                            } else if (! qm.hasAccess(super.getPrincipal(), parent)) {
+                                return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified parent project is forbidden").build();
+                            }
+                        }
+                        project = qm.createProject(trimmedProjectName, null, trimmedProjectVersion, null, parent, null, true, true);
                         Principal principal = getPrincipal();
                         qm.updateNewProjectACL(project, principal);
                     } else {

--- a/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -50,22 +50,47 @@ public final class BomSubmitRequest {
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The project version may only contain printable characters")
     private final String projectVersion;
 
+    @Pattern(regexp = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", message = "The parent UUID must be a valid 36 character UUID")
+    private final String parentUUID;
+
+    @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The parent name may only contain printable characters")
+    private final String parentName;
+
+    @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The parent version may only contain printable characters")
+    private final String parentVersion;
+
     @NotNull
     @Pattern(regexp = "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$", message = "The BOM must be Base64 encoded")
     private final String bom;
 
     private final boolean autoCreate;
 
+    public BomSubmitRequest(String project,
+                            String projectName,
+                            String projectVersion,
+                            boolean autoCreate,
+                            String bom) {
+        this(project, projectName, projectVersion, autoCreate, null, null, null, bom);
+    }
+
     @JsonCreator
     public BomSubmitRequest(@JsonProperty(value = "project", required = false) String project,
                             @JsonProperty(value = "projectName", required = false) String projectName,
                             @JsonProperty(value = "projectVersion", required = false) String projectVersion,
                             @JsonProperty(value = "autoCreate", required = false) boolean autoCreate,
+                            @JsonProperty(value = "parentUUID", required = false) String parentUUID,
+                            @JsonProperty(value = "parentName", required = false) String parentName,
+                            @JsonProperty(value = "parentVersion", required = false) String parentVersion,
                             @JsonProperty(value = "bom", required = true) String bom) {
         this.project = project;
         this.projectName = projectName;
         this.projectVersion = projectVersion;
         this.autoCreate = autoCreate;
+        this.parentUUID = parentUUID;
+        this.parentName = parentName;
+        this.parentVersion = parentVersion;
         this.bom = bom;
     }
 
@@ -79,6 +104,18 @@ public final class BomSubmitRequest {
 
     public String getProjectVersion() {
         return projectVersion;
+    }
+
+    public String getParentUUID() {
+        return parentUUID;
+    }
+
+    public String getParentName() {
+        return parentName;
+    }
+
+    public String getParentVersion() {
+        return parentVersion;
     }
 
     public boolean isAutoCreate() {

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -726,4 +726,89 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertEquals("The principal does not have permission to create project.", body);
     }
 
+    @Test
+    public void uploadBomAutoCreateTestWithParentTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
+        // Upload parent project
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Parent", "1.0", true, bomString);
+        Response response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Project parent = qm.getProject("Acme Parent", "1.0");
+        Assert.assertNotNull(parent);
+        String parentUUID = parent.getUuid().toString();
+
+        // Upload first child, search parent by UUID
+        request = new BomSubmitRequest(null, "Acme Example", "1.0", true, parentUUID, null, null, bomString);
+        response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(200, response.getStatus(), 0);
+        json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertNotNull(json.getString("token"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        Project child = qm.getProject("Acme Example", "1.0");
+        Assert.assertNotNull(child);
+        Assert.assertNotNull(child.getParent());
+        Assert.assertEquals(parentUUID, child.getParent().getUuid().toString());
+
+
+        // Upload second child, search parent by name+ver
+        request = new BomSubmitRequest(null, "Acme Example", "2.0", true, null, "Acme Parent", "1.0", bomString);
+        response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(200, response.getStatus(), 0);
+        json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertNotNull(json.getString("token"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        child = qm.getProject("Acme Example", "2.0");
+        Assert.assertNotNull(child);
+        Assert.assertNotNull(child.getParent());
+        Assert.assertEquals(parentUUID, child.getParent().getUuid().toString());
+
+        // Upload third child, specify parent's UUID, name, ver. Name and ver are ignored when UUID is specified.
+        request = new BomSubmitRequest(null, "Acme Example", "3.0", true, parentUUID, "Non-existent parent", "1.0", bomString);
+        response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(200, response.getStatus(), 0);
+        json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertNotNull(json.getString("token"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
+        child = qm.getProject("Acme Example", "3.0");
+        Assert.assertNotNull(child);
+        Assert.assertNotNull(child.getParent());
+        Assert.assertEquals(parentUUID, child.getParent().getUuid().toString());
+    }
+
+    @Test
+    public void uploadBomInvalidParentTest() throws Exception {
+        initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
+        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
+        BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", true, UUID.randomUUID().toString(), null, null, bomString);
+        Response response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(404, response.getStatus(), 0);
+        String body = getPlainTextBody(response);
+        Assert.assertEquals("The parent component could not be found.", body);
+
+        request = new BomSubmitRequest(null, "Acme Example", "2.0", true, null, "Non-existent parent", null, bomString);
+        response = target(V1_BOM).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(request, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(404, response.getStatus(), 0);
+        body = getPlainTextBody(response);
+        Assert.assertEquals("The parent component could not be found.", body);
+    }
 }


### PR DESCRIPTION
### Description

At the moment the API does not hava a parameter to specifiy the parent, when uploading a bom and using projectname/version.
Add a parameter "parent" to /v1/bom which consumes and sets the parant on upload.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/374 -> Enhancement -> 'API /v1/bom should have a parameter parent'

### Checklist

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
