### PR TITLE
BOM upload processing tweaks

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -431,16 +431,12 @@ public class BomResource extends AlpineResource {
     }
 
     private File validateAndStoreBom(final byte[] bomBytes, final Project project) throws IOException, ParseException {
-        if (!BomParserFactory.looksLikeCycloneDX(bomBytes)) {
-            throw new IllegalArgumentException("The uploaded file is not a CycloneDX BOM");
-        }
-
         final List<ParseException> validationErrors;
         try {
             final Parser parser = BomParserFactory.createParser(bomBytes);
             validationErrors = parser.validate(bomBytes);
         } catch (JsonParseException e) {
-            throw new IllegalArgumentException("The uploaded CycloneDX file contains malformed JSON or XML", e);
+            throw new IllegalArgumentException("The uploaded file contains malformed JSON or XML", e);
         }
 
         if (!validationErrors.isEmpty()) {

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -387,12 +387,7 @@ public class BomUploadProcessingTask implements Subscriber {
             throw new BomConsumptionException(ctx, "Failed to read BOM file", e);
         }
 
-        if (!BomParserFactory.looksLikeCycloneDX(bomBytes)) {
-            throw new BomConsumptionException(ctx, """
-                    The BOM uploaded is not in a supported format. \
-                    Supported formats include CycloneDX XML and JSON""");
-        }
-
+        // The file is verified to contain valid CycloneDX upon upload.
         ctx.bomFormat = Bom.Format.CYCLONEDX;
 
         final org.cyclonedx.model.Bom bom;

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -318,10 +318,6 @@ public class BomUploadProcessingTask implements Subscriber {
                 trx.commit();
             } finally {
                 if (trx.isActive()) {
-                    LOGGER.warn("""
-                            Rolling back uncommitted transaction; This suggests that the transaction was not committed \
-                            by accident, or the default rollback behavior in case of an exception has changed (%s)"""
-                            .formatted(ctx));
                     trx.rollback();
                 }
             }

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -740,7 +740,7 @@ public class BomResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertEquals("The uploaded file is not a CycloneDX BOM", getPlainTextBody(response));
+        Assert.assertEquals("The specified BOM is not in a supported format. Supported formats are XML and JSON", getPlainTextBody(response));
     }
 
     @Test
@@ -777,7 +777,7 @@ public class BomResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(400, response.getStatus(), 0);
-        Assert.assertEquals("The uploaded CycloneDX file contains malformed JSON or XML", getPlainTextBody(response));
+        Assert.assertEquals("The uploaded file contains malformed JSON or XML", getPlainTextBody(response));
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

* Don't log warning when rolling back BOM processing transaction
   * A rollback is never performed automatically by DataNucleus, so this message will always be logged when the transaction failed. We already log the actual cause as error, so this rollback message is just producing noise.
* Avoid redundant copies of uploaded BOM content in-memory
   * The `BomParserFactory#looksLikeCycloneDX` accepts `byte[]`, and looks for certain CycloneDX markers in the provided value. It does so by converting the byte array to `String`, which internally will copy the entire array's content. We already validate the file anyway.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
