### PR TITLE
Fix various bugs in parsing of mirrored vulnerabilities

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
@@ -239,19 +239,19 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
                 case GREATER_THAN_OR_EQUAL -> versionStartIncluding = constraint.version();
                 case LESS_THAN_OR_EQUAL -> versionEndIncluding = constraint.version();
                 case LESS_THAN -> versionEndExcluding = constraint.version();
-                default -> LOGGER.warn("Encountered unexpected comparator %s in vers %s for %s; Skipping"
+                default -> LOGGER.warn("Encountered unexpected comparator %s in %s for %s; Skipping"
                         .formatted(constraint.comparator(), vers, vulnId));
             }
         }
 
         if (versionStartIncluding == null && versionStartExcluding == null
                 && versionEndIncluding == null && versionEndExcluding == null) {
-            LOGGER.warn("Unable to assemble a version range from vers %s for %s".formatted(vers, vulnId));
+            LOGGER.warn("Unable to assemble a version range from %s for %s".formatted(vers, vulnId));
             return null;
         }
         if ((versionStartIncluding != null || versionStartExcluding != null)
                 && (versionEndIncluding == null && versionEndExcluding == null)) {
-            LOGGER.warn("Skipping indefinite version range assembled from vers %s for %s".formatted(vers, vulnId));
+            LOGGER.warn("Skipping indefinite version range assembled from %s for %s".formatted(vers, vulnId));
             return null;
         }
 

--- a/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
@@ -9,18 +9,23 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.Record;
 import org.cyclonedx.proto.v1_4.Bom;
+import org.cyclonedx.proto.v1_4.Component;
+import org.cyclonedx.proto.v1_4.VulnerabilityAffects;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.hyades.ModelConverterCdxToVuln;
 import org.dependencytrack.parser.nvd.ModelConverter;
+import org.dependencytrack.parser.vers.Comparator;
+import org.dependencytrack.parser.vers.Constraint;
+import org.dependencytrack.parser.vers.Vers;
+import org.dependencytrack.parser.vers.VersException;
 import org.dependencytrack.persistence.QueryManager;
 import us.springett.parsers.cpe.exceptions.CpeEncodingException;
 import us.springett.parsers.cpe.exceptions.CpeParsingException;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.Optional;
 
 
 public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void, Void> {
@@ -72,36 +77,35 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
 //                    }
 //                });
 //            }
-            if (!cycloneVuln.getAffectsList().isEmpty()) {
-                final List<VulnerableSoftware> vsList = new ArrayList<>();
-                cycloneVuln.getAffectsList().stream().forEach(affect -> {
-                    AtomicReference<String> purlStr = new AtomicReference<>();
-                    AtomicReference<String> cpeStr = new AtomicReference<>();
-                    if (!bom.getComponentsList().isEmpty()) {
-                        bom.getComponentsList().stream().forEach(component -> {
-                            if (component.getBomRef().equals(affect.getRef())) {
-                                purlStr.set(component.getPurl());
-                                cpeStr.set(component.getCpe());
-                            }
-                        });
+            final List<VulnerableSoftware> vsList = new ArrayList<>();
+            for (final VulnerabilityAffects affect : cycloneVuln.getAffectsList()) {
+                final Optional<Component> component = bom.getComponentsList().stream()
+                        .filter(c -> c.getBomRef().equals(affect.getRef()))
+                        .findFirst();
+                if (component.isEmpty()) {
+                    LOGGER.warn("No component in the BOV for %s is matching the BOM ref \"%s\" of the affects node; Skipping"
+                            .formatted(synchronizedVulnerability.getVulnId(), affect.getRef()));
+                    continue;
+                }
+
+                affect.getVersionsList().forEach(version -> {
+                    if (version.hasRange()) {
+                        final VulnerableSoftware vs = mapAffectedRangeToVulnerableSoftware(qm,
+                                vulnerability.getVulnId(), version.getRange(), component.get().getPurl(), component.get().getCpe());
+                        if (vs != null) {
+                            vsList.add(vs);
+                        }
                     }
-
-                    if (StringUtils.isEmpty(purlStr.get()) && StringUtils.isEmpty(cpeStr.get())) {
-                        LOGGER.debug("No PURL or CPE provided for affected package  - skipping " + affect.getRef());
-
-                    } else {
-                        affect.getVersionsList().stream().forEach(version -> {
-                            if (version.hasRange()) {
-                                VulnerableSoftware vs = mapAffectedRangeToVulnerableSoftware(qm, version.getRange(), purlStr.get(), cpeStr.get());
-                                if (vs != null) {
-                                    vsList.add(vs);
-                                }
-                            } if (version.hasVersion()) {
-                                vsList.add(mapAffectedVersionToVulnerableSoftware(qm, version.getVersion(), purlStr.get(), cpeStr.get()));
-                            }
-                        });
+                    if (version.hasVersion()) {
+                        final VulnerableSoftware vs = mapAffectedVersionToVulnerableSoftware(qm,
+                                vulnerability.getVulnId(), version.getVersion(), component.get().getPurl(), component.get().getCpe());
+                        if (vs != null) {
+                            vsList.add(vs);
+                        }
                     }
                 });
+            }
+            if (!vsList.isEmpty()) {
                 qm.persist(vsList);
                 qm.updateAffectedVersionAttributions(synchronizedVulnerability, vsList, source);
                 var reconciledVsList = qm.reconcileVulnerableSoftware(synchronizedVulnerability, vsListOld, vsList, source);
@@ -117,9 +121,17 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
         }
     }
 
-    public VulnerableSoftware mapAffectedVersionToVulnerableSoftware(QueryManager qm, String version, String purlStr, String cpeStr) {
+    public VulnerableSoftware mapAffectedVersionToVulnerableSoftware(final QueryManager qm, final String vulnId,
+                                                                     String version, String purlStr, String cpeStr) {
+        version = StringUtils.trimToNull(version);
+        cpeStr = StringUtils.trimToNull(cpeStr);
+        purlStr = StringUtils.trimToNull(purlStr);
+        if (version == null || (cpeStr == null && purlStr == null)) {
+            return null;
+        }
+
         var vs = new VulnerableSoftware();
-        if (!StringUtils.isEmpty(purlStr)) {
+        if (purlStr != null) {
             final PackageURL purl;
             try {
                 purl = new PackageURL(purlStr);
@@ -135,91 +147,121 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
                     vs.setVersion(version);
                 }
             } catch (MalformedPackageURLException e) {
-                LOGGER.debug("Invalid PURL provided for affected package  - skipping", e);
+                LOGGER.warn("Failed to parse PURL from \"%s\" for %s; Skipping".formatted(purlStr, vulnId), e);
                 return null;
             }
-        } else if (!StringUtils.isEmpty(cpeStr)) {
+        } else {
             try {
-
-                VulnerableSoftware vsExisting = qm.getVulnerableSoftwareByCpe23AndVersion(cpeStr, version);
-                if (vsExisting != null) {
-                    return vsExisting;
+                vs = qm.getVulnerableSoftwareByCpe23AndVersion(cpeStr, version);
+                if (vs != null) {
+                    return vs;
                 } else {
                     vs = ModelConverter.convertCpe23UriToVulnerableSoftware(cpeStr);
                     vs.setVersion(version);
-                    vs.setVulnerable(true);
                 }
             } catch (CpeParsingException | CpeEncodingException e) {
-                LOGGER.warn("An error occurred while parsing: " + cpeStr);
+                LOGGER.warn("Failed to parse CPE from \"%s\" for %s; Skipping".formatted(cpeStr, vulnId), e);
+                return null;
             }
         }
+        vs.setVulnerable(true);
         return vs;
     }
 
-    public VulnerableSoftware mapAffectedRangeToVulnerableSoftware(final QueryManager qm, String range, String purlStr, String cpeStr) {
-        VulnerableSoftware vs = new VulnerableSoftware();
-        // Other sources do not populate the versionStartIncluding with 0.
-        // Semantically, versionStartIncluding=null is equivalent to >=0.
-        // Omit zero values here for consistency's sake.
+    public VulnerableSoftware mapAffectedRangeToVulnerableSoftware(final QueryManager qm, final String vulnId,
+                                                                   String range, String purlStr, String cpeStr) {
+        range = StringUtils.trimToNull(range);
+        cpeStr = StringUtils.trimToNull(cpeStr);
+        purlStr = StringUtils.trimToNull(purlStr);
+        if (range == null || (cpeStr == null && purlStr == null)) {
+            return null;
+        }
+
+        final Vers vers;
+        try {
+            vers = Vers.parse(range);
+        } catch (VersException e) {
+            LOGGER.warn("Failed to parse vers range from \"%s\" for %s".formatted(range, vulnId), e);
+            return null;
+        }
+
+        if (vers.constraints().isEmpty()) {
+            LOGGER.debug("Vers range \"%s\" (parsed: %s) for %s does not contain any constraints; Skipping".formatted(range, vers, vulnId));
+            return null;
+        } else if (vers.constraints().size() == 1 && vers.constraints().get(0).comparator() == Comparator.WILDCARD) {
+            LOGGER.warn("Vers range \"%s\" (parsed: %s) for %s is a wildcard; Skipping".formatted(range, vers, vulnId));
+            return null;
+        } else if (vers.constraints().size() > 2) {
+            // Vers ranges can express multiple "branches", which means that this method must potentially be able to return
+            // multiple `VulnerableSoftware`s, not just one. For example:
+            //   vers:tomee/>=1.0.0-beta1|<=1.7.5|>=7.0.0-M1|<=7.0.7|>=7.1.0|<=7.1.2|>=8.0.0-M1|<=8.0.1
+            // would result in the following branches:
+            //   * vers:tomee/>=1.0.0-beta1|<=1.7.5
+            //   * vers:tomee/>=7.0.0-M1|<=7.0.7
+            //   * vers:tomee/>=7.1.0|<=7.1.2
+            //   * vers:tomee/>=8.0.0-M1|<=8.0.1
+            //
+            // Branches are not always pairs, for example:
+            //   vers:npm/1.2.3|>=2.0.0|<5.0.0
+            // would result in:
+            //   * vers:npm/1.2.3
+            //   * vers:npm/>=2.0.0|5.0.0
+            // In both cases, separate `VulnerableSoftware`s are required.
+            //
+            // Because mirror-service does not currently produce such complex ranges, we log a warning
+            // and skip them if we encounter them. Occurrences of this log would indicate broken parsing
+            // logic in mirror-service.
+            LOGGER.warn("Vers range \"%s\" (parsed: %s) for %s contains more than two constraints; Skipping".formatted(range, vers, vulnId));
+            return null;
+        }
+
         String versionStartIncluding = null;
         String versionStartExcluding = null;
         String versionEndIncluding = null;
         String versionEndExcluding = null;
-        if (StringUtils.trimToNull(range) != null) {
-            // Range should arrive in format:
-            //   vers:<versioning-scheme>/<version-constraint>|<version-constraint>|...
-            final String[] versParts = range.split("/", 2);
-            if (versParts.length != 2) {
-                LOGGER.warn("Encountered version range in invalid format: %s".formatted(range));
-                return null;
+
+        for (final Constraint constraint : vers.constraints()) {
+            if (constraint.version() == null
+                    || constraint.version().equals("0")
+                    || constraint.version().equals("*")) {
+                // Semantically, ">=0" is equivalent to versionStartIncluding=null,
+                // and ">0" is equivalent to versionStartExcluding=null.
+                //
+                // "<0", "<=0", and "=0" can be normalized to versionStartIncluding=null.
+                //
+                // "*" is a wildcard and can only be used on its own, without any comparator.
+                // The Vers parsing / validation performed above will thus fail for ranges like "vers:generic/>=*".
+                continue;
             }
 
-            range = versParts[1];
-            final String[] parts;
-            if (range.contains("|")) {
-                parts = Arrays.stream(range.split("\\|")).map(String::trim).toArray(String[]::new);
-            } else {
-                parts = Arrays.stream(range.split(" ")).map(String::trim).toArray(String[]::new);
-            }
-            for (String part : parts) {
-                if (part.startsWith(">=") || part.startsWith("[")) {
-                    versionStartIncluding = part.replace(">=", "").replace("[", "").trim();
-                    if (versionStartIncluding.length() == 0 || versionStartIncluding.contains("*")) {
-                        versionStartIncluding = null;
-                    }
-                } else if (part.startsWith(">") || part.startsWith("(")) {
-                    versionStartExcluding = part.replace(">", "").replace("(", "").trim();
-                    if (versionStartExcluding.length() == 0 || versionStartExcluding.contains("*")) {
-                        versionStartIncluding = null;
-                    }
-                } else if (part.startsWith("<=") || part.endsWith("]")) {
-                    versionEndIncluding = part.replace("<=", "").replace("]", "").trim();
-                } else if (part.startsWith("<") || part.endsWith(")")) {
-                    versionEndExcluding = part.replace("<", "").replace(")", "").trim();
-                    if (versionEndExcluding.length() == 0 || versionEndExcluding.contains("*")) {
-                        versionStartIncluding = null;
-                    }
-                } else if (part.startsWith("=")) {
-                    versionStartIncluding = part.replace("=", "").trim();
-                    versionEndIncluding = part.replace("=", "").trim();
-                    if (versionStartIncluding.length() == 0 || versionStartIncluding.contains("*")) {
-                        versionStartIncluding = null;
-                    }
-                    if (versionEndIncluding.length() == 0 || versionEndIncluding.contains("*")) {
-                        versionStartIncluding = null;
-                    }
-                } else { //since we are not able to parse specific range, we do not want to end up with false positives and therefore this part will be skipped from being saved to db.
-                    LOGGER.debug("Range not definite");
-                }
+            switch (constraint.comparator()) {
+                case GREATER_THAN -> versionStartExcluding = constraint.version();
+                case GREATER_THAN_OR_EQUAL -> versionStartIncluding = constraint.version();
+                case LESS_THAN_OR_EQUAL -> versionEndIncluding = constraint.version();
+                case LESS_THAN -> versionEndExcluding = constraint.version();
+                default -> LOGGER.warn("Encountered unexpected comparator %s in vers %s for %s; Skipping"
+                        .formatted(constraint.comparator(), vers, vulnId));
             }
         }
 
-        if (!StringUtils.isEmpty(purlStr)) {
+        if (versionStartIncluding == null && versionStartExcluding == null
+                && versionEndIncluding == null && versionEndExcluding == null) {
+            LOGGER.warn("Unable to assemble a version range from vers %s for %s".formatted(vers, vulnId));
+            return null;
+        }
+        if ((versionStartIncluding != null || versionStartExcluding != null)
+                && (versionEndIncluding == null && versionEndExcluding == null)) {
+            LOGGER.warn("Skipping indefinite version range assembled from vers %s for %s".formatted(vers, vulnId));
+            return null;
+        }
+
+        VulnerableSoftware vs;
+        if (purlStr != null) {
             final PackageURL purl;
             try {
                 purl = new PackageURL(purlStr);
             } catch (MalformedPackageURLException e) {
-                LOGGER.debug("Invalid PURL provided for affected package  - skipping", e);
+                LOGGER.warn("Failed to parse PURL from \"%s\" for %s; Skipping".formatted(purlStr, vulnId), e);
                 return null;
             }
             vs = qm.getVulnerableSoftwareByPurl(purl.getType(), purl.getNamespace(), purl.getName(),
@@ -232,8 +274,7 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
             vs.setPurlNamespace(purl.getNamespace());
             vs.setPurlName(purl.getName());
             vs.setPurl(purl.canonicalize());
-
-        } else if (!StringUtils.isEmpty(cpeStr)) {
+        } else {
             vs = qm.getVulnerableSoftwareByCpe23(cpeStr, versionEndExcluding,
                     versionEndIncluding, versionStartExcluding, versionStartIncluding);
             if (vs != null) {
@@ -242,11 +283,13 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
             try {
                 vs = ModelConverter.convertCpe23UriToVulnerableSoftware(cpeStr);
             } catch (CpeParsingException | CpeEncodingException e) {
-                LOGGER.warn("An error occurred while parsing: " + cpeStr);
+                LOGGER.warn("Failed to parse CPE from \"%s\" for %s; Skipping".formatted(cpeStr, vulnId), e);
+                return null;
             }
         }
 
         vs.setVulnerable(true);
+        vs.setVersionStartExcluding(versionStartExcluding);
         vs.setVersionStartIncluding(versionStartIncluding);
         vs.setVersionEndExcluding(versionEndExcluding);
         vs.setVersionEndIncluding(versionEndIncluding);

--- a/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java
@@ -188,9 +188,6 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
         if (vers.constraints().isEmpty()) {
             LOGGER.debug("Vers range \"%s\" (parsed: %s) for %s does not contain any constraints; Skipping".formatted(range, vers, vulnId));
             return null;
-        } else if (vers.constraints().size() == 1 && vers.constraints().get(0).comparator() == Comparator.WILDCARD) {
-            LOGGER.warn("Vers range \"%s\" (parsed: %s) for %s is a wildcard; Skipping".formatted(range, vers, vulnId));
-            return null;
         } else if (vers.constraints().size() > 2) {
             // Vers ranges can express multiple "branches", which means that this method must potentially be able to return
             // multiple `VulnerableSoftware`s, not just one. For example:
@@ -213,6 +210,18 @@ public class MirrorVulnerabilityProcessor implements Processor<String, Bom, Void
             // logic in mirror-service.
             LOGGER.warn("Vers range \"%s\" (parsed: %s) for %s contains more than two constraints; Skipping".formatted(range, vers, vulnId));
             return null;
+        }
+
+        if (vers.constraints().size() == 1 && vers.constraints().get(0).comparator() == Comparator.WILDCARD) {
+            // Wildcards in VulnerableSoftware can be represented via either:
+            //   * version=*, or
+            //   * versionStartIncluding=0
+            // We choose the more explicit first option.
+            //
+            // Also, as wildcards have the potential to lead to lots of false positives,
+            // we want to be informed when they enter our system. So logging a warning.
+            LOGGER.warn("Wildcard range %s was reported for %s".formatted(vers, vulnId));
+            return mapAffectedVersionToVulnerableSoftware(qm, vulnId, "*", purlStr, cpeStr);
         }
 
         String versionStartIncluding = null;

--- a/src/main/java/org/dependencytrack/parser/vers/Comparator.java
+++ b/src/main/java/org/dependencytrack/parser/vers/Comparator.java
@@ -1,0 +1,29 @@
+package org.dependencytrack.parser.vers;
+
+public enum Comparator {
+
+    LESS_THAN_OR_EQUAL("<="),
+
+    LESS_THAN("<"),
+
+    EQUAL("="),
+
+    NOT_EQUAL("!="),
+
+    GREATER_THAN(">"),
+
+    GREATER_THAN_OR_EQUAL(">="),
+
+    WILDCARD("*");
+
+    private final String operator;
+
+    Comparator(final String operator) {
+        this.operator = operator;
+    }
+
+    String operator() {
+        return operator;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/parser/vers/Constraint.java
+++ b/src/main/java/org/dependencytrack/parser/vers/Constraint.java
@@ -1,0 +1,68 @@
+package org.dependencytrack.parser.vers;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
+
+public record Constraint(Comparator comparator, String version) {
+
+    public Constraint {
+        if (comparator == null) {
+            throw new VersException("comparator must not be null");
+        }
+        if (comparator == Comparator.WILDCARD && version != null) {
+            throw new VersException("comparator %s is not allowed with version".formatted(comparator));
+        } else if (comparator != Comparator.WILDCARD && version == null) {
+            throw new VersException("comparator %s is not allowed without version".formatted(comparator));
+        }
+    }
+
+    static Constraint parse(final String constraintStr) {
+        final Comparator comparator;
+        if (constraintStr.startsWith("<=")) {
+            comparator = Comparator.LESS_THAN_OR_EQUAL;
+        } else if (constraintStr.startsWith(">=")) {
+            comparator = Comparator.GREATER_THAN_OR_EQUAL;
+        } else if (constraintStr.startsWith("!=")) {
+            comparator = Comparator.NOT_EQUAL;
+        } else if (constraintStr.startsWith("<")) {
+            comparator = Comparator.LESS_THAN;
+        } else if (constraintStr.startsWith(">")) {
+            comparator = Comparator.GREATER_THAN;
+        } else {
+            comparator = Comparator.EQUAL;
+        }
+
+        final String versionStr = constraintStr.replaceFirst("^" + Pattern.quote(comparator.operator()), "").trim();
+        if (versionStr.isBlank()) {
+            throw new VersException("comparator %s is not allowed without version".formatted(comparator));
+        }
+
+        return new Constraint(comparator, maybeUrlDecode(versionStr));
+    }
+
+    private static String maybeUrlDecode(final String version) {
+        if (version.contains("%")) {
+            return URLDecoder.decode(version, StandardCharsets.UTF_8);
+        }
+
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        if (comparator == Comparator.WILDCARD) {
+            // Wildcard cannot have a version.
+            return Comparator.WILDCARD.operator();
+        }
+
+        if (comparator == Comparator.EQUAL) {
+            // Operator is omitted for equality.
+            return URLEncoder.encode(version(), StandardCharsets.UTF_8);
+        }
+
+        return comparator.operator() + URLEncoder.encode(version, StandardCharsets.UTF_8);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/parser/vers/PairwiseIterator.java
+++ b/src/main/java/org/dependencytrack/parser/vers/PairwiseIterator.java
@@ -1,0 +1,42 @@
+package org.dependencytrack.parser.vers;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+class PairwiseIterator<T> implements Iterator<Map.Entry<T, T>> {
+
+    private final Iterator<T> delegate;
+    private T current;
+    private T next;
+
+    PairwiseIterator(final Iterable<T> iterable) {
+        this.delegate = iterable.iterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return delegate.hasNext();
+    }
+
+    @Override
+    public Pair<T, T> next() {
+        if (!delegate.hasNext()) {
+            throw new NoSuchElementException();
+        }
+
+        if (current == null) {
+            current = delegate.next();
+        }
+        if (delegate.hasNext()) {
+            next = delegate.next();
+        }
+
+        final var item = Pair.of(current, next);
+        current = next;
+        return item;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/parser/vers/Vers.java
+++ b/src/main/java/org/dependencytrack/parser/vers/Vers.java
@@ -1,0 +1,135 @@
+package org.dependencytrack.parser.vers;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record Vers(String versioningScheme, List<Constraint> constraints) {
+
+    public Vers {
+        if (versioningScheme == null) {
+            throw new VersException("versioning scheme must not be null");
+        }
+        if (constraints == null || constraints.isEmpty()) {
+            throw new VersException("constraints must not be null or empty");
+        }
+    }
+
+    public static Vers parse(final String versString) {
+        if (versString == null || versString.isBlank()) {
+            throw new VersException("vers string must not be null or blank");
+        }
+
+        String[] parts = versString.split(":", 2);
+        if (parts.length != 2) {
+            throw new VersException("vers string does not contain a URI scheme separator");
+        }
+
+        if (!"vers".equals(parts[0])) {
+            throw new VersException("URI scheme must be \"vers\", but is \"%s\"".formatted(parts[0]));
+        }
+
+        parts = parts[1].split("/", 2);
+        if (parts.length != 2) {
+            throw new VersException("vers string does not contain a versioning scheme separator");
+        }
+
+        final String versioningScheme = parts[0];
+        final String constraintsString = parts[1].replaceAll("^\\|+", "").replaceAll("\\|+$", "");
+        if ("*".equals(constraintsString)) {
+            return new Vers(versioningScheme, List.of(new Constraint(Comparator.WILDCARD, null)));
+        }
+
+        parts = constraintsString.split("\\|");
+        if (parts.length == 0) {
+            throw new VersException("vers string contains no constraints");
+        }
+
+        final List<Constraint> constraints = Arrays.stream(parts)
+                .map(Constraint::parse)
+                .toList();
+
+        return new Vers(versioningScheme, constraints).validate();
+    }
+
+    public Vers validate() {
+        // The special star "*" comparator matches any version.
+        // It must be used alone exclusive of any other constraint and must not be followed by a version.
+        // For example "vers:deb/*" represent all the versions of a Debian package.
+        // This includes past, current and possible future versions.
+        // https://github.com/package-url/purl-spec/blob/version-range-spec/VERSION-RANGE-SPEC.rst#version-constraint
+        final boolean containsWildcard = constraints.stream()
+                .map(Constraint::comparator)
+                .anyMatch(Comparator.WILDCARD::equals);
+        if (containsWildcard && constraints.size() > 1) {
+            throw new VersException("comparator %s is only allowed with a single constraint".formatted(Comparator.WILDCARD));
+        }
+
+        // Ignoring all constraints with "!=" comparators...
+        List<Constraint> tmpConstraints = constraints.stream()
+                .filter(constraint -> constraint.comparator() != Comparator.NOT_EQUAL)
+                .toList();
+        if (tmpConstraints.size() < 2) {
+            // Either no, or only one constraint remaining; Nothing to validate further.
+            return this;
+        }
+
+        // A "=" constraint must be followed only by a constraint with one of "=", ">", ">=" as comparator (or no constraint).
+        var constraintIter = new PairwiseIterator<>(tmpConstraints);
+        while (constraintIter.hasNext()) {
+            final Pair<Constraint, Constraint> constraintPair = constraintIter.next();
+            final Constraint currConstraint = constraintPair.getLeft();
+            final Constraint nextConstraint = constraintPair.getRight();
+
+            if (currConstraint.comparator() == Comparator.EQUAL
+                    && !Set.of(Comparator.EQUAL, Comparator.GREATER_THAN, Comparator.GREATER_THAN_OR_EQUAL).contains(nextConstraint.comparator())) {
+                throw new VersException("A = comparator must only be followed by a > or >= operator, but got: %s".formatted(nextConstraint.comparator().operator()));
+            }
+        }
+
+        // And ignoring all constraints with "=" or "!=" comparators...
+        tmpConstraints = tmpConstraints.stream()
+                .filter(constraint -> constraint.comparator() != Comparator.EQUAL)
+                .toList();
+        if (tmpConstraints.size() < 2) {
+            // Either no, or only one constraint remaining; Nothing to validate further.
+            return this;
+        }
+
+        // ... the sequence of constraint comparators must be an alternation of greater and lesser comparators:
+        //   * "<" and "<=" must be followed by one of ">", ">=" (or no constraint).
+        //   * ">" and ">=" must be followed by one of "<", "<=" (or no constraint).
+        constraintIter = new PairwiseIterator<>(tmpConstraints);
+        while (constraintIter.hasNext()) {
+            final Pair<Constraint, Constraint> constraintPair = constraintIter.next();
+            final Constraint currConstraint = constraintPair.getLeft();
+            final Constraint nextConstraint = constraintPair.getRight();
+
+            if (Set.of(Comparator.LESS_THAN, Comparator.LESS_THAN_OR_EQUAL).contains(currConstraint.comparator())
+                    && !Set.of(Comparator.GREATER_THAN, Comparator.GREATER_THAN_OR_EQUAL).contains(nextConstraint.comparator())) {
+                throw new VersException("A < or <= comparator must only be followed by a > or >= comparator, but got: %s"
+                        .formatted(nextConstraint.comparator().operator()));
+            }
+            if (Set.of(Comparator.GREATER_THAN, Comparator.GREATER_THAN_OR_EQUAL).contains(currConstraint.comparator())
+                    && !Set.of(Comparator.LESS_THAN, Comparator.LESS_THAN_OR_EQUAL).contains(nextConstraint.comparator())) {
+                throw new VersException("A > or >= comparator must only be followed by a < or <= comparator, but got: %s"
+                        .formatted(nextConstraint.comparator().operator()));
+            }
+        }
+
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        final String constraintsStr = constraints.stream()
+                .map(Constraint::toString)
+                .collect(Collectors.joining("|"));
+        return "vers:%s/%s".formatted(versioningScheme, constraintsStr);
+    }
+
+
+}

--- a/src/main/java/org/dependencytrack/parser/vers/VersException.java
+++ b/src/main/java/org/dependencytrack/parser/vers/VersException.java
@@ -1,0 +1,13 @@
+package org.dependencytrack.parser.vers;
+
+public class VersException extends RuntimeException {
+
+    VersException(final String message) {
+        this(message, null);
+    }
+
+    VersException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/parser/vers/package-info.java
+++ b/src/main/java/org/dependencytrack/parser/vers/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package vers contains a simplified version of the versatile library.
+ * <p>
+ * Most notably, this version is missing logic for version comparisons, and version range simplification.
+ *
+ * @see <a href="https://github.com/nscuro/versatile">versatile</a>
+ */
+package org.dependencytrack.parser.vers;

--- a/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
@@ -688,6 +688,10 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                       "publisher": "thinkcmf",
                       "name": "thinkcmf",
                       "cpe": "cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*"
+                    },
+                    {
+                      "bomRef": "ed08bfc7-e88a-4647-bb2a-cad271aec5cc",
+                      "purl": "pkg:maven/com.example/foo"
                     }
                   ],
                   "vulnerabilities": [
@@ -715,6 +719,12 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                             { "range": "vers:generic/>9|>=10" },
                             { "range": "vers:generic/<11|<=12" },
                             { "range": "vers:generic/<13" }
+                          ]
+                        },
+                        {
+                          "ref": "ed08bfc7-e88a-4647-bb2a-cad271aec5cc",
+                          "versions": [
+                            { "range": "vers:generic/*" }
                           ]
                         }
                       ]
@@ -776,6 +786,33 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                     assertThat(vs.getVersionStartExcluding()).isNull();
                     assertThat(vs.getVersionEndIncluding()).isNull();
                     assertThat(vs.getVersionEndExcluding()).isEqualTo("1");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isNull();
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isNull();
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isNull();
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
+                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
+                    assertThat(vs.getPart()).isEqualTo("a");
+                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
+                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
+                    assertThat(vs.getVersion()).isEqualTo("*");
+                    assertThat(vs.getUpdate()).isEqualTo("*");
+                    assertThat(vs.getEdition()).isEqualTo("*");
+                    assertThat(vs.getLanguage()).isEqualTo("*");
+                    assertThat(vs.getSwEdition()).isEqualTo("*");
+                    assertThat(vs.getTargetSw()).isEqualTo("*");
+                    assertThat(vs.getTargetHw()).isEqualTo("*");
+                    assertThat(vs.getOther()).isEqualTo("*");
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isNull();
                     assertThat(vs.isVulnerable()).isTrue();
                     assertThat(vs.getPurlType()).isNull();
                     assertThat(vs.getPurlNamespace()).isNull();
@@ -865,6 +902,33 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                     assertThat(vs.getPurlQualifiers()).isNull();
                     assertThat(vs.getPurlSubpath()).isNull();
                     assertThat(vs.getPurl()).isNull();
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isEqualTo("*");
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isNull();
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("maven");
+                    assertThat(vs.getPurlNamespace()).isEqualTo("com.example");
+                    assertThat(vs.getPurlName()).isEqualTo("foo");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:maven/com.example/foo");
                 }
         );
     }

--- a/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
@@ -553,4 +553,394 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
         );
     }
 
+    @Test
+    public void testProcessVulnWithoutAffects() throws Exception {
+        inputTopic.pipeInput("NVD/CVE-2022-40489", KafkaTestUtil.generateBomFromJson("""
+                {
+                  "components": [
+                    {
+                      "bomRef": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                      "type": "CLASSIFICATION_APPLICATION",
+                      "publisher": "thinkcmf",
+                      "name": "thinkcmf",
+                      "cpe": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2022-40489",
+                      "source": { "name": "NVD" }
+                    }
+                  ]
+                }
+                """));
+
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2022-40489");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-2022-40489");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("NVD");
+        assertThat(vuln.getTitle()).isNull();
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isNull();
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).isNull();
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isNull();
+        assertThat(vuln.getUpdated()).isNull();
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.UNASSIGNED);
+        assertThat(vuln.getReferences()).isNull();
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
+        assertThat(vuln.getVulnerableSoftware()).isEmpty();
+    }
+
+    @Test
+    public void testProcessVulnWithUnmatchedAffectsBomRef() throws Exception {
+        inputTopic.pipeInput("NVD/CVE-2022-40489", KafkaTestUtil.generateBomFromJson("""
+                {
+                  "components": [
+                    {
+                      "bomRef": "9828f8e4-b24d-429c-b14b-a426a42785dc",
+                      "type": "CLASSIFICATION_APPLICATION",
+                      "publisher": "thinkcmf",
+                      "name": "thinkcmf",
+                      "cpe": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2022-40489",
+                      "source": { "name": "NVD" },
+                      "affects": [
+                        {
+                          "ref": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                          "versions": [
+                            { "version": "6.0.7" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """));
+
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2022-40489");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-2022-40489");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("NVD");
+        assertThat(vuln.getTitle()).isNull();
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isNull();
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).isNull();
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isNull();
+        assertThat(vuln.getUpdated()).isNull();
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.UNASSIGNED);
+        assertThat(vuln.getReferences()).isNull();
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
+        assertThat(vuln.getVulnerableSoftware()).isEmpty();
+    }
+
+    @Test
+    public void testProcessVulnWithVersConstraints() throws Exception {
+        inputTopic.pipeInput("NVD/CVE-2022-40489", KafkaTestUtil.generateBomFromJson("""
+                {
+                  "components": [
+                    {
+                      "bomRef": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                      "type": "CLASSIFICATION_APPLICATION",
+                      "publisher": "thinkcmf",
+                      "name": "thinkcmf",
+                      "cpe": "cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2022-40489",
+                      "source": { "name": "NVD" },
+                      "affects": [
+                        {
+                          "ref": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                          "versions": [
+                            { "range": null },
+                            { "range": "" },
+                            { "range": "<999" },
+                            { "range": "vers:" },
+                            { "range": "vers:foobar/<1" },
+                            { "range": "vers:generic/*" },
+                            { "range": "vers:generic/0" },
+                            { "range": "vers:generic/>0" },
+                            { "range": "vers:generic/1" },
+                            { "range": "vers:generic/>2" },
+                            { "range": "vers:generic/>3|< 4" },
+                            { "range": "vers:generic/>5|<6|6.0.1" },
+                            { "range": "vers:generic/>*|<7" },
+                            { "range": "vers:generic/>8" },
+                            { "range": "vers:generic/>9|>=10" },
+                            { "range": "vers:genrric/<11|<=12" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """));
+
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2022-40489");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-2022-40489");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("NVD");
+        assertThat(vuln.getTitle()).isNull();
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isNull();
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).isNull();
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isNull();
+        assertThat(vuln.getUpdated()).isNull();
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.UNASSIGNED);
+        assertThat(vuln.getReferences()).isNull();
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
+
+        assertThat(vuln.getVulnerableSoftware()).satisfiesExactly(
+                vs -> {
+                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
+                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
+                    assertThat(vs.getPart()).isEqualTo("a");
+                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
+                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
+                    assertThat(vs.getVersion()).isEqualTo("*");
+                    assertThat(vs.getUpdate()).isEqualTo("*");
+                    assertThat(vs.getEdition()).isEqualTo("*");
+                    assertThat(vs.getLanguage()).isEqualTo("*");
+                    assertThat(vs.getSwEdition()).isEqualTo("*");
+                    assertThat(vs.getTargetSw()).isEqualTo("*");
+                    assertThat(vs.getTargetHw()).isEqualTo("*");
+                    assertThat(vs.getOther()).isEqualTo("*");
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("1");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isNull();
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isNull();
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isNull();
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
+                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
+                    assertThat(vs.getPart()).isEqualTo("a");
+                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
+                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
+                    assertThat(vs.getVersion()).isEqualTo("*");
+                    assertThat(vs.getUpdate()).isEqualTo("*");
+                    assertThat(vs.getEdition()).isEqualTo("*");
+                    assertThat(vs.getLanguage()).isEqualTo("*");
+                    assertThat(vs.getSwEdition()).isEqualTo("*");
+                    assertThat(vs.getTargetSw()).isEqualTo("*");
+                    assertThat(vs.getTargetHw()).isEqualTo("*");
+                    assertThat(vs.getOther()).isEqualTo("*");
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isEqualTo("3");
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("4");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isNull();
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isNull();
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isNull();
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
+                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
+                    assertThat(vs.getPart()).isEqualTo("a");
+                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
+                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
+                    assertThat(vs.getVersion()).isEqualTo("*");
+                    assertThat(vs.getUpdate()).isEqualTo("*");
+                    assertThat(vs.getEdition()).isEqualTo("*");
+                    assertThat(vs.getLanguage()).isEqualTo("*");
+                    assertThat(vs.getSwEdition()).isEqualTo("*");
+                    assertThat(vs.getTargetSw()).isEqualTo("*");
+                    assertThat(vs.getTargetHw()).isEqualTo("*");
+                    assertThat(vs.getOther()).isEqualTo("*");
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("7");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isNull();
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isNull();
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isNull();
+                }
+        );
+    }
+
+    @Test
+    public void testProcessVulnWithInvalidCpeOrPurl() throws Exception {
+        inputTopic.pipeInput("NVD/CVE-2022-40489", KafkaTestUtil.generateBomFromJson("""
+                {
+                  "components": [
+                    {
+                      "bomRef": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                      "cpe": "invalid"
+                    },
+                    {
+                      "bomRef": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                      "purl": "invalid"
+                    },
+                    {
+                      "bomRef": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                      "cpe": null,
+                      "purl": null
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2022-40489",
+                      "source": { "name": "NVD" },
+                      "affects": [
+                        {
+                          "ref": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                          "versions": [
+                            { "version": "6.0.7" }
+                          ]
+                        },
+                        {
+                          "ref": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                          "versions": [
+                            { "range": "vers:generic/<=6.0.7" }
+                          ]
+                        },
+                        {
+                          "ref": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                          "versions": [
+                            { "version": "6.0.7" }
+                          ]
+                        },
+                        {
+                          "ref": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                          "versions": [
+                            { "range": "vers:generic/<=6.0.7" }
+                          ]
+                        },
+                        {
+                          "ref": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                          "versions": [
+                            { "version": "6.0.7" }
+                          ]
+                        },
+                        {
+                          "ref": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                          "versions": [
+                            { "range": "vers:generic/<=6.0.7" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """));
+
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2022-40489");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-2022-40489");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("NVD");
+        assertThat(vuln.getTitle()).isNull();
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isNull();
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).isNull();
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isNull();
+        assertThat(vuln.getUpdated()).isNull();
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.UNASSIGNED);
+        assertThat(vuln.getReferences()).isNull();
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
+        assertThat(vuln.getVulnerableSoftware()).isEmpty();
+    }
+
 }

--- a/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
@@ -713,7 +713,8 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                             { "range": "vers:generic/>*|<7" },
                             { "range": "vers:generic/>8" },
                             { "range": "vers:generic/>9|>=10" },
-                            { "range": "vers:genrric/<11|<=12" }
+                            { "range": "vers:generic/<11|<=12" },
+                            { "range": "vers:generic/<13" }
                           ]
                         }
                       ]
@@ -829,6 +830,33 @@ public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
                     assertThat(vs.getVersionStartExcluding()).isNull();
                     assertThat(vs.getVersionEndIncluding()).isNull();
                     assertThat(vs.getVersionEndExcluding()).isEqualTo("7");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isNull();
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isNull();
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isNull();
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
+                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
+                    assertThat(vs.getPart()).isEqualTo("a");
+                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
+                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
+                    assertThat(vs.getVersion()).isEqualTo("*");
+                    assertThat(vs.getUpdate()).isEqualTo("*");
+                    assertThat(vs.getEdition()).isEqualTo("*");
+                    assertThat(vs.getLanguage()).isEqualTo("*");
+                    assertThat(vs.getSwEdition()).isEqualTo("*");
+                    assertThat(vs.getTargetSw()).isEqualTo("*");
+                    assertThat(vs.getTargetHw()).isEqualTo("*");
+                    assertThat(vs.getOther()).isEqualTo("*");
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("13");
                     assertThat(vs.isVulnerable()).isTrue();
                     assertThat(vs.getPurlType()).isNull();
                     assertThat(vs.getPurlNamespace()).isNull();

--- a/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessorTest.java
@@ -1,167 +1,556 @@
 package org.dependencytrack.event.kafka.processor;
 
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.Consumed;
 import org.cyclonedx.proto.v1_4.Bom;
-import org.cyclonedx.proto.v1_4.Source;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerde;
+import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
-import org.dependencytrack.model.VulnerableSoftware;
-import org.dependencytrack.parser.hyades.ModelConverterCdxToVuln;
+import org.dependencytrack.persistence.CweImporter;
 import org.dependencytrack.util.KafkaTestUtil;
-import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MirrorVulnerabilityProcessorTest extends PersistenceCapableTest {
 
-   Bom bom;
+    private TopologyTestDriver testDriver;
+    private TestInputTopic<String, Bom> inputTopic;
 
     @Before
-    public void setup() throws IOException {
-        bom = KafkaTestUtil.generateBomFromJson("""
+    public void setUp() throws Exception {
+        final var streamsBuilder = new StreamsBuilder();
+        streamsBuilder
+                .stream("input-topic", Consumed
+                        .with(Serdes.String(), new KafkaProtobufSerde<>(Bom.parser())))
+                .process(MirrorVulnerabilityProcessor::new);
+
+        testDriver = new TopologyTestDriver(streamsBuilder.build());
+        inputTopic = testDriver.createInputTopic("input-topic",
+                new StringSerializer(), new KafkaProtobufSerializer<>());
+
+        new CweImporter().processCweDefinitions(); // Required for CWE mapping
+    }
+
+    @After
+    public void tearDown() {
+        if (testDriver != null) {
+            testDriver.close();
+        }
+    }
+
+    @Test
+    public void testProcessNvdVuln() throws Exception {
+        inputTopic.pipeInput("NVD/CVE-2022-40489", KafkaTestUtil.generateBomFromJson("""
                 {
-                   "version": 1,
-                   "components": [
-                     {
-                       "name": "org.http4s:blaze-core_2.11",
-                       "purl": "pkg:maven/org.http4s/blaze-core_2.11",
-                       "bomRef": "076d7f91-1a19-484e-929d-4895b2820ef0"
-                     },
-                     {
-                       "name": "org.http4s:blaze-core_2.13",
-                       "cpe": "cpe:2.3:a:oracle:mysql:*:*:*:*:*:*:*:*",
-                       "bomRef": "82145ba5-a2e8-420b-acea-8b36f7f8885dc"
-                     }
-                   ],
-                   "externalReferences": [],
-                   "vulnerabilities": [
-                     {
-                       "id": "GHSA-xmw9-q7x9-j5qc",
-                       "references": [
-                         {
-                           "id": "CVE-2021-21293",
-                           "source": {
-                             "name": "NVD"
-                           }
-                         }
-                       ],
-                       "ratings": [
-                         {
-                           "score": 7.5,
-                           "severity": 2,
-                           "method": 2,
-                           "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-                         }
-                       ],
-                       "cwes": [
-                         400,
-                         770
-                       ],
-                       "description": "Unbounded connection acceptance leads to file handle exhaustion",
-                       "detail": "### Impact\\n\\nAll servers running blaze-core <= 0.14.14, including blaze-http and http4s-blaze-server users, are affected.\\n\\nBlaze, accepts connections unconditionally on a dedicated thread pool. This has the net effect of amplifying degradation in services that are unable to handle their current request load, since incoming connections are still accepted and added to an unbounded queue. Each connection allocates a socket handle, which drains a scarce OS resource. This can also confound higher level circuit breakers which work based on detecting failed connections.\\n\\nThe vast majority of affected users are using it as part of http4s-blaze-server <= 0.21.16.  http4s provides a mechanism for limiting open connections, but is enforced inside the Blaze accept loop, after the connection is accepted and the socket opened. Thus, the limit only prevents the number of connections which can be simultaneously processed, not the number of connections which can be held open.\\n\\n### Patches\\n\\nThe issue is fixed in version 0.14.15 for `NIO1SocketServerGroup`.  A `maxConnections` parameter is added, with a default value of 512.  Concurrent connections beyond this limit are rejected.  To run unbounded, which is not recommended, set a negative number.\\n\\nThe `NIO2SocketServerGroup`  has no such setting and is now deprecated.\\n\\n### Workarounds\\n* An Nginx side-car acting as a reverse proxy for the local http4s-blaze-server instance would be able to apply a connection limiting semantic before the sockets reach blaze-core. Nginx’s connection bounding is both asynchronous and properly respects backpressure.\\n* A similar sidecar strategy is viable for other non-HTTP services running on blaze-core.\\n* http4s-ember-server is an alternative to http4s-blaze-server, but does not yet have HTTP/2 or web socket support.  Its performance in terms of RPS is appreciably behind Blaze’s, and as the newest backend, has substantially less industrial uptake.\\n* http4s-jetty is an alternative to http4s-blaze-server, but does not yet have web socket support.  Its performance in terms of requests per second is somewhat behind Blaze’s, and despite Jetty's industrial adoption, the http4s integration has substantially less industrial uptake.\\n* http4s-tomcat is an alternative to http4s-blaze-server, but does not yet have HTTP/2 web socket support.  Its performance in terms of requests per second is somewhat behind Blaze’s, and despite Jetty's industrial adoption, the http4s integration has substantially less industrial uptake.\\n\\n### For more information\\nIf you have any questions or comments about this advisory:\\n* Open an issue in [http4s/blaze](http://github.com/http4s/blaze)\\n* Contact us according to the [http4s security policy](https://github.com/http4s/http4s/security/policy)",
-                       "advisories": [
-                         {
-                           "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-21293"
-                         }
-                       ],
-                       "published": "2021-02-02T21:42:49Z",
-                       "updated": "2023-01-10T05:22:31Z",
-                       "properties": [
-                            {
-                                "name": "dependency-track:vuln:title",
-                                "value": "test title value"
-                            }
-                       ],
-                       "affects": [
-                         {
-                           "ref": "076d7f91-1a19-484e-929d-4895b2820ef0",
-                           "versions": [
-                             {
-                               "range": "vers:maven/>=0|<0.14.15"
-                             },
-                             {
-                               "version": "0.10.0"
-                             },
-                             {
-                               "version": "0.10.1"
-                             }
-                           ]
-                         },
-                         {
-                           "ref": "82145ba5-a2e8-420b-acea-8b36f7f8885dc",
-                           "versions": [
-                             {
-                               "range": "vers:generic/>=2.3|<=3.8"
-                             }
-                           ]
-                         }
-                       ]
-                     }
-                   ]
-                 }
+                  "components": [
+                    {
+                      "bomRef": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                      "type": "CLASSIFICATION_APPLICATION",
+                      "publisher": "thinkcmf",
+                      "name": "thinkcmf",
+                      "cpe": "cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2022-40489",
+                      "source": { "name": "NVD" },
+                      "description": "ThinkCMF version 6.0.7 is affected by a",
+                      "cwes": [ 352 ],
+                      "published": "2022-12-01T05:15:11Z",
+                      "updated": "2022-12-02T17:17:02Z",
+                      "ratings": [
+                        {
+                          "method": "SCORE_METHOD_CVSSV31",
+                          "score": 8.8,
+                          "severity": "SEVERITY_HIGH",
+                          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                          "source": { "name": "NVD" }
+                        }
+                      ],
+                      "affects": [
+                        {
+                          "ref": "02cd44fb-2f0a-569b-a508-1e179e123e38",
+                          "versions": [
+                            { "version": "6.0.7" }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "externalReferences": [
+                    { "url": "https://github.com/thinkcmf/thinkcmf/issues/736" }
+                  ]
+                }
+                """));
+
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("NVD", "CVE-2022-40489");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("CVE-2022-40489");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("NVD");
+        assertThat(vuln.getTitle()).isNull();
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isEqualTo("ThinkCMF version 6.0.7 is affected by a");
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).containsOnly(352);
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isEqualTo("2022-12-01T05:15:11Z");
+        assertThat(vuln.getUpdated()).isEqualTo("2022-12-02T17:17:02Z");
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
+        assertThat(vuln.getCvssV3BaseScore()).isEqualTo("8.8");
+        assertThat(vuln.getCvssV3ImpactSubScore()).isEqualTo("5.9");
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isEqualTo("2.8");
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.HIGH);
+        assertThat(vuln.getReferences()).isEqualTo("""
+                * [https://github.com/thinkcmf/thinkcmf/issues/736](https://github.com/thinkcmf/thinkcmf/issues/736)
                 """);
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
+
+        assertThat(vuln.getVulnerableSoftware()).satisfiesExactly(vs -> {
+            assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf:6.0.7");
+            assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:6.0.7:*:*:*:*:*:*:*");
+            assertThat(vs.getPart()).isEqualTo("a");
+            assertThat(vs.getVendor()).isEqualTo("thinkcmf");
+            assertThat(vs.getProduct()).isEqualTo("thinkcmf");
+            assertThat(vs.getVersion()).isEqualTo("6.0.7");
+            assertThat(vs.getUpdate()).isEqualTo("*");
+            assertThat(vs.getEdition()).isEqualTo("*");
+            assertThat(vs.getLanguage()).isEqualTo("*");
+            assertThat(vs.getSwEdition()).isEqualTo("*");
+            assertThat(vs.getTargetSw()).isEqualTo("*");
+            assertThat(vs.getTargetHw()).isEqualTo("*");
+            assertThat(vs.getOther()).isEqualTo("*");
+            assertThat(vs.getVersionStartIncluding()).isNull();
+            assertThat(vs.getVersionStartExcluding()).isNull();
+            assertThat(vs.getVersionEndIncluding()).isNull();
+            assertThat(vs.getVersionEndExcluding()).isNull();
+            assertThat(vs.isVulnerable()).isTrue();
+            assertThat(vs.getPurlType()).isNull();
+            assertThat(vs.getPurlNamespace()).isNull();
+            assertThat(vs.getPurlName()).isNull();
+            assertThat(vs.getPurlVersion()).isNull();
+            assertThat(vs.getPurlQualifiers()).isNull();
+            assertThat(vs.getPurlSubpath()).isNull();
+            assertThat(vs.getPurl()).isNull();
+        });
     }
 
     @Test
-    public void testVulnRangeParsing(){
-        Vulnerability vuln = ModelConverterCdxToVuln.convert(qm, bom, bom.getVulnerabilities(0), false);
-        Assert.assertNotNull(vuln);
-        Assert.assertEquals("GHSA-xmw9-q7x9-j5qc",vuln.getVulnId());
-        Assert.assertEquals("test title value",vuln.getTitle());
-        Assert.assertEquals("Unbounded connection acceptance leads to file handle exhaustion",vuln.getDescription());
-        Assert.assertTrue(vuln.getDetail().startsWith("### Impact"));
-        Assert.assertEquals("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H", vuln.getCvssV3Vector());
+    public void testProcessGitHubVuln() throws Exception {
+        inputTopic.pipeInput("GITHUB/GHSA-fxwm-579q-49qq", KafkaTestUtil.generateBomFromJson("""
+                {
+                  "components": [
+                    {
+                      "bomRef": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                      "purl": "pkg:nuget/bootstrap"
+                    },
+                    {
+                      "bomRef": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                      "purl": "pkg:nuget/bootstrap.sass"
+                    },
+                    {
+                      "bomRef": "c8e5d671-0b0d-5fda-a404-730615325a7f",
+                      "purl": "pkg:nuget/Bootstrap.Less"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "GHSA-fxwm-579q-49qq",
+                      "source": { "name": "GITHUB" },
+                      "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1,",
+                      "properties": [
+                          {
+                            "name": "dependency-track:vuln:title",
+                            "value": "Moderate severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass"
+                          }
+                      ],
+                      "published": "2019-02-22T20:54:40Z",
+                      "updated": "2021-12-03T14:54:43Z",
+                      "ratings": [
+                        {
+                          "method": "SCORE_METHOD_OTHER",
+                          "severity": "SEVERITY_MEDIUM",
+                          "source": { "name": "GITHUB" }
+                        }
+                      ],
+                      "affects": [
+                        {
+                          "ref": "3c41e06b-5923-5392-a1e3-64a630c97591",
+                          "versions": [
+                            { "range": "vers:nuget/>= 3.0.0|< 3.4.1" },
+                            { "range": "vers:nuget/>= 4.0.0|< 4.3.1" }
+                          ]
+                        },
+                        {
+                          "ref": "e5dc290a-c649-5f73-b814-c9a47690a48a",
+                          "versions": [
+                            { "range": "vers:nuget/< 4.3.1" }
+                          ]
+                        },
+                        {
+                          "ref": "c8e5d671-0b0d-5fda-a404-730615325a7f",
+                          "versions": [
+                            { "range": "vers:nuget/>= 3.0.0|< 3.4.1" }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "externalReferences": [
+                    { "url": "https://github.com/advisories/GHSA-fxwm-579q-49qq" }
+                  ]
+                }
+                """));
 
-        // references
-        Assert.assertEquals("* [https://nvd.nist.gov/vuln/detail/CVE-2021-21293](https://nvd.nist.gov/vuln/detail/CVE-2021-21293)\n",vuln.getReferences());
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-fxwm-579q-49qq");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("GHSA-fxwm-579q-49qq");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("GITHUB");
+        assertThat(vuln.getTitle()).isEqualTo("Moderate severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass");
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isEqualTo("In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1,");
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).isNull();
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isEqualTo("2019-02-22T20:54:40Z");
+        assertThat(vuln.getUpdated()).isEqualTo("2021-12-03T14:54:43Z");
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isNull();
+        assertThat(vuln.getCvssV3BaseScore()).isNull();
+        assertThat(vuln.getCvssV3ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.MEDIUM);
+        assertThat(vuln.getReferences()).isEqualTo("""
+                * [https://github.com/advisories/GHSA-fxwm-579q-49qq](https://github.com/advisories/GHSA-fxwm-579q-49qq)
+                """);
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
 
-        // dates
-        Assert.assertNull(vuln.getCreated());
-        Assert.assertNotNull(vuln.getPublished());
-        Assert.assertNotNull(vuln.getUpdated());
-
-        // severity
-        Severity severity = ModelConverterCdxToVuln.calculateSeverity(bom);
-        Assert.assertEquals("HIGH", severity.name());
-        Vulnerability.Source source = ModelConverterCdxToVuln.extractSource("GHSA-xmw9-q7x9-j5qc", bom.getVulnerabilities(0).getSource());
-        Assert.assertEquals("GITHUB", source.name());
-
-        MirrorVulnerabilityProcessor processor = new MirrorVulnerabilityProcessor();
-
-        // Range mapping
-        VulnerableSoftware vs = processor.mapAffectedRangeToVulnerableSoftware(qm, bom.getVulnerabilities(0).getAffects(0).getVersions(0).getRange(), "pkg:maven/org.http4s/blaze-core_2.11", null);
-        Assert.assertNotNull(vs);
-        Assert.assertEquals("0", vs.getVersionStartIncluding());
-        Assert.assertEquals("0.14.15", vs.getVersionEndExcluding());
-        Assert.assertEquals("blaze-core_2.11", vs.getPurlName());
-        Assert.assertEquals("maven", vs.getPurlType());
-        Assert.assertEquals("org.http4s", vs.getPurlNamespace());
-
-        vs = processor.mapAffectedRangeToVulnerableSoftware(qm, bom.getVulnerabilities(0).getAffects(1).getVersions(0).getRange(), null, "cpe:2.3:a:oracle:mysql:*:*:*:*:*:*:*:*");
-        Assert.assertNotNull(vs);
-        Assert.assertEquals("2.3", vs.getVersionStartIncluding());
-        Assert.assertEquals("3.8", vs.getVersionEndIncluding());
-        Assert.assertEquals("cpe:2.3:a:oracle:mysql:*:*:*:*:*:*:*:*", vs.getCpe23());
-
-        // Version mapping
-        vs = processor.mapAffectedVersionToVulnerableSoftware(qm, bom.getVulnerabilities(0).getAffects(0).getVersions(1).getVersion(), "pkg:maven/org.http4s/blaze-core_2.11", null);
-        Assert.assertNotNull(vs);
-        Assert.assertEquals("0.10.0", vs.getVersion());
-        Assert.assertEquals("blaze-core_2.11", vs.getPurlName());
-        Assert.assertEquals("maven", vs.getPurlType());
-        Assert.assertEquals("org.http4s", vs.getPurlNamespace());
-
-        vs = processor.mapAffectedVersionToVulnerableSoftware(qm, bom.getVulnerabilities(0).getAffects(0).getVersions(2).getVersion(), "pkg:maven/org.http4s/blaze-core_2.11", null);
-        Assert.assertNotNull(vs);
-        Assert.assertEquals("0.10.1", vs.getVersion());
+        assertThat(vuln.getVulnerableSoftware()).satisfiesExactlyInAnyOrder(
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isNull();
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isEqualTo("3.0.0");
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("3.4.1");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("nuget");
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isEqualTo("bootstrap");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:nuget/bootstrap");
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isNull();
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isEqualTo("4.0.0");
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("4.3.1");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("nuget");
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isEqualTo("bootstrap");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:nuget/bootstrap");
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isNull();
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("4.3.1");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("nuget");
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isEqualTo("bootstrap.sass");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:nuget/bootstrap.sass");
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isNull();
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isEqualTo("3.0.0");
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("3.4.1");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("nuget");
+                    assertThat(vs.getPurlNamespace()).isNull();
+                    assertThat(vs.getPurlName()).isEqualTo("Bootstrap.Less");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:nuget/Bootstrap.Less");
+                }
+        );
     }
 
     @Test
-    public void testExtractSource() {
-        Source source = Source.newBuilder().setName("OSV").build();
-        Assert.assertEquals(Vulnerability.Source.OSV, ModelConverterCdxToVuln.extractSource("OSV-test-id", source));
+    public void testProcessOsvVuln() throws Exception {
+        inputTopic.pipeInput("OSV/GHSA-2cc5-23r7-vc4v", KafkaTestUtil.generateBomFromJson("""
+                {
+                  "components": [
+                    {
+                      "bomRef": "2a24a29f-9ff3-52b8-bc81-471f326a5b3e",
+                      "name": "io.ratpack:ratpack-session",
+                      "purl": "pkg:maven/io.ratpack/ratpack-session"
+                    }
+                  ],
+                  "vulnerabilities": [
+                    {
+                      "id": "GHSA-2cc5-23r7-vc4v",
+                      "source": { "name": "GITHUB" },
+                      "description": "### Impact",
+                      "cwes": [ 330, 340 ],
+                      "published": "2021-07-01T17:02:26Z",
+                      "updated": "2023-03-28T05:45:27Z",
+                      "ratings": [
+                        {
+                          "method": "SCORE_METHOD_CVSSV3",
+                          "score": 4.4,
+                          "severity": "SEVERITY_MEDIUM",
+                          "vector": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N"
+                        }
+                      ],
+                      "advisories": [
+                        { "url": "https://nvd.nist.gov/vuln/detail/CVE-2021-29480" }
+                      ],
+                      "properties": [
+                          {
+                            "name": "dependency-track:vuln:title",
+                            "value": "Ratpack's default client side session signing key is highly predictable"
+                          }
+                      ],
+                      "affects": [
+                        {
+                          "ref": "2a24a29f-9ff3-52b8-bc81-471f326a5b3e",
+                          "versions": [
+                            { "range": "vers:maven/>=0|<1.9.0" },
+                            { "version": "0.9.0" },
+                            { "version": "0.9.1" }
+                          ]
+                        }
+                      ]
+                    }
+                  ],
+                  "externalReferences": [
+                    { "url": "https://github.com/ratpack/ratpack/security/advisories/GHSA-2cc5-23r7-vc4v" },
+                    { "url": "https://github.com/ratpack/ratpack" },
+                    { "url": "https://github.com/ratpack/ratpack/blob/29434f7ac6fd4b36a4495429b70f4c8163100332/ratpack-session/src/main/java/ratpack/session/clientside/ClientSideSessionConfig.java#L29" }
+                  ]
+                }
+                """));
+
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-2cc5-23r7-vc4v");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getVulnId()).isEqualTo("GHSA-2cc5-23r7-vc4v");
+        assertThat(vuln.getFriendlyVulnId()).isNull();
+        assertThat(vuln.getSource()).isEqualTo("GITHUB");
+        assertThat(vuln.getTitle()).isEqualTo("Ratpack's default client side session signing key is highly predictable");
+        assertThat(vuln.getSubTitle()).isNull();
+        assertThat(vuln.getDescription()).isEqualTo("### Impact");
+        assertThat(vuln.getDetail()).isNull();
+        assertThat(vuln.getRecommendation()).isNull();
+        assertThat(vuln.getCwes()).containsOnly(330, 340);
+        assertThat(vuln.getCreated()).isNull();
+        assertThat(vuln.getPublished()).isEqualTo("2021-07-01T17:02:26Z");
+        assertThat(vuln.getUpdated()).isEqualTo("2023-03-28T05:45:27Z");
+        assertThat(vuln.getCvssV2Vector()).isNull();
+        assertThat(vuln.getCvssV2BaseScore()).isNull();
+        assertThat(vuln.getCvssV2ImpactSubScore()).isNull();
+        assertThat(vuln.getCvssV2ExploitabilitySubScore()).isNull();
+        assertThat(vuln.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:N");
+        assertThat(vuln.getCvssV3BaseScore()).isEqualTo("4.4");
+        assertThat(vuln.getCvssV3ImpactSubScore()).isEqualTo("2.5");
+        assertThat(vuln.getCvssV3ExploitabilitySubScore()).isEqualTo("1.8");
+        assertThat(vuln.getOwaspRRVector()).isNull();
+        assertThat(vuln.getOwaspRRLikelihoodScore()).isNull();
+        assertThat(vuln.getOwaspRRBusinessImpactScore()).isNull();
+        assertThat(vuln.getOwaspRRTechnicalImpactScore()).isNull();
+        assertThat(vuln.getSeverity()).isEqualTo(Severity.MEDIUM);
+        assertThat(vuln.getReferences()).isEqualTo("""
+                * [https://github.com/ratpack/ratpack/security/advisories/GHSA-2cc5-23r7-vc4v](https://github.com/ratpack/ratpack/security/advisories/GHSA-2cc5-23r7-vc4v)
+                * [https://github.com/ratpack/ratpack](https://github.com/ratpack/ratpack)
+                * [https://github.com/ratpack/ratpack/blob/29434f7ac6fd4b36a4495429b70f4c8163100332/ratpack-session/src/main/java/ratpack/session/clientside/ClientSideSessionConfig.java#L29](https://github.com/ratpack/ratpack/blob/29434f7ac6fd4b36a4495429b70f4c8163100332/ratpack-session/src/main/java/ratpack/session/clientside/ClientSideSessionConfig.java#L29)
+                * [https://nvd.nist.gov/vuln/detail/CVE-2021-29480](https://nvd.nist.gov/vuln/detail/CVE-2021-29480)
+                """);
+        assertThat(vuln.getCredits()).isNull();
+        assertThat(vuln.getVulnerableVersions()).isNull();
+        assertThat(vuln.getPatchedVersions()).isNull();
+        assertThat(vuln.getEpssScore()).isNull();
+        assertThat(vuln.getEpssPercentile()).isNull();
+
+        assertThat(vuln.getVulnerableSoftware()).satisfiesExactlyInAnyOrder(
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isNull();
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isEqualTo("1.9.0");
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("maven");
+                    assertThat(vs.getPurlNamespace()).isEqualTo("io.ratpack");
+                    assertThat(vs.getPurlName()).isEqualTo("ratpack-session");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:maven/io.ratpack/ratpack-session");
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isEqualTo("0.9.0");
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isNull();
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("maven");
+                    assertThat(vs.getPurlNamespace()).isEqualTo("io.ratpack");
+                    assertThat(vs.getPurlName()).isEqualTo("ratpack-session");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:maven/io.ratpack/ratpack-session");
+                },
+                vs -> {
+                    assertThat(vs.getCpe22()).isNull();
+                    assertThat(vs.getCpe23()).isNull();
+                    assertThat(vs.getPart()).isNull();
+                    assertThat(vs.getVendor()).isNull();
+                    assertThat(vs.getProduct()).isNull();
+                    assertThat(vs.getVersion()).isEqualTo("0.9.1");
+                    assertThat(vs.getUpdate()).isNull();
+                    assertThat(vs.getEdition()).isNull();
+                    assertThat(vs.getLanguage()).isNull();
+                    assertThat(vs.getSwEdition()).isNull();
+                    assertThat(vs.getTargetSw()).isNull();
+                    assertThat(vs.getTargetHw()).isNull();
+                    assertThat(vs.getOther()).isNull();
+                    assertThat(vs.getVersionStartIncluding()).isNull();
+                    assertThat(vs.getVersionStartExcluding()).isNull();
+                    assertThat(vs.getVersionEndIncluding()).isNull();
+                    assertThat(vs.getVersionEndExcluding()).isNull();
+                    assertThat(vs.isVulnerable()).isTrue();
+                    assertThat(vs.getPurlType()).isEqualTo("maven");
+                    assertThat(vs.getPurlNamespace()).isEqualTo("io.ratpack");
+                    assertThat(vs.getPurlName()).isEqualTo("ratpack-session");
+                    assertThat(vs.getPurlVersion()).isNull();
+                    assertThat(vs.getPurlQualifiers()).isNull();
+                    assertThat(vs.getPurlSubpath()).isNull();
+                    assertThat(vs.getPurl()).isEqualTo("pkg:maven/io.ratpack/ratpack-session");
+                }
+        );
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

* If a vulnerability rating contained only a severity, but no method, score, or vector, the severity was not applied. This is now fixed by applying such severities only when no better option (CVSSv2, CVSSv3, OWASP RR) rating could be applied.
* Vers range parsing failed to correctly parse ranges like `vers:nuget/< 4.3.1`. The splitting logic (https://github.com/DependencyTrack/hyades-apiserver/blob/dd9b8ed2a3753aa7ddb6f6875f56a8cbab4efa51/src/main/java/org/dependencytrack/event/kafka/processor/MirrorVulnerabilityProcessor.java#L179-L183) would break such ranges up into the parts `<` and `4.3.1`, whereas it should've been just `<4.3.1` instead.
* Log messages informing about failures during processing now include the vulnerability ID, to give a little more context.
* Vers ranges are now parsed according to the spec; The implementation for this has been extracted and simplified from https://github.com/nscuro/versatile.
* `MirrorVulnerabilityProcessorTest` now asserts *all* fields of ingested vulnerabilities.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/732

Potentially fixes https://github.com/DependencyTrack/hyades/issues/731 (need to verify)

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

This PR relies on the mirror-service changes from https://github.com/DependencyTrack/hyades/pull/756

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
