### PR TITLE
Let GitHub generate release notes

### DIFF
--- a/.github/default-release-notes.md
+++ b/.github/default-release-notes.md
@@ -1,2 +1,0 @@
-For official releases, refer to [Dependency Track Docs >> Changelogs](https://docs.dependencytrack.org/changelog/) for information about improvements and upgrade notes.
-If additional details are required, consult the closed issues for this release milestone.

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+  - title: Enhancements 🚀
+    labels:
+    - enhancement
+  - title: Bug Fixes 🐛
+    labels:
+    - bug
+  - title: Dependency Updates 🤖
+    labels:
+    - dependencies
+  - title: Other Changes
+    labels:
+    - "*"

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -70,15 +70,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.BOT_RELEASE_TOKEN }}
         run: |-
-          cat << EOF >> .github/default-release-notes.md
-          \`\`\`text
-          $(cat target/checksums.txt)
-          \`\`\`
-          EOF
-
-          gh release edit ${{ needs.read-version.outputs.version }} \
-            --notes-file ".github/default-release-notes.md"
-
           gh release upload ${{ needs.read-version.outputs.version }} \
             --clobber \
             target/dependency-track-apiserver.jar \

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -97,8 +97,7 @@ jobs:
         run: |-
           gh release create "${{ needs.prepare-release.outputs.version }}" \
             --target "${{ needs.prepare-release.outputs.release-branch }}" \
-            --title "${{ needs.prepare-release.outputs.version }}" \
-            --notes-file ".github/default-release-notes.md"
+            --generate-notes
 
   post-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Switches release notes to being automatically generated by GitHub.

This is analogue to how we're doing it for the hyades repository already.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
