### PR TITLE
Add `vers` range validation before compilation

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptHost.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptHost.java
@@ -118,7 +118,14 @@ public class CelPolicyScriptHost {
 
             final Ast ast = astIssuesTuple.getAst();
             final Program program = environment.program(ast);
-            final MultiValuedMap<Type, String> requirements = analyzeRequirements(CEL.astToCheckedExpr(ast));
+            final var expr = CEL.astToCheckedExpr(ast);
+            final MultiValuedMap<Type, String> requirements = analyzeRequirements(expr);
+
+            // perform vers range validity
+            if (requirements.get(TYPE_PROJECT).contains("version") || requirements.get(TYPE_COMPONENT).contains("version")) {
+                final var visitor = new CelPolicyScriptVisitor(expr.getTypeMapMap());
+                visitor.visitVersRangeCheck(expr.getExpr());
+            }
 
             script = new CelPolicyScript(program, requirements);
             if (cacheMode == CacheMode.CACHE) {

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVisitor.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVisitor.java
@@ -119,7 +119,8 @@ class CelPolicyScriptVisitor {
 
     public void visitVersRangeCheck(final Expr expr) throws ScriptCreateException {
         final var callExpr = expr.getCallExpr();
-        if (!callExpr.getArgsList().isEmpty()
+        if (callExpr.getFunction().equals("matches_range")
+                && !callExpr.getArgsList().isEmpty()
                 && callExpr.getArgsList().get(0).getExprKindCase() == CONST_EXPR) {
             var versArg = callExpr.getArgsList().get(0).getConstExpr().getStringValue();
             try {

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVisitor.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVisitor.java
@@ -3,15 +3,26 @@ package org.dependencytrack.policy.cel;
 import alpine.common.logging.Logger;
 import com.google.api.expr.v1alpha1.Expr;
 import com.google.api.expr.v1alpha1.Type;
+import io.github.nscuro.versatile.Vers;
+import io.github.nscuro.versatile.VersException;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
+import org.projectnessie.cel.common.CELError;
+import org.projectnessie.cel.common.Errors;
+import org.projectnessie.cel.common.Location;
+import org.projectnessie.cel.tools.ScriptCreateException;
 
 import java.util.ArrayDeque;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import static com.google.api.expr.v1alpha1.Expr.ExprKindCase.CONST_EXPR;
+import static org.projectnessie.cel.Issues.newIssues;
+import static org.projectnessie.cel.common.Source.newTextSource;
 
 class CelPolicyScriptVisitor {
 
@@ -104,6 +115,23 @@ class CelPolicyScriptVisitor {
 
     private void visitStruct(final Expr expr) {
         logExpr(expr);
+    }
+
+    public void visitVersRangeCheck(final Expr expr) throws ScriptCreateException {
+        final var callExpr = expr.getCallExpr();
+        if (!callExpr.getArgsList().isEmpty()
+                && callExpr.getArgsList().get(0).getExprKindCase() == CONST_EXPR) {
+            var versArg = callExpr.getArgsList().get(0).getConstExpr().getStringValue();
+            try {
+                Vers.parse(versArg);
+            } catch (VersException e) {
+                throw new ScriptCreateException("Failed to parse the vers range ", newIssues(new Errors(newTextSource(versArg))
+                        .append(Collections.singletonList(
+                                new CELError(e, Location.newLocation(1, 1), e.getMessage())
+                        ))
+                ));
+            }
+        }
     }
 
     private void logExpr(final Expr expr) {

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVisitor.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVisitor.java
@@ -120,25 +120,25 @@ class CelPolicyScriptVisitor {
     public void visitVersRangeCheck(final Expr expr) throws ScriptCreateException {
         for (Expr argExpr : expr.getCallExpr().getArgsList()) {
             if (argExpr.hasCallExpr()) {
-                checkVersRange(argExpr.getCallExpr());
+                validateVersRange(argExpr.getCallExpr());
                 visitVersRangeCheck(argExpr);
             }
             if (argExpr.hasComprehensionExpr()) {
                 var argCallExpr = argExpr.getComprehensionExpr();
                 if (argCallExpr.hasLoopStep()) {
-                    checkVersRange(argCallExpr.getLoopStep().getCallExpr());
+                    validateVersRange(argCallExpr.getLoopStep().getCallExpr());
                     visitVersRangeCheck(argCallExpr.getLoopStep());
                 }
             }
         }
     }
 
-    private static void checkVersRange(Expr.Call callExpr) throws ScriptCreateException {
+    private static void validateVersRange(Expr.Call callExpr) throws ScriptCreateException {
         if (callExpr.getFunction().equals("matches_range") && !callExpr.getArgsList().isEmpty()
             && callExpr.getArgsList().get(0).getExprKindCase() == CONST_EXPR) {
             var versArg = callExpr.getArgsList().get(0).getConstExpr().getStringValue();
             try {
-                Vers.parse(versArg);
+                Vers.parse(versArg).validate();
             } catch (VersException e) {
                 throw new ScriptCreateException("Failed to parse the vers range ", newIssues(new Errors(newTextSource(versArg))
                         .append(Collections.singletonList(

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
@@ -88,9 +88,18 @@ public class CelPolicyScriptHostTest {
 
     public void testVisitVersRangeCheck() {
         var exception = assertThrows(ScriptCreateException.class, () -> CelPolicyScriptHost.getInstance().compile("""
-                project.matches_range("vers:generic<1")
+                project.name == "foo" && project.matches_range("vers:generic<1")
                 """, CacheMode.NO_CACHE));
         assertThat(exception.getMessage()).contains("Failed to parse the vers range");
+
+        assertThrows(ScriptCreateException.class, () -> CelPolicyScriptHost.getInstance().compile("""
+                component.matches_range("vers:generic<1") == "foo" && project.matches_range("vers:generic<1")
+                """, CacheMode.NO_CACHE));
+
+        exception = assertThrows(ScriptCreateException.class, () -> CelPolicyScriptHost.getInstance().compile("""
+                component.name == "foo" || vulns.exists(vuln, vuln.id == "foo" && component.matches_range("versgeneric/<1"))
+                """, CacheMode.NO_CACHE));
+        assertThat(exception.getMessage()).contains("vers string does not contain a URI scheme separator");
 
         assertDoesNotThrow(() -> CelPolicyScriptHost.getInstance().compile("""
                 project.matches_range("vers:generic/<1")

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
@@ -5,6 +5,7 @@ import com.google.api.expr.v1alpha1.Type;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.dependencytrack.policy.cel.CelPolicyScriptHost.CacheMode;
 import org.junit.Test;
+import org.projectnessie.cel.tools.ScriptCreateException;
 
 import java.util.Collection;
 import java.util.Map;
@@ -16,6 +17,8 @@ import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_LICENSE;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_LICENSE_GROUP;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_PROJECT;
 import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_VULNERABILITY;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class CelPolicyScriptHostTest {
 
@@ -81,4 +84,16 @@ public class CelPolicyScriptHostTest {
                 "severity");
     }
 
+    @Test
+
+    public void testVisitVersRangeCheck() {
+        var exception = assertThrows(ScriptCreateException.class, () -> CelPolicyScriptHost.getInstance().compile("""
+                project.matches_range("vers:generic<1")
+                """, CacheMode.NO_CACHE));
+        assertThat(exception.getMessage()).contains("Failed to parse the vers range");
+
+        assertDoesNotThrow(() -> CelPolicyScriptHost.getInstance().compile("""
+                project.matches_range("vers:generic/<1")
+                """, CacheMode.NO_CACHE));
+    }
 }

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
@@ -85,7 +85,6 @@ public class CelPolicyScriptHostTest {
     }
 
     @Test
-
     public void testVisitVersRangeCheck() {
         var exception = assertThrows(ScriptCreateException.class, () -> CelPolicyScriptHost.getInstance().compile("""
                 project.name == "foo" && project.matches_range("vers:generic<1")


### PR DESCRIPTION
### Description

It would be good if we could perform the validation during the CEL script compilation, in order to give users feedback synchronously.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/873

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
