### PR TITLE
extend lock only when it is about to expire

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java
@@ -141,7 +141,7 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
                 if(isLockToBeExtended(cumulativeDurationInMillis)) {
                     Duration extendLockByDuration = Duration.ofMillis(processDurationInMillis).plus(portfolioMetricsTaskConfig.getLockAtLeastFor());
                     LOGGER.debug("Extending lock duration by ms: " + extendLockByDuration);
-                    LockExtender.extendActiveLock(extendLockByDuration, ZERO);
+                    LockExtender.extendActiveLock(extendLockByDuration, portfolioMetricsTaskConfig.getLockAtLeastFor());
                 }
                 activeProjects = fetchNextActiveProjectsPage(pm, lastId);
             }

--- a/src/main/java/org/dependencytrack/util/LockProvider.java
+++ b/src/main/java/org/dependencytrack/util/LockProvider.java
@@ -94,7 +94,7 @@ public class LockProvider {
         return null;
     }
 
-    private static LockConfiguration getLockConfigurationByLockName(LockName lockName) {
+    public static LockConfiguration getLockConfigurationByLockName(LockName lockName) {
         return switch(lockName) {
             case PORTFOLIO_METRICS_TASK_LOCK -> new LockConfiguration(Instant.now(),
                     PORTFOLIO_METRICS_TASK_LOCK.name(),


### PR DESCRIPTION
### Description

Lock for extendable tasks is being released as soon as task finishes. This will cause execution on 2 pods if tasks are "too fast".

PR will extend lock only when it is about to expire and it sets the least duration again

### Addressed Issue



### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
