### PR TITLE
send integrity meta events outside of transaction and handle integrity violation

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -29,7 +29,6 @@ import org.dependencytrack.event.IntegrityMetaInitializer;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.ConfigPropertyConstants;
-import org.dependencytrack.model.IntegrityMetaComponent;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
@@ -759,9 +758,5 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             }
         }
         dependencyGraph.putAll(addToDependencyGraph);
-    }
-
-    public IntegrityMetaComponent createIntegrityMetaComponent(IntegrityMetaComponent integrityMetaComponent) {
-        return persist(integrityMetaComponent);
     }
 }

--- a/src/main/java/org/dependencytrack/persistence/IntegrityMetaQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/IntegrityMetaQueryManager.java
@@ -73,6 +73,34 @@ public class IntegrityMetaQueryManager extends QueryManager implements IQueryMan
         }
     }
 
+    public IntegrityMetaComponent createIntegrityMetaComponent(IntegrityMetaComponent integrityMetaComponent) {
+        return persist(integrityMetaComponent);
+    }
+
+    public void createIntegrityMetaHandlingConflict(IntegrityMetaComponent integrityMetaComponent) {
+        final String createQuery = """
+                    INSERT INTO "INTEGRITY_META_COMPONENT" ("PURL", "STATUS", "LAST_FETCH")
+                    VALUES (?, ?, ?) 
+                    ON CONFLICT DO NOTHING
+                """;
+        Connection connection = null;
+        PreparedStatement preparedStatement = null;
+        try {
+            connection = (Connection) pm.getDataStoreConnection();
+            preparedStatement = connection.prepareStatement(createQuery);
+            preparedStatement.setString(1, integrityMetaComponent.getPurl().toString());
+            preparedStatement.setString(2, integrityMetaComponent.getStatus().toString());
+            preparedStatement.setTimestamp(3, new java.sql.Timestamp(integrityMetaComponent.getLastFetch().getTime()));
+            preparedStatement.execute();
+        } catch (Exception ex) {
+            LOGGER.error("Error in creating integrity meta component", ex);
+            throw new RuntimeException(ex);
+        } finally {
+            DbUtil.close(preparedStatement);
+            DbUtil.close(connection);
+        }
+    }
+
     /**
      * Synchronizes IntegrityMetaComponent with purls from COMPONENT. This is part of initializer.
      */

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1742,7 +1742,11 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     public IntegrityMetaComponent createIntegrityMetaComponent(IntegrityMetaComponent integrityMetaComponent) {
-        return getComponentQueryManager().createIntegrityMetaComponent(integrityMetaComponent);
+        return getIntegrityMetaQueryManager().createIntegrityMetaComponent(integrityMetaComponent);
+    }
+
+    public void createIntegrityMetaHandlingConflict(IntegrityMetaComponent integrityMetaComponent) {
+        getIntegrityMetaQueryManager().createIntegrityMetaHandlingConflict(integrityMetaComponent);
     }
 
     public IntegrityAnalysis getIntegrityAnalysisByComponentUuid(UUID uuid) {

--- a/src/test/java/org/dependencytrack/persistence/IntegrityMetaQueryManagerPostgresTest.java
+++ b/src/test/java/org/dependencytrack/persistence/IntegrityMetaQueryManagerPostgresTest.java
@@ -1,0 +1,29 @@
+package org.dependencytrack.persistence;
+
+import org.dependencytrack.AbstractPostgresEnabledTest;
+import org.dependencytrack.model.FetchStatus;
+import org.dependencytrack.model.IntegrityMetaComponent;
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IntegrityMetaQueryManagerPostgresTest extends AbstractPostgresEnabledTest {
+
+    @Test
+    public void testCreateIntegrityMetadataHandlingConflict() {
+        var integrityMeta = new IntegrityMetaComponent();
+        integrityMeta.setPurl("pkg:maven/acme/example@1.0.0?type=jar");
+        integrityMeta.setStatus(FetchStatus.IN_PROGRESS);
+        integrityMeta.setLastFetch(new Date());
+        qm.createIntegrityMetaHandlingConflict(integrityMeta);
+
+        var integrityMeta2 = new IntegrityMetaComponent();
+        //inserting same purl twice should not cause exception
+        integrityMeta2.setPurl("pkg:maven/acme/example@1.0.0?type=jar");
+        integrityMeta2.setStatus(FetchStatus.IN_PROGRESS);
+        integrityMeta2.setLastFetch(new Date());
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(1);
+    }
+}

--- a/src/test/java/org/dependencytrack/persistence/IntegrityMetaQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/IntegrityMetaQueryManagerTest.java
@@ -12,7 +12,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class IntegrityMetaQueryManagerTest extends PersistenceCapableTest {
 

--- a/src/test/java/org/dependencytrack/persistence/IntegrityMetaQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/IntegrityMetaQueryManagerTest.java
@@ -12,6 +12,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class IntegrityMetaQueryManagerTest extends PersistenceCapableTest {
 

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -20,7 +20,6 @@ package org.dependencytrack.tasks;
 
 import com.github.packageurl.PackageURL;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.awaitility.Awaitility;
 import org.dependencytrack.AbstractPostgresEnabledTest;
 import org.dependencytrack.event.BomUploadEvent;
 import org.dependencytrack.event.kafka.KafkaEventDispatcher;
@@ -99,6 +98,7 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
+                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name())
         );
@@ -184,6 +184,7 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
+                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name())
         );
@@ -519,7 +520,7 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                 .map(ProducerRecord::topic)
                 .filter(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()::equals)
                 .count();
-        assertThat(repoMetaAnalysisCommandsSent).isEqualTo(9056);
+        assertThat(repoMetaAnalysisCommandsSent).isEqualTo(18112);
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/2519
@@ -647,6 +648,7 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                     assertThat(notification.getGroup()).isEqualTo(Group.GROUP_BOM_CONSUMED);
                 },
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
+                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name())
                 // BOM_PROCESSED notification should not have been sent.
         );


### PR DESCRIPTION
### Description

This PR fixes unqiue constraint violation on integrity meta component when 2 components having same purl arrive at the same time. 
Integrity meta component events are sent outside of transaction

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
