### PR TITLE
Offload policy evaluation to internal task queue

### DIFF
--- a/src/main/java/org/dependencytrack/event/ComponentPolicyEvaluationEvent.java
+++ b/src/main/java/org/dependencytrack/event/ComponentPolicyEvaluationEvent.java
@@ -1,0 +1,26 @@
+package org.dependencytrack.event;
+
+import alpine.event.framework.AbstractChainableEvent;
+import alpine.event.framework.Event;
+import org.dependencytrack.model.Component;
+
+import java.util.UUID;
+
+/**
+ * Defines an {@link Event} used to trigger policy evaluations for {@link Component}s.
+ *
+ * @since 5.0.0
+ */
+public class ComponentPolicyEvaluationEvent extends AbstractChainableEvent {
+
+    private final UUID uuid;
+
+    public ComponentPolicyEvaluationEvent(final UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -37,6 +37,7 @@ import org.dependencytrack.tasks.KennaSecurityUploadTask;
 import org.dependencytrack.tasks.NewVulnerableDependencyAnalysisTask;
 import org.dependencytrack.tasks.NistMirrorTask;
 import org.dependencytrack.tasks.OsvDownloadTask;
+import org.dependencytrack.tasks.PolicyEvaluationTask;
 import org.dependencytrack.tasks.RepositoryMetaAnalyzerTask;
 import org.dependencytrack.tasks.TaskScheduler;
 import org.dependencytrack.tasks.VexUploadProcessingTask;
@@ -99,6 +100,8 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(VulnerabilityScanCleanupEvent.class, VulnerabilityScanCleanupTask.class);
         EVENT_SERVICE.subscribe(NistMirrorEvent.class, NistMirrorTask.class);
         EVENT_SERVICE.subscribe(EpssMirrorEvent.class, EpssMirrorTask.class);
+        EVENT_SERVICE.subscribe(ComponentPolicyEvaluationEvent.class, PolicyEvaluationTask.class);
+        EVENT_SERVICE.subscribe(ProjectPolicyEvaluationEvent.class, PolicyEvaluationTask.class);
 
         EVENT_SERVICE_ST.subscribe(IndexEvent.class, IndexTask.class);
 
@@ -134,6 +137,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.unsubscribe(VulnerabilityScanCleanupTask.class);
         EVENT_SERVICE.unsubscribe(NistMirrorTask.class);
         EVENT_SERVICE.unsubscribe(EpssMirrorTask.class);
+        EVENT_SERVICE.unsubscribe(PolicyEvaluationTask.class);
         EVENT_SERVICE.shutdown();
 
         EVENT_SERVICE_ST.unsubscribe(IndexTask.class);

--- a/src/main/java/org/dependencytrack/event/ProjectPolicyEvaluationEvent.java
+++ b/src/main/java/org/dependencytrack/event/ProjectPolicyEvaluationEvent.java
@@ -1,0 +1,26 @@
+package org.dependencytrack.event;
+
+import alpine.event.framework.AbstractChainableEvent;
+import alpine.event.framework.Event;
+import org.dependencytrack.model.Project;
+
+import java.util.UUID;
+
+/**
+ * Defines an {@link Event} used to trigger policy evaluations for {@link Project}s.
+ *
+ * @since 5.0.0
+ */
+public class ProjectPolicyEvaluationEvent extends AbstractChainableEvent {
+
+    private final UUID uuid;
+
+    public ProjectPolicyEvaluationEvent(final UUID uuid) {
+        this.uuid = uuid;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/tasks/PolicyEvaluationTask.java
+++ b/src/main/java/org/dependencytrack/tasks/PolicyEvaluationTask.java
@@ -1,0 +1,38 @@
+package org.dependencytrack.tasks;
+
+import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
+import org.dependencytrack.event.ComponentPolicyEvaluationEvent;
+import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.policy.PolicyEngine;
+
+/**
+ * A {@link Subscriber} task that executes policy evaluations for {@link Project}s or {@link Component}s.
+ *
+ * @since 5.0.0
+ */
+public class PolicyEvaluationTask implements Subscriber {
+
+    private static final Logger LOGGER = Logger.getLogger(PolicyEvaluationTask.class);
+
+    @Override
+    public void inform(final Event e) {
+        if (e instanceof final ProjectPolicyEvaluationEvent event) {
+            try {
+                new PolicyEngine().evaluateProject(event.getUuid());
+            } catch (Exception ex) {
+                LOGGER.error("An unexpected error occurred while evaluating policies for project " + event.getUuid(), ex);
+            }
+        } else if (e instanceof final ComponentPolicyEvaluationEvent event) {
+            try {
+                new PolicyEngine().evaluate(event.getUuid());
+            } catch (Exception ex) {
+                LOGGER.error("An unexpected error occurred while evaluating policies for component " + event.getUuid(), ex);
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
@@ -8,6 +8,7 @@ import net.mguenther.kafka.junit.SendKeyValues;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
+import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
@@ -16,6 +17,7 @@ import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.model.VulnerabilityScan;
 import org.dependencytrack.model.VulnerabilityScan.TargetType;
+import org.dependencytrack.tasks.PolicyEvaluationTask;
 import org.hyades.proto.repometaanalysis.v1.AnalysisResult;
 import org.hyades.proto.vulnanalysis.v1.ScanKey;
 import org.hyades.proto.vulnanalysis.v1.ScanResult;
@@ -60,6 +62,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsTest {
 
     @BeforeClass
     public static void setUpClass() {
+        EventService.getInstance().subscribe(ProjectPolicyEvaluationEvent.class, PolicyEvaluationTask.class);
         EventService.getInstance().subscribe(ProjectMetricsUpdateEvent.class, EventSubscriber.class);
     }
 
@@ -71,6 +74,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsTest {
 
     @AfterClass
     public static void tearDownClass() {
+        EventService.getInstance().unsubscribe(PolicyEvaluationTask.class);
         EventService.getInstance().unsubscribe(EventSubscriber.class);
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Execute policy evaluations in DT's internal task queue instead of in a Kafka consumer thread.

This is a temporary solution until we have policy evaluation in a state where it cannot block the Kafka consumer thread for too long anymore.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/529

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
