### PR TITLE
Add null check on publishedAt

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1862,8 +1862,14 @@ public class QueryManager extends AlpineQueryManager {
             preparedStatement.setString(1, uuid.toString());
             ResultSet resultSet = preparedStatement.executeQuery();
             if (resultSet.next()) {
-                var publishedDate = Date.from(resultSet.getTimestamp("PUBLISHED_AT").toInstant());
-                Date lastFetch = Date.from(resultSet.getTimestamp("LAST_FETCH").toInstant());
+                Date publishedDate = null;
+                Date lastFetch = null;
+                if(resultSet.getTimestamp("PUBLISHED_AT") != null) {
+                    publishedDate = Date.from(resultSet.getTimestamp("PUBLISHED_AT").toInstant());
+                }
+                if(resultSet.getTimestamp("LAST_FETCH") != null) {
+                    lastFetch = Date.from(resultSet.getTimestamp("LAST_FETCH").toInstant());
+                }
                 return new ComponentMetaInformation(publishedDate,
                         IntegrityMatchStatus.valueOf(resultSet.getString("INTEGRITY_CHECK_STATUS")),
                         lastFetch);

--- a/src/test/java/org/dependencytrack/persistence/QueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/QueryManagerTest.java
@@ -8,13 +8,14 @@ import org.dependencytrack.model.IntegrityAnalysis;
 import org.dependencytrack.model.IntegrityMatchStatus;
 import org.dependencytrack.model.IntegrityMetaComponent;
 import org.dependencytrack.model.Project;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Date;
 
 import static org.dependencytrack.model.IntegrityMatchStatus.HASH_MATCH_PASSED;
 import static org.dependencytrack.model.IntegrityMatchStatus.HASH_MATCH_UNKNOWN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class QueryManagerTest extends PersistenceCapableTest {
     @Test
@@ -43,8 +44,36 @@ public class QueryManagerTest extends PersistenceCapableTest {
         qm.createIntegrityMetaComponent(integrityMetaComponent);
         component = qm.createComponent(component, false);
         ComponentMetaInformation componentMetaInformation = qm.getMetaInformation(component.getUuid());
-        Assert.assertEquals(HASH_MATCH_PASSED, componentMetaInformation.integrityMatchStatus());
-        Assert.assertEquals(integrityMetaComponent.getPublishedAt(), componentMetaInformation.publishedDate());
-        Assert.assertEquals(integrityMetaComponent.getLastFetch(), componentMetaInformation.lastFetched());
+        assertEquals(HASH_MATCH_PASSED, componentMetaInformation.integrityMatchStatus());
+        assertEquals(integrityMetaComponent.getPublishedAt(), componentMetaInformation.publishedDate());
+        assertEquals(integrityMetaComponent.getLastFetch(), componentMetaInformation.lastFetched());
+    }
+
+    @Test
+    public void testGetMetaInformationWhenPublishedAtIsMissing() {
+        Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("ABC");
+        component.setPurl("pkg:maven/org.acme/abc");
+        IntegrityAnalysis integrityAnalysis = new IntegrityAnalysis();
+        integrityAnalysis.setComponent(component);
+        integrityAnalysis.setIntegrityCheckStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setUpdatedAt(new Date());
+        integrityAnalysis.setId(component.getId());
+        integrityAnalysis.setMd5HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setSha1HashMatchStatus(HASH_MATCH_UNKNOWN);
+        integrityAnalysis.setSha256HashMatchStatus(HASH_MATCH_UNKNOWN);
+        integrityAnalysis.setSha512HashMatchStatus(HASH_MATCH_PASSED);
+        qm.persist(integrityAnalysis);
+        IntegrityMetaComponent integrityMetaComponent = new IntegrityMetaComponent();
+        integrityMetaComponent.setPurl(component.getPurl().toString());
+        integrityMetaComponent.setStatus(FetchStatus.PROCESSED);
+        qm.createIntegrityMetaComponent(integrityMetaComponent);
+        component = qm.createComponent(component, false);
+        ComponentMetaInformation componentMetaInformation = qm.getMetaInformation(component.getUuid());
+        assertEquals(HASH_MATCH_PASSED, componentMetaInformation.integrityMatchStatus());
+        assertNull(componentMetaInformation.publishedDate());
+        assertNull(componentMetaInformation.lastFetched());
     }
 }


### PR DESCRIPTION
### Description

This PR is to fix NPE when published at is converted from sql timestamp to date because publishedAt could be missing in database

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
