### PR TITLE
Move nist mirror task to eventservice and add developer docs for skipping NVD mirroring

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -115,6 +115,33 @@ mvn jetty:run -P enhance -Dlogback.configurationFile=src/main/docker/logback.xml
 The above command is also suitable for debugging. For IntelliJ, simply *Debug* the [Jetty](./.run/Jetty.run.xml) run
 configuration.
 
+### Skipping NVD mirroring
+
+For local debugging and testing, it is sometimes desirable to skip the NVD mirroring process
+that is executed a minute after Dependency-Track has started.
+
+This can be achieved by tricking Dependency-Track into thinking that it already
+mirrored the NVD data, so there's no need to re-download it again.
+
+Prior to starting Dependency-Track, execute the `data-nist-generate-dummy.sh` script:
+
+```shell
+./scripts/data-nist-generate-dummy.sh
+```
+
+> **Note**
+> The `modified` feed will still be downloaded. But that feed is so small that it
+> doesn't really have an impact.
+When testing containerized deployments, simply mount the local directory containing the prepared
+NVD data into the container:
+
+```shell
+./scripts/data-nist-generate-dummy.sh
+docker run -d --name dtrack \
+  -v "$HOME/.dependency-track:/data/.dependency-track" \
+  -p '127.0.0.1:8080:8080' dependencytrack/apiserver:snapshot
+```
+
 ## Debugging with Frontend
 
 Start the API server via the Jetty Maven plugin (see [Debugging](#debugging) above). The API server will listen on

--- a/scripts/data-nist-generate-dummy.sh
+++ b/scripts/data-nist-generate-dummy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NIST_DIR="$HOME/.dependency-track/nist"
+
+function printHelp() {
+  echo "Purges and re-populates the local NVD mirror directory with dummy data."
+  echo ""
+  echo "The dummy data will cause Dependency-Track to NOT download the actual"
+  echo "feeds from NIST when it starts. Exception is the 'modified' feed, which"
+  echo "is negligible in size."
+  echo "Skipping NVD mirroring can be desirable for local testing."
+  echo ""
+  echo "The local NVD mirror directory is located at $NIST_DIR"
+  echo ""
+  echo "Usage: $0"
+  echo ""
+}
+
+while getopts ":h" opt; do
+  case $opt in
+    h)
+      printHelp
+      exit
+      ;;
+    *)
+      ;;
+  esac
+done
+
+rm -rf "$NIST_DIR"
+mkdir -p "$NIST_DIR"
+
+for feed in $(seq "2023" "2002"); do
+  touch "$NIST_DIR/nvdcve-1.1-$feed.json.gz"
+  echo "9999999999999" > "$NIST_DIR/nvdcve-1.1-$feed.json.gz.ts"
+done

--- a/src/main/java/org/dependencytrack/event/EpssMirrorEvent.java
+++ b/src/main/java/org/dependencytrack/event/EpssMirrorEvent.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+import java.util.UUID;
 
 /**
  * Defines an event used to start a mirror of EPSS.
@@ -26,6 +28,12 @@ import alpine.event.framework.Event;
  * @author Steve Springett
  * @since 4.5.0
  */
-public class EpssMirrorEvent implements Event {
+public class EpssMirrorEvent extends SingletonCapableEvent {
 
+    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("63aa687a-17f0-4e2d-abd3-e2016b3c4f0a");
+
+    public EpssMirrorEvent() {
+        setChainIdentifier(CHAIN_IDENTIFIER);
+        setSingleton(true);
+    }
 }

--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -101,10 +101,10 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(CallbackEvent.class, CallbackTask.class);
         EVENT_SERVICE.subscribe(NewVulnerableDependencyAnalysisEvent.class, NewVulnerableDependencyAnalysisTask.class);
         EVENT_SERVICE.subscribe(VulnerabilityScanCleanupEvent.class, VulnerabilityScanCleanupTask.class);
+        EVENT_SERVICE.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
+        EVENT_SERVICE.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
 
         EVENT_SERVICE_ST.subscribe(IndexEvent.class, IndexTask.class);
-        EVENT_SERVICE_ST.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
-        EVENT_SERVICE_ST.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
 
         TaskScheduler.getInstance();
     }
@@ -137,11 +137,11 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.unsubscribe(CallbackTask.class);
         EVENT_SERVICE.unsubscribe(NewVulnerableDependencyAnalysisTask.class);
         EVENT_SERVICE.unsubscribe(VulnerabilityScanCleanupTask.class);
+        EVENT_SERVICE.unsubscribe(NistMirrorTask.class);
+        EVENT_SERVICE.unsubscribe(EpssMirrorTask.class);
         EVENT_SERVICE.shutdown();
 
         EVENT_SERVICE_ST.unsubscribe(IndexTask.class);
-        EVENT_SERVICE_ST.unsubscribe(NistMirrorTask.class);
-        EVENT_SERVICE_ST.unsubscribe(EpssMirrorTask.class);
         EVENT_SERVICE_ST.shutdown();
     }
 }

--- a/src/main/java/org/dependencytrack/event/NistMirrorEvent.java
+++ b/src/main/java/org/dependencytrack/event/NistMirrorEvent.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+import java.util.UUID;
 
 /**
  * Defines an event used to start a mirror of the NVD.
@@ -26,6 +28,12 @@ import alpine.event.framework.Event;
  * @author Steve Springett
  * @since 3.0.0
  */
-public class NistMirrorEvent implements Event {
+public class NistMirrorEvent extends SingletonCapableEvent {
 
+    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("077fa5fe-2f7a-457f-a0f1-9e9a0e578ede");
+
+    public NistMirrorEvent() {
+        setChainIdentifier(CHAIN_IDENTIFIER);
+        setSingleton(true);
+    }
 }


### PR DESCRIPTION
### Description

- This PR slightly reduces the overall memory footprint of DT while NVD mirroring is taking place. It also enables search index updates while NVD and EPSS mirroring are running.
- Add developer docs and helper script for skipping NVD mirroring for local testing purposes.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/374 -> 2 enhancements

### Checklist

- [x] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/dependency-track/blob/github-templates/CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
