### PR TITLE
Optimize initialization of policy engine

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -424,6 +424,10 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().getProjectsWithoutDescendantsOf(name, excludeInactive, project);
     }
 
+    public List<UUID> getParents(final Project project) {
+        return getProjectQueryManager().getParents(project);
+    }
+
     public boolean hasAccess(final Principal principal, final Project project) {
         return getProjectQueryManager().hasAccess(principal, project);
     }
@@ -618,6 +622,10 @@ public class QueryManager extends AlpineQueryManager {
         return getPolicyQueryManager().getAllPolicies();
     }
 
+    public List<Policy> getApplicablePolicies(final Project project) {
+        return getPolicyQueryManager().getApplicablePolicies(project);
+    }
+
     public Policy getPolicy(final String name) {
         return getPolicyQueryManager().getPolicy(name);
     }
@@ -724,8 +732,12 @@ public class QueryManager extends AlpineQueryManager {
         getPolicyQueryManager().deletePolicyViolations(component);
     }
 
-    void deletePolicyViolations(Project project) {
+    public void deletePolicyViolations(Project project) {
         getPolicyQueryManager().deletePolicyViolations(project);
+    }
+
+    public void deletePolicyViolationsOfComponent(final Component component) {
+        getPolicyQueryManager().deletePolicyViolationsOfComponent(component);
     }
 
     public long getAuditedCount(final Component component, final PolicyViolation.Type type) {
@@ -1369,15 +1381,17 @@ public class QueryManager extends AlpineQueryManager {
      * @param fetchGroups Fetch groups to use for this operation
      * @param <T>         Type of the object
      * @return The object if found, otherwise {@code null}
-     * @throws Exception When closing the query failed
      * @since 4.6.0
      */
-    public <T> T getObjectByUuid(final Class<T> clazz, final UUID uuid, final List<String> fetchGroups) throws Exception {
-        try (final Query<T> query = pm.newQuery(clazz)) {
+    public <T> T getObjectByUuid(final Class<T> clazz, final UUID uuid, final List<String> fetchGroups) {
+        final Query<T> query = pm.newQuery(clazz);
+        try {
             query.setFilter("uuid == :uuid");
             query.setParameters(uuid);
             query.getFetchPlan().setGroups(fetchGroups);
             return query.executeUnique();
+        } finally {
+            query.closeAll();
         }
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Currently, the API server will iterate over all components of a project even when no policies are actually applicable to the project. Additionally, the applicability of policies is evaluated in-memory, by first loading *all* policies from the database.

Fetching a policy means also fetching all associated policy conditions (as they are in the default fetch group), which can be expensive and should be avoided if possible.

* Instead of fetching all policies upfront and evaluating applicability in-memory, handle it all in a few database queries
* Short-circuit when no policies apply

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
