### PR TITLE
Fix component published date not being returned when no integrity analysis exists for it

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1894,15 +1894,17 @@ public class QueryManager extends AlpineQueryManager {
             if (resultSet.next()) {
                 Date publishedDate = null;
                 Date lastFetch = null;
+                IntegrityMatchStatus integrityMatchStatus = null;
                 if(resultSet.getTimestamp("PUBLISHED_AT") != null) {
                     publishedDate = Date.from(resultSet.getTimestamp("PUBLISHED_AT").toInstant());
                 }
                 if(resultSet.getTimestamp("LAST_FETCH") != null) {
                     lastFetch = Date.from(resultSet.getTimestamp("LAST_FETCH").toInstant());
                 }
-                return new ComponentMetaInformation(publishedDate,
-                        IntegrityMatchStatus.valueOf(resultSet.getString("INTEGRITY_CHECK_STATUS")),
-                        lastFetch);
+                if(resultSet.getString("INTEGRITY_CHECK_STATUS") != null) {
+                    integrityMatchStatus = IntegrityMatchStatus.valueOf(resultSet.getString("INTEGRITY_CHECK_STATUS"));
+                }
+                return new ComponentMetaInformation(publishedDate, integrityMatchStatus, lastFetch);
 
             }
         } catch (Exception ex) {

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1883,7 +1883,7 @@ public class QueryManager extends AlpineQueryManager {
         PreparedStatement preparedStatement = null;
         String queryString = """
                 SELECT "C"."ID", "C"."PURL", "IMC"."LAST_FETCH",  "IMC"."PUBLISHED_AT", "IA"."INTEGRITY_CHECK_STATUS" FROM "COMPONENT" "C"
-                JOIN "INTEGRITY_META_COMPONENT" "IMC" ON "C"."PURL" ="IMC"."PURL" JOIN "INTEGRITY_ANALYSIS" "IA" ON "IA"."COMPONENT_ID" ="C"."ID"  WHERE "C"."UUID" = ?
+                JOIN "INTEGRITY_META_COMPONENT" "IMC" ON "C"."PURL" ="IMC"."PURL" LEFT JOIN "INTEGRITY_ANALYSIS" "IA" ON "IA"."COMPONENT_ID" ="C"."ID"  WHERE "C"."UUID" = ?
                 """;
         try {
             connection = (Connection) pm.getDataStoreConnection();

--- a/src/test/java/org/dependencytrack/persistence/QueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/QueryManagerTest.java
@@ -25,6 +25,12 @@ public class QueryManagerTest extends PersistenceCapableTest {
         component.setProject(project);
         component.setName("ABC");
         component.setPurl("pkg:maven/org.acme/abc");
+        //add another component for better testing
+        Component component2 = new Component();
+        component2.setProject(project);
+        component2.setName("ABC");
+        component2.setPurl("pkg:maven/org.acme/abc");
+
         IntegrityAnalysis integrityAnalysis = new IntegrityAnalysis();
         integrityAnalysis.setComponent(component);
         integrityAnalysis.setIntegrityCheckStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
@@ -73,6 +79,23 @@ public class QueryManagerTest extends PersistenceCapableTest {
         component = qm.createComponent(component, false);
         ComponentMetaInformation componentMetaInformation = qm.getMetaInformation(component.getUuid());
         assertEquals(HASH_MATCH_PASSED, componentMetaInformation.integrityMatchStatus());
+        assertNull(componentMetaInformation.publishedDate());
+        assertNull(componentMetaInformation.lastFetched());
+    }
+
+    @Test
+    public void testGetMetaInformationWhenIntregrityAnalysisIsMissing() {
+        Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
+        Component component = new Component();
+        component.setProject(project);
+        component.setName("ABC");
+        component.setPurl("pkg:maven/org.acme/abc");
+        IntegrityMetaComponent integrityMetaComponent = new IntegrityMetaComponent();
+        integrityMetaComponent.setPurl(component.getPurl().toString());
+        integrityMetaComponent.setStatus(FetchStatus.PROCESSED);
+        qm.createIntegrityMetaComponent(integrityMetaComponent);
+        component = qm.createComponent(component, false);
+        ComponentMetaInformation componentMetaInformation = qm.getMetaInformation(component.getUuid());
         assertNull(componentMetaInformation.publishedDate());
         assertNull(componentMetaInformation.lastFetched());
     }


### PR DESCRIPTION
### Description

Query to fetch integrity metadata should perform a left join on integrity analysis table. We could be having "published_at" data but not integrity analysis data

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
