### PR TITLE
Skip unnecessary repartition of vuln scan results

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyFactory.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyFactory.java
@@ -3,6 +3,7 @@ package org.dependencytrack.event.kafka;
 import alpine.event.framework.ChainableEvent;
 import alpine.event.framework.Event;
 import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
@@ -13,8 +14,8 @@ import org.apache.kafka.streams.kstream.Repartitioned;
 import org.datanucleus.PropertyNames;
 import org.dependencytrack.event.ComponentMetricsUpdateEvent;
 import org.dependencytrack.event.ComponentPolicyEvaluationEvent;
-import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
+import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
 import org.dependencytrack.event.kafka.processor.MirrorVulnerabilityProcessor;
 import org.dependencytrack.event.kafka.processor.RepositoryMetaResultProcessor;
 import org.dependencytrack.event.kafka.processor.VulnerabilityScanResultProcessor;
@@ -40,28 +41,23 @@ class KafkaStreamsTopologyFactory {
                         .withName("consume_from_%s_topic".formatted(KafkaTopics.VULN_ANALYSIS_RESULT.name())));
 
         // Process the vulnerabilities reported by the scanners.
-        // Re-key the result stream to component UUIDs to ensure that results
-        // for the same component are processed in a serial fashion.
-        //
-        // Results with status COMPLETE are re-keyed back to scan keys
-        // and forwarded, all other results are dropped after successful processing.
-        final KStream<UUID, ScanResult> processedVulnScanResultStream = vulnScanResultStream
-                .selectKey((scanKey, scanResult) -> UUID.fromString(scanKey.getComponentUuid()),
-                        Named.as("re-key_vuln_scan_result_to_component_uuid"))
-                .repartition(Repartitioned
-                        .with(Serdes.UUID(), KafkaTopics.VULN_ANALYSIS_RESULT.valueSerde())
-                        .withName("vuln-scan-result-by-component-uuid"))
+        final KStream<ScanKey, ScanResult> processedVulnScanResultStream = vulnScanResultStream
                 .processValues(VulnerabilityScanResultProcessor::new, Named.as("process_vuln_scan_result"));
 
         // Re-key processed results to their respective scan token, and record their arrival.
         final KStream<String, VulnerabilityScan> completedVulnScanStream = processedVulnScanResultStream
-                .selectKey((componentUuid, scanResult) -> scanResult.getKey().getScanToken())
+                .map((scanKey, scanResult) -> {
+                    // Drop scanner results, as they can be rather large, and we don't need them anymore.
+                    // Dropping them will save us some compression and network overhead during the repartition.
+                    // We can remove this step should we ever need access to the results again.
+                    final var strippedScanResult = ScanResult.newBuilder(scanResult).clearScannerResults().build();
+                    return KeyValue.pair(scanKey.getScanToken(), strippedScanResult);
+                }, Named.as("re-key_scan-result_to_scan-token"))
                 .repartition(Repartitioned
                         .with(Serdes.String(), KafkaTopics.VULN_ANALYSIS_RESULT.valueSerde())
                         .withName("processed-vuln-scan-result-by-scan-token"))
-                .mapValues((scanToken, scanResult) -> {
-                    try (final var qm = new QueryManager()) {
-                        qm.getPersistenceManager().setProperty(PropertyNames.PROPERTY_CACHE_L2_TYPE, "none");
+                .mapValues((scanToken, value) -> {
+                    try (final var qm = new QueryManager().withL2CacheDisabled()) {
                         // Detach VulnerabilityScan objects when committing changes. Without this,
                         // all fields except the ID field will be unloaded on commit (the object will become HOLLOW),
                         // causing the call to getStatus() to trigger a database query behind the scenes.
@@ -79,6 +75,8 @@ class KafkaStreamsTopologyFactory {
                 }, Named.as("record_processed_vuln_scan_result"))
                 .filter((scanToken, vulnScan) -> vulnScan != null,
                         Named.as("filter_completed_vuln_scans"));
+
+        // TODO: Send VULNERABILITY_SCAN_COMPLETED notification
 
         completedVulnScanStream
                 .foreach((scanToken, vulnScan) -> {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -52,7 +52,7 @@ import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
 /**
  * A {@link ContextualProcessor} responsible for processing {@link ScanResult}s.
  */
-public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcessor<UUID, ScanResult, ScanResult> {
+public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcessor<ScanKey, ScanResult, ScanResult> {
 
     private static final Logger LOGGER = Logger.getLogger(VulnerabilityScanResultProcessor.class);
     private static final Timer TIMER = Timer.builder("vuln_scan_result_processing")
@@ -62,10 +62,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     private final KafkaEventDispatcher eventDispatcher = new KafkaEventDispatcher();
 
     @Override
-    public void process(final FixedKeyRecord<UUID, ScanResult> record) {
-        final UUID componentUuid = record.key();
+    public void process(final FixedKeyRecord<ScanKey, ScanResult> record) {
+        final ScanKey scanKey = record.key();
         final ScanResult result = record.value();
-        final ScanKey scanKey = result.getKey();
+        final UUID componentUuid = UUID.fromString(scanKey.getComponentUuid());
         final VulnerabilityAnalysisLevel analysisLevel = determineAnalysisLevel(record);
 
         final Timer.Sample timerSample = Timer.start();

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -5,9 +5,6 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.common.serialization.Serdes;
-import org.apache.kafka.common.serialization.UUIDDeserializer;
-import org.apache.kafka.common.serialization.UUIDSerializer;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.TestInputTopic;
 import org.apache.kafka.streams.TestOutputTopic;
@@ -74,24 +71,24 @@ import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_SNYK;
 public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest {
 
     private TopologyTestDriver testDriver;
-    private TestInputTopic<UUID, ScanResult> inputTopic;
-    private TestOutputTopic<UUID, ScanResult> outputTopic;
+    private TestInputTopic<ScanKey, ScanResult> inputTopic;
+    private TestOutputTopic<ScanKey, ScanResult> outputTopic;
 
     @Before
     public void setUp() throws Exception {
         final var streamsBuilder = new StreamsBuilder();
         streamsBuilder
                 .stream("input-topic", Consumed
-                        .with(Serdes.UUID(), new KafkaProtobufSerde<>(ScanResult.parser())))
+                        .with(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser())))
                 .processValues(VulnerabilityScanResultProcessor::new)
                 .to("output-topic", Produced
-                        .with(Serdes.UUID(), new KafkaProtobufSerde<>(ScanResult.parser())));
+                        .with(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser())));
 
         testDriver = new TopologyTestDriver(streamsBuilder.build());
         inputTopic = testDriver.createInputTopic("input-topic",
-                new UUIDSerializer(), new KafkaProtobufSerializer<>());
+                new KafkaProtobufSerializer<>(), new KafkaProtobufSerializer<>());
         outputTopic = testDriver.createOutputTopic("output-topic",
-                new UUIDDeserializer(), new KafkaProtobufDeserializer<>(ScanResult.parser()));
+                new KafkaProtobufDeserializer<>(ScanKey.parser()), new KafkaProtobufDeserializer<>(ScanResult.parser()));
 
         new CweImporter().processCweDefinitions(); // Required for CWE mapping
     }
@@ -126,7 +123,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                         .setFailureReason("just because"))
                 .build();
 
-        inputTopic.pipeInput(component.getUuid(), scanResult);
+        inputTopic.pipeInput(scanKey, scanResult);
 
         assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
 
@@ -167,7 +164,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                         .setStatus(SCAN_STATUS_PENDING))
                 .build();
 
-        inputTopic.pipeInput(component.getUuid(), scanResult);
+        inputTopic.pipeInput(scanKey, scanResult);
 
         assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
 
@@ -192,7 +189,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                                 .setSource(SOURCE_INTERNAL)))
                 .build();
 
-        inputTopic.pipeInput(componentUuid, scanResult);
+        inputTopic.pipeInput(scanKey, scanResult);
 
         assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
 
@@ -243,7 +240,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
         final Headers headers = new RecordHeaders();
         headers.add(KafkaEventHeaders.VULN_ANALYSIS_LEVEL, VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS.name().getBytes());
 
-        inputTopic.pipeInput(new TestRecord<>(componentUuid, scanResult, headers));
+        inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult, headers));
 
         assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
 
@@ -329,7 +326,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                                 .setSource(SOURCE_NVD)))
                 .build();
 
-        inputTopic.pipeInput(component.getUuid(), scanResult);
+        inputTopic.pipeInput(scanKey, scanResult);
 
         qm.getPersistenceManager().refreshAll(component, vulnerability);
         assertThat(component.getVulnerabilities()).satisfiesExactly(
@@ -430,7 +427,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                                 .setDescription("modified description")))
                 .build();
 
-        inputTopic.pipeInput(component.getUuid(), scanResult);
+        inputTopic.pipeInput(scanKey, scanResult);
 
         qm.getPersistenceManager().refreshAll(component, vulnerability);
         assertThat(component.getVulnerabilities()).satisfiesExactly(
@@ -534,7 +531,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
                         ))
                 .build();
 
-        inputTopic.pipeInput(component.getUuid(), scanResult);
+        inputTopic.pipeInput(scanKey, scanResult);
 
         qm.getPersistenceManager().refreshAll(component, vulnerability);
         assertThat(component.getVulnerabilities()).hasSize(1);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The intention behind the repartition was to avoid race conditions when results for the same component would be processed in parallel. However, this case should be rather rare, and we already perform retries should a transaction fail due to a unique constraint violation.

It had the ugly side effect of doubling the partition count necessary to process vuln scan results, without adding much benefit.

Additionally, the re-keying of results to scan tokens also causes a repartition. This repartition included the scanner results, despite them not being needed by any of the following processing steps. To save some overhead, we now strip the scanner results before performing the repartition.

> **Note**  
> The `dtrack-apiserver-vuln-scan-result-by-component-uuid-repartition` topic is no longer required and can be deleted from existing deployments.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

#### Old Topology

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/38574c38-7670-412a-8bb8-b51c6a780e1f)

#### New Topology

The number of sub-topologies is reduced from 5 to 4.

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/869ed088-9424-4347-956c-087c2e825d3a)


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
