### PR TITLE
add notification when project is created

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -478,6 +478,15 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
         // Event.dispatch(new IndexEvent(IndexEvent.Action.CREATE, pm.detachCopy(result)));
         // commitSearchIndex(commitIndex, Project.class);
+
+        NotificationUtil.dispatchNotificationsWithSubject(project.getUuid(),
+                NotificationScope.PORTFOLIO,
+                NotificationGroup.PROJECT_CREATED,
+                NotificationConstants.Title.PROJECT_CREATED,
+                result.getName() + " was created",
+                NotificationLevel.INFORMATIONAL,
+                pm.detachCopy(result)
+        );
         return result;
     }
 

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
@@ -218,7 +218,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                 });
 
         await("Workflow completion")
-                .atMost(Duration.ofSeconds(7))
+                .atMost(Duration.ofMinutes(1))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
                     var workflowStatus = qm.getWorkflowStateByTokenAndStep(scanToken, WorkflowStep.VULN_ANALYSIS);

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
@@ -218,7 +218,7 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
                 });
 
         await("Workflow completion")
-                .atMost(Duration.ofSeconds(5))
+                .atMost(Duration.ofSeconds(7))
                 .pollInterval(Duration.ofMillis(250))
                 .untilAsserted(() -> {
                     var workflowStatus = qm.getWorkflowStateByTokenAndStep(scanToken, WorkflowStep.VULN_ANALYSIS);

--- a/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/PolicyEngineTest.java
@@ -307,9 +307,9 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         // Evaluate policies and ensure that a notification has been sent.
         final var policyEngine = new PolicyEngine();
         assertThat(policyEngine.evaluate(component.getUuid())).hasSize(1);
-
-        assertConditionWithTimeout(() -> kafkaMockProducer.history().size() == 1, Duration.ofSeconds(5));
-        final org.hyades.proto.notification.v1.Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_POLICY_VIOLATION, kafkaMockProducer.history().get(0));
+        //2 Notifications will be sent, one for project created and another for policy violation
+        assertConditionWithTimeout(() -> kafkaMockProducer.history().size() == 2, Duration.ofSeconds(5));
+        final org.hyades.proto.notification.v1.Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_POLICY_VIOLATION, kafkaMockProducer.history().get(1));
         assertThat(notification).isNotNull();
         assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
         assertThat(notification.getGroup()).isEqualTo(GROUP_POLICY_VIOLATION);
@@ -322,7 +322,7 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         final var policyConditionB = qm.createPolicyCondition(policy, PolicyCondition.Subject.VERSION, PolicyCondition.Operator.NUMERIC_EQUAL, "1.2.3");
         assertThat(policyEngine.evaluate(component.getUuid())).hasSize(2);
 
-        assertConditionWithTimeout(() -> kafkaMockProducer.history().size() == 2, Duration.ofSeconds(5));
+        assertConditionWithTimeout(() -> kafkaMockProducer.history().size() == 3, Duration.ofSeconds(5));
         final org.hyades.proto.notification.v1.Notification notificationPolicyA = deserializeValue(KafkaTopics.NOTIFICATION_POLICY_VIOLATION, kafkaMockProducer.history().get(0));
         assertThat(notificationPolicyA).isNotNull();
 
@@ -337,7 +337,7 @@ public class PolicyEngineTest extends PersistenceCapableTest {
         // Delete a policy condition and re-evaluate policies again. No new notifications should be sent.
         qm.deletePolicyCondition(policyConditionA);
         assertThat(policyEngine.evaluate(component.getUuid())).hasSize(1);
-        assertConditionWithTimeout(() -> kafkaMockProducer.history().size() == 2, Duration.ofSeconds(5));
+        assertConditionWithTimeout(() -> kafkaMockProducer.history().size() == 3, Duration.ofSeconds(5));
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR is to send Notification for PROJECT_CREATED when project is created manually

### Addressed Issue

Fixes https://github.com/DependencyTrack/hyades/issues/741

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
