### PR TITLE
Ensure Kafka producer exceptions are always logged

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/KafkaDefaultProducerCallback.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaDefaultProducerCallback.java
@@ -1,0 +1,34 @@
+package org.dependencytrack.event.kafka;
+
+import alpine.common.logging.Logger;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+/**
+ * A Kafka producer {@link Callback} that simply logs any errors.
+ * <p>
+ * It is used by {@link KafkaEventDispatcher} when no other {@link Callback} is provided.
+ */
+class KafkaDefaultProducerCallback implements Callback {
+
+    private final Logger logger;
+    private final String topic;
+    private final Object key;
+
+    KafkaDefaultProducerCallback(final Logger logger, final String topic, final Object key) {
+        this.logger = logger;
+        this.topic = topic;
+        this.key = key;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onCompletion(final RecordMetadata metadata, final Exception exception) {
+        if (exception != null) {
+            logger.error("Failed to produce record with key %s to topic %s".formatted(key, topic), exception);
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventDispatcher.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventDispatcher.java
@@ -24,10 +24,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
+import static java.util.Objects.requireNonNullElseGet;
+
 /**
  * An {@link Event} dispatcher that wraps a Kafka {@link Producer}.
  */
 public class KafkaEventDispatcher {
+
     private static final Logger LOGGER = Logger.getLogger(KafkaEventDispatcher.class);
 
     private final Producer<byte[], byte[]> producer;
@@ -53,7 +56,8 @@ public class KafkaEventDispatcher {
      *
      * @param event    The {@link Event} to dispatch
      * @param callback A {@link Callback} to execute once the record has been acknowledged by the broker,
-     *                 or sending the record failed
+     *                 or sending the record failed; When {@code null}, {@link KafkaDefaultProducerCallback}
+     *                 will be used
      * @return A {@link Future} holding a {@link RecordMetadata} instance for the dispatched event,
      * or {@code null} when the event was not dispatched
      * @throws IllegalArgumentException When dispatching the given {@link Event} to Kafka is not supported
@@ -149,7 +153,8 @@ public class KafkaEventDispatcher {
             }
         }
 
-        return producer.send(record, callback);
+        return producer.send(record, requireNonNullElseGet(callback,
+                () -> new KafkaDefaultProducerCallback(LOGGER, record.topic(), event.key())));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

When we dispatch large quantities of events to Kafka, we do it asynchronously to make use of the producer's batching behavior.

By producing asynchronously, the calling code does not get feedback about whether the production succeeded or not.

The producer's built in retry behavior will kick in nonetheless. For non-retryable errors though, we want to be informed. Per default, the producer does not log such errors, but relies on user-provided `Callback`s to do it instead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
