### PR TITLE
Integrity analysis if integrity metadata is present

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/componentmeta/IntegrityCheck.java
+++ b/src/main/java/org/dependencytrack/event/kafka/componentmeta/IntegrityCheck.java
@@ -29,7 +29,6 @@ public class IntegrityCheck {
             LOGGER.debug("Integrity check is disabled");
             return;
         }
-
         //if integritymeta is in result with hashses but component uuid is not present, result has integrity data for existing
         // components. Get components from database and perform integrity check
         if (StringUtils.isBlank(result.getComponent().getUuid())) {
@@ -39,16 +38,13 @@ public class IntegrityCheck {
         //check if the object is not null
         final Component component = qm.getObjectByUuid(Component.class, result.getComponent().getUuid());
         if (component == null) {
-            LOGGER.info("Component is not present in database for which Integrity Check is performed");
+            LOGGER.debug("Component is not present in database for which Integrity metadata is received so skipping analysis");
             return;
         }
         calculateIntegrityResult(integrityMetaComponent, component, qm);
     }
 
     private static void integrityAnalysisOfExistingComponents(final IntegrityMetaComponent integrityMetaComponent, final AnalysisResult result, final QueryManager qm) {
-        //if integritymeta is in result with hashses but component uuid is not present, result has integrity data for existing
-        // components. Get components from database and perform integrity check
-
         if (integrityMetaComponent != null) {
             List<Component> componentList = qm.getComponentsByPurl(result.getComponent().getPurl());
             for (Component component : componentList) {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessor.java
@@ -45,7 +45,9 @@ public class RepositoryMetaResultProcessor implements Processor<String, Analysis
         try (final var qm = new QueryManager()) {
             synchronizeRepositoryMetadata(qm, record);
             IntegrityMetaComponent integrityMetaComponent = synchronizeIntegrityMetadata(qm, record);
-            performIntegrityCheck(integrityMetaComponent, record.value(), qm);
+            if(integrityMetaComponent != null) {
+                performIntegrityCheck(integrityMetaComponent, record.value(), qm);
+            }
         } catch (Exception e) {
             LOGGER.error("An unexpected error occurred while processing record %s".formatted(record), e);
         } finally {

--- a/src/test/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessorTest.java
@@ -275,7 +275,7 @@ public class RepositoryMetaResultProcessorTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testIntegrityCheckWithDataInDb() {
+    public void testIntegrityAnalysisWillNotBePerformedIfNoIntegrityDataInResult() {
         // Create an active project with one component.
         final var projectA = qm.createProject("acme-app-a", null, "1.0.0", null, null, null, true, false);
         final var componentProjectA = new Component();
@@ -309,13 +309,7 @@ public class RepositoryMetaResultProcessorTest extends PersistenceCapableTest {
         inputTopic.pipeInput(new TestRecord<>("pkg:maven/foo/bar@1.2.3", result, Instant.now()));
 
         IntegrityAnalysis analysis = qm.getIntegrityAnalysisByComponentUuid(c.getUuid());
-        assertThat(analysis.getIntegrityCheckStatus()).isEqualTo(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        assertThat(analysis.getMd5HashMatchStatus()).isEqualTo(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        assertThat(analysis.getSha1HashMatchStatus()).isEqualTo(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        assertThat(analysis.getSha256HashMatchStatus()).isEqualTo(IntegrityMatchStatus.COMPONENT_MISSING_HASH_AND_MATCH_UNKNOWN);
-        assertThat(analysis.getSha512HashMatchStatus()).isEqualTo(IntegrityMatchStatus.COMPONENT_MISSING_HASH_AND_MATCH_UNKNOWN);
-        assertThat(analysis.getUpdatedAt()).isNotNull();
-        assertThat(analysis.getComponent().getPurl().toString()).isEqualTo("pkg:maven/foo/bar@1.2.3");
+        assertThat(analysis).isNull();
     }
 
     @Test


### PR DESCRIPTION
### Description

Integrity Check should only be performed if result has integrity meta component data.
A bug was injected in https://github.com/DependencyTrack/hyades-apiserver/pull/399 which allowed integrity analysis even when no integrity meta component was present in result. 

### Addressed Issue


### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
