### PR TITLE
Allow operator and violation when creating policy

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -124,9 +124,17 @@ public class PolicyResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             Policy policy = qm.getPolicy(StringUtils.trimToNull(jsonPolicy.getName()));
             if (policy == null) {
+                Policy.Operator operator = jsonPolicy.getOperator();
+                if (operator == null) {
+                    operator = Policy.Operator.ANY;
+                }
+                Policy.ViolationState violationState = jsonPolicy.getViolationState();
+                if (violationState == null) {
+                    violationState = Policy.ViolationState.INFO;
+                }
                 policy = qm.createPolicy(
                         StringUtils.trimToNull(jsonPolicy.getName()),
-                        Policy.Operator.ANY, Policy.ViolationState.INFO);
+                        operator, violationState);
                 return Response.status(Response.Status.CREATED).entity(policy).build();
             } else {
                 return Response.status(Response.Status.CONFLICT).entity("A policy with the specified name already exists.").build();

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -117,6 +117,50 @@ public class PolicyResourceTest extends ResourceTest {
     }
 
     @Test
+    public void createPolicySpecifyOperatorAndViolationStateTest() {
+        final Policy policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.FAIL);
+
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(201);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+        assertThat(json.getString("operator")).isEqualTo("ALL");
+        assertThat(json.getString("violationState")).isEqualTo("FAIL");
+        assertThat(UuidUtil.isValidUUID(json.getString("uuid")));
+        assertThat(json.getBoolean("includeChildren")).isEqualTo(false);
+    }
+
+    @Test
+    public void createPolicyUseDefaultValueTest() {
+        final Policy policy = new Policy();
+        policy.setName("policy");
+
+        final Response response = target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
+
+        assertThat(response.getStatus()).isEqualTo(201);
+
+        final JsonObject json = parseJsonObject(response);
+        assertThat(json).isNotNull();
+        assertThat(json.getString("name")).isEqualTo("policy");
+        assertThat(json.getString("operator")).isEqualTo("ANY");
+        assertThat(json.getString("violationState")).isEqualTo("INFO");
+        assertThat(UuidUtil.isValidUUID(json.getString("uuid")));
+        assertThat(json.getBoolean("includeChildren")).isEqualTo(false);
+    }
+
+    @Test
     public void updatePolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 


### PR DESCRIPTION
### Description

Allow operator and violation when creating a policy instead of hardcoding
PR ports the change from https://github.com/DependencyTrack/dependency-track/pull/2997

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
