### PR TITLE
Add rest endpoint for workflow status

### DIFF
--- a/src/main/java/org/dependencytrack/model/WorkflowState.java
+++ b/src/main/java/org/dependencytrack/model/WorkflowState.java
@@ -1,5 +1,6 @@
 package org.dependencytrack.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.jdo.annotations.Column;
@@ -21,6 +22,7 @@ public class WorkflowState implements Serializable {
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
+    @JsonIgnore
     private long id;
 
     // null allowed because first step will have no parent and will be the first step of recursion

--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -41,7 +41,8 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.BomUploadEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
-import org.dependencytrack.model.VulnerabilityScan;
+import org.dependencytrack.model.WorkflowState;
+import org.dependencytrack.model.WorkflowStatus;
 import org.dependencytrack.parser.cyclonedx.CycloneDXExporter;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.BomSubmitRequest;
@@ -73,8 +74,8 @@ import java.nio.file.StandardOpenOption;
 import java.security.Principal;
 import java.util.Base64;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 /**
@@ -342,20 +343,16 @@ public class BomResource extends AlpineResource {
     public Response isTokenBeingProcessed(
             @ApiParam(value = "The UUID of the token to query", required = true)
             @PathParam("uuid") String uuid) {
-        // Check whether any internal tasks are processing events related to the token.
-        final boolean processingInternally = Event.isEventBeingProcessed(UUID.fromString(uuid));
-
-        // Check for pending vulnerability scans.
-        final VulnerabilityScan.Status vulnScanStatus;
+        // Check workflow states for the token.
+        List<WorkflowState> workflowStates;
         try (final var qm = new QueryManager()) {
-            final VulnerabilityScan vulnScan = qm.getVulnerabilityScan(uuid);
-            vulnScanStatus = Optional.ofNullable(vulnScan)
-                    .map(VulnerabilityScan::getStatus)
-                    .orElse(VulnerabilityScan.Status.UNKNOWN);
+            workflowStates = qm.getAllWorkflowStatesForAToken(UUID.fromString(uuid));
         }
-
+        AtomicBoolean hasTerminalStatus = new AtomicBoolean(true);
         IsTokenBeingProcessedResponse response = new IsTokenBeingProcessedResponse();
-        response.setProcessing(processingInternally || vulnScanStatus == VulnerabilityScan.Status.IN_PROGRESS);
+        workflowStates.stream().forEach(workflowState -> hasTerminalStatus.set(hasTerminalStatus.get() && (workflowState.getStatus() != WorkflowStatus.PENDING
+                && workflowState.getStatus() != WorkflowStatus.TIMED_OUT)));
+        response.setProcessing(!hasTerminalStatus.get());
         return Response.ok(response).build();
     }
 

--- a/src/main/java/org/dependencytrack/resources/v1/WorkflowResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/WorkflowResource.java
@@ -1,0 +1,54 @@
+package org.dependencytrack.resources.v1;
+
+import alpine.common.logging.Logger;
+import alpine.server.auth.PermissionRequired;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.WorkflowState;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.v1.vo.IsTokenBeingProcessedResponse;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.util.List;
+import java.util.UUID;
+
+@Path("/v1/workflow")
+@Api(value = "workflow", authorizations = @Authorization(value = "X-Api-Key"))
+public class WorkflowResource {
+
+    private static final Logger LOGGER = Logger.getLogger(WorkflowResource.class);
+
+    @GET
+    @Path("/token/{uuid}/status")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Retrieves workflow states associated with the token received from bom upload .", response = IsTokenBeingProcessedResponse.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized")
+    })
+    @PermissionRequired(Permissions.Constants.BOM_UPLOAD)
+    public Response isTokenBeingProcessed(
+            @ApiParam(value = "The UUID of the token to query", required = true)
+            @PathParam("uuid") String uuid) {
+        List<WorkflowState> workflowStates;
+        try (final var qm = new QueryManager()) {
+            workflowStates = qm.getAllWorkflowStatesForAToken(UUID.fromString(uuid));
+            if (workflowStates.isEmpty()) {
+                return Response.status(Response.Status.NOT_FOUND).entity("Provided token " + uuid + " does not exist.").build();
+            }
+        } catch (Exception e) {
+            LOGGER.error("An error occurred while fetching workflow status", e);
+            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+        }
+        return Response.ok(workflowStates).build();
+    }
+}

--- a/src/main/java/org/dependencytrack/resources/v1/WorkflowResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/WorkflowResource.java
@@ -36,7 +36,7 @@ public class WorkflowResource {
             @ApiResponse(code = 401, message = "Unauthorized")
     })
     @PermissionRequired(Permissions.Constants.BOM_UPLOAD)
-    public Response isTokenBeingProcessed(
+    public Response getWorkflowStates(
             @ApiParam(value = "The UUID of the token to query", required = true)
             @PathParam("uuid") String uuid) {
         List<WorkflowState> workflowStates;

--- a/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/src/test/java/org/dependencytrack/ResourceTest.java
@@ -75,6 +75,7 @@ public abstract class ResourceTest extends JerseyTest {
     protected final String V1_USER = "/v1/user";
     protected final String V1_VIOLATION_ANALYSIS = "/v1/violation/analysis";
     protected final String V1_VULNERABILITY = "/v1/vulnerability";
+    protected final String V1_WORKFLOW = "/v1/workflow";
     protected final String ORDER_BY = "orderBy";
     protected final String SORT = "sort";
     protected final String SORT_ASC = "asc";

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -34,6 +34,7 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.WorkflowState;
 import org.dependencytrack.resources.v1.vo.BomSubmitRequest;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -54,6 +55,11 @@ import java.util.UUID;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.model.WorkflowStatus.COMPLETED;
+import static org.dependencytrack.model.WorkflowStatus.FAILED;
+import static org.dependencytrack.model.WorkflowStatus.PENDING;
+import static org.dependencytrack.model.WorkflowStep.BOM_CONSUMPTION;
+import static org.dependencytrack.model.WorkflowStep.BOM_PROCESSING;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class BomResourceTest extends ResourceTest {
@@ -864,5 +870,65 @@ public class BomResourceTest extends ResourceTest {
         Assert.assertEquals(404, response.getStatus(), 0);
         body = getPlainTextBody(response);
         Assert.assertEquals("The parent component could not be found.", body);
+    }
+
+    @Test
+    public void isTokenBeingProcessedTrueTest() {
+        UUID uuid = UUID.randomUUID();
+        WorkflowState workflowState1 = new WorkflowState();
+        workflowState1.setParent(null);
+        workflowState1.setStep(BOM_CONSUMPTION);
+        workflowState1.setStatus(COMPLETED);
+        workflowState1.setToken(uuid);
+        var workflowState1Persisted = qm.persist(workflowState1);
+        WorkflowState workflowState2 = new WorkflowState();
+        workflowState2.setParent(workflowState1Persisted);
+        workflowState2.setStep(BOM_PROCESSING);
+        workflowState2.setStatus(PENDING);
+        workflowState2.setToken(uuid);
+        qm.persist(workflowState2);
+
+        Response response = target(V1_BOM + "/token/" + uuid).request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        final String jsonResponse = getPlainTextBody(response);
+        assertThatJson(jsonResponse)
+                .withMatcher("isBeingProcessed", equalTo(true))
+                .isEqualTo(json("""
+                    {
+                        "processing": "${json-unit.matches:isBeingProcessed}"
+                    }
+                """));
+    }
+
+    @Test
+    public void isTokenBeingProcessedFalseTest() {
+        UUID uuid = UUID.randomUUID();
+        WorkflowState workflowState1 = new WorkflowState();
+        workflowState1.setParent(null);
+        workflowState1.setStep(BOM_CONSUMPTION);
+        workflowState1.setStatus(COMPLETED);
+        workflowState1.setToken(uuid);
+        var workflowState1Persisted = qm.persist(workflowState1);
+        WorkflowState workflowState2 = new WorkflowState();
+        workflowState2.setParent(workflowState1Persisted);
+        workflowState2.setStep(BOM_PROCESSING);
+        workflowState2.setStatus(FAILED);
+        workflowState2.setToken(uuid);
+        qm.persist(workflowState2);
+
+        Response response = target(V1_BOM + "/token/" + uuid).request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        final String jsonResponse = getPlainTextBody(response);
+        assertThatJson(jsonResponse)
+                .withMatcher("isBeingProcessed", equalTo(false))
+                .isEqualTo(json("""
+                    {
+                        "processing": "${json-unit.matches:isBeingProcessed}"
+                    }
+                """));
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/WorkflowResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/WorkflowResourceTest.java
@@ -1,0 +1,98 @@
+package org.dependencytrack.resources.v1;
+
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import org.apache.http.HttpStatus;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.model.WorkflowState;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.Test;
+
+import javax.json.JsonArray;
+import javax.ws.rs.core.Response;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.model.WorkflowStatus.COMPLETED;
+import static org.dependencytrack.model.WorkflowStatus.PENDING;
+import static org.dependencytrack.model.WorkflowStep.BOM_CONSUMPTION;
+import static org.dependencytrack.model.WorkflowStep.BOM_PROCESSING;
+
+public class WorkflowResourceTest extends ResourceTest {
+
+    @Override
+    protected DeploymentContext configureDeployment() {
+        return ServletDeploymentContext.forServlet(new ServletContainer(
+                        new ResourceConfig(WorkflowResource.class)
+                                .register(ApiFilter.class)
+                                .register(AuthenticationFilter.class)
+                                .register(MultiPartFeature.class)))
+                .build();
+    }
+
+    @Test
+    public void getWorkflowStatusOk() {
+        UUID uuid = UUID.randomUUID();
+        WorkflowState workflowState1 = new WorkflowState();
+        workflowState1.setParent(null);
+        workflowState1.setFailureReason(null);
+        workflowState1.setStep(BOM_CONSUMPTION);
+        workflowState1.setStatus(COMPLETED);
+        workflowState1.setToken(uuid);
+        var workflowState1Persisted = qm.persist(workflowState1);
+
+        WorkflowState workflowState2 = new WorkflowState();
+        workflowState2.setParent(workflowState1Persisted);
+        workflowState2.setFailureReason(null);
+        workflowState2.setStep(BOM_PROCESSING);
+        workflowState2.setStatus(PENDING);
+        workflowState2.setToken(uuid);
+        workflowState2.setStartedAt(Date.from(Instant.now()));
+        workflowState2.setUpdatedAt(Date.from(Instant.now()));
+        qm.persist(workflowState2);
+
+        Response response = target(V1_WORKFLOW + "/token/" + uuid + "/status").request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        JsonArray json = parseJsonArray(response);
+        assertThat(json).isNotNull();
+        assertThat(json.size()).isEqualTo(2);
+        var result = json.getJsonObject(0);
+        assertThat(result.getInt("id")).isEqualTo(1);
+        assertThat(result.getString("token")).isEqualTo(uuid.toString());
+        assertThat(result.getString("step")).isEqualTo("BOM_CONSUMPTION");
+        assertThat(result.getString("status")).isEqualTo("COMPLETED");
+        result = json.getJsonObject(1);
+        assertThat(result.getInt("id")).isEqualTo(2);
+        assertThat(result.getString("token")).isEqualTo(uuid.toString());
+        assertThat(result.getString("step")).isEqualTo("BOM_PROCESSING");
+        assertThat(result.getString("status")).isEqualTo("PENDING");
+    }
+
+    @Test
+    public void getWorkflowStatusNotFound() {
+        WorkflowState workflowState1 = new WorkflowState();
+        workflowState1.setParent(null);
+        workflowState1.setFailureReason(null);
+        workflowState1.setStep(BOM_CONSUMPTION);
+        workflowState1.setStatus(COMPLETED);
+        workflowState1.setToken(UUID.randomUUID());
+        qm.persist(workflowState1);
+
+        UUID randomUuid = UUID.randomUUID();
+        Response response = target(V1_WORKFLOW + "/token/" + randomUuid + "/status").request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
+        assertThat(getPlainTextBody(response)).isEqualTo("Provided token " + randomUuid + " does not exist.");
+    }
+}


### PR DESCRIPTION
### Description

Add a REST endpoint to fetch status of workflow state upon bom upload.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/684

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
