### PR TITLE
Disable DataNucleus L2 cache globally

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -128,6 +128,7 @@ public class QueryManager extends AlpineQueryManager {
      */
     public QueryManager() {
         super();
+        disableL2Cache();
     }
 
     /**
@@ -137,6 +138,7 @@ public class QueryManager extends AlpineQueryManager {
      */
     public QueryManager(final PersistenceManager pm) {
         super(pm);
+        disableL2Cache();
     }
 
     /**
@@ -146,6 +148,7 @@ public class QueryManager extends AlpineQueryManager {
      */
     public QueryManager(final AlpineRequest request) {
         super(request);
+        disableL2Cache();
         this.request = request;
     }
 
@@ -156,6 +159,7 @@ public class QueryManager extends AlpineQueryManager {
      */
     public QueryManager(final PersistenceManager pm, final AlpineRequest request) {
         super(pm, request);
+        disableL2Cache();
         this.request = request;
     }
 
@@ -350,6 +354,10 @@ public class QueryManager extends AlpineQueryManager {
         return principalTeamIds;
     }
 
+    private void disableL2Cache() {
+        pm.setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
+    }
+
     /**
      * Disables the second level cache for this {@link QueryManager} instance.
      * <p>
@@ -362,7 +370,7 @@ public class QueryManager extends AlpineQueryManager {
      * @see <a href="https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#cache_level2">L2 Cache docs</a>
      */
     public QueryManager withL2CacheDisabled() {
-        pm.setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
+        disableL2Cache();
         return this;
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Disables the DataNucleus L2 cache on the `QueryManager` level.

Some persistence operations executed by the Alpine framework may still use the cache, but all operations performed by DT directly will not.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
