### PR TITLE
Address performance regression during BOM processing

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -26,11 +26,9 @@ import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
-import com.google.common.collect.ImmutableMap;
 import io.micrometer.core.instrument.Timer;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.BomParserFactory;
 import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.model.Dependency;
@@ -266,8 +264,6 @@ public class BomUploadProcessingTask implements Subscriber {
 
         final var vulnAnalysisEvents = new ArrayList<ComponentVulnerabilityAnalysisEvent>();
         final var repoMetaAnalysisEvents = new ArrayList<ComponentRepositoryMetaAnalysisEvent>();
-        final var integrityMetaAnalysisEvents = new ArrayList<ComponentRepositoryMetaAnalysisEvent>();
-        Map<ComponentIdentity, Component> copyOfPersistentComponents;
 
         try (final var qm = new QueryManager()) {
             final PersistenceManager pm = qm.getPersistenceManager();
@@ -316,7 +312,6 @@ public class BomUploadProcessingTask implements Subscriber {
                         processServices(qm, project, services, identitiesByBomRef, bomRefsByIdentity);
                 processDependencyGraph(ctx, pm, cdxBom, project, persistentComponents, persistentServices, identitiesByBomRef);
                 recordBomImport(ctx, pm, project);
-                copyOfPersistentComponents = ImmutableMap.copyOf(persistentComponents);
 
                 // BOM ref <-> ComponentIdentity indexes are no longer needed.
                 // Let go of their contents to make it eligible for GC sooner.
@@ -328,8 +323,14 @@ public class BomUploadProcessingTask implements Subscriber {
                     // The constructors of ComponentRepositoryMetaAnalysisEvent and ComponentVulnerabilityAnalysisEvent
                     // merely call a few getters on it, but the component object itself is not passed around.
                     // Detaching would imply additional database interactions that we'd rather not do.
-                    if(component.getPurl() != null) {
-                        repoMetaAnalysisEvents.add(new ComponentRepositoryMetaAnalysisEvent(component.getUuid(), component.getPurlCoordinates().toString(), component.isInternal(), FetchMeta.FETCH_META_LATEST_VERSION));
+                    if (component.getPurl() != null) {
+                        if (SUPPORTED_PACKAGE_URLS_FOR_INTEGRITY_CHECK.contains(component.getPurl().getType())) {
+                            repoMetaAnalysisEvents.add(new ComponentRepositoryMetaAnalysisEvent(component.getUuid(),
+                                    component.getPurl().canonicalize(), component.isInternal(), FetchMeta.FETCH_META_INTEGRITY_DATA_AND_LATEST_VERSION));
+                        } else {
+                            repoMetaAnalysisEvents.add(new ComponentRepositoryMetaAnalysisEvent(component.getUuid(),
+                                    component.getPurlCoordinates().toString(), component.isInternal(), FetchMeta.FETCH_META_LATEST_VERSION));
+                        }
                     }
                     vulnAnalysisEvents.add(new ComponentVulnerabilityAnalysisEvent(
                             ctx.uploadToken, component, VulnerabilityAnalysisLevel.BOM_UPLOAD_ANALYSIS, component.isNew()));
@@ -342,22 +343,10 @@ public class BomUploadProcessingTask implements Subscriber {
                 }
             }
 
-            //only integrity metadata events have to be sent because latest version events
-            //have been sent already
-            for (final Component component : copyOfPersistentComponents.values()) {
-                // Note: component does not need to be detached.
-                // The constructors of ComponentRepositoryMetaAnalysisEvent and ComponentVulnerabilityAnalysisEvent
-                // merely call a few getters on it, but the component object itself is not passed around.
-                // Detaching would imply additional database interactions that we'd rather not do
-                if (component.getPurl() != null) {
-                    if(SUPPORTED_PACKAGE_URLS_FOR_INTEGRITY_CHECK.contains(component.getPurl().getType())) {
-                        ComponentRepositoryMetaAnalysisEvent event = integrityRepoMetaAnalysisEvent(component, qm);
-                        if (event != null) {
-                            integrityMetaAnalysisEvents.add(event);
-                        }
-                    }
-                }
-            }
+            // Clear the PersistenceManager's L1 cache.
+            // Lessens some overhead of DataNucleus-internal housekeeping during
+            // the following persistence operations.
+            pm.evictAll();
 
             var vulnAnalysisState = qm.getWorkflowStateByTokenAndStep(ctx.uploadToken, WorkflowStep.VULN_ANALYSIS);
             if (!vulnAnalysisEvents.isEmpty()) {
@@ -398,19 +387,30 @@ public class BomUploadProcessingTask implements Subscriber {
                 }
             }
 
-            repoMetaAnalysisEvents.forEach(event -> kafkaEventDispatcher.dispatchAsync(event, (metadata, exception) -> {
-                if (exception != null) {
-                    // Include context in the log message to make log correlation easier.
-                    LOGGER.error("Failed to produce %s to Kafka (%s)".formatted(event, ctx), exception);
+            for (final ComponentRepositoryMetaAnalysisEvent event : repoMetaAnalysisEvents) {
+                final ComponentRepositoryMetaAnalysisEvent eventToSend;
+                if (event.fetchMeta() == FetchMeta.FETCH_META_INTEGRITY_DATA_AND_LATEST_VERSION) {
+                    final boolean shouldFetchIntegrityData = qm.runInTransaction(() -> prepareIntegrityMetaComponent(event, qm));
+                    if (shouldFetchIntegrityData) {
+                        eventToSend = event;
+                    } else {
+                        // If integrity metadata was fetched recently, we don't want to fetch it again
+                        // as it's unlikely to change frequently. Fall back to fetching only the latest
+                        // version information.
+                        eventToSend = new ComponentRepositoryMetaAnalysisEvent(null, event.purlCoordinates(),
+                                event.internal(), FetchMeta.FETCH_META_LATEST_VERSION);
+                    }
+                } else {
+                    eventToSend = event;
                 }
-            }));
 
-            integrityMetaAnalysisEvents.forEach(event -> kafkaEventDispatcher.dispatchAsync(event, (metadata, exception) -> {
-                if (exception != null) {
-                    // Include context in the log message to make log correlation easier.
-                    LOGGER.error("Failed to produce %s to Kafka (%s)".formatted(event, ctx), exception);
-                }
-            }));
+                kafkaEventDispatcher.dispatchAsync(eventToSend, (metadata, exception) -> {
+                    if (exception != null) {
+                        // Include context in the log message to make log correlation easier.
+                        LOGGER.error("Failed to produce %s to Kafka (%s)".formatted(eventToSend, ctx), exception);
+                    }
+                });
+            }
 
             // TODO: Trigger index updates
         }
@@ -1063,20 +1063,17 @@ public class BomUploadProcessingTask implements Subscriber {
 
     }
 
-
-    private ComponentRepositoryMetaAnalysisEvent integrityRepoMetaAnalysisEvent(Component component, QueryManager qm) {
-        IntegrityMetaComponent integrityMetaComponent = qm.getIntegrityMetaComponent(component.getPurl().toString());
+    private static boolean prepareIntegrityMetaComponent(ComponentRepositoryMetaAnalysisEvent event, QueryManager qm) {
+        final IntegrityMetaComponent integrityMetaComponent = qm.getIntegrityMetaComponent(event.purlCoordinates());
         if (integrityMetaComponent == null) {
-            qm.createIntegrityMetaHandlingConflict(AbstractMetaHandler.createIntegrityMetaComponent(component.getPurl().toString()));
-            return new ComponentRepositoryMetaAnalysisEvent(component.getUuid(), component.getPurl().canonicalize(), component.isInternal(), FetchMeta.FETCH_META_INTEGRITY_DATA);
-        }
-        else if (integrityMetaComponent.getStatus() == null || (integrityMetaComponent.getStatus() == FetchStatus.IN_PROGRESS && (Date.from(Instant.now()).getTime() - integrityMetaComponent.getLastFetch().getTime()) > TIME_SPAN)) {
+            qm.createIntegrityMetaHandlingConflict(AbstractMetaHandler.createIntegrityMetaComponent(event.purlCoordinates()));
+            return true;
+        } else if (integrityMetaComponent.getStatus() == null || (integrityMetaComponent.getStatus() == FetchStatus.IN_PROGRESS && (Date.from(Instant.now()).getTime() - integrityMetaComponent.getLastFetch().getTime()) > TIME_SPAN)) {
             integrityMetaComponent.setLastFetch(Date.from(Instant.now()));
-            qm.getPersistenceManager().makePersistent(integrityMetaComponent);
-            return new ComponentRepositoryMetaAnalysisEvent(component.getUuid(), component.getPurl().canonicalize(), component.isInternal(), FetchMeta.FETCH_META_INTEGRITY_DATA);
+            return true;
         }
         //don't send event because integrity metadata would be in db already in Processed state or sent recently
         //and don't want to send again
-        return null;
+        return false;
     }
 }

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -104,7 +104,6 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
-                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name())
         );
         qm.getPersistenceManager().refresh(project);
@@ -195,7 +194,6 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
-                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name())
         );
@@ -534,7 +532,7 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                 .map(ProducerRecord::topic)
                 .filter(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()::equals)
                 .count();
-        assertThat(repoMetaAnalysisCommandsSent).isEqualTo(18112);
+        assertThat(repoMetaAnalysisCommandsSent).isEqualTo(9056);
     }
 
     @Test // https://github.com/DependencyTrack/dependency-track/issues/2519
@@ -670,7 +668,6 @@ public class BomUploadProcessingTaskTest extends AbstractPostgresEnabledTest {
                     assertThat(notification.getGroup()).isEqualTo(Group.GROUP_BOM_CONSUMED);
                 },
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name()),
-                event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name()),
                 event -> assertThat(event.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name())
                 // BOM_PROCESSED notification should not have been sent.
         );


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Persistent objects become `HOLLOW` after the transaction is committed, causing all their fields except their ID to be unloaded. Accessing any other field afterward triggers a SQL query behind the scenes.

This was happening when creating integrity metadata events, and is now fixed by preparing those events while the transaction is still active.

This change further reduces the number of repository meta events being sent.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Results from profiling `BomUploadProcessingTaskTest#informWithBloatedBomTest`:

Before (run time: 1m10s):
![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/a5015d33-3c10-4e08-8588-a473149c04ea)
![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/399a2870-100f-494f-b2fb-961b4ca25081)

After (run time: 18s):
![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/0f029abc-a3a7-4287-8620-70a4ce874806)
![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/188bd3d0-2412-4235-b93d-4de19ce02412)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
