### PR TITLE
Disable DataNucleus L2 cache for mirroring tasks

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
@@ -40,7 +40,7 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
     public void process(final Record<String, Bom> record) {
         final Timer.Sample timerSample = Timer.start();
 
-        try (QueryManager qm = new QueryManager()) {
+        try (QueryManager qm = new QueryManager().withL2CacheDisabled()) {
             LOGGER.debug("Synchronizing Mirrored Vulnerability : " + record.key());
             Bom bom = record.value();
             String key = record.key();

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -70,9 +70,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         final VulnerabilityAnalysisLevel analysisLevel = determineAnalysisLevel(record);
 
         final Timer.Sample timerSample = Timer.start();
-        try (final var qm = new QueryManager()) {
-            qm.getPersistenceManager().setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
-
+        try (final var qm = new QueryManager().withL2CacheDisabled()) {
             final Component component = qm.getObjectByUuid(Component.class, componentUuid, List.of(Component.FetchGroup.IDENTITY.name()));
             if (component == null) {
                 LOGGER.warn("Received result for component %s, but it does not exist (scanKey: %s)"

--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -55,6 +55,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -537,12 +538,10 @@ public class Vulnerability implements Serializable {
         if (cwes == null) {
             this.cwes = null;
         } else {
-            this.cwes = new ArrayList<>();
-            for (final Integer integer : cwes) {
-                if (integer != null) {
-                    this.cwes.add(integer);
-                }
-            }
+            final List<Integer> nonNullCwes = cwes.stream()
+                    .filter(Objects::nonNull)
+                    .toList();
+            this.cwes = new ArrayList<>(nonNullCwes);
         }
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -32,6 +32,7 @@ import com.github.packageurl.PackageURL;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryConfig;
 import org.apache.commons.lang3.ClassUtils;
+import org.datanucleus.PropertyNames;
 import org.datanucleus.api.jdo.JDOQuery;
 import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.AffectedVersionAttribution;
@@ -361,6 +362,22 @@ public class QueryManager extends AlpineQueryManager {
         }
 
         return principalTeamIds;
+    }
+
+    /**
+     * Disables the second level cache for this {@link QueryManager} instance.
+     * <p>
+     * Disabling the L2 cache is useful in situations where large amounts of objects
+     * are created or updated in close succession, and it's unlikely that they'll be
+     * accessed again anytime soon. Keeping those objects in cache would unnecessarily
+     * blow up heap usage.
+     *
+     * @return This {@link QueryManager} instance
+     * @see <a href="https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#cache_level2">L2 Cache docs</a>
+     */
+    public QueryManager withL2CacheDisabled() {
+        pm.setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
+        return this;
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
### Description

This PR lowers the memory footprint of mirroring operations, by disabling the "Second Level" cache of the object relational mapper we use (DataNucleus). The cache is only disabled for mirroring operations, other areas of DT are not impacted.

Prior to this change, heap usage would kreep up to almost 5.5 GB while mirroring the NVD and EPSS. Even after a manual GC invocation at the end, ~2.8 GB would still remain in heap.

After disabling L2 caching, overall heap usage stays lower (peaks at ~4.2 GB), and a manual GC shows that pretty much the entire heap can be reclaimed.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/374

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
