### PR TITLE
Reduce volume of records to be processed for vulnerability scan completion tracking

### DIFF
--- a/src/main/java/org/dependencytrack/event/PortfolioVulnerabilityAnalysisEvent.java
+++ b/src/main/java/org/dependencytrack/event/PortfolioVulnerabilityAnalysisEvent.java
@@ -28,7 +28,7 @@ import java.util.UUID;
  */
 public final class PortfolioVulnerabilityAnalysisEvent extends SingletonCapableEvent {
 
-    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("cf3c8e14-ca5c-45a3-86f9-cb87529a200a");
+    public static final UUID CHAIN_IDENTIFIER = UUID.fromString("cf3c8e14-ca5c-45a3-86f9-cb87529a200a");
 
     public PortfolioVulnerabilityAnalysisEvent() {
         setChainIdentifier(CHAIN_IDENTIFIER);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Completion of recurring portfolio analysis is currently not tracked, because there's no use case for evaluating the progress.

Yet, all scan results are funnelled through the completion tracking pipeline, preventing scans that we legitimately want to track from being processed sooner.

This change now drops scan results from periodic portfolio analysis, AFTER the vulnerability data within them has been processed.

Causes a significant reduction in records sent to the `dtrack-apiserver-processed-vuln-scan-result-by-scan-token` topic, and consequently database queries being performed.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
