### PR TITLE
Integrity Analysis on Bom Upload when integrity metadata already exists

### DIFF
--- a/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
+++ b/src/main/java/org/dependencytrack/event/EventSubsystemInitializer.java
@@ -30,6 +30,7 @@ import org.dependencytrack.tasks.DefectDojoUploadTask;
 import org.dependencytrack.tasks.EpssMirrorTask;
 import org.dependencytrack.tasks.FortifySscUploadTask;
 import org.dependencytrack.tasks.GitHubAdvisoryMirrorTask;
+import org.dependencytrack.tasks.IntegrityAnalysisTask;
 import org.dependencytrack.tasks.IntegrityMetaInitializerTask;
 import org.dependencytrack.tasks.InternalComponentIdentificationTask;
 import org.dependencytrack.tasks.KennaSecurityUploadTask;
@@ -100,6 +101,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.subscribe(ProjectPolicyEvaluationEvent.class, PolicyEvaluationTask.class);
         EVENT_SERVICE.subscribe(WorkflowStateCleanupEvent.class, WorkflowStateCleanupTask.class);
         EVENT_SERVICE.subscribe(IntegrityMetaInitializerEvent.class, IntegrityMetaInitializerTask.class);
+        EVENT_SERVICE.subscribe(IntegrityAnalysisEvent.class, IntegrityAnalysisTask.class);
 
         TaskScheduler.getInstance();
     }
@@ -135,6 +137,7 @@ public class EventSubsystemInitializer implements ServletContextListener {
         EVENT_SERVICE.unsubscribe(PolicyEvaluationTask.class);
         EVENT_SERVICE.unsubscribe(WorkflowStateCleanupTask.class);
         EVENT_SERVICE.unsubscribe(IntegrityMetaInitializerTask.class);
+        EVENT_SERVICE.unsubscribe(IntegrityAnalysisTask.class);
         EVENT_SERVICE.shutdown(DRAIN_TIMEOUT_DURATION);
     }
 }

--- a/src/main/java/org/dependencytrack/event/IntegrityAnalysisEvent.java
+++ b/src/main/java/org/dependencytrack/event/IntegrityAnalysisEvent.java
@@ -1,0 +1,26 @@
+package org.dependencytrack.event;
+
+import alpine.event.framework.Event;
+import org.dependencytrack.model.IntegrityMetaComponent;
+
+import java.util.UUID;
+
+public class IntegrityAnalysisEvent implements Event {
+
+    private UUID uuid;
+
+    private IntegrityMetaComponent integrityMetaComponent;
+
+    public IntegrityAnalysisEvent(UUID uuid, IntegrityMetaComponent integrityMetaComponent) {
+        this.uuid = uuid;
+        this.integrityMetaComponent = integrityMetaComponent;
+    }
+
+    public UUID getUuid() {
+        return uuid;
+    }
+
+    public IntegrityMetaComponent getIntegrityMetaComponent() {
+        return integrityMetaComponent;
+    }
+}

--- a/src/main/java/org/dependencytrack/event/kafka/componentmeta/IntegrityCheck.java
+++ b/src/main/java/org/dependencytrack/event/kafka/componentmeta/IntegrityCheck.java
@@ -32,7 +32,7 @@ public class IntegrityCheck {
         //if integritymeta is in result with hashses but component uuid is not present, result has integrity data for existing
         // components. Get components from database and perform integrity check
         if (StringUtils.isBlank(result.getComponent().getUuid())) {
-            integrityAnalysisOfExistingComponents(integrityMetaComponent, result, qm);
+            integrityAnalysisOfExistingComponents(integrityMetaComponent, qm);
             return;
         }
         //check if the object is not null
@@ -44,9 +44,9 @@ public class IntegrityCheck {
         calculateIntegrityResult(integrityMetaComponent, component, qm);
     }
 
-    private static void integrityAnalysisOfExistingComponents(final IntegrityMetaComponent integrityMetaComponent, final AnalysisResult result, final QueryManager qm) {
+    private static void integrityAnalysisOfExistingComponents(final IntegrityMetaComponent integrityMetaComponent, final QueryManager qm) {
         if (integrityMetaComponent != null) {
-            List<Component> componentList = qm.getComponentsByPurl(result.getComponent().getPurl());
+            List<Component> componentList = qm.getComponentsByPurl(integrityMetaComponent.getPurl());
             for (Component component : componentList) {
                 LOGGER.debug("calculate integrity for component : " + component.getUuid());
                 calculateIntegrityResult(integrityMetaComponent, component, qm);
@@ -67,7 +67,7 @@ public class IntegrityCheck {
         return componentHash.equals(metadataHash) ? HASH_MATCH_PASSED : HASH_MATCH_FAILED;
     }
 
-    private static void calculateIntegrityResult(final IntegrityMetaComponent integrityMetaComponent, final Component component, final QueryManager qm) {
+    public static void calculateIntegrityResult(final IntegrityMetaComponent integrityMetaComponent, final Component component, final QueryManager qm) {
         //if integritymetacomponent is  null, try to get it from db
         //it could be that integrity metadata is already in db
         IntegrityMetaComponent metadata = integrityMetaComponent == null ? qm.getIntegrityMetaComponent(component.getPurl().toString()) : integrityMetaComponent;

--- a/src/main/java/org/dependencytrack/tasks/IntegrityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/IntegrityAnalysisTask.java
@@ -1,0 +1,39 @@
+package org.dependencytrack.tasks;
+
+import alpine.Config;
+import alpine.common.logging.Logger;
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
+import org.dependencytrack.common.ConfigKey;
+import org.dependencytrack.event.IntegrityAnalysisEvent;
+import org.dependencytrack.event.kafka.componentmeta.IntegrityCheck;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.IntegrityMetaComponent;
+import org.dependencytrack.persistence.QueryManager;
+
+import java.util.UUID;
+
+import static org.dependencytrack.event.kafka.componentmeta.IntegrityCheck.calculateIntegrityResult;
+
+public class IntegrityAnalysisTask implements Subscriber {
+
+    private static final Logger LOGGER = Logger.getLogger(IntegrityAnalysisTask.class);
+
+    public void inform(final Event e) {
+        if (e instanceof final IntegrityAnalysisEvent event) {
+            if (!Config.getInstance().getPropertyAsBoolean(ConfigKey.INTEGRITY_CHECK_ENABLED)) {
+                return;
+            }
+            LOGGER.debug("Performing integrity analysis for component: " + event.getUuid());
+            if(event.getUuid() == null) {
+                return;
+            }
+            try (final var qm = new QueryManager()) {
+                UUID uuid = event.getUuid();
+                IntegrityMetaComponent integrityMetaComponent = event.getIntegrityMetaComponent();
+                Component component = qm.getObjectByUuid(Component.class, uuid);
+                calculateIntegrityResult(integrityMetaComponent, component, qm);
+            }
+        }
+    }
+}

--- a/src/test/java/org/dependencytrack/event/kafka/componentmeta/SupportedMetaHandlerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/componentmeta/SupportedMetaHandlerTest.java
@@ -75,4 +75,33 @@ public class SupportedMetaHandlerTest extends AbstractPostgresEnabledTest {
         Assertions.assertEquals(FetchStatus.IN_PROGRESS, integrityMetaComponent.getStatus());
         assertThat(integrityMetaComponent.getLastFetch()).isAfter(Date.from(Instant.now().minus(2, ChronoUnit.MINUTES)));
     }
+
+    @Test
+    public void testHandleIntegrityWhenMetadataExists() throws MalformedPackageURLException {
+        Handler handler;
+        UUID uuid = UUID.randomUUID();
+        KafkaEventDispatcher kafkaEventDispatcher = new KafkaEventDispatcher();
+        PackageURL packageUrl = new PackageURL("pkg:maven/org.http4s/blaze-core_2.12");
+        ComponentProjection componentProjection = new ComponentProjection(uuid, PurlUtil.silentPurlCoordinatesOnly(packageUrl).toString(), false, packageUrl);
+        var integrityMeta = new IntegrityMetaComponent();
+        integrityMeta.setPurl("pkg:maven/org.http4s/blaze-core_2.12");
+        integrityMeta.setMd5("md5hash");
+        integrityMeta.setStatus(FetchStatus.PROCESSED);
+        integrityMeta.setLastFetch(Date.from(Instant.now().minus(2, ChronoUnit.HOURS)));
+        qm.createIntegrityMetaComponent(integrityMeta);
+        handler = HandlerFactory.createHandler(componentProjection, qm, kafkaEventDispatcher, FetchMeta.FETCH_META_INTEGRITY_DATA_AND_LATEST_VERSION);
+        IntegrityMetaComponent integrityMetaComponent = handler.handle();
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(
+                record -> {
+                    assertThat(record.topic()).isEqualTo(KafkaTopics.REPO_META_ANALYSIS_COMMAND.name());
+                    final var command = deserializeValue(KafkaTopics.REPO_META_ANALYSIS_COMMAND, record);
+                    assertThat(command.getComponent().getPurl()).isEqualTo("pkg:maven/org.http4s/blaze-core_2.12");
+                    assertThat(command.getComponent().getUuid()).isEqualTo(uuid.toString());
+                    assertThat(command.getComponent().getInternal()).isFalse();
+                    assertThat(command.getFetchMeta()).isEqualTo(FetchMeta.FETCH_META_LATEST_VERSION);
+                }
+
+        );
+        Assertions.assertEquals(FetchStatus.PROCESSED, integrityMetaComponent.getStatus());
+    }
 }

--- a/src/test/java/org/dependencytrack/tasks/IntegrityAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/IntegrityAnalysisTaskTest.java
@@ -1,0 +1,94 @@
+package org.dependencytrack.tasks;
+
+import org.dependencytrack.AbstractPostgresEnabledTest;
+import org.dependencytrack.event.IntegrityAnalysisEvent;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.FetchStatus;
+import org.dependencytrack.model.IntegrityAnalysis;
+import org.dependencytrack.model.IntegrityMetaComponent;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.model.IntegrityMatchStatus.HASH_MATCH_PASSED;
+
+public class IntegrityAnalysisTaskTest extends AbstractPostgresEnabledTest {
+
+    @Rule
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @Before
+    public void before() {
+        environmentVariables.set("INTEGRITY_INITIALIZER_ENABLED", "true");
+    }
+
+    @Test
+    public void shouldPerformIntegrityAnalysisIfMetaDataExists() {
+        // Create an active project with one component.
+        final var projectA = qm.createProject("acme-app-a", null, "1.0.0", null, null, null, true, false);
+        final var componentProjectA = new Component();
+        UUID uuid = UUID.randomUUID();
+        componentProjectA.setProject(projectA);
+        componentProjectA.setName("acme-lib-a");
+        componentProjectA.setVersion("1.0.1");
+        componentProjectA.setPurl("pkg:maven/foo/bar@1.2.3");
+        componentProjectA.setPurlCoordinates("pkg:maven/foo/bar@1.2.3");
+        componentProjectA.setUuid(uuid);
+        componentProjectA.setMd5("098f6bcd4621d373cade4e832627b4f6");
+        componentProjectA.setSha1("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+
+        Component c = qm.persist(componentProjectA);
+
+        var integrityMetaComponent = new IntegrityMetaComponent();
+        integrityMetaComponent.setPurl("pkg:maven/foo/bar@1.2.3");
+        integrityMetaComponent.setStatus(FetchStatus.PROCESSED);
+        integrityMetaComponent.setMd5("098f6bcd4621d373cade4e832627b4f6");
+        integrityMetaComponent.setSha1("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+        Date date = Date.from(Instant.now().minus(15, ChronoUnit.MINUTES));
+        integrityMetaComponent.setLastFetch(date);
+        IntegrityMetaComponent integrityData = qm.persist(integrityMetaComponent);
+
+        new IntegrityAnalysisTask().inform(new IntegrityAnalysisEvent(c.getUuid(), integrityData));
+        IntegrityAnalysis integrityResult = qm.getIntegrityAnalysisByComponentUuid(c.getUuid());
+        assertThat(integrityResult).isNotNull();
+        assertThat(integrityResult.getIntegrityCheckStatus()).isEqualTo(HASH_MATCH_PASSED);
+    }
+
+    @Test
+    public void shouldNotPerformAnalysisIfComponentUuidIsMissing() {
+        // Create an active project with one component.
+        final var projectA = qm.createProject("acme-app-a", null, "1.0.0", null, null, null, true, false);
+        final var componentProjectA = new Component();
+        UUID uuid = UUID.randomUUID();
+        componentProjectA.setProject(projectA);
+        componentProjectA.setName("acme-lib-a");
+        componentProjectA.setVersion("1.0.1");
+        componentProjectA.setPurl("pkg:maven/foo/bar@1.2.3");
+        componentProjectA.setPurlCoordinates("pkg:maven/foo/bar@1.2.3");
+        componentProjectA.setUuid(uuid);
+        componentProjectA.setMd5("098f6bcd4621d373cade4e832627b4f6");
+        componentProjectA.setSha1("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+
+        Component c = qm.persist(componentProjectA);
+
+        var integrityMetaComponent = new IntegrityMetaComponent();
+        integrityMetaComponent.setPurl("pkg:maven/foo/bar@1.2.3");
+        integrityMetaComponent.setStatus(FetchStatus.PROCESSED);
+        integrityMetaComponent.setMd5("098f6bcd4621d373cade4e832627b4f6");
+        integrityMetaComponent.setSha1("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3");
+        Date date = Date.from(Instant.now().minus(15, ChronoUnit.MINUTES));
+        integrityMetaComponent.setLastFetch(date);
+        IntegrityMetaComponent integrityData = qm.persist(integrityMetaComponent);
+
+        new IntegrityAnalysisTask().inform(new IntegrityAnalysisEvent(null, integrityData));
+        IntegrityAnalysis integrityResult = qm.getIntegrityAnalysisByComponentUuid(c.getUuid());
+        assertThat(integrityResult).isNull();
+    }
+}

--- a/src/test/java/org/dependencytrack/tasks/IntegrityAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/IntegrityAnalysisTaskTest.java
@@ -26,7 +26,7 @@ public class IntegrityAnalysisTaskTest extends AbstractPostgresEnabledTest {
 
     @Before
     public void before() {
-        environmentVariables.set("INTEGRITY_INITIALIZER_ENABLED", "true");
+        environmentVariables.set("INTEGRITY_CHECK_ENABLED", "true");
     }
 
     @Test


### PR DESCRIPTION
### Description

This PR is to trigger integrity analysis on Bom upload when purl integrity metadata is already present in database. I handles the same on Component create and update also.

### Addressed Issue



### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
