### PR TITLE
Add cpe parsing in mirror vulnerability

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
@@ -16,9 +16,11 @@ import org.dependencytrack.event.IndexEvent;
 import org.dependencytrack.model.Cwe;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
-import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerableSoftware;
+import org.dependencytrack.parser.nvd.ModelConverter;
 import org.dependencytrack.persistence.QueryManager;
+import us.springett.parsers.cpe.exceptions.CpeEncodingException;
+import us.springett.parsers.cpe.exceptions.CpeParsingException;
 
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -103,25 +105,22 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
 
     public VulnerableSoftware mapAffectedPackageToVulnerableSoftware(final QueryManager qm, final Bom affectedPackage, String range, String bomRef) {
         AtomicReference<String> purlStr = new AtomicReference<>();
+        AtomicReference<String> cpeStr = new AtomicReference<>();
         if (!affectedPackage.getComponentsList().isEmpty()) {
             affectedPackage.getComponentsList().stream().forEach(component -> {
                 if (component.getBomRef().equals(bomRef)) {
                     purlStr.set(component.getPurl());
+                    cpeStr.set(component.getCpe());
                 }
             });
         }
-        if (purlStr.get() == null) {
-            LOGGER.debug("No PURL provided for affected package  - skipping");
+
+        if (StringUtils.isEmpty(purlStr.get()) && StringUtils.isEmpty(cpeStr.get())) {
+            LOGGER.debug("No PURL or CPE provided for affected package  - skipping");
             return null;
         }
 
-        final PackageURL purl;
-        try {
-            purl = new PackageURL(purlStr.get());
-        } catch (MalformedPackageURLException e) {
-            LOGGER.debug("Invalid PURL provided for affected package  - skipping", e);
-            return null;
-        }
+        VulnerableSoftware vs = new VulnerableSoftware();
 
         // Other sources do not populate the versionStartIncluding with 0.
         // Semantically, versionStartIncluding=null is equivalent to >=0.
@@ -130,10 +129,8 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
         String versionStartExcluding = null;
         String versionEndIncluding = null;
         String versionEndExcluding = null;
-
-
         final String[] parts;
-        if(range != null) {
+        if (range != null) {
             range = range.split("/")[1];
             if (range.contains("|")) {
                 parts = Arrays.stream(range.split("\\|")).map(String::trim).toArray(String[]::new);
@@ -168,23 +165,43 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
                         versionStartIncluding = null;
                     }
                 } else { //since we are not able to parse specific range, we do not want to end up with false positives and therefore this part will be skipped from being saved to db.
-                    LOGGER.debug("Range not definite. Not saving this vulnerable software information. The purl was: " + purl);
+                    LOGGER.debug("Range not definite");
                 }
             }
         }
 
+        if (!StringUtils.isEmpty(purlStr.get())) {
+            final PackageURL purl;
+            try {
+                purl = new PackageURL(purlStr.get());
+            } catch (MalformedPackageURLException e) {
+                LOGGER.debug("Invalid PURL provided for affected package  - skipping", e);
+                return null;
+            }
+            vs = qm.getVulnerableSoftwareByPurl(purl.getType(), purl.getNamespace(), purl.getName(),
+                    versionEndExcluding, versionEndIncluding, null, versionStartIncluding);
+            if (vs != null) {
+                return vs;
+            }
+            vs = new VulnerableSoftware();
+            vs.setPurlType(purl.getType());
+            vs.setPurlNamespace(purl.getNamespace());
+            vs.setPurlName(purl.getName());
+            vs.setPurl(purl.canonicalize());
 
-        VulnerableSoftware vs = qm.getVulnerableSoftwareByPurl(purl.getType(), purl.getNamespace(), purl.getName(),
-                versionEndExcluding, versionEndIncluding, null, versionStartIncluding);
-        if (vs != null) {
-            return vs;
+        } else if (!StringUtils.isEmpty(cpeStr.get())) {
+            vs = qm.getVulnerableSoftwareByCpe23(cpeStr.get(), versionEndExcluding,
+                    versionEndIncluding, versionStartExcluding, versionStartIncluding);
+            if (vs != null) {
+                return vs;
+            }
+            try {
+                vs = ModelConverter.convertCpe23UriToVulnerableSoftware(cpeStr.get());
+            } catch (CpeParsingException | CpeEncodingException e) {
+                LOGGER.warn("An error occurred while parsing: " + cpeStr);
+            }
         }
 
-        vs = new VulnerableSoftware();
-        vs.setPurlType(purl.getType());
-        vs.setPurlNamespace(purl.getNamespace());
-        vs.setPurlName(purl.getName());
-        vs.setPurl(purl.canonicalize());
         vs.setVulnerable(true);
         vs.setVersionStartIncluding(versionStartIncluding);
         vs.setVersionEndExcluding(versionEndExcluding);

--- a/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
@@ -35,8 +35,8 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                      },
                      {
                        "name": "org.http4s:blaze-core_2.13",
-                       "purl": "pkg:maven/org.http4s/blaze-core_2.13",
-                       "bomRef": "22145ba5-a2e8-420b-acea-8b36f7f333fc"
+                       "cpe": "cpe:2.3:a:oracle:mysql:*:*:*:*:*:*:*:*",
+                       "bomRef": "82145ba5-a2e8-420b-acea-8b36f7f8885dc"
                      }
                    ],
                    "externalReferences": [],
@@ -96,13 +96,10 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                            ]
                          },
                          {
-                           "ref": "22145ba5-a2e8-420b-acea-8b36f7f333fc",
+                           "ref": "82145ba5-a2e8-420b-acea-8b36f7f8885dc",
                            "versions": [
                              {
-                               "range": "vers:maven/>=0|<0.14.15"
-                             },
-                             {
-                               "version": "vers:maven/0.14.10|0.14.11|0.14.12|0.14.13|0.14.14|0.14.5|0.14.6|0.14.7|0.14.8|0.14.9"
+                               "range": "vers:generic/>=2.3|<=3.8"
                              }
                            ]
                          }
@@ -124,6 +121,7 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
         Assert.assertEquals("HIGH", severity.name());
         Vulnerability.Source source = processor.extractSource("GHSA-xmw9-q7x9-j5qc", bom.getVulnerabilities(0).getSource());
         Assert.assertEquals("GITHUB", source.name());
+
         VulnerableSoftware vs = processor.mapAffectedPackageToVulnerableSoftware(qm, bom, bom.getVulnerabilities(0).getAffects(0).getVersions(0).getRange(), bom.getVulnerabilities(0).getAffects(0).getRef());
         Assert.assertNotNull(vs);
         Assert.assertEquals("0", vs.getVersionStartIncluding());
@@ -131,6 +129,12 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
         Assert.assertEquals("blaze-core_2.11", vs.getPurlName());
         Assert.assertEquals("maven", vs.getPurlType());
         Assert.assertEquals("org.http4s", vs.getPurlNamespace());
+
+        vs = processor.mapAffectedPackageToVulnerableSoftware(qm, bom, bom.getVulnerabilities(0).getAffects(2).getVersions(0).getRange(), bom.getVulnerabilities(0).getAffects(2).getRef());
+        Assert.assertNotNull(vs);
+        Assert.assertEquals("2.3", vs.getVersionStartIncluding());
+        Assert.assertEquals("3.8", vs.getVersionEndIncluding());
+        Assert.assertEquals("cpe:2.3:a:oracle:mysql:*:*:*:*:*:*:*:*", vs.getCpe23());
     }
 
     @Test


### PR DESCRIPTION
### Description

Add missing CPE parsing for NVD vulnerabilities in apiserver.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/486

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
