### PR TITLE
Fix failure of `VULN_ANALYSIS` step not cancelling `POLICY_EVALUATION` and `METRICS_UPDATE`

### DIFF
--- a/src/main/java/org/dependencytrack/model/VulnerabilityScan.java
+++ b/src/main/java/org/dependencytrack/model/VulnerabilityScan.java
@@ -105,6 +105,8 @@ public class VulnerabilityScan {
     @Column(name = "UPDATED_AT", allowsNull = "false")
     private Date updatedAt;
 
+    private transient String failureReason;
+
     public long getId() {
         return id;
     }
@@ -200,4 +202,13 @@ public class VulnerabilityScan {
     public void setScanFailed(long scanFailed) {
         this.scanFailed = scanFailed;
     }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
 }

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
@@ -214,7 +214,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                 .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
 
         await("Result processing")
-                .atMost(Duration.ofSeconds(5))
+                .atMost(Duration.ofSeconds(15))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
                     assertThat(qm.getAllVulnerabilities(componentA)).hasSize(1);
@@ -222,7 +222,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                 });
 
         await("Workflow completion")
-                .atMost(Duration.ofSeconds(15))
+                .atMost(Duration.ofSeconds(5))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
                     var workflowStatus = qm.getWorkflowStateByTokenAndStep(scanToken, WorkflowStep.VULN_ANALYSIS);

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
@@ -4,13 +4,19 @@ import alpine.event.framework.Event;
 import alpine.event.framework.EventService;
 import alpine.event.framework.Subscriber;
 import net.mguenther.kafka.junit.KeyValue;
+import net.mguenther.kafka.junit.ReadKeyValues;
 import net.mguenther.kafka.junit.SendKeyValues;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.TopologyDescription;
+import org.assertj.core.api.SoftAssertions;
 import org.cyclonedx.proto.v1_4.Bom;
 import org.cyclonedx.proto.v1_4.Source;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
+import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
@@ -20,12 +26,13 @@ import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityScan;
 import org.dependencytrack.model.VulnerabilityScan.TargetType;
-import org.dependencytrack.model.WorkflowState;
 import org.dependencytrack.model.WorkflowStatus;
 import org.dependencytrack.model.WorkflowStep;
 import org.dependencytrack.notification.vo.ComponentVulnAnalysisComplete;
 import org.dependencytrack.tasks.PolicyEvaluationTask;
 import org.dependencytrack.util.NotificationUtil;
+import org.hyades.proto.notification.v1.Notification;
+import org.hyades.proto.notification.v1.ProjectVulnAnalysisCompleteSubject;
 import org.hyades.proto.repometaanalysis.v1.AnalysisResult;
 import org.hyades.proto.vulnanalysis.v1.ScanKey;
 import org.hyades.proto.vulnanalysis.v1.ScanResult;
@@ -47,9 +54,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Supplier;
 
+import static java.util.stream.Collectors.joining;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeout;
+import static org.hyades.proto.notification.v1.ProjectVulnAnalysisStatus.PROJECT_VULN_ANALYSIS_STATUS_COMPLETED;
+import static org.hyades.proto.notification.v1.ProjectVulnAnalysisStatus.PROJECT_VULN_ANALYSIS_STATUS_FAILED;
 import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
 import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_SUCCESSFUL;
 import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
@@ -96,6 +106,25 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
     }
 
     @Test
+    public void processorNodeNamingTest() {
+        final TopologyDescription topologyDescription = new KafkaStreamsTopologyFactory().createTopology().describe();
+
+        final var softAsserts = new SoftAssertions();
+        for (final TopologyDescription.Subtopology subtopology : topologyDescription.subtopologies()) {
+            for (final TopologyDescription.Node node : subtopology.nodes()) {
+                softAsserts.assertThat(node.name())
+                        .as("Processor node has an invalid name (subTopology %d; parents: %s; children: %s)", subtopology.id(),
+                                node.predecessors().stream().map(TopologyDescription.Node::name).collect(joining(", ")),
+                                node.successors().stream().map(TopologyDescription.Node::name).collect(joining(", "))
+                        )
+                        .matches("^[a-z-_.]+$");
+            }
+        }
+
+        softAsserts.assertAll();
+    }
+
+    @Test
     public void repoMetaAnalysisResultProcessingTest() throws Exception {
         final Date beforeTestTimestamp = Date.from(Instant.now());
 
@@ -127,10 +156,10 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
 
     @Test
     public void vulnScanResultProcessingTest() throws Exception {
-        var project = new Project();
+        final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
-        project = qm.createProject(project, null, false);
+        qm.persist(project);
 
         final var componentA = new org.dependencytrack.model.Component();
         componentA.setName("acme-lib-a");
@@ -162,6 +191,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                 .setSource(Source.newBuilder().setName("OSSINDEX").build())
                 .build();
 
+        qm.createVulnerabilityScan(TargetType.PROJECT, project.getUuid(), scanToken.toString(), 2);
         qm.createWorkflowSteps(scanToken);
         kafka.send(SendKeyValues.to(KafkaTopics.VULN_ANALYSIS_RESULT.name(), List.of(
                         new KeyValue<>(scanKeyComponentA,
@@ -182,7 +212,8 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                                         .build())))
                 .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class)
                 .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
-        await()
+
+        await("Result processing")
                 .atMost(Duration.ofSeconds(5))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
@@ -190,8 +221,32 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                     assertThat(qm.getAllVulnerabilities(componentB)).hasSize(1);
                 });
 
-        var workflowStatus = qm.getWorkflowStateByTokenAndStep(scanToken, WorkflowStep.VULN_ANALYSIS);
-        assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.PENDING);
+        await("Workflow completion")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    var workflowStatus = qm.getWorkflowStateByTokenAndStep(scanToken, WorkflowStep.VULN_ANALYSIS);
+                    assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.COMPLETED);
+                });
+
+        await("Analysis complete notification")
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    assertThat(kafka.readValues(ReadKeyValues
+                            .from(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name(), String.class, Notification.class)
+                            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+                    ).satisfiesExactly(
+                            notification -> {
+                                final ProjectVulnAnalysisCompleteSubject subject =
+                                        notification.getSubject().unpack(ProjectVulnAnalysisCompleteSubject.class);
+                                assertThat(subject.getStatus()).isEqualTo(PROJECT_VULN_ANALYSIS_STATUS_COMPLETED);
+                                assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                                assertThat(subject.getFindingsCount()).isEqualTo(2);
+                            }
+                    );
+                });
     }
 
     @Test
@@ -230,7 +285,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                     .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
         }
 
-        await()
+        await("Result processing")
                 .atMost(Duration.ofSeconds(15))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
@@ -253,7 +308,11 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
 
     @Test
     public void vulnScanFailureTest() throws Exception {
-        final var projectUuid = UUID.randomUUID();
+        final var project = new Project();
+        project.setName("foo");
+        qm.persist(project);
+
+        final var projectUuid = project.getUuid();
         final var scanToken = UUID.randomUUID().toString();
 
         final VulnerabilityScan scan = qm.createVulnerabilityScan(TargetType.PROJECT, projectUuid, scanToken, 100);
@@ -286,7 +345,8 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                     .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class)
                     .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
         }
-        await()
+
+        await("Result processing")
                 .atMost(Duration.ofSeconds(15))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
@@ -303,15 +363,43 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
         assertThat(scan.getStatus()).isEqualTo(VulnerabilityScan.Status.FAILED);
         assertThat(scan.getUpdatedAt()).isAfter(scan.getStartedAt());
 
-        var workflowStatus = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.VULN_ANALYSIS);
-        assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.FAILED);
-        assertThat(workflowStatus.getFailureReason()).isEqualTo("Failure threshold of 0.05% exceeded: 0.06% of scans failed");
+        await("Workflow completion")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    var workflowStatus = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.VULN_ANALYSIS);
+                    assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.FAILED);
+                    assertThat(workflowStatus.getFailureReason()).isEqualTo("Failure threshold of 0.05% exceeded: 0.06% of scans failed");
 
-        workflowStatus = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.POLICY_EVALUATION);
-        assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.CANCELLED);
+                    workflowStatus = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.POLICY_EVALUATION);
+                    assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.CANCELLED);
 
-        workflowStatus = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.METRICS_UPDATE);
-        assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.CANCELLED);
+                    workflowStatus = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.METRICS_UPDATE);
+                    assertThat(workflowStatus.getStatus()).isEqualTo(WorkflowStatus.CANCELLED);
+                });
+
+        await("Analysis complete notification")
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> {
+                    assertThat(kafka.readValues(ReadKeyValues
+                            .from(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name(), String.class, Notification.class)
+                            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+                    ).satisfiesExactly(
+                            notification -> {
+                                final ProjectVulnAnalysisCompleteSubject subject =
+                                        notification.getSubject().unpack(ProjectVulnAnalysisCompleteSubject.class);
+                                assertThat(subject.getStatus()).isEqualTo(PROJECT_VULN_ANALYSIS_STATUS_FAILED);
+                                assertThat(subject.getProject().getUuid()).isEqualTo(projectUuid.toString());
+                                assertThat(subject.getFindingsCount()).isZero();
+                            }
+                    );
+                });
+
+        // Policy evaluation and metrics were cancelled,
+        // so no such events should've been emitted.
+        assertThat(EVENTS).isEmpty();
     }
 
     @Test
@@ -481,14 +569,21 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
         map.put(componentA.getUuid().toString(), qm.getAllVulnerabilities(componentA));
         map.put(componentB.getUuid().toString(), qm.getAllVulnerabilities(componentB));
         List<ComponentVulnAnalysisComplete> componentAnalysisCompleteList = NotificationUtil.createList(qm.getAllComponents(project), map);
-        assertThat(componentAnalysisCompleteList.get(0).getComponent().getName().equals("acme-lib-a"));
+        assertThat(componentAnalysisCompleteList.get(0).getComponent().getName()).isEqualTo("acme-lib-a");
         Assertions.assertEquals(1, componentAnalysisCompleteList.get(0).getVulnerabilityList().size());
         Assertions.assertEquals("SNYK", componentAnalysisCompleteList.get(0).getVulnerabilityList().get(0).getSource());
         Assertions.assertEquals("SNYK-001", componentAnalysisCompleteList.get(0).getVulnerabilityList().get(0).getVulnId());
-        assertThat(componentAnalysisCompleteList.get(1).getComponent().getName().equals("acme-lib-b"));
+        assertThat(componentAnalysisCompleteList.get(1).getComponent().getName()).isEqualTo("acme-lib-b");
         Assertions.assertEquals(1, componentAnalysisCompleteList.get(1).getVulnerabilityList().size());
         Assertions.assertEquals("OSSINDEX", componentAnalysisCompleteList.get(1).getVulnerabilityList().get(0).getSource());
         Assertions.assertEquals("SONATYPE-001", componentAnalysisCompleteList.get(1).getVulnerabilityList().get(0).getVulnId());
+    }
+
+    public static class NotificationDeserializer extends KafkaProtobufDeserializer<Notification> {
+
+        public NotificationDeserializer() {
+            super(Notification.parser());
+        }
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR fixes the failure of `VULN_ANALYSIS` step not cancelling `POLICY_EVALUATION` and `METRICS_UPDATE`.

Steps now remain cancelled:

![Screenshot from 2023-08-03 19-33-31](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/bae3f0a5-0838-435e-86a8-af91b5c8d9dc)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/716

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Relevant part of the Kafka Streams topology now looks like this:

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/2a0fb0a2-a37a-45af-a9c3-9a70d43fdd3a)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
