### PR TITLE
Improve analysis event dispatch throughput

### DIFF
--- a/src/main/java/org/dependencytrack/event/ComponentRepositoryMetaAnalysisEvent.java
+++ b/src/main/java/org/dependencytrack/event/ComponentRepositoryMetaAnalysisEvent.java
@@ -1,19 +1,21 @@
 package org.dependencytrack.event;
 
 import alpine.event.framework.Event;
+import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 
-import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Defines an {@link Event} triggered when requesting a component to be analyzed for meta information.
  *
- * @param component The {@link Component} to analyze
+ * @param purl     The package URL of the {@link Component} to analyze
+ * @param internal Whether the {@link Component} is internal
  */
-public record ComponentRepositoryMetaAnalysisEvent(Component component) implements Event {
+public record ComponentRepositoryMetaAnalysisEvent(String purl, Boolean internal) implements Event {
 
     public ComponentRepositoryMetaAnalysisEvent(final Component component) {
-        this.component = Objects.requireNonNull(component);
+        this(Optional.ofNullable(component.getPurl()).map(PackageURL::canonicalize).orElse(null), component.isInternal());
     }
 
 }

--- a/src/main/java/org/dependencytrack/event/ComponentVulnerabilityAnalysisEvent.java
+++ b/src/main/java/org/dependencytrack/event/ComponentVulnerabilityAnalysisEvent.java
@@ -1,23 +1,43 @@
 package org.dependencytrack.event;
 
 import alpine.event.framework.Event;
+import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
  * Defines an {@link Event} triggered when requesting a component to be analyzed for vulnerabilities.
  *
- * @param component The {@link Component} to analyze
+ * @param token     The scan token
+ * @param uuid      The {@link UUID} of the {@link Component} to scan
+ * @param purl      The package URL of the {@link Component} to scan
+ * @param cpe       The CPE of the {@link Component} to scan
+ * @param swidTagId The SWID tag ID of the {@link Component} to scan
+ * @param internal  Whether the {@link Component} is internal
+ * @param level     The {@link VulnerabilityAnalysisLevel} of the scan
  */
-public record ComponentVulnerabilityAnalysisEvent(UUID token, Component component, VulnerabilityAnalysisLevel level) implements Event {
+public record ComponentVulnerabilityAnalysisEvent(UUID token, UUID uuid, String purl, String cpe,
+                                                  String swidTagId, Boolean internal,
+                                                  VulnerabilityAnalysisLevel level) implements Event {
+
+    public ComponentVulnerabilityAnalysisEvent(final UUID token, final UUID uuid, final String purl, final String cpe,
+                                               final String swidTagId, final Boolean internal, final VulnerabilityAnalysisLevel level) {
+        this.token = Objects.requireNonNull(token);
+        this.uuid = Objects.requireNonNull(uuid);
+        this.purl = purl;
+        this.cpe = cpe;
+        this.swidTagId = swidTagId;
+        this.internal = internal;
+        this.level = Objects.requireNonNull(level);
+    }
 
     public ComponentVulnerabilityAnalysisEvent(final UUID token, final Component component, VulnerabilityAnalysisLevel level) {
-        this.token = Objects.requireNonNull(token);
-        this.component = Objects.requireNonNull(component);
-        this.level = Objects.requireNonNull(level);
+        this(token, component.getUuid(), Optional.ofNullable(component.getPurl()).map(PackageURL::canonicalize).orElse(null),
+                component.getCpe(), component.getSwidTagId(), component.isInternal(), level);
     }
 
 }

--- a/src/main/java/org/dependencytrack/event/PortfolioRepositoryMetaAnalysisEvent.java
+++ b/src/main/java/org/dependencytrack/event/PortfolioRepositoryMetaAnalysisEvent.java
@@ -10,7 +10,7 @@ import java.util.UUID;
  */
 public final class PortfolioRepositoryMetaAnalysisEvent extends SingletonCapableEvent {
 
-    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("208343a5-48b1-4ca1-b649-0bdf49422b4e");
+    public static final UUID CHAIN_IDENTIFIER = UUID.fromString("208343a5-48b1-4ca1-b649-0bdf49422b4e");
 
     public PortfolioRepositoryMetaAnalysisEvent() {
         setChainIdentifier(CHAIN_IDENTIFIER);

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -87,20 +87,6 @@ import java.util.UUID;
                 @Persistent(name = "id"),
                 @Persistent(name = "lastInheritedRiskScore"),
                 @Persistent(name = "uuid")
-        }),
-        @FetchGroup(name = "REPOSITORY_META_ANALYSIS", members = {
-                @Persistent(name = "uuid"),
-                @Persistent(name = "purl"),
-                @Persistent(name = "internal")
-        }),
-        @FetchGroup(name = "VULNERABILITY_ANALYSIS", members = {
-                @Persistent(name = "uuid"),
-                @Persistent(name = "group"),
-                @Persistent(name = "name"),
-                @Persistent(name = "version"),
-                @Persistent(name = "cpe"),
-                @Persistent(name = "purl"),
-                @Persistent(name = "internal")
         })
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -115,9 +101,7 @@ public class Component implements Serializable {
         ALL,
         IDENTITY,
         INTERNAL_IDENTIFICATION,
-        METRICS_UPDATE,
-        REPOSITORY_META_ANALYSIS,
-        VULNERABILITY_ANALYSIS
+        METRICS_UPDATE
     }
 
     @PrimaryKey

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -83,8 +83,6 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             }
 
             final PersistenceManager pm = qm.getPersistenceManager();
-            pm.getFetchPlan().setGroup(Component.FetchGroup.VULNERABILITY_ANALYSIS.name());
-
             final long componentCount = getComponentCount(pm, project);
             if (componentCount == 0) {
                 LOGGER.info("Project %s does not have any components; Skipping".formatted(projectUuid));
@@ -92,14 +90,11 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             }
 
             qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, projectUuid, scanToken.toString(), toIntExact(componentCount));
-            List<Component> components = fetchNextComponentsPage(pm, project, null);
+            List<ComponentProjection> components = fetchNextComponentsPage(pm, project, null);
             while (!components.isEmpty()) {
-                for (final var component : components) {
-                    eventDispatcher.dispatchAsync(new ComponentVulnerabilityAnalysisEvent(scanToken,
-                            pm.detachCopy(component), VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS));
-                }
+                dispatchComponents(scanToken, components);
 
-                final long lastId = components.get(components.size() - 1).getId();
+                final long lastId = components.get(components.size() - 1).id();
                 components = fetchNextComponentsPage(qm.getPersistenceManager(), project, lastId);
             }
         }
@@ -112,16 +107,11 @@ public class VulnerabilityAnalysisTask implements Subscriber {
 
         try (final QueryManager qm = new QueryManager()) {
             final PersistenceManager pm = qm.getPersistenceManager();
-            pm.getFetchPlan().setGroup(Component.FetchGroup.VULNERABILITY_ANALYSIS.name());
-
-            List<Component> components = fetchNextComponentsPage(pm, null, null);
+            List<ComponentProjection> components = fetchNextComponentsPage(pm, null, null);
             while (!components.isEmpty()) {
-                for (final var component : components) {
-                    eventDispatcher.dispatchAsync(new ComponentVulnerabilityAnalysisEvent(scanToken,
-                            pm.detachCopy(component), VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS));
-                }
+                dispatchComponents(scanToken, components);
 
-                final long lastId = components.get(components.size() - 1).getId();
+                final long lastId = components.get(components.size() - 1).id();
                 components = fetchNextComponentsPage(qm.getPersistenceManager(), null, lastId);
             }
         }
@@ -129,7 +119,15 @@ public class VulnerabilityAnalysisTask implements Subscriber {
         LOGGER.info("All components in portfolio submitted for vulnerability analysis");
     }
 
-    private List<Component> fetchNextComponentsPage(final PersistenceManager pm, final Project project, final Long lastId) throws Exception {
+    private void dispatchComponents(final UUID scanToken, final List<ComponentProjection> components) {
+        for (final var component : components) {
+            eventDispatcher.dispatchAsync(new ComponentVulnerabilityAnalysisEvent(scanToken,
+                    component.uuid(), component.purl(), component.cpe(), component.swidTagId(),
+                    component.internal(), VulnerabilityAnalysisLevel.PERIODIC_ANALYSIS));
+        }
+    }
+
+    private List<ComponentProjection> fetchNextComponentsPage(final PersistenceManager pm, final Project project, final Long lastId) throws Exception {
         try (final Query<Component> query = pm.newQuery(Component.class)) {
             var filter = "project.active == :projectActive";
             var params = new HashMap<String, Object>();
@@ -145,8 +143,9 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             query.setFilter(filter);
             query.setNamedParameters(params);
             query.setOrdering("id DESC");
-            query.setRange(0, 500);
-            return List.copyOf(query.executeList());
+            query.setRange(0, 5000);
+            query.setResult("id, uuid, purl, cpe, swidTagId, internal");
+            return List.copyOf(query.executeResultList(ComponentProjection.class));
         }
     }
 
@@ -157,6 +156,9 @@ public class VulnerabilityAnalysisTask implements Subscriber {
             query.setResult("count(this)");
             return query.executeResultUnique(Long.class);
         }
+    }
+
+    public record ComponentProjection(long id, UUID uuid, String purl, String cpe, String swidTagId, Boolean internal) {
     }
 
 }

--- a/src/test/java/org/dependencytrack/event/ComponentVulnerabilityAnalysisEventTest.java
+++ b/src/test/java/org/dependencytrack/event/ComponentVulnerabilityAnalysisEventTest.java
@@ -15,12 +15,21 @@ public class ComponentVulnerabilityAnalysisEventTest {
     public void testConstructor() {
         final var token = UUID.randomUUID();
         final var component = new Component();
+        component.setUuid(UUID.randomUUID());
+        component.setPurl("pkg:maven/foo/bar@1.2.3");
+        component.setCpe("cpe:/a:acme:application:9.1.1");
+        component.setSwidTagId("foobar");
+        component.setInternal(true);
 
         final var event = new ComponentVulnerabilityAnalysisEvent(token,
                 component, VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS);
 
         assertThat(event.token()).isEqualTo(token);
-        assertThat(event.component()).isEqualTo(component);
+        assertThat(event.uuid()).isEqualTo(component.getUuid());
+        assertThat(event.purl()).isEqualTo("pkg:maven/foo/bar@1.2.3");
+        assertThat(event.cpe()).isEqualTo("cpe:/a:acme:application:9.1.1");
+        assertThat(event.swidTagId()).isEqualTo("foobar");
+        assertThat(event.internal()).isTrue();
         assertThat(event.level()).isEqualTo(VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS);
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR is an attempt of increasing throughput when dispatching events for vulnerability, or repository metadata analysis for all components in the portfolio.

* Query data using "dumb" projections; Saves some ORM overhead
* Fetch components in batches of 5000 instead of 500; Saves lots of network calls
  * Memory impact should be minimal as projection records are tiny

Also added the `/api/v1/finding/portfolio/analyze` REST endpoint to manually trigger a portfolio analysis.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
