### PR TITLE
Logs for tasks should print after lock has been acquired

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/EpssMirrorTask.java
+++ b/src/main/java/org/dependencytrack/tasks/EpssMirrorTask.java
@@ -82,18 +82,7 @@ public class EpssMirrorTask implements LoggableSubscriber {
      */
     public void inform(final Event e) {
         if (e instanceof EpssMirrorEvent && this.isEnabled) {
-            final long start = System.currentTimeMillis();
-            LOGGER.info("Starting EPSS mirroring task");
-            final File mirrorPath = new File(MIRROR_DIR);
-            setOutputDir(mirrorPath.getAbsolutePath());
-
             LockProvider.executeWithLock(EPSS_MIRROR_TASK_LOCK, (Runnable) () -> getAllFiles());
-
-            final long end = System.currentTimeMillis();
-            LOGGER.info("EPSS mirroring complete");
-            LOGGER.info("Time spent (d/l):   " + metricDownloadTime + "ms");
-            LOGGER.info("Time spent (parse): " + metricParseTime + "ms");
-            LOGGER.info("Time spent (total): " + (end - start) + "ms");
         }
     }
 
@@ -116,11 +105,20 @@ public class EpssMirrorTask implements LoggableSubscriber {
      * Download all EPSS files
      */
     private void getAllFiles() {
+        final long start = System.currentTimeMillis();
+        LOGGER.info("Starting EPSS mirroring task");
+        final File mirrorPath = new File(MIRROR_DIR);
+        setOutputDir(mirrorPath.getAbsolutePath());
         doDownload(this.feedUrl + "/" + FILENAME);
         if (mirroredWithoutErrors) {
             String content = "Mirroring of the Exploit Prediction Scoring System completed successfully";
             NotificationUtil.dispatchExceptionNotifications(NotificationScope.SYSTEM, NotificationGroup.DATASOURCE_MIRRORING, NotificationConstants.Title.EPSS_MIRROR, content, NotificationLevel.INFORMATIONAL);
         }
+        LOGGER.info("EPSS mirroring complete");
+        final long end = System.currentTimeMillis();
+        LOGGER.info("Time spent (d/l):   " + metricDownloadTime + "ms");
+        LOGGER.info("Time spent (parse): " + metricParseTime + "ms");
+        LOGGER.info("Time spent (total): " + (end - start) + "ms");
     }
 
     /**

--- a/src/main/java/org/dependencytrack/tasks/InternalComponentIdentificationTask.java
+++ b/src/main/java/org/dependencytrack/tasks/InternalComponentIdentificationTask.java
@@ -55,19 +55,17 @@ public class InternalComponentIdentificationTask implements Subscriber {
     @Override
     public void inform(final Event e) {
         if (e instanceof InternalComponentIdentificationEvent) {
-            LOGGER.info("Starting internal component identification");
-            final Instant startTime = Instant.now();
             try {
                 LockProvider.executeWithLock(INTERNAL_COMPONENT_IDENTIFICATION_TASK_LOCK, (LockingTaskExecutor.Task) () -> analyze());
             } catch (Throwable ex) {
                 LOGGER.error("Error in acquiring lock and executing internal component identification task", ex);
             }
-            LOGGER.info("Internal component identification completed in "
-                    + DateFormatUtils.format(Duration.between(startTime, Instant.now()).toMillis(), "mm:ss:SS"));
         }
     }
 
     private void analyze() throws Exception {
+        final Instant startTime = Instant.now();
+        LOGGER.info("Starting internal component identification");
         try (final var qm = new QueryManager()) {
             final PersistenceManager pm = qm.getPersistenceManager();
 
@@ -123,6 +121,8 @@ public class InternalComponentIdentificationTask implements Subscriber {
                 components = fetchNextComponentsPage(pm, lastId);
             }
         }
+        LOGGER.info("Internal component identification completed in "
+                + DateFormatUtils.format(Duration.between(startTime, Instant.now()).toMillis(), "mm:ss:SS"));
     }
 
     /**


### PR DESCRIPTION
### Description

Some of the logs could be misleading because they appear before lock has been acquired. This PR is to clean up those misleading logs.


### Addressed Issue

Minor clean up of logs. They should appear when task is locked and starts executing

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
