### PR TITLE
Fix missing subject in `PROJECT_CREATED` notification

### DIFF
--- a/src/main/java/org/dependencytrack/parser/hyades/NotificationModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/hyades/NotificationModelConverter.java
@@ -169,8 +169,10 @@ public final class NotificationModelConverter {
             return Optional.of(Any.pack(convert(vcop)));
         } else if (subject instanceof final PolicyViolationIdentified pvi) {
             return Optional.of(Any.pack(convert(pvi)));
-        } else if (subject instanceof final ProjectVulnAnalysisComplete projectAnalysisCompleteNotification) {
-            return Optional.of(Any.pack(convert(projectAnalysisCompleteNotification)));
+        } else if (subject instanceof final ProjectVulnAnalysisComplete pac) {
+            return Optional.of(Any.pack(convert(pac)));
+        } else if (subject instanceof final org.dependencytrack.model.Project p) {
+            return Optional.of(Any.pack(convert(p)));
         }
 
         return Optional.empty();

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -457,7 +457,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 NotificationConstants.Title.PROJECT_CREATED,
                 result.getName() + " was created",
                 NotificationLevel.INFORMATIONAL,
-                NotificationUtil.toJson(pm.detachCopy(result))
+                pm.detachCopy(result)
         );
         commitSearchIndex(commitIndex, Project.class);
         return result;

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -30,7 +30,6 @@ import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
-import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.ViolationAnalysis;
 import org.dependencytrack.model.ViolationAnalysisState;
 import org.dependencytrack.model.Vulnerability;
@@ -49,9 +48,6 @@ import org.dependencytrack.notification.vo.ViolationAnalysisDecisionChange;
 import org.dependencytrack.persistence.QueryManager;
 
 import javax.jdo.FetchPlan;
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -251,29 +247,6 @@ public final class NotificationUtil {
                 .content(generateNotificationContent(pv))
                 .subject(new PolicyViolationIdentified(pv, pv.getComponent(), pv.getProject()))
         );
-    }
-
-    public static JsonObject toJson(final Project project) {
-        final JsonObjectBuilder projectBuilder = Json.createObjectBuilder();
-        projectBuilder.add("uuid", project.getUuid().toString());
-        JsonUtil.add(projectBuilder, "name", project.getName());
-        JsonUtil.add(projectBuilder, "version", project.getVersion());
-        JsonUtil.add(projectBuilder, "description", project.getDescription());
-        if (project.getPurl() != null) {
-            projectBuilder.add("purl", project.getPurl().canonicalize());
-        }
-        if (project.getTags() != null && project.getTags().size() > 0) {
-            final StringBuilder sb = new StringBuilder();
-            for (final Tag tag : project.getTags()) {
-                sb.append(tag.getName()).append(",");
-            }
-            String tags = sb.toString();
-            if (tags.endsWith(",")) {
-                tags = tags.substring(0, tags.length() - 1);
-            }
-            JsonUtil.add(projectBuilder, "tags", tags);
-        }
-        return projectBuilder.build();
     }
 
     public static void loadDefaultNotificationPublishers(QueryManager qm) throws IOException {

--- a/src/test/java/org/dependencytrack/parser/hyades/NotificationModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/hyades/NotificationModelConverterTest.java
@@ -528,12 +528,8 @@ public class NotificationModelConverterTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testConvertProjectCreatedNotification() {
+    public void testConvertProjectCreatedNotification() throws Exception {
         final org.dependencytrack.model.Project project = createProject();
-        final org.dependencytrack.model.Component component = createComponent(project);
-        final org.dependencytrack.model.Policy policy = createPolicy();
-        final org.dependencytrack.model.PolicyCondition policyCondition = createPolicyCondition(policy);
-        final org.dependencytrack.model.PolicyViolation policyViolation = createPolicyViolation(policyCondition, component);
 
         final var alpineNotification = new alpine.notification.Notification();
         alpineNotification.setScope(NotificationScope.PORTFOLIO.name());
@@ -541,6 +537,7 @@ public class NotificationModelConverterTest extends PersistenceCapableTest {
         alpineNotification.setGroup(NotificationGroup.PROJECT_CREATED.name());
         alpineNotification.setTitle("Foo");
         alpineNotification.setContent("Bar");
+        alpineNotification.setSubject(project);
 
         final Notification notification = NotificationModelConverter.convert(alpineNotification);
         assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
@@ -549,7 +546,11 @@ public class NotificationModelConverterTest extends PersistenceCapableTest {
         assertThat(notification.getTitle()).isEqualTo("Foo");
         assertThat(notification.getContent()).isEqualTo("Bar");
         assertThat(notification.getTimestamp().getSeconds()).isNotZero();
-        assertThat(notification.hasSubject()).isFalse();
+        assertThat(notification.hasSubject()).isTrue();
+        assertThat(notification.getSubject().is(Project.class)).isTrue();
+
+        final var subject = notification.getSubject().unpack(Project.class);
+        assertProject(subject);
     }
 
     private org.dependencytrack.model.Project createProject() {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes `PROJECT_CREATED` notifications missing their subject when being published to Kafka.

<img width="749" alt="Screenshot 2023-06-24 at 21 54 31" src="https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/da720f5e-3dde-429d-8395-1530d1c35721">

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/602

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
