### PR TITLE
Synchronously validate and persist uploaded BOMs to disk

### DIFF
--- a/src/main/java/org/dependencytrack/event/BomUploadEvent.java
+++ b/src/main/java/org/dependencytrack/event/BomUploadEvent.java
@@ -32,15 +32,7 @@ import java.util.UUID;
 public class BomUploadEvent extends AbstractChainableEvent {
 
     private final UUID projectUuid;
-    private File file;
-    private byte[] bom;
-
-    public BomUploadEvent(final UUID projectUuid, final byte[] bom) {
-        this.projectUuid = projectUuid;
-        if (bom != null) {
-            this.bom = bom.clone();
-        }
-    }
+    private final File file;
 
     public BomUploadEvent(final UUID projectUuid, final File file) {
         this.projectUuid = projectUuid;
@@ -49,10 +41,6 @@ public class BomUploadEvent extends AbstractChainableEvent {
 
     public UUID getProjectUuid() {
         return projectUuid;
-    }
-
-    public byte[] getBom() {
-        return bom == null ? null : bom.clone();
     }
 
     public File getFile() {

--- a/src/test/java/org/dependencytrack/event/BomUploadEventTest.java
+++ b/src/test/java/org/dependencytrack/event/BomUploadEventTest.java
@@ -28,23 +28,11 @@ import java.util.UUID;
 public class BomUploadEventTest {
 
     @Test
-    public void testByteArrayConstructor() {
-        UUID uuid = UUID.randomUUID();
-        byte[] bom = "testing".getBytes();
-        BomUploadEvent event = new BomUploadEvent(uuid, bom);
-        Assert.assertEquals(uuid, event.getProjectUuid());
-        Assert.assertNotEquals(bom, event.getBom()); // should be a cloned byte array - not the same reference
-        Assert.assertTrue(event.getBom().length > 0);
-        Assert.assertNull(event.getFile());
-    }
-
-    @Test
     public void testFileConstructor() {
         UUID uuid = UUID.randomUUID();
         File bitBucket = new File(SystemUtil.getBitBucket());
         BomUploadEvent event = new BomUploadEvent(uuid, bitBucket);
         Assert.assertEquals(uuid, event.getProjectUuid());
         Assert.assertEquals(bitBucket, event.getFile());
-        Assert.assertNull(event.getBom());
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -22,18 +22,19 @@ import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpStatus;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
+import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.resources.v1.vo.BomSubmitRequest;
-import org.dependencytrack.model.AnalyzerIdentity;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -667,7 +668,7 @@ public class BomResourceTest extends ResourceTest {
     public void uploadBomTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        File file = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(project.getUuid().toString(), null, null, false, bomString);
         Response response = target(V1_BOM).request()
@@ -683,7 +684,7 @@ public class BomResourceTest extends ResourceTest {
     @Test
     public void uploadBomInvalidProjectTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        File file = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(UUID.randomUUID().toString(), null, null, false, bomString);
         Response response = target(V1_BOM).request()
@@ -698,7 +699,7 @@ public class BomResourceTest extends ResourceTest {
     @Test
     public void uploadBomAutoCreateTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        File file = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", true, bomString);
         Response response = target(V1_BOM).request()
@@ -715,7 +716,7 @@ public class BomResourceTest extends ResourceTest {
 
     @Test
     public void uploadBomUnauthorizedTest() throws Exception {
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        File file = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", true, bomString);
         Response response = target(V1_BOM).request()
@@ -729,7 +730,7 @@ public class BomResourceTest extends ResourceTest {
     @Test
     public void uploadBomAutoCreateTestWithParentTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        File file = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         // Upload parent project
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Parent", "1.0", true, bomString);
@@ -793,7 +794,7 @@ public class BomResourceTest extends ResourceTest {
     @Test
     public void uploadBomInvalidParentTest() throws Exception {
         initializeWithPermissions(Permissions.BOM_UPLOAD, Permissions.PROJECT_CREATION_UPLOAD);
-        File file = new File(Thread.currentThread().getContextClassLoader().getResource("bom-1.xml").toURI());
+        File file = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
         String bomString = Base64.getEncoder().encodeToString(FileUtils.readFileToByteArray(file));
         BomSubmitRequest request = new BomSubmitRequest(null, "Acme Example", "1.0", true, UUID.randomUUID().toString(), null, null, bomString);
         Response response = target(V1_BOM).request()

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.tasks;
 
+import org.apache.commons.io.IOUtils;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.BomUploadEvent;
 import org.dependencytrack.event.kafka.KafkaTopics;
@@ -32,9 +33,7 @@ import org.hyades.proto.notification.v1.Notification;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.File;
 import java.time.Duration;
 import java.util.List;
 
@@ -65,9 +64,9 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     public void informTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final byte[] bomBytes = Files.readAllBytes(Paths.get(getClass().getClassLoader().getResource("bom-1.xml").toURI()));
+        final var bomFile = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
 
-        final var bomUploadEvent = new BomUploadEvent(project.getUuid(), bomBytes);
+        final var bomUploadEvent = new BomUploadEvent(project.getUuid(), bomFile);
         new BomUploadProcessingTask().inform(bomUploadEvent);
         assertConditionWithTimeout(() -> kafkaMockProducer.history().size() >= 5, Duration.ofSeconds(5));
         assertThat(kafkaMockProducer.history()).satisfiesExactly(
@@ -106,15 +105,9 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     public void informWithEmptyBomTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final byte[] bomBytes = """
-                {
-                  "bomFormat": "CycloneDX",
-                  "specVersion": "1.4",
-                  "components": []
-                }
-                """.getBytes(StandardCharsets.UTF_8);
+        final var bomFile = new File(IOUtils.resourceToURL("/unit/bom-empty.json").toURI());
 
-        final var bomUploadEvent = new BomUploadEvent(project.getUuid(), bomBytes);
+        final var bomUploadEvent = new BomUploadEvent(project.getUuid(), bomFile);
         new BomUploadProcessingTask().inform(bomUploadEvent);
         assertConditionWithTimeout(() -> kafkaMockProducer.history().size() >= 3, Duration.ofSeconds(5));
         assertThat(kafkaMockProducer.history()).satisfiesExactly(
@@ -138,12 +131,9 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     public void informWithInvalidBomTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final byte[] bomBytes = """
-                {
-                  "bomFormat": "CycloneDX",
-                """.getBytes(StandardCharsets.UTF_8);
+        final var bomFile = new File(IOUtils.resourceToURL("/unit/bom-invalid.json").toURI());
 
-        new BomUploadProcessingTask().inform(new BomUploadEvent(project.getUuid(), bomBytes));
+        new BomUploadProcessingTask().inform(new BomUploadEvent(project.getUuid(), bomFile));
         assertConditionWithTimeout(() -> kafkaMockProducer.history().size() >= 2, Duration.ofSeconds(5));
         assertThat(kafkaMockProducer.history()).satisfiesExactly(
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -34,6 +34,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.List;
 
@@ -64,7 +68,11 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     public void informTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final var bomFile = new File(IOUtils.resourceToURL("/bom-1.xml").toURI());
+        // The task will delete the input file after processing it,
+        // so create a temporary copy to not impact other tests.
+        final Path bomFilePath = Files.createTempFile(null, null);
+        Files.copy(Paths.get(IOUtils.resourceToURL("/bom-1.xml").toURI()), bomFilePath, StandardCopyOption.REPLACE_EXISTING);
+        final var bomFile = bomFilePath.toFile();
 
         final var bomUploadEvent = new BomUploadEvent(project.getUuid(), bomFile);
         new BomUploadProcessingTask().inform(bomUploadEvent);
@@ -105,7 +113,11 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     public void informWithEmptyBomTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final var bomFile = new File(IOUtils.resourceToURL("/unit/bom-empty.json").toURI());
+        // The task will delete the input file after processing it,
+        // so create a temporary copy to not impact other tests.
+        final Path bomFilePath = Files.createTempFile(null, null);
+        Files.copy(Paths.get(IOUtils.resourceToURL("/unit/bom-empty.json").toURI()), bomFilePath, StandardCopyOption.REPLACE_EXISTING);
+        final var bomFile = bomFilePath.toFile();
 
         final var bomUploadEvent = new BomUploadEvent(project.getUuid(), bomFile);
         new BomUploadProcessingTask().inform(bomUploadEvent);
@@ -131,7 +143,11 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
     public void informWithInvalidBomTest() throws Exception {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        final var bomFile = new File(IOUtils.resourceToURL("/unit/bom-invalid.json").toURI());
+        // The task will delete the input file after processing it,
+        // so create a temporary copy to not impact other tests.
+        final Path bomFilePath = Files.createTempFile(null, null);
+        Files.copy(Paths.get(IOUtils.resourceToURL("/unit/bom-invalid.json").toURI()), bomFilePath, StandardCopyOption.REPLACE_EXISTING);
+        final var bomFile = bomFilePath.toFile();
 
         new BomUploadProcessingTask().inform(new BomUploadEvent(project.getUuid(), bomFile));
         assertConditionWithTimeout(() -> kafkaMockProducer.history().size() >= 2, Duration.ofSeconds(5));

--- a/src/test/resources/unit/bom-empty.json
+++ b/src/test/resources/unit/bom-empty.json
@@ -1,0 +1,5 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "components": []
+}

--- a/src/test/resources/unit/bom-invalid.json
+++ b/src/test/resources/unit/bom-invalid.json
@@ -1,0 +1,2 @@
+{
+  "bomFormat": "CycloneDX",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

... instead of validating them asynchronously, and passing them around entirely in-memory.

In situations where lots of BOMs are uploaded in close-ish succession, a large number of BOMs will pile up in memory as the API server struggles to keep up with processing them. This can cause memory limits of the JVM to be exceeded.

Additionally, in order to provide faster feedback to users uploading BOMs, validation is now performed before enqueueing the processing event.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
