### PR TITLE
Fix missing `cvssv3` field in `PROJECT_VULN_ANALYSIS_COMPLETE` notification

### DIFF
--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -374,17 +374,16 @@ public final class NotificationUtil {
                 vulnerability1.setId(vulnerability.getId());
                 vulnerability1.setVulnId(vulnerability.getVulnId());
                 vulnerability1.setSource(vulnerability.getSource());
-                vulnerability1.setOwaspRRBusinessImpactScore(vulnerability.getOwaspRRBusinessImpactScore());
                 vulnerability1.setTitle(vulnerability.getTitle());
                 vulnerability1.setSubTitle(vulnerability.getSubTitle());
                 vulnerability1.setRecommendation(vulnerability.getRecommendation());
+                vulnerability1.setSeverity(vulnerability.getSeverity());
                 vulnerability1.setCvssV2BaseScore(vulnerability.getCvssV2BaseScore());
                 vulnerability1.setCvssV3BaseScore(vulnerability.getCvssV3BaseScore());
-                vulnerability1.setSeverity(vulnerability.getSeverity());
-                vulnerability1.setCwes(vulnerability.getCwes());
                 vulnerability1.setOwaspRRLikelihoodScore(vulnerability.getOwaspRRLikelihoodScore());
                 vulnerability1.setOwaspRRTechnicalImpactScore(vulnerability.getOwaspRRTechnicalImpactScore());
                 vulnerability1.setOwaspRRBusinessImpactScore(vulnerability.getOwaspRRBusinessImpactScore());
+                vulnerability1.setCwes(vulnerability.getCwes());
                 vulnerability1.setUuid(vulnerability.getUuid());
                 vulnerability1.setVulnerableSoftware(vulnerability.getVulnerableSoftware());
                 if (vulnerability.getAliases() != null && !vulnerability.getAliases().isEmpty()) {


### PR DESCRIPTION
### Description

The cvss_v3 field is not populated for vulnerabilities in the PROJECT_VULN_ANALYSIS_COMPLETE notification.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/776

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
