### PR TITLE
Reduce volume of repo meta analysis commands sent

### DIFF
--- a/src/main/java/org/dependencytrack/event/ComponentRepositoryMetaAnalysisEvent.java
+++ b/src/main/java/org/dependencytrack/event/ComponentRepositoryMetaAnalysisEvent.java
@@ -9,13 +9,13 @@ import java.util.Optional;
 /**
  * Defines an {@link Event} triggered when requesting a component to be analyzed for meta information.
  *
- * @param purl     The package URL of the {@link Component} to analyze
- * @param internal Whether the {@link Component} is internal
+ * @param purlCoordinates The package URL coordinates of the {@link Component} to analyze
+ * @param internal        Whether the {@link Component} is internal
  */
-public record ComponentRepositoryMetaAnalysisEvent(String purl, Boolean internal) implements Event {
+public record ComponentRepositoryMetaAnalysisEvent(String purlCoordinates, Boolean internal) implements Event {
 
     public ComponentRepositoryMetaAnalysisEvent(final Component component) {
-        this(Optional.ofNullable(component.getPurl()).map(PackageURL::canonicalize).orElse(null), component.isInternal());
+        this(Optional.ofNullable(component.getPurlCoordinates()).map(PackageURL::canonicalize).orElse(null), component.isInternal());
     }
 
 }

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
@@ -46,19 +46,19 @@ final class KafkaEventConverter {
     }
 
     static KafkaEvent<String, AnalysisCommand> convert(final ComponentRepositoryMetaAnalysisEvent event) {
-        if (event == null || event.purl() == null) {
+        if (event == null || event.purlCoordinates() == null) {
             return null;
         }
 
         final var componentBuilder = org.hyades.proto.repometaanalysis.v1.Component.newBuilder()
-                .setPurl(event.purl());
+                .setPurl(event.purlCoordinates());
         Optional.ofNullable(event.internal()).ifPresent(componentBuilder::setInternal);
 
         final var analysisCommand = AnalysisCommand.newBuilder()
                 .setComponent(componentBuilder)
                 .build();
 
-        return new KafkaEvent<>(KafkaTopics.REPO_META_ANALYSIS_COMMAND, event.purl(), analysisCommand, null);
+        return new KafkaEvent<>(KafkaTopics.REPO_META_ANALYSIS_COMMAND, event.purlCoordinates(), analysisCommand, null);
     }
 
     static KafkaEvent<String, Notification> convert(final alpine.notification.Notification alpineNotification) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

As repo meta analysis is entirely based on PURLs right now, and results are not associated with individual `Component`s, but `RepositoryMetaComponent`, there is no point in submitting an analysis command for every single `Component`.

Instead, we can de-duplicate based on `purlCoordinates` when querying the database. In portfolios with many shared components, this may result in a significant reduction in system load.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
