### PR TITLE
Send integrity meta events only for supported types

### DIFF
--- a/src/test/java/org/dependencytrack/tasks/IntegrityMetaInitializerTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/IntegrityMetaInitializerTaskTest.java
@@ -50,6 +50,16 @@ public class IntegrityMetaInitializerTaskTest extends AbstractPostgresEnabledTes
     }
 
     @Test
+    public void shouldNotDispatchEventIfPackageTypeIsNotSupported() {
+        final var IntegrityMetaComponent = new IntegrityMetaComponent();
+        IntegrityMetaComponent.setPurl("pkg:golang/github.com/prometheus/client_model@0.2.0?type=module");
+        qm.persist(IntegrityMetaComponent);
+        new IntegrityMetaInitializerTask().inform(new IntegrityMetaInitializerEvent());
+        assertThat(qm.getIntegrityMetaComponentCount()).isEqualTo(1);
+        assertThat(kafkaMockProducer.history()).isEmpty();
+    }
+
+    @Test
     public void testIntegrityMetaInitializerWithExistingDataFetchedNotRecently() {
         // data exists in IntegrityMetaComponent but last fetched 3 hours ago > 1 hour wait time
         var integrityMetaExisting = new IntegrityMetaComponent();


### PR DESCRIPTION
### Description

This PR fixes a bug of sending integrity meta events only when package types are supported

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
