### PR TITLE
Fix inconsistent severities when updating vulnerabilities from scanner results

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -14,7 +14,6 @@ import org.dependencytrack.event.kafka.KafkaUtil;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.FindingAttribution;
-import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
@@ -240,6 +239,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getPublished, existingVuln::setPublished);
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getUpdated, existingVuln::setUpdated);
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCwes, existingVuln::setCwes);
+                // Calling setSeverity nulls all CVSS and OWASP RR fields. getSeverity calculates the severity on-the-fly,
+                // and will return UNASSIGNED even when no severity is set explicitly. Thus, calling setSeverity
+                // must happen before CVSS and OWASP RR fields are set, to avoid null-ing them again.
+                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getSeverity, existingVuln::setSeverity);
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2BaseScore, existingVuln::setCvssV2BaseScore);
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2ImpactSubScore, existingVuln::setCvssV2ImpactSubScore);
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2ExploitabilitySubScore, existingVuln::setCvssV2ExploitabilitySubScore);
@@ -256,12 +259,6 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 // Synchronization of aliases is performed after synchronizing the vulnerability.
                 // updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getAliases, existingVuln::setAliases);
 
-                // Calling setSeverity nulls all CVSS and OWASP RR fields. getSeverity calculates the severity on-the-fly,
-                // and will return UNASSIGNED even when no severity is set explicitly.
-                if (existingVuln.getSeverity() == Severity.UNASSIGNED && vuln.getSeverity() != Severity.UNASSIGNED) {
-                    existingVuln.setSeverity(vuln.getSeverity());
-                    updated = true;
-                }
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getVulnerableVersions, existingVuln::setVulnerableVersions);
                 updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getPatchedVersions, existingVuln::setPatchedVersions);
                 // EPSS is an additional enrichment that no scanner currently provides.
@@ -351,7 +348,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
     private static boolean determineIsComponentNew(final FixedKeyRecord<?, ?> record) {
         return KafkaUtil.getEventHeader(record.headers(), KafkaEventHeaders.IS_NEW_COMPONENT)
-                .map(value -> Boolean.parseBoolean(value))
+                .map(Boolean::parseBoolean)
                 .orElse(false);
     }
 

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -28,6 +28,7 @@ import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Finding;
 import org.dependencytrack.model.FindingAttribution;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.notification.NotificationConstants;
@@ -476,6 +477,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
         vulnerability.setPublished(Date.from(Instant.ofEpochSecond(1672614000))); // Sun Jan 01 2023 23:00:00 GMT+0000
         vulnerability.setUpdated(Date.from(Instant.ofEpochSecond(1672700400))); // Mon Jan 02 2023 23:00:00 GMT+0000
         vulnerability.setCwes(List.of(666, 777));
+        vulnerability.setSeverity(Severity.LOW);
         vulnerability.setCvssV2BaseScore(BigDecimal.valueOf(2.2));
         vulnerability.setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(2.2));
         vulnerability.setCvssV2ImpactSubScore(BigDecimal.valueOf(2.3));
@@ -548,6 +550,7 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
         assertThat(vulnerability.getPublished()).isEqualTo(Instant.ofEpochSecond(1673391600));
         assertThat(vulnerability.getUpdated()).isEqualTo(Instant.ofEpochSecond(1673478000));
         assertThat(vulnerability.getCwes()).containsOnly(999);
+        assertThat(vulnerability.getSeverity()).isEqualTo(Severity.CRITICAL);
         assertThat(vulnerability.getCvssV2BaseScore()).isEqualTo("9.3");
         assertThat(vulnerability.getCvssV2ExploitabilitySubScore()).isEqualTo("8.6");
         assertThat(vulnerability.getCvssV2ImpactSubScore()).isEqualTo("10.0");


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

When a vulnerability already had a severity assigned, `VulnerabilityScanResultProcessor` would not update it, even though CVSS scores (and thus, the severity) had changed. This could leave vulnerabilities with a "static" severity of e.g. `LOW`, and CVSS scores of `HIGH`, which is inconsistent.

Also fix some incorrect comparisons in `ModelConverterCdxToVuln`:

* Proto models will never return `null`; Presence of values must be checked with `has*` or `*Count > 0` methods
* String equality must be checked with `equals`, not `==` / `!=`

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
