### PR TITLE
Add status mapping in notificationConverter

### DIFF
--- a/src/main/java/org/dependencytrack/notification/vo/ProjectVulnAnalysisComplete.java
+++ b/src/main/java/org/dependencytrack/notification/vo/ProjectVulnAnalysisComplete.java
@@ -23,4 +23,8 @@ public class ProjectVulnAnalysisComplete {
     public Project getProject(){
         return this.project;
     }
+
+    public ProjectVulnAnalysisStatus getStatus() {
+        return status;
+    }
 }

--- a/src/main/java/org/dependencytrack/parser/hyades/NotificationModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/hyades/NotificationModelConverter.java
@@ -318,6 +318,7 @@ public final class NotificationModelConverter {
         builder.setProject(convert(notification.getProject()));
         List<ComponentVulnAnalysisCompleteSubject> componentAnalysisCompleteSubjects = notification.getComponentAnalysisCompleteList().stream().map(NotificationModelConverter::convert).toList();
         builder.addAllFindings(componentAnalysisCompleteSubjects);
+        builder.setStatus(notification.getStatus());
         return builder.build();
     }
 

--- a/src/test/java/org/dependencytrack/parser/hyades/NotificationModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/hyades/NotificationModelConverterTest.java
@@ -744,5 +744,6 @@ public class NotificationModelConverterTest extends PersistenceCapableTest {
         assertProject(subject.getProject());
         assertComponent(subject.getFindingsList().get(0).getComponent());
         assertVulnerability(subject.getFindingsList().get(0).getVulnerability(0));
+        assertThat(subject.getStatus()).isEqualTo(ProjectVulnAnalysisStatus.PROJECT_VULN_ANALYSIS_STATUS_COMPLETED);
     }
 }


### PR DESCRIPTION
### Description

Status mapping was missing while converting notification.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
