### PR TITLE
Add `now` variable for time comparisons in CEL expressions

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.api.expr.v1alpha1.Type;
+import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
 import io.micrometer.core.instrument.Timer;
 import org.apache.commons.collections4.MultiValuedMap;
@@ -75,6 +76,7 @@ import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_PROJECT;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_PROJECT_PROPERTY;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_VULNERABILITY;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_COMPONENT;
+import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_NOW;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_PROJECT;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_VULNERABILITIES;
 
@@ -192,6 +194,7 @@ public class CelPolicyEngine {
 
             // Evaluate all policy conditions against all components.
             final var conditionsViolated = new HashSetValuedHashMap<Long, PolicyCondition>();
+            final Timestamp protoNow = Timestamps.now(); // Use consistent now timestamp for all evaluations.
             for (final ComponentProjection component : components) {
                 final org.dependencytrack.proto.policy.v1.Component protoComponent = mapToProto(component, licenseById);
                 final List<org.dependencytrack.proto.policy.v1.Vulnerability> protoVulns =
@@ -201,6 +204,7 @@ public class CelPolicyEngine {
 
                 conditionsViolated.putAll(component.id, evaluateConditions(conditionScriptPairs, Map.of(
                         VAR_COMPONENT, protoComponent,
+                        VAR_NOW, protoNow,
                         VAR_PROJECT, protoProject,
                         VAR_VULNERABILITIES, protoVulns
                 )));


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds a `now` variable of type `google.protobuf.Timestamp` for time comparisons in CEL expressions.

Also tweaked logging in `CelPolicyLibrary` to always include the function emitting them.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
