### PR TITLE
Update component purl length

### DIFF
--- a/docs/_docs/getting-started/database-support.md
+++ b/docs/_docs/getting-started/database-support.md
@@ -165,15 +165,15 @@ java -cp h2-2.1.214.jar org.h2.tools.RunScript \
 ### Improve query performance
 
 #### PostgreSQL
-To improve the performance, JPA uses index for faster retrieval. However, some fetch queries while matching strings to make comparison uses String method like LOWER on a field. Index is not applied in such cases.
+To improve the performance, database uses index for faster retrieval. However, some fetch queries while matching strings to make comparison uses String method like LOWER on a field. Index is not applied in such cases.
 
 For example, the index defined on component's purl (COMPONENT_PURL_IDX) is not used in query using purl match (either equals or LIKE) because it queries on method "lower(purl)".
 In such cases, indices can be created manually while setting up database using any index method :
 
 1. GIN index for search using LIKE %purlString%
 
-`create index "COMPONENT_PURL_IDX" on "COMPONENT" using gin (lower("PURL"::text) gin_trgm_ops);`
+`create index "COMPONENT_PURL_IDX_GIN" on "COMPONENT" using gin (lower("PURL"::text) gin_trgm_ops);`
 
 3. BTREE index for search using LIKE purlString% or equals comparison
 
-`create index "COMPONENT_PURL_IDX" on "COMPONENT" (lower("PURL"::text) text_pattern_ops);`
+`create index "COMPONENT_PURL_IDX_BTREE" on "COMPONENT" (lower("PURL"::text) text_pattern_ops);`

--- a/docs/_docs/getting-started/database-support.md
+++ b/docs/_docs/getting-started/database-support.md
@@ -161,3 +161,19 @@ java -cp h2-2.1.214.jar org.h2.tools.RunScript \
 [HikariCP]: https://github.com/brettwooldridge/HikariCP
 [Monitoring]: {{ site.baseurl }}{% link _docs/getting-started/monitoring.md %}
 [SQL mode]: https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html
+
+### Improve query performance
+
+#### PostgreSQL
+To improve the performance, JPA uses index for faster retrieval. However, some fetch queries while matching strings to make comparison uses String method like LOWER on a field. Index is not applied in such cases.
+
+For example, the index defined on component's purl (COMPONENT_PURL_IDX) is not used in query using purl match (either equals or LIKE) because it queries on method "lower(purl)".
+In such cases, indices can be created manually while setting up database using any index method :
+
+1. GIN index for search using LIKE %purlString%
+
+`create index "COMPONENT_PURL_IDX" on "COMPONENT" using gin (lower("PURL"::text) gin_trgm_ops);`
+
+3. BTREE index for search using LIKE purlString% or equals comparison
+
+`create index "COMPONENT_PURL_IDX" on "COMPONENT" (lower("PURL"::text) text_pattern_ops);`

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -243,7 +243,7 @@ public class Component implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_IDX")
-    @Size(max = 255)
+    @Column(name = "PURL", jdbcType = "VARCHAR", length = 1024)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String purl;

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -244,6 +244,7 @@ public class Component implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_IDX")
     @Column(name = "PURL", jdbcType = "VARCHAR", length = 1024)
+    @Size(max = 1024)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String purl;

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -33,7 +33,6 @@ import org.hyades.proto.notification.v1.Notification;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -102,7 +101,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         assertThat(component.getVersion()).isEqualTo("1.0.0");
         assertThat(component.getDescription()).isEqualTo("A makebelieve XML utility library");
         assertThat(component.getCpe()).isEqualTo("cpe:/a:example:xmlutil:1.0.0");
-        assertThat(component.getPurl().canonicalize()).isEqualTo("pkg:maven/com.example/xmlutil@1.0.0?packaging=jar");
+        assertThat(component.getPurl().canonicalize()).isEqualTo("pkg:maven/com.example/xmlutil@1.0.0?download_url=https%3A%2F%2Fon-premises.url%2Frepository%2Fnpm%2F%40babel%2Fhelper-split-export-declaration%2Fhelper-split-export-declaration%2Fhelper-split-export-declaration%2Fhelper-split-export-declaration%2Fhelper-split-export-declaration-7.18.6.tgz");
         assertThat(component.getLicenseUrl()).isEqualTo("https://www.apache.org/licenses/LICENSE-2.0.txt");
 
         final VulnerabilityScan vulnerabilityScan = qm.getVulnerabilityScan(bomUploadEvent.getChainIdentifier().toString());

--- a/src/test/resources/bom-1.xml
+++ b/src/test/resources/bom-1.xml
@@ -41,7 +41,7 @@
             </licenses>
             <copyright>Copyright Example Inc. All rights reserved.</copyright>
             <cpe>cpe:/a:example:xmlutil:1.0.0</cpe>
-            <purl>pkg:maven/com.example/xmlutil@1.0.0?packaging=jar</purl>
+            <purl>pkg:maven/com.example/xmlutil@1.0.0?download_url=https://on-premises.url/repository/npm/@babel/helper-split-export-declaration/helper-split-export-declaration/helper-split-export-declaration/helper-split-export-declaration/helper-split-export-declaration-7.18.6.tgz</purl>
             <modified>false</modified>
         </component>
     </components>


### PR DESCRIPTION
### Description

Due to the chosen database schema, Dependency-Track is not able to import components with package URLs that have a length of 255 characters or more. It should be able to import components with PURLs of arbitrary length.

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
