### PR TITLE
Diff changes made by scanners to existing vulnerabilities

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -25,6 +25,7 @@ import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.parser.hyades.ModelConverterCdxToVuln;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.PersistenceUtil;
+import org.dependencytrack.util.PersistenceUtil.Differ;
 import org.hyades.proto.vulnanalysis.v1.ScanKey;
 import org.hyades.proto.vulnanalysis.v1.ScanResult;
 import org.hyades.proto.vulnanalysis.v1.ScanStatus;
@@ -42,8 +43,6 @@ import java.util.UUID;
 import static org.dependencytrack.parser.hyades.ModelConverterCdxToVuln.convert;
 import static org.dependencytrack.util.NotificationUtil.generateNotificationContent;
 import static org.dependencytrack.util.NotificationUtil.generateNotificationTitle;
-import static org.dependencytrack.util.PersistenceUtil.applyIfChanged;
-import static org.dependencytrack.util.PersistenceUtil.applyIfNonNullAndChanged;
 import static org.dependencytrack.util.VulnerabilityUtil.canBeMirrored;
 import static org.dependencytrack.util.VulnerabilityUtil.isAuthoritativeSource;
 import static org.dependencytrack.util.VulnerabilityUtil.isMirroringEnabled;
@@ -225,52 +224,52 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             }
 
             if (canUpdateVulnerability(existingVuln, scanner)) {
-                var updated = false;
+                final var differ = new Differ<>(existingVuln, vuln);
 
                 // TODO: Consider using something like javers to get a rich diff of WHAT changed; https://github.com/javers/javers
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getTitle, existingVuln::setTitle);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getSubTitle, existingVuln::setSubTitle);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getDescription, existingVuln::setDescription);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getDetail, existingVuln::setDetail);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getRecommendation, existingVuln::setRecommendation);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getReferences, existingVuln::setReferences);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCredits, existingVuln::setCredits);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCreated, existingVuln::setCreated);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getPublished, existingVuln::setPublished);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getUpdated, existingVuln::setUpdated);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCwes, existingVuln::setCwes);
+                differ.applyIfChanged("title", Vulnerability::getTitle, existingVuln::setTitle);
+                differ.applyIfChanged("subTitle", Vulnerability::getSubTitle, existingVuln::setSubTitle);
+                differ.applyIfChanged("description", Vulnerability::getDescription, existingVuln::setDescription);
+                differ.applyIfChanged("detail", Vulnerability::getDetail, existingVuln::setDetail);
+                differ.applyIfChanged("recommendation", Vulnerability::getRecommendation, existingVuln::setRecommendation);
+                differ.applyIfChanged("references", Vulnerability::getReferences, existingVuln::setReferences);
+                differ.applyIfChanged("credits", Vulnerability::getCredits, existingVuln::setCredits);
+                differ.applyIfChanged("created", Vulnerability::getCreated, existingVuln::setCreated);
+                differ.applyIfChanged("published", Vulnerability::getPublished, existingVuln::setPublished);
+                differ.applyIfChanged("updated", Vulnerability::getUpdated, existingVuln::setUpdated);
+                differ.applyIfChanged("cwes", Vulnerability::getCwes, existingVuln::setCwes);
                 // Calling setSeverity nulls all CVSS and OWASP RR fields. getSeverity calculates the severity on-the-fly,
                 // and will return UNASSIGNED even when no severity is set explicitly. Thus, calling setSeverity
                 // must happen before CVSS and OWASP RR fields are set, to avoid null-ing them again.
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getSeverity, existingVuln::setSeverity);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2BaseScore, existingVuln::setCvssV2BaseScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2ImpactSubScore, existingVuln::setCvssV2ImpactSubScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2ExploitabilitySubScore, existingVuln::setCvssV2ExploitabilitySubScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV2Vector, existingVuln::setCvssV2Vector);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV3BaseScore, existingVuln::setCvssV3BaseScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV3ImpactSubScore, existingVuln::setCvssV3ImpactSubScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV3ExploitabilitySubScore, existingVuln::setCvssV3ExploitabilitySubScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getCvssV3Vector, existingVuln::setCvssV3Vector);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getOwaspRRLikelihoodScore, existingVuln::setOwaspRRLikelihoodScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getOwaspRRTechnicalImpactScore, existingVuln::setOwaspRRTechnicalImpactScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getOwaspRRBusinessImpactScore, existingVuln::setOwaspRRBusinessImpactScore);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getOwaspRRVector, existingVuln::setOwaspRRVector);
+                differ.applyIfChanged("severity", Vulnerability::getSeverity, existingVuln::setSeverity);
+                differ.applyIfChanged("cvssV2BaseScore", Vulnerability::getCvssV2BaseScore, existingVuln::setCvssV2BaseScore);
+                differ.applyIfChanged("cvssV2ImpactSubScore", Vulnerability::getCvssV2ImpactSubScore, existingVuln::setCvssV2ImpactSubScore);
+                differ.applyIfChanged("cvssV2ExploitabilitySubScore", Vulnerability::getCvssV2ExploitabilitySubScore, existingVuln::setCvssV2ExploitabilitySubScore);
+                differ.applyIfChanged("cvssV2Vector", Vulnerability::getCvssV2Vector, existingVuln::setCvssV2Vector);
+                differ.applyIfChanged("cvssv3BaseScore", Vulnerability::getCvssV3BaseScore, existingVuln::setCvssV3BaseScore);
+                differ.applyIfChanged("cvssV3ImpactSubScore", Vulnerability::getCvssV3ImpactSubScore, existingVuln::setCvssV3ImpactSubScore);
+                differ.applyIfChanged("cvssV3ExploitabilitySubScore", Vulnerability::getCvssV3ExploitabilitySubScore, existingVuln::setCvssV3ExploitabilitySubScore);
+                differ.applyIfChanged("cvssV3Vector", Vulnerability::getCvssV3Vector, existingVuln::setCvssV3Vector);
+                differ.applyIfChanged("owaspRRLikelihoodScore", Vulnerability::getOwaspRRLikelihoodScore, existingVuln::setOwaspRRLikelihoodScore);
+                differ.applyIfChanged("owaspRRTechnicalImpactScore", Vulnerability::getOwaspRRTechnicalImpactScore, existingVuln::setOwaspRRTechnicalImpactScore);
+                differ.applyIfChanged("owaspRRBusinessImpactScore", Vulnerability::getOwaspRRBusinessImpactScore, existingVuln::setOwaspRRBusinessImpactScore);
+                differ.applyIfChanged("owaspRRVector", Vulnerability::getOwaspRRVector, existingVuln::setOwaspRRVector);
                 // Aliases of existingVuln will always be null, as they'd have to be fetched separately.
                 // Synchronization of aliases is performed after synchronizing the vulnerability.
                 // updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getAliases, existingVuln::setAliases);
 
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getVulnerableVersions, existingVuln::setVulnerableVersions);
-                updated |= applyIfChanged(existingVuln, vuln, Vulnerability::getPatchedVersions, existingVuln::setPatchedVersions);
+                differ.applyIfChanged("vulnerableVersions", Vulnerability::getVulnerableVersions, existingVuln::setVulnerableVersions);
+                differ.applyIfChanged("patchedVersions", Vulnerability::getPatchedVersions, existingVuln::setPatchedVersions);
                 // EPSS is an additional enrichment that no scanner currently provides.
                 // We don't want EPSS scores of CVEs to be purged just because the CVE information came from e.g. OSS Index.
-                updated |= applyIfNonNullAndChanged(existingVuln, vuln, Vulnerability::getEpssScore, existingVuln::setEpssScore);
-                updated |= applyIfNonNullAndChanged(existingVuln, vuln, Vulnerability::getEpssPercentile, existingVuln::setEpssPercentile);
+                differ.applyIfNonNullAndChanged("epssScore", Vulnerability::getEpssScore, existingVuln::setEpssScore);
+                differ.applyIfNonNullAndChanged("epssPercentile", Vulnerability::getEpssPercentile, existingVuln::setEpssPercentile);
 
-                if (updated) {
+                if (!differ.getDiffs().isEmpty()) {
                     // TODO: Send a notification?
                     //   (But notifications should only be sent if the transaction was committed)
-                    // TODO: Reduce to DEBUG; It's set to WARN for testing
-                    LOGGER.warn("Vulnerability %s/%s was updated by %s".formatted(vuln.getSource(), vuln.getVulnId(), scanner));
+                    // TODO: Reduce to DEBUG; It's set to INFO for testing
+                    LOGGER.info("Vulnerability %s/%s was updated by %s: %s".formatted(vuln.getSource(), vuln.getVulnId(), scanner, differ.getDiffs()));
                 }
             }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Instead of only logging *that* they were changed, also log which field was updated, and from which to which value.

Also reduce log level from `WARN` to `INFO`.

This is more or less a good-enough temporary solution, I realize we'll want similar functionality in various places throughout the code base.

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/08f502a2-a560-4f9b-b2e8-aa79a53fbcde)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
