### PR TITLE
added changes for authentication

### DIFF
--- a/src/main/java/org/dependencytrack/model/Repository.java
+++ b/src/main/java/org/dependencytrack/model/Repository.java
@@ -86,6 +86,12 @@ public class Repository implements Serializable {
     @NotNull
     private Boolean internal; // New column, must allow nulls on existing databases
 
+    //New column to determine if authentication is required for a repository
+    @Persistent
+    @Column(name = "AUTHENTICATIONREQUIRED")
+    @NotNull
+    private Boolean authenticationRequired;
+
     @Persistent
     @Column(name = "USERNAME")
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
@@ -97,7 +103,8 @@ public class Repository implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Index(name = "REPOSITORY_UUID_IDX") // Cannot be @Unique. Microsoft SQL Server throws an exception
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "true")  // New column, must allow nulls on existing databases
+    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "true")
+    // New column, must allow nulls on existing databases
     @NotNull
     private UUID uuid;
 
@@ -151,6 +158,14 @@ public class Repository implements Serializable {
 
     public Boolean isInternal() {
         return internal;
+    }
+
+    public Boolean isAuthenticationRequired() {
+        return authenticationRequired;
+    }
+
+    public void setAuthenticationRequired(Boolean authenticationRequired) {
+        this.authenticationRequired = authenticationRequired;
     }
 
     public void setInternal(Boolean internal) {

--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -206,20 +206,20 @@ public class DefaultObjectGenerator implements ServletContextListener {
     private void loadDefaultRepositories() {
         try (QueryManager qm = new QueryManager()) {
             LOGGER.info("Synchronizing default repositories to datastore");
-            qm.createRepository(RepositoryType.CPAN, "cpan-public-registry", "https://fastapi.metacpan.org/v1/", true, false);
-            qm.createRepository(RepositoryType.GEM, "rubygems.org", "https://rubygems.org/", true, false);
-            qm.createRepository(RepositoryType.HEX, "hex.pm", "https://hex.pm/", true, false);
-            qm.createRepository(RepositoryType.MAVEN, "central", "https://repo1.maven.org/maven2/", true, false);
-            qm.createRepository(RepositoryType.MAVEN, "atlassian-public", "https://packages.atlassian.com/content/repositories/atlassian-public/", true, false);
-            qm.createRepository(RepositoryType.MAVEN, "jboss-releases", "https://repository.jboss.org/nexus/content/repositories/releases/", true, false);
-            qm.createRepository(RepositoryType.MAVEN, "clojars", "https://repo.clojars.org/", true, false);
-            qm.createRepository(RepositoryType.MAVEN, "google-android", "https://maven.google.com/", true, false);
-            qm.createRepository(RepositoryType.NPM, "npm-public-registry", "https://registry.npmjs.org/", true, false);
-            qm.createRepository(RepositoryType.PYPI, "pypi.org", "https://pypi.org/", true, false);
-            qm.createRepository(RepositoryType.NUGET, "nuget-gallery", "https://api.nuget.org/", true, false);
-            qm.createRepository(RepositoryType.COMPOSER, "packagist", "https://repo.packagist.org/", true, false);
-            qm.createRepository(RepositoryType.CARGO, "crates.io", "https://crates.io", true, false);
-            qm.createRepository(RepositoryType.GO_MODULES, "proxy.golang.org", "https://proxy.golang.org", true, false);
+            qm.createRepository(RepositoryType.CPAN, "cpan-public-registry", "https://fastapi.metacpan.org/v1/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.GEM, "rubygems.org", "https://rubygems.org/", true, false, false,null, null);
+            qm.createRepository(RepositoryType.HEX, "hex.pm", "https://hex.pm/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.MAVEN, "central", "https://repo1.maven.org/maven2/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.MAVEN, "atlassian-public", "https://packages.atlassian.com/content/repositories/atlassian-public/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.MAVEN, "jboss-releases", "https://repository.jboss.org/nexus/content/repositories/releases/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.MAVEN, "clojars", "https://repo.clojars.org/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.MAVEN, "google-android", "https://maven.google.com/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.NPM, "npm-public-registry", "https://registry.npmjs.org/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.PYPI, "pypi.org", "https://pypi.org/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.NUGET, "nuget-gallery", "https://api.nuget.org/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.COMPOSER, "packagist", "https://repo.packagist.org/", true, false, false, null, null);
+            qm.createRepository(RepositoryType.CARGO, "crates.io", "https://crates.io", true, false, false, null, null);
+            qm.createRepository(RepositoryType.GO_MODULES, "proxy.golang.org", "https://proxy.golang.org", true, false, false, null, null);
         }
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1165,12 +1165,12 @@ public class QueryManager extends AlpineQueryManager {
         return getRepositoryQueryManager().repositoryExist(type, identifier);
     }
 
-    public Repository createRepository(RepositoryType type, String identifier, String url, boolean enabled, boolean internal) {
-        return getRepositoryQueryManager().createRepository(type, identifier, url, enabled, internal);
+    public Repository createRepository(RepositoryType type, String identifier, String url, boolean enabled, boolean internal, boolean isAuthenticationRequired, String username, String password) {
+        return getRepositoryQueryManager().createRepository(type, identifier, url, enabled, internal, isAuthenticationRequired, username, password);
     }
 
-    public Repository updateRepository(UUID uuid, String identifier, String url, boolean internal, String username, String password, boolean enabled) {
-        return getRepositoryQueryManager().updateRepository(uuid, identifier, url, internal, username, password, enabled);
+    public Repository updateRepository(UUID uuid, String identifier, String url, boolean internal, boolean authenticationRequired, String username, String password, boolean enabled) {
+        return getRepositoryQueryManager().updateRepository(uuid, identifier, url, internal, authenticationRequired, username, password, enabled);
     }
 
     public RepositoryMetaComponent getRepositoryMetaComponent(RepositoryType repositoryType, String namespace, String name) {

--- a/src/main/java/org/dependencytrack/persistence/RepositoryQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/RepositoryQueryManager.java
@@ -18,8 +18,11 @@
  */
 package org.dependencytrack.persistence;
 
+import alpine.common.logging.Logger;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
+import alpine.security.crypto.DataEncryption;
+import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
@@ -31,9 +34,12 @@ import java.util.UUID;
 
 public class RepositoryQueryManager extends QueryManager implements IQueryManager {
 
+    private static final Logger LOGGER = Logger.getLogger(RepositoryQueryManager.class);
+
 
     /**
      * Constructs a new QueryManager.
+     *
      * @param pm a PersistenceManager object
      */
     RepositoryQueryManager(final PersistenceManager pm) {
@@ -42,7 +48,8 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
 
     /**
      * Constructs a new QueryManager.
-     * @param pm a PersistenceManager object
+     *
+     * @param pm      a PersistenceManager object
      * @param request an AlpineRequest object
      */
     RepositoryQueryManager(final PersistenceManager pm, final AlpineRequest request) {
@@ -52,6 +59,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
 
     /**
      * Returns a list of all repositories.
+     *
      * @return a List of Repositories
      */
     public PaginatedResult getRepositories() {
@@ -70,6 +78,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
     /**
      * Returns a list of all repositories
      * This method if designed NOT to provide paginated results.
+     *
      * @return a List of Repositories
      */
     public List<Repository> getAllRepositories() {
@@ -80,6 +89,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
 
     /**
      * Returns a list of repositories by it's type.
+     *
      * @param type the type of repository (required)
      * @return a List of Repository objects
      */
@@ -94,6 +104,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
     /**
      * Returns a list of repositories by it's type in the order in which the repository should be used in resolution.
      * This method if designed NOT to provide paginated results.
+     *
      * @param type the type of repository (required)
      * @return a List of Repository objects
      */
@@ -101,12 +112,13 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
     public List<Repository> getAllRepositoriesOrdered(RepositoryType type) {
         final Query<Repository> query = pm.newQuery(Repository.class, "type == :type");
         query.setOrdering("resolutionOrder asc");
-        return (List<Repository>)query.execute(type);
+        return (List<Repository>) query.execute(type);
     }
 
     /**
      * Determines if the repository exists in the database.
-     * @param type the type of repository (required)
+     *
+     * @param type       the type of repository (required)
      * @param identifier the repository identifier
      * @return true if object exists, false if not
      */
@@ -118,13 +130,18 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
 
     /**
      * Creates a new Repository.
-     * @param type the type of repository
+     *
+     * @param type       the type of repository
      * @param identifier a unique (to the type) identifier for the repo
-     * @param url the URL to the repository
-     * @param enabled if the repo is enabled or not
+     * @param url        the URL to the repository
+     * @param enabled    if the repo is enabled or not
+     * @param internal if the repo is internal or not
+     * @param isAuthenticationRequired if the repository needs authentication or not
+     * @param username   the username to access the (authenticated) repository with
+     * @param password   the password to access the (authenticated) repository with
      * @return the created Repository
      */
-    public Repository createRepository(RepositoryType type, String identifier, String url, boolean enabled, boolean internal) {
+    public Repository createRepository(RepositoryType type, String identifier, String url, boolean enabled, boolean internal, boolean isAuthenticationRequired, String username, String password) {
         if (repositoryExist(type, identifier)) {
             return null;
         }
@@ -144,27 +161,40 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
         repo.setResolutionOrder(order + 1);
         repo.setEnabled(enabled);
         repo.setInternal(internal);
+        repo.setAuthenticationRequired(isAuthenticationRequired);
+        if (Boolean.TRUE.equals(isAuthenticationRequired) && (username != null || password != null)) {
+            repo.setUsername(StringUtils.trimToNull(username));
+            try {
+                if (password != null) {
+                    repo.setPassword(DataEncryption.encryptAsString(password));
+                }
+            } catch (Exception e) {
+                LOGGER.error("An error occurred while saving password in encrypted state");
+            }
+        }
         return persist(repo);
     }
 
     /**
      * Updates an existing Repository.
-     * @param uuid the uuid of the repository to update
+     *
+     * @param uuid       the uuid of the repository to update
      * @param identifier the identifier of the repository
-     * @param url a url of the repository
-     * @param internal specifies if the repository is internal
-     * @param username the username to access the (internal) repository with
-     * @param password the password to access the (internal) repository with
-     * @param enabled specifies if the repository is enabled
+     * @param url        a url of the repository
+     * @param internal   specifies if the repository is internal
+     * @param authenticationRequired if the repository needs authentication or not
+     * @param username   the username to access the (authenticated) repository with
+     * @param password   the password to access the (authenticated) repository with
+     * @param enabled    specifies if the repository is enabled
      * @return the updated Repository
      */
-    public Repository updateRepository(UUID uuid, String identifier, String url, boolean internal, String username, String password, boolean enabled) {
+    public Repository updateRepository(UUID uuid, String identifier, String url, boolean internal, boolean authenticationRequired, String username, String password, boolean enabled) {
         final Repository repository = getObjectByUuid(Repository.class, uuid);
         repository.setIdentifier(identifier);
         repository.setUrl(url);
         repository.setInternal(internal);
-
-        if (!internal) {
+        repository.setAuthenticationRequired(authenticationRequired);
+        if (!authenticationRequired) {
             repository.setUsername(null);
             repository.setPassword(null);
         } else {
@@ -178,9 +208,10 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
 
     /**
      * Returns a RepositoryMetaComponent object from the specified type, group, and name.
+     *
      * @param repositoryType the type of repository
-     * @param namespace the Package URL namespace of the meta component
-     * @param name the Package URL name of the meta component
+     * @param namespace      the Package URL namespace of the meta component
+     * @param name           the Package URL name of the meta component
      * @return a RepositoryMetaComponent object, or null if not found
      */
     public RepositoryMetaComponent getRepositoryMetaComponent(RepositoryType repositoryType, String namespace, String name) {
@@ -192,6 +223,7 @@ public class RepositoryQueryManager extends QueryManager implements IQueryManage
 
     /**
      * Synchronizes a RepositoryMetaComponent, updating it if it needs updating, or creating it if it doesn't exist.
+     *
      * @param transientRepositoryMetaComponent the RepositoryMetaComponent object to synchronize
      * @return a synchronized RepositoryMetaComponent object
      */

--- a/src/main/java/org/dependencytrack/resources/v1/RepositoryResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/RepositoryResource.java
@@ -96,7 +96,7 @@ public class RepositoryResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
     public Response getRepositoriesByType(
             @ApiParam(value = "The type of repositories to retrieve", required = true)
-            @PathParam("type")RepositoryType type) {
+            @PathParam("type") RepositoryType type) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getRepositories(type);
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
@@ -162,24 +162,15 @@ public class RepositoryResource extends AlpineResource {
 
         try (QueryManager qm = new QueryManager()) {
             final boolean exists = qm.repositoryExist(jsonRepository.getType(), StringUtils.trimToNull(jsonRepository.getIdentifier()));
-            if (! exists) {
+            if (!exists) {
                 final Repository repository = qm.createRepository(
                         jsonRepository.getType(),
                         StringUtils.trimToNull(jsonRepository.getIdentifier()),
                         StringUtils.trimToNull(jsonRepository.getUrl()),
                         jsonRepository.isEnabled(),
-                        jsonRepository.isInternal());
-
-                if (Boolean.TRUE.equals(jsonRepository.isInternal()) && (jsonRepository.getUsername() != null || jsonRepository.getPassword() != null)) {
-                    repository.setUsername(StringUtils.trimToNull(jsonRepository.getUsername()));
-                    try {
-                        if (jsonRepository.getPassword() != null) {
-                            repository.setPassword(DataEncryption.encryptAsString(jsonRepository.getPassword()));
-                        }
-                    } catch (Exception e) {
-                        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("The specified repository password could not be encrypted.").build();
-                    }
-                }
+                        jsonRepository.isInternal(),
+                        jsonRepository.isAuthenticationRequired(),
+                        jsonRepository.getUsername(), jsonRepository.getPassword());
 
                 return Response.status(Response.Status.CREATED).entity(repository).build();
             } else {
@@ -202,7 +193,7 @@ public class RepositoryResource extends AlpineResource {
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
     public Response updateRepository(Repository jsonRepository) {
         final Validator validator = super.getValidator();
-        failOnValidationError(
+        failOnValidationError(validator.validateProperty(jsonRepository, "identifier"),
                 validator.validateProperty(jsonRepository, "url")
         );
 
@@ -217,7 +208,7 @@ public class RepositoryResource extends AlpineResource {
                             : repository.getPassword();
 
                     repository = qm.updateRepository(jsonRepository.getUuid(), repository.getIdentifier(), url,
-                            jsonRepository.isInternal(), jsonRepository.getUsername(), updatedPassword, jsonRepository.isEnabled());
+                            jsonRepository.isInternal(), jsonRepository.isAuthenticationRequired(), jsonRepository.getUsername(), updatedPassword, jsonRepository.isEnabled());
                     return Response.ok(repository).build();
                 } catch (Exception e) {
                     return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("The specified repository password could not be encrypted.").build();

--- a/src/test/java/org/dependencytrack/model/RepositoryTest.java
+++ b/src/test/java/org/dependencytrack/model/RepositoryTest.java
@@ -64,4 +64,18 @@ public class RepositoryTest {
         repo.setEnabled(true);
         Assert.assertTrue(repo.isEnabled());
     }
+
+    @Test
+    public void testAuthenticationRequiredTrue() {
+        Repository repo = new Repository();
+        repo.setAuthenticationRequired(true);
+        Assert.assertTrue(repo.isAuthenticationRequired());
+    }
+
+    @Test
+    public void testAuthenticationRequiredFalse() {
+        Repository repo = new Repository();
+        repo.setAuthenticationRequired(false);
+        Assert.assertFalse(repo.isAuthenticationRequired());
+    }
 } 

--- a/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -18,12 +18,15 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.security.crypto.DataEncryption;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.Repository;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
+import org.dependencytrack.persistence.QueryManager;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.glassfish.jersey.test.DeploymentContext;
@@ -34,17 +37,20 @@ import org.junit.Test;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.Date;
+import java.util.List;
 
 public class RepositoryResourceTest extends ResourceTest {
 
     @Override
     protected DeploymentContext configureDeployment() {
         return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(RepositoryResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
+                        new ResourceConfig(RepositoryResource.class)
+                                .register(ApiFilter.class)
+                                .register(AuthenticationFilter.class)))
                 .build();
     }
 
@@ -65,7 +71,7 @@ public class RepositoryResourceTest extends ResourceTest {
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
         Assert.assertEquals(14, json.size());
-        for (int i=0; i<json.size(); i++) {
+        for (int i = 0; i < json.size(); i++) {
             Assert.assertNotNull(json.getJsonObject(i).getString("type"));
             Assert.assertNotNull(json.getJsonObject(i).getString("identifier"));
             Assert.assertNotNull(json.getJsonObject(i).getString("url"));
@@ -84,8 +90,9 @@ public class RepositoryResourceTest extends ResourceTest {
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
         Assert.assertEquals(5, json.size());
-        for (int i=0; i<json.size(); i++) {
+        for (int i = 0; i < json.size(); i++) {
             Assert.assertEquals("MAVEN", json.getJsonObject(i).getString("type"));
+            Assert.assertFalse(json.getJsonObject(i).getBoolean("authenticationRequired"));
             Assert.assertNotNull(json.getJsonObject(i).getString("identifier"));
             Assert.assertNotNull(json.getJsonObject(i).getString("url"));
             Assert.assertTrue(json.getJsonObject(i).getInt("resolutionOrder") > 0);
@@ -168,5 +175,112 @@ public class RepositoryResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assert.assertEquals("The repository metadata for the specified component cannot be found.", body);
+    }
+
+    @Test
+    public void createRepositoryTest() {
+        Repository repository = new Repository();
+        repository.setAuthenticationRequired(true);
+        repository.setEnabled(true);
+        repository.setUsername("testuser");
+        repository.setPassword("testPassword");
+        repository.setInternal(true);
+        repository.setIdentifier("test");
+        repository.setUrl("www.foobar.com");
+        repository.setType(RepositoryType.MAVEN);
+        Response response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
+                .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus());
+
+
+        response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals(String.valueOf(15), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(15, json.size());
+        Assert.assertEquals("MAVEN", json.getJsonObject(11).getString("type"));
+        Assert.assertEquals("test", json.getJsonObject(11).getString("identifier"));
+        Assert.assertEquals("www.foobar.com", json.getJsonObject(11).getString("url"));
+        Assert.assertTrue(json.getJsonObject(11).getInt("resolutionOrder") > 0);
+        Assert.assertTrue(json.getJsonObject(11).getBoolean("authenticationRequired"));
+        Assert.assertEquals("testuser", json.getJsonObject(11).getString("username"));
+        Assert.assertTrue(json.getJsonObject(11).getBoolean("enabled"));
+
+        //Verify password entry
+        try (QueryManager qm = new QueryManager()) {
+            List<Repository> repositoryList = qm.getRepositories(RepositoryType.MAVEN).getList(Repository.class);
+            for (Repository repository1 : repositoryList) {
+                if (repository1.getIdentifier().equals("test")) {
+                    Assert.assertEquals("testPassword",repository1.getPassword());
+                    break;
+                }
+            }
+        }
+    }
+
+    @Test
+    public void createRepositoryAuthFalseTest() {
+        Repository repository = new Repository();
+        repository.setAuthenticationRequired(false);
+        repository.setEnabled(true);
+        repository.setInternal(true);
+        repository.setIdentifier("test");
+        repository.setUrl("www.foobar.com");
+        repository.setType(RepositoryType.MAVEN);
+        Response response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
+                .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus());
+
+
+        response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals(String.valueOf(15), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals(15, json.size());
+        Assert.assertEquals("MAVEN", json.getJsonObject(11).getString("type"));
+        Assert.assertEquals("test", json.getJsonObject(11).getString("identifier"));
+        Assert.assertEquals("www.foobar.com", json.getJsonObject(11).getString("url"));
+        Assert.assertTrue(json.getJsonObject(11).getInt("resolutionOrder") > 0);
+        Assert.assertFalse(json.getJsonObject(11).getBoolean("authenticationRequired"));
+        Assert.assertTrue(json.getJsonObject(11).getBoolean("enabled"));
+
+    }
+
+    @Test
+    public void updateRepositoryTest() throws Exception{
+        Repository repository = new Repository();
+        repository.setAuthenticationRequired(true);
+        repository.setEnabled(true);
+        repository.setUsername("testuser");
+        repository.setPassword("testPassword");
+        repository.setInternal(true);
+        repository.setIdentifier("test");
+        repository.setUrl("www.foobar.com");
+        repository.setType(RepositoryType.MAVEN);
+        Response response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
+                .put(Entity.entity(repository, MediaType.APPLICATION_JSON));
+        Assert.assertEquals(201, response.getStatus());
+        try (QueryManager qm = new QueryManager()) {
+            List<Repository> repositoryList = qm.getRepositories(RepositoryType.MAVEN).getList(Repository.class);
+            for (Repository repository1 : repositoryList) {
+                if (repository1.getIdentifier().equals("test")) {
+                    repository1.setAuthenticationRequired(false);
+                    response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey)
+                            .post(Entity.entity(repository1, MediaType.APPLICATION_JSON));
+                    Assert.assertEquals(200, response.getStatus());
+                    break;
+                }
+            }
+            repositoryList = qm.getRepositories(RepositoryType.MAVEN).getList(Repository.class);
+            for (Repository repository1 : repositoryList) {
+                if (repository1.getIdentifier().equals(DataEncryption.encryptAsString("testPassword"))) {
+                    Assert.assertEquals(false, repository1.isAuthenticationRequired());
+                    break;
+                }
+            }
+        }
+
     }
 }


### PR DESCRIPTION
### Description

Added global authentication for repositories.
Currently a repository only allows for authentication if the packages we need are internal.
However, there might be external packages as well that could only be downloaded from a repo that is authenticated.
With this change, a repository can be marked as internal. At the same time there is a choice of whether it is authenticated or not. If authenticated then user can enter the corresponding credentials for the same

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
