### PR TITLE
Fix breaking change in `NEW_VULNERABILITY` notification JSON format

### DIFF
--- a/src/main/java/org/dependencytrack/parser/hyades/NotificationModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/hyades/NotificationModelConverter.java
@@ -181,11 +181,12 @@ public final class NotificationModelConverter {
                 .setComponent(convert(subject.getComponent()))
                 .setProject(convert(subject.getComponent().getProject()))
                 .setVulnerability(convert(subject.getVulnerability()))
-                .setAffectedProjects(BackReference.newBuilder()
+                .setAffectedProjectsReference(BackReference.newBuilder()
                         .setApiUri("/api/v1/vulnerability/source/%s/vuln/%s/projects"
                                 .formatted(subject.getVulnerability().getSource(), subject.getVulnerability().getVulnId()))
                         .setFrontendUri("/vulnerabilities/%s/%s/affectedProjects"
-                                .formatted(subject.getVulnerability().getSource(), subject.getVulnerability().getVulnId())));
+                                .formatted(subject.getVulnerability().getSource(), subject.getVulnerability().getVulnId())))
+                .addAffectedProjects(convert(subject.getComponent().getProject()));
 
         Optional.ofNullable(subject.getVulnerabilityAnalysisLevel())
                 .map(Enum::name)

--- a/src/main/proto/org/hyades/notification/v1/notification.proto
+++ b/src/main/proto/org/hyades/notification/v1/notification.proto
@@ -177,19 +177,19 @@ message Vulnerability {
   string source = 3;
   repeated Alias aliases = 4;
   optional string title = 5;
-  optional string sub_title = 6;
+  optional string sub_title = 6 [json_name = "subtitle"];
   optional string description = 7;
   optional string recommendation = 8;
-  optional double cvss_v2 = 9;
-  optional double cvss_v3 = 10;
-  optional double owasp_rr_likelihood = 11;
-  optional double owasp_rr_technical_impact = 12;
-  optional double owasp_rr_business_impact = 13;
+  optional double cvss_v2 = 9 [json_name = "cvssv2"];
+  optional double cvss_v3 = 10 [json_name = "cvssv3"];
+  optional double owasp_rr_likelihood = 11 [json_name = "owaspRRLikelihood"];
+  optional double owasp_rr_technical_impact = 12 [json_name = "owaspRRTechnicalImpact"];
+  optional double owasp_rr_business_impact = 13 [json_name = "owaspRRBusinessImpact"];
   optional string severity = 14;
   repeated Cwe cwes = 15;
 
   message Alias {
-    string id = 1;
+    string id = 1 [json_name = "vulnId"];
     string source = 2;
   }
 

--- a/src/main/proto/org/hyades/notification/v1/notification.proto
+++ b/src/main/proto/org/hyades/notification/v1/notification.proto
@@ -86,8 +86,14 @@ message NewVulnerabilitySubject {
   Component component = 1;
   Project project = 2;
   Vulnerability vulnerability = 3;
-  BackReference affected_projects = 4;
+  BackReference affected_projects_reference = 4;
   optional string vulnerability_analysis_level = 5;
+  // List of projects affected by the vulnerability.
+  // DEPRECATED: This list only holds one item, and it is identical to the one in the project field.
+  // The field is kept for backward compatibility of JSON notifications, but consumers should not expect multiple projects here.
+  // Transmitting all affected projects in one notification is not feasible for large portfolios,
+  // see https://github.com/DependencyTrack/hyades/issues/467 for details.
+  repeated Project affected_projects = 6 [deprecated = true];
 }
 
 message NewVulnerableDependencySubject {

--- a/src/main/resources/templates/notification/publisher/webhook.peb
+++ b/src/main/resources/templates/notification/publisher/webhook.peb
@@ -3,7 +3,7 @@
     "level": "{{ notification.level | escape(strategy="json") }}",
     "scope": "{{ notification.scope | escape(strategy="json") }}",
     "group": "{{ notification.group | escape(strategy="json") }}",
-    "timestamp": "{{ notification.timestamp }}",
+    "timestamp": "{{ timestamp }}",
     "title": "{{ notification.title | escape(strategy="json") }}",
     "content": "{{ notification.content | escape(strategy="json") }}",
     "subject": {{ subjectJson | raw }}

--- a/src/test/java/org/dependencytrack/parser/hyades/NotificationModelConverterTest.java
+++ b/src/test/java/org/dependencytrack/parser/hyades/NotificationModelConverterTest.java
@@ -228,11 +228,12 @@ public class NotificationModelConverterTest extends PersistenceCapableTest {
         assertComponent(subject.getComponent());
         assertProject(subject.getProject());
         assertVulnerability(subject.getVulnerability());
-        assertThat(subject.getAffectedProjects().getApiUri())
+        assertThat(subject.getAffectedProjectsReference().getApiUri())
                 .isEqualTo("/api/v1/vulnerability/source/INTERNAL/vuln/INT-001/projects");
-        assertThat(subject.getAffectedProjects().getFrontendUri())
+        assertThat(subject.getAffectedProjectsReference().getFrontendUri())
                 .isEqualTo("/vulnerabilities/INTERNAL/INT-001/affectedProjects");
         assertThat(subject.getVulnerabilityAnalysisLevel()).isEqualTo("BOM_UPLOAD_ANALYSIS");
+        assertThat(subject.getAffectedProjectsList()).satisfiesExactly(this::assertProject);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The breaking change was introduced for https://github.com/DependencyTrack/hyades/issues/467, and is causing issues for consumers of Webhook notifications that expect the `affectedProjects` field to be an array of projects. Whereas now it is an object holding references.

To fix the JSON representation, an array field named `affectedProjects` is added again. It will be populated with the same value that the `project` field holds.

Because only the field *name* is changed in the Protobuf schema, this is not a breaking change for the notification publisher.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Also fixed the Webhook notification template using the wrong field for `timestamp`, causing it to be ill-formatted.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
