### PR TITLE
Add temporary feature to delay `BOM_PROCESSED` notification until vulnerability analysis completes

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -70,7 +70,8 @@ public enum ConfigKey implements Config.Key {
     TASK_PORTFOLIO_VULN_ANALYSIS_LOCK_AT_LEAST_FOR("task.portfolio.vulnAnalysis.lockAtLeastForInMillis", String.valueOf(Duration.ofMinutes(5).toMillis())),
     BOM_UPLOAD_PROCESSING_TRX_FLUSH_THRESHOLD("bom.upload.processing.trx.flush.threshold", "10000"),
     WORKFLOW_RETENTION_DURATION("workflow.retention.duration", "P3D"),
-    WORKFLOW_STEP_TIMEOUT_DURATION("workflow.step.timeout.duration", "PT1H");
+    WORKFLOW_STEP_TIMEOUT_DURATION("workflow.step.timeout.duration", "PT1H"),
+    TMP_DELAY_BOM_PROCESSED_NOTIFICATION("tmp.delay.bom.processed.notification", "false");
 
     private final String propertyName;
     private final Object defaultValue;

--- a/src/main/java/org/dependencytrack/event/kafka/processor/DelayedBomProcessedNotificationProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/DelayedBomProcessedNotificationProcessor.java
@@ -1,0 +1,88 @@
+package org.dependencytrack.event.kafka.processor;
+
+import alpine.common.logging.Logger;
+import alpine.notification.NotificationLevel;
+import org.apache.kafka.streams.processor.api.ContextualProcessor;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.Record;
+import org.dependencytrack.model.Bom;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.VulnerabilityScan;
+import org.dependencytrack.model.WorkflowStatus;
+import org.dependencytrack.model.WorkflowStep;
+import org.dependencytrack.notification.NotificationConstants;
+import org.dependencytrack.notification.NotificationGroup;
+import org.dependencytrack.notification.NotificationScope;
+import org.dependencytrack.notification.vo.BomConsumedOrProcessed;
+import org.dependencytrack.persistence.QueryManager;
+import org.hyades.proto.notification.v1.Notification;
+
+import javax.jdo.Query;
+import java.util.UUID;
+
+import static org.dependencytrack.parser.hyades.NotificationModelConverter.convert;
+
+/**
+ * A {@link Processor} responsible for dispatching {@link NotificationGroup#BOM_PROCESSED} notifications
+ * upon detection of a completed {@link VulnerabilityScan}.
+ */
+public class DelayedBomProcessedNotificationProcessor extends ContextualProcessor<String, VulnerabilityScan, String, Notification> {
+
+    private static final Logger LOGGER = Logger.getLogger(DelayedBomProcessedNotificationProcessor.class);
+
+    @Override
+    public void process(final Record<String, VulnerabilityScan> record) {
+        final VulnerabilityScan vulnScan = record.value();
+
+        if (vulnScan.getStatus() != VulnerabilityScan.Status.COMPLETED
+                && vulnScan.getStatus() != VulnerabilityScan.Status.FAILED) {
+            LOGGER.warn("Received vulnerability scan with non-terminal status %s; Dropping (token=%s, project=%s)"
+                    .formatted(vulnScan.getStatus(), vulnScan.getToken(), vulnScan.getTargetIdentifier()));
+            return;
+        }
+
+        final Project project;
+        try (final var qm = new QueryManager()) {
+            if (!qm.hasWorkflowStepWithStatus(UUID.fromString(vulnScan.getToken()), WorkflowStep.BOM_PROCESSING, WorkflowStatus.COMPLETED)) {
+                LOGGER.debug("Received completed vulnerability scan, but no %s step exists in this workflow; Dropping (token=%s, project=%s)"
+                        .formatted(WorkflowStep.BOM_PROCESSING, vulnScan.getToken(), vulnScan.getTargetIdentifier()));
+                return;
+            }
+
+            project = getProject(qm, vulnScan.getTargetIdentifier());
+            if (project == null) {
+                LOGGER.warn("Received completed vulnerability scan, but the target project does not exist; Dropping (token=%s, project=%s)"
+                        .formatted(vulnScan.getToken(), vulnScan.getTargetIdentifier()));
+                return;
+            }
+        }
+
+        final var alpineNotification = new alpine.notification.Notification()
+                .scope(NotificationScope.PORTFOLIO)
+                .group(NotificationGroup.BOM_PROCESSED)
+                .level(NotificationLevel.INFORMATIONAL)
+                .title(NotificationConstants.Title.BOM_PROCESSED)
+                // BOM format and spec version are hardcoded because we don't have this information at this point.
+                // DT currently only accepts CycloneDX anyway.
+                .content("A %s BOM was processed".formatted(Bom.Format.CYCLONEDX.getFormatShortName()))
+                .subject(new BomConsumedOrProcessed(project, /* bom */ "(Omitted)", Bom.Format.CYCLONEDX, "Unknown"));
+
+        context().forward(record.withKey(project.getUuid().toString()).withValue(convert(alpineNotification)));
+        LOGGER.info("Dispatched delayed %s notification (token=%s, project=%s)"
+                .formatted(NotificationGroup.BOM_PROCESSED, vulnScan.getToken(), vulnScan.getTargetIdentifier()));
+    }
+
+    private static Project getProject(final QueryManager qm, final UUID uuid) {
+        final Query<Project> projectQuery = qm.getPersistenceManager().newQuery(Project.class);
+        projectQuery.setFilter("uuid == :uuid");
+        projectQuery.setParameters(uuid);
+        projectQuery.getFetchPlan().clearGroups(); // Ensure we're not loading too much bloat.
+        projectQuery.getFetchPlan().setGroup(Project.FetchGroup.NOTIFICATION.name());
+        try {
+            return qm.getPersistenceManager().detachCopy(projectQuery.executeResultUnique(Project.class));
+        } finally {
+            projectQuery.closeAll();
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -100,6 +100,14 @@ import java.util.UUID;
                 @Persistent(name = "lastInheritedRiskScore"),
                 @Persistent(name = "uuid")
         }),
+        @FetchGroup(name = "NOTIFICATION", members = {
+                @Persistent(name = "uuid"),
+                @Persistent(name = "name"),
+                @Persistent(name = "version"),
+                @Persistent(name = "description"),
+                @Persistent(name = "purl"),
+                @Persistent(name = "tags")
+        }),
         @FetchGroup(name = "PARENT", members = {
                 @Persistent(name = "parent")
         })
@@ -116,6 +124,7 @@ public class Project implements Serializable {
         ALL,
         IDENTIFIERS,
         METRICS_UPDATE,
+        NOTIFICATION,
         PARENT
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1637,4 +1637,9 @@ public class QueryManager extends AlpineQueryManager {
     public void updateWorkflowStateToFailed(WorkflowState workflowState, String failureReason) {
         getWorkflowStateQueryManager().updateWorkflowStateToFailed(workflowState, failureReason);
     }
+
+    public boolean hasWorkflowStepWithStatus(final UUID token, final WorkflowStep step, final WorkflowStatus status) {
+        return getWorkflowStateQueryManager().hasWorkflowStepWithStatus(token, step, status);
+    }
+
 }

--- a/src/main/java/org/dependencytrack/persistence/WorkflowStateQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/WorkflowStateQueryManager.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class WorkflowStateQueryManager extends QueryManager implements IQueryManager {
@@ -311,4 +312,21 @@ public class WorkflowStateQueryManager extends QueryManager implements IQueryMan
             }
         }
     }
+
+    public boolean hasWorkflowStepWithStatus(final UUID token, final WorkflowStep step, final WorkflowStatus status) {
+        final Query<WorkflowState> stateQuery = pm.newQuery(WorkflowState.class);
+        stateQuery.setFilter("token == :token && step == :step && status == :status");
+        stateQuery.setNamedParameters(Map.of(
+                "token", token,
+                "step", step,
+                "status", status
+        ));
+        stateQuery.setResult("count(this)");
+        try {
+            return stateQuery.executeResultUnique(Long.class) > 0;
+        } finally {
+            stateQuery.closeAll();
+        }
+    }
+
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -456,3 +456,10 @@ workflow.step.timeout.duration=PT1H
 # state (CANCELLED, COMPLETED, FAILED, NOT_APPLICABLE).
 # The duration must be specified in ISO8601 notation (https://en.wikipedia.org/wiki/ISO_8601#Durations).
 workflow.retention.duration=P3D
+
+# Optional
+# Delays the BOM_PROCESSED notification until the vulnerability analysis associated with a given BOM upload
+# is completed. The intention being that it is then "safe" to query the API for any identified vulnerabilities.
+# This is specifically for cases where polling the /api/v1/bom/token/<TOKEN> endpoint is not feasible.
+# THIS IS A TEMPORARY FUNCTIONALITY AND MAY BE REMOVED IN FUTURE RELEASES WITHOUT FURTHER NOTICE.
+tmp.delay.bom.processed.notification=false

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsDelayedBomProcessedNotificationTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsDelayedBomProcessedNotificationTest.java
@@ -1,0 +1,293 @@
+package org.dependencytrack.event.kafka;
+
+import net.mguenther.kafka.junit.KeyValue;
+import net.mguenther.kafka.junit.ReadKeyValues;
+import net.mguenther.kafka.junit.SendKeyValues;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.VulnerabilityScan;
+import org.dependencytrack.model.WorkflowState;
+import org.dependencytrack.model.WorkflowStatus;
+import org.dependencytrack.model.WorkflowStep;
+import org.hyades.proto.notification.v1.BomConsumedOrProcessedSubject;
+import org.hyades.proto.notification.v1.Notification;
+import org.hyades.proto.notification.v1.ProjectVulnAnalysisCompleteSubject;
+import org.hyades.proto.vulnanalysis.v1.ScanKey;
+import org.hyades.proto.vulnanalysis.v1.ScanResult;
+import org.hyades.proto.vulnanalysis.v1.ScannerResult;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hyades.proto.notification.v1.ProjectVulnAnalysisStatus.PROJECT_VULN_ANALYSIS_STATUS_COMPLETED;
+import static org.hyades.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_SUCCESSFUL;
+import static org.hyades.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
+
+public class KafkaStreamsDelayedBomProcessedNotificationTest extends KafkaStreamsPostgresTest {
+
+    public KafkaStreamsDelayedBomProcessedNotificationTest() {
+        super(new KafkaStreamsTopologyFactory(true)::createTopology);
+    }
+
+    @Test
+    public void shouldSendBomProcessedNotification() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setDescription("Some Description");
+        project.setPurl("pkg:maven/com.acme/acme-app");
+        qm.persist(project);
+        qm.bind(project, List.of(
+                qm.createTag("tag-a"),
+                qm.createTag("tag-b")
+        ));
+
+        final var scanToken = UUID.randomUUID().toString();
+
+        // Initialize a vulnerability scan for 5 components, and create a workflow for it accordingly.
+        final VulnerabilityScan scan = qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, project.getUuid(), scanToken, 5);
+        qm.createWorkflowSteps(UUID.fromString(scanToken));
+
+        // Transition the BOM_PROCESSING step of the workflow to COMPLETED. A delayed BOM_PROCESSED notification
+        // will only be sent, when there's a successful BOM_PROCESSING step in the workflow.
+        final WorkflowState state = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.BOM_PROCESSING);
+        state.setStatus(WorkflowStatus.COMPLETED);
+        qm.updateWorkflowState(state);
+
+        // Emulate arrival of 5 vulnerability scan results, one for each component in the project.
+        final var componentUuids = new ArrayList<UUID>();
+        for (int i = 0; i < 5; i++) {
+            componentUuids.add(UUID.randomUUID());
+        }
+        for (final UUID uuid : componentUuids) {
+            final ScanKey scanKey = ScanKey.newBuilder()
+                    .setScanToken(scanToken)
+                    .setComponentUuid(uuid.toString())
+                    .build();
+
+            kafka.send(SendKeyValues.to(KafkaTopics.VULN_ANALYSIS_RESULT.name(), List.of(
+                            new KeyValue<>(
+                                    scanKey,
+                                    ScanResult.newBuilder()
+                                            .setKey(scanKey)
+                                            .addScannerResults(ScannerResult.newBuilder()
+                                                    .setScanner(SCANNER_INTERNAL)
+                                                    .setStatus(SCAN_STATUS_SUCCESSFUL))
+                                            .build()))
+                    )
+                    .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class)
+                    .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
+        }
+
+        // Wait for vulnerability scan to transition to COMPLETED status.
+        await("Result processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    qm.getPersistenceManager().refresh(scan);
+                    assertThat(scan).isNotNull();
+                    assertThat(scan.getStatus()).isEqualTo(VulnerabilityScan.Status.COMPLETED);
+                });
+
+        await("BOM processed notification")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    assertThat(kafka.readValues(ReadKeyValues
+                            .from(KafkaTopics.NOTIFICATION_BOM.name(), String.class, Notification.class)
+                            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+                    ).satisfiesExactly(
+                            notification -> {
+                                final BomConsumedOrProcessedSubject subject =
+                                        notification.getSubject().unpack(BomConsumedOrProcessedSubject.class);
+                                assertThat(subject.getBom().getContent()).isEqualTo("(Omitted)");
+                                assertThat(subject.getBom().getFormat()).isEqualTo("CycloneDX");
+                                assertThat(subject.getBom().getSpecVersion()).isEqualTo("Unknown");
+                                assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                                assertThat(subject.getProject().getName()).isEqualTo(project.getName());
+                                assertThat(subject.getProject().getVersion()).isEqualTo(project.getVersion());
+                                assertThat(subject.getProject().getDescription()).isEqualTo(project.getDescription());
+                                assertThat(subject.getProject().getPurl()).isEqualTo(project.getPurl().toString());
+                                assertThat(subject.getProject().getTagsList()).containsExactlyInAnyOrder("tag-a", "tag-b");
+                            }
+                    );
+                });
+
+        // ... we still want to get a PROJECT_VULN_ANALYSIS_COMPLETE notification though.
+        // In this case, no vulnerabilities were found, so no findings are expected.
+        await("Analysis complete notification")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    assertThat(kafka.readValues(ReadKeyValues
+                            .from(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name(), String.class, Notification.class)
+                            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+                    ).satisfiesExactly(
+                            notification -> {
+                                final ProjectVulnAnalysisCompleteSubject subject =
+                                        notification.getSubject().unpack(ProjectVulnAnalysisCompleteSubject.class);
+                                assertThat(subject.getStatus()).isEqualTo(PROJECT_VULN_ANALYSIS_STATUS_COMPLETED);
+                                assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                                assertThat(subject.getFindingsList()).isEmpty();
+                            }
+                    );
+                });
+    }
+
+    @Test
+    public void shouldNotSendBomProcessedNotificationWhenWorkflowHasNoCompletedBomProcessingStep() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var scanToken = UUID.randomUUID().toString();
+
+        // Initialize a vulnerability scan for 5 components, and create a workflow for a manual re-analysis.
+        // This workflow does not include a BOM_PROCESSING step. Without it, no BOM_PROCESSED notification should be sent.
+        final VulnerabilityScan scan = qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, project.getUuid(), scanToken, 5);
+        qm.createReanalyzeSteps(UUID.fromString(scanToken));
+
+        // Emulate arrival of 5 vulnerability scan results, one for each component in the project.
+        final var componentUuids = new ArrayList<UUID>();
+        for (int i = 0; i < 5; i++) {
+            componentUuids.add(UUID.randomUUID());
+        }
+        for (final UUID uuid : componentUuids) {
+            final ScanKey scanKey = ScanKey.newBuilder()
+                    .setScanToken(scanToken)
+                    .setComponentUuid(uuid.toString())
+                    .build();
+
+            kafka.send(SendKeyValues.to(KafkaTopics.VULN_ANALYSIS_RESULT.name(), List.of(
+                            new KeyValue<>(
+                                    scanKey,
+                                    ScanResult.newBuilder()
+                                            .setKey(scanKey)
+                                            .addScannerResults(ScannerResult.newBuilder()
+                                                    .setScanner(SCANNER_INTERNAL)
+                                                    .setStatus(SCAN_STATUS_SUCCESSFUL))
+                                            .build()))
+                    )
+                    .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class)
+                    .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
+        }
+
+        // Wait for vulnerability scan to transition to COMPLETED status.
+        await("Result processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    qm.getPersistenceManager().refresh(scan);
+                    assertThat(scan).isNotNull();
+                    assertThat(scan.getStatus()).isEqualTo(VulnerabilityScan.Status.COMPLETED);
+                });
+
+        // We still want to get a PROJECT_VULN_ANALYSIS_COMPLETE notification though.
+        // In this case, no vulnerabilities were found, so no findings are expected.
+        await("Analysis complete notification")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    assertThat(kafka.readValues(ReadKeyValues
+                            .from(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name(), String.class, Notification.class)
+                            .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                            .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+                    ).satisfiesExactly(
+                            notification -> {
+                                final ProjectVulnAnalysisCompleteSubject subject =
+                                        notification.getSubject().unpack(ProjectVulnAnalysisCompleteSubject.class);
+                                assertThat(subject.getStatus()).isEqualTo(PROJECT_VULN_ANALYSIS_STATUS_COMPLETED);
+                                assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                                assertThat(subject.getFindingsList()).isEmpty();
+                            }
+                    );
+                });
+
+        // No BOM_PROCESSED notification should've been sent.
+        assertThat(kafka.readValues(ReadKeyValues
+                .from(KafkaTopics.NOTIFICATION_BOM.name(), String.class, Notification.class)
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+        ).isEmpty();
+    }
+
+    @Test
+    public void shouldNotSendBomProcessedNotificationWhenProjectDoesNotExistAnymore() throws Exception {
+        // Instead of creating a project, just generate a random project UUID.
+        // Internally, vulnerability analysis should still complete, but no notification should be sent.
+        final var projectUuid = UUID.randomUUID();
+
+        final var scanToken = UUID.randomUUID().toString();
+
+        // Initialize a vulnerability scan for 5 components, and create a workflow for it accordingly.
+        final VulnerabilityScan scan = qm.createVulnerabilityScan(VulnerabilityScan.TargetType.PROJECT, projectUuid, scanToken, 5);
+        qm.createWorkflowSteps(UUID.fromString(scanToken));
+
+        // Transition the BOM_PROCESSING step of the workflow to COMPLETED. A delayed BOM_PROCESSED notification
+        // will only be sent, when there's a successful BOM_PROCESSING step in the workflow.
+        final WorkflowState state = qm.getWorkflowStateByTokenAndStep(UUID.fromString(scanToken), WorkflowStep.BOM_PROCESSING);
+        state.setStatus(WorkflowStatus.COMPLETED);
+        qm.updateWorkflowState(state);
+
+        // Emulate arrival of 5 vulnerability scan results, one for each component in the project.
+        final var componentUuids = new ArrayList<UUID>();
+        for (int i = 0; i < 5; i++) {
+            componentUuids.add(UUID.randomUUID());
+        }
+        for (final UUID uuid : componentUuids) {
+            final ScanKey scanKey = ScanKey.newBuilder()
+                    .setScanToken(scanToken)
+                    .setComponentUuid(uuid.toString())
+                    .build();
+
+            kafka.send(SendKeyValues.to(KafkaTopics.VULN_ANALYSIS_RESULT.name(), List.of(
+                            new KeyValue<>(
+                                    scanKey,
+                                    ScanResult.newBuilder()
+                                            .setKey(scanKey)
+                                            .addScannerResults(ScannerResult.newBuilder()
+                                                    .setScanner(SCANNER_INTERNAL)
+                                                    .setStatus(SCAN_STATUS_SUCCESSFUL))
+                                            .build()))
+                    )
+                    .with(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class)
+                    .with(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, KafkaProtobufSerializer.class));
+        }
+
+        // Wait for vulnerability scan to transition to COMPLETED status.
+        await("Result processing")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(250))
+                .untilAsserted(() -> {
+                    qm.getPersistenceManager().refresh(scan);
+                    assertThat(scan).isNotNull();
+                    assertThat(scan.getStatus()).isEqualTo(VulnerabilityScan.Status.COMPLETED);
+                });
+
+        // No PROJECT_VULN_ANALYSIS_COMPLETE notification should've been sent.
+        assertThat(kafka.readValues(ReadKeyValues
+                .from(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name(), String.class, Notification.class)
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+        ).isEmpty();
+
+        // No BOM_PROCESSED notification should've been sent.
+        assertThat(kafka.readValues(ReadKeyValues
+                .from(KafkaTopics.NOTIFICATION_BOM.name(), String.class, Notification.class)
+                .with(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class)
+                .with(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, NotificationDeserializer.class))
+        ).isEmpty();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsPostgresTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsPostgresTest.java
@@ -4,7 +4,10 @@ import net.mguenther.kafka.junit.ExternalKafkaCluster;
 import net.mguenther.kafka.junit.TopicConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
 import org.dependencytrack.AbstractPostgresEnabledTest;
+import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
+import org.hyades.proto.notification.v1.Notification;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,6 +17,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.function.Supplier;
 
 import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeout;
 
@@ -25,7 +29,16 @@ abstract class KafkaStreamsPostgresTest extends AbstractPostgresEnabledTest {
 
     KafkaStreams kafkaStreams;
     ExternalKafkaCluster kafka;
+    private final Supplier<Topology> topologySupplier;
     private Path kafkaStreamsStateDirectory;
+
+    protected KafkaStreamsPostgresTest() {
+        this(new KafkaStreamsTopologyFactory()::createTopology);
+    }
+
+    protected KafkaStreamsPostgresTest(final Supplier<Topology> topologySupplier) {
+        this.topologySupplier = topologySupplier;
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -57,7 +70,7 @@ abstract class KafkaStreamsPostgresTest extends AbstractPostgresEnabledTest {
         streamsConfig.put(StreamsConfig.STATE_DIR_CONFIG, kafkaStreamsStateDirectory.toString());
         streamsConfig.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "3");
 
-        kafkaStreams = new KafkaStreams(new KafkaStreamsTopologyFactory().createTopology(), streamsConfig);
+        kafkaStreams = new KafkaStreams(topologySupplier.get(), streamsConfig);
         kafkaStreams.start();
 
         assertConditionWithTimeout(() -> KafkaStreams.State.RUNNING == kafkaStreams.state(), Duration.ofSeconds(5));
@@ -72,6 +85,14 @@ abstract class KafkaStreamsPostgresTest extends AbstractPostgresEnabledTest {
             kafkaStreamsStateDirectory.toFile().delete();
         }
         super.tearDown();
+    }
+
+    public static class NotificationDeserializer extends KafkaProtobufDeserializer<Notification> {
+
+        public NotificationDeserializer() {
+            super(Notification.parser());
+        }
+
     }
 
 }

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaStreamsTopologyTest.java
@@ -19,7 +19,6 @@ import org.cyclonedx.proto.v1_4.VulnerabilityRating;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
-import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
@@ -620,13 +619,6 @@ public class KafkaStreamsTopologyTest extends KafkaStreamsPostgresTest {
         qm.getPersistenceManager().refresh(scan);
         assertThat(scan.getReceivedResults()).isZero();
         assertThat(scan.getStatus()).isEqualTo(VulnerabilityScan.Status.IN_PROGRESS);
-    }
-
-    public static class NotificationDeserializer extends KafkaProtobufDeserializer<Notification> {
-
-        public NotificationDeserializer() {
-            super(Notification.parser());
-        }
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Delays the `BOM_PROCESSED` notification until the vulnerability analysis associated with a given BOM upload
is completed. The intention being that it is then "safe" to query the API for any identified vulnerabilities.

This is specifically for cases where polling the `/api/v1/bom/token/<TOKEN>` endpoint is not feasible.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

This is a temporary feature and may be removed in future releases without further notice.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
