### PR TITLE
Schema upgrade v5.2.0

### DIFF
--- a/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
+++ b/src/main/java/org/dependencytrack/upgrade/UpgradeItems.java
@@ -20,6 +20,7 @@ package org.dependencytrack.upgrade;
 
 import alpine.server.upgrade.UpgradeItem;
 import org.dependencytrack.upgrade.v510.v510Updater;
+import org.dependencytrack.upgrade.v520.v520Updater;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,7 @@ class UpgradeItems {
 
     static {
         UPGRADE_ITEMS.add(v510Updater.class);
+        UPGRADE_ITEMS.add(v520Updater.class);
     }
 
     static List<Class<? extends UpgradeItem>> getUpgradeItems() {

--- a/src/main/java/org/dependencytrack/upgrade/v520/v520Updater.java
+++ b/src/main/java/org/dependencytrack/upgrade/v520/v520Updater.java
@@ -1,0 +1,42 @@
+package org.dependencytrack.upgrade.v520;
+
+import alpine.common.logging.Logger;
+import alpine.persistence.AlpineQueryManager;
+import alpine.server.upgrade.AbstractUpgradeItem;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+public class v520Updater extends AbstractUpgradeItem {
+
+    private static final Logger LOGGER = Logger.getLogger(v520Updater.class);
+
+    @Override
+    public String getSchemaVersion() {
+        return "5.2.0";
+    }
+
+    @Override
+    public void executeUpgrade(final AlpineQueryManager qm, final Connection connection) throws Exception {
+        changePurlColumnLengthInIntegrityMetaComponentTable(connection);
+        dropStatusCheckConstraintOnIntegrityMetaComponentTable(connection);
+    }
+
+    private static void changePurlColumnLengthInIntegrityMetaComponentTable(final Connection connection) throws Exception {
+        LOGGER.info("Changing length of \"PURL\" from VARCHAR(255) to VARCHAR(1024)");
+        try (final PreparedStatement ps = connection.prepareStatement("""
+                	ALTER TABLE "INTEGRITY_META_COMPONENT" ALTER "PURL" TYPE VARCHAR(1024);
+                """)) {
+            ps.execute();
+        }
+    }
+
+    private static void dropStatusCheckConstraintOnIntegrityMetaComponentTable(final Connection connection) throws Exception {
+        LOGGER.info("Dropping constraint \"INTEGRITY_META_COMPONENT_STATUS_check\" if it exists on \"INTEGRITY_META_COMPONENT\" table");
+        try (final PreparedStatement ps = connection.prepareStatement("""
+                	ALTER TABLE "INTEGRITY_META_COMPONENT" DROP CONSTRAINT IF EXISTS "INTEGRITY_META_COMPONENT_STATUS_check" RESTRICT;
+                """)) {
+            ps.execute();
+        }
+    }
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
