### PR TITLE
Add initialiser for integrity meta component sync

### DIFF
--- a/src/main/java/org/dependencytrack/event/IntegrityMetaInitializer.java
+++ b/src/main/java/org/dependencytrack/event/IntegrityMetaInitializer.java
@@ -1,0 +1,25 @@
+package org.dependencytrack.event;
+
+import alpine.common.logging.Logger;
+import org.dependencytrack.persistence.QueryManager;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class IntegrityMetaInitializer implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(IntegrityMetaInitializer.class);
+
+    @Override
+    public void contextInitialized(final ServletContextEvent event) {
+        LOGGER.info("Initializing integrity meta component sync");
+        try (final var qm = new QueryManager()) {
+            // Sync purls from Component only if IntegrityMetaComponent is empty
+            if (qm.getIntegrityMetaComponentCount() == 0) {
+                qm.synchronizeIntegrityMetaComponent();
+            } else {
+                LOGGER.info("Skipping initial integrity meta component synchronizing as data already exists.");
+            }
+        }
+    }
+}

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -785,4 +785,14 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             DbUtil.close(connection);
         }
     }
+
+    /**
+     * Returns the count of records in IntegrityMetaComponent.
+     *
+     * @return the count of records
+     */
+    public int getIntegrityMetaComponentCount() {
+        final Query<IntegrityMetaComponent> query = pm.newQuery(IntegrityMetaComponent.class);
+        return query.executeList().size();
+    }
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1691,4 +1691,8 @@ public class QueryManager extends AlpineQueryManager {
     public void synchronizeIntegrityMetaComponent() {
         getComponentQueryManager().synchronizeIntegrityMetaComponent();
     }
+
+    public int getIntegrityMetaComponentCount() {
+        return getComponentQueryManager().getIntegrityMetaComponentCount();
+    }
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -59,6 +59,9 @@
     <listener>
         <listener-class>org.dependencytrack.persistence.H2WebConsoleInitializer</listener-class>
     </listener>
+    <listener>
+        <listener-class>org.dependencytrack.event.IntegrityMetaInitializer</listener-class>
+    </listener>
 
     <filter>
         <filter-name>WhitelistUrlFilter</filter-name>

--- a/src/test/java/org/dependencytrack/persistence/ComponentQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ComponentQueryManagerTest.java
@@ -118,6 +118,7 @@ public class ComponentQueryManagerTest extends PersistenceCapableTest {
         assertThat(result).isNull();
 
         result = qm.persist(integrityMeta);
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(1);
         assertThat(qm.getIntegrityMetaComponent(result.getPurl())).satisfies(
                 meta -> {
                     assertThat(meta.getStatus()).isEqualTo(FetchStatus.TIMED_OUT);
@@ -160,12 +161,13 @@ public class ComponentQueryManagerTest extends PersistenceCapableTest {
 
         // without any component in database
         qm.synchronizeIntegrityMetaComponent();
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(0);
         assertThat(qm.getIntegrityMetaComponent(component.getPurl().toString())).isNull();
 
         // with existing component in database
         qm.persist(component);
         qm.synchronizeIntegrityMetaComponent();
-
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(1);
         assertThat(qm.getIntegrityMetaComponent(component.getPurl().toString())).satisfies(
                 meta -> {
                     assertThat(meta.getStatus()).isNull();

--- a/src/test/java/org/dependencytrack/tasks/IntegrityMetaInitializerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/IntegrityMetaInitializerTest.java
@@ -1,0 +1,53 @@
+package org.dependencytrack.tasks;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.IntegrityMetaInitializer;
+import org.dependencytrack.model.Component;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntegrityMetaInitializerTest extends PersistenceCapableTest {
+
+    @Test
+    public void testIntegrityMetaInitializer() {
+
+        IntegrityMetaInitializer initializer = new IntegrityMetaInitializer();
+
+        // no existing data in IntegrityMetaComponent
+        initializer.contextInitialized(null);
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(0);
+
+        final var projectA = qm.createProject("acme-app-a", null, "1.0.0", null, null, null, true, false);
+        final var componentProjectA = new Component();
+        componentProjectA.setProject(projectA);
+        componentProjectA.setName("acme-lib-a");
+        componentProjectA.setPurl("pkg:maven/acme/acme-lib-a@1.0.1?foo=bar");
+
+        qm.persist(componentProjectA);
+
+        initializer.contextInitialized(null);
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(1);
+        assertThat(qm.getIntegrityMetaComponent(componentProjectA.getPurl().toString())).satisfies(
+                meta -> {
+                    assertThat(meta.getStatus()).isNull();
+                    assertThat(meta.getPurl()).isEqualTo("pkg:maven/acme/acme-lib-a@1.0.1?foo=bar");
+                    assertThat(meta.getId()).isEqualTo(1L);
+                    assertThat(meta.getMd5()).isNull();
+                    assertThat(meta.getSha1()).isNull();
+                    assertThat(meta.getSha256()).isNull();
+                    assertThat(meta.getLastFetch()).isNull();
+                    assertThat(meta.getPublishedAt()).isNull();
+                }
+        );
+
+        // data now exists in IntegrityMetaComponent so sync will be skipped
+        final var componentProjectB = new Component();
+        componentProjectB.setProject(projectA);
+        componentProjectB.setName("acme-lib-b");
+        componentProjectA.setPurl("pkg:maven/acme/acme-lib-c@3.0.1?foo=bar");
+        qm.persist(componentProjectB);
+        initializer.contextInitialized(null);
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
### Description

Create Initialiser which will kick off update of new table with hash information and publishedAt date on application startup.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/699

### Checklist

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
