### PR TITLE
Implement `VulnerabilityPolicyEvaluator` (without dynamic loading of required fields)

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -41,14 +41,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-class CelPolicyLibrary implements Library {
+class CelCommonPolicyLibrary implements Library {
 
-    private static final Logger LOGGER = Logger.getLogger(CelPolicyLibrary.class);
-
-    static final String VAR_COMPONENT = "component";
-    static final String VAR_NOW = "now";
-    static final String VAR_PROJECT = "project";
-    static final String VAR_VULNERABILITIES = "vulns";
+    private static final Logger LOGGER = Logger.getLogger(CelCommonPolicyLibrary.class);
 
     static final Type TYPE_COMPONENT = Decls.newObjectType(Component.getDescriptor().getFullName());
     static final Type TYPE_LICENSE = Decls.newObjectType(License.getDescriptor().getFullName());
@@ -56,7 +51,6 @@ class CelPolicyLibrary implements Library {
     static final Type TYPE_PROJECT = Decls.newObjectType(Project.getDescriptor().getFullName());
     static final Type TYPE_PROJECT_PROPERTY = Decls.newObjectType(Project.Property.getDescriptor().getFullName());
     static final Type TYPE_VULNERABILITY = Decls.newObjectType(Vulnerability.getDescriptor().getFullName());
-    static final Type TYPE_VULNERABILITIES = Decls.newListType(TYPE_VULNERABILITY);
     static final Type TYPE_VULNERABILITY_ALIAS = Decls.newObjectType(Vulnerability.Alias.getDescriptor().getFullName());
 
     static final String FUNC_DEPENDS_ON = "depends_on";
@@ -69,22 +63,6 @@ class CelPolicyLibrary implements Library {
     public List<EnvOption> getCompileOptions() {
         return List.of(
                 EnvOption.declarations(
-                        Decls.newVar(
-                                VAR_COMPONENT,
-                                TYPE_COMPONENT
-                        ),
-                        Decls.newVar(
-                                VAR_NOW,
-                                Decls.Timestamp
-                        ),
-                        Decls.newVar(
-                                VAR_PROJECT,
-                                TYPE_PROJECT
-                        ),
-                        Decls.newVar(
-                                VAR_VULNERABILITIES,
-                                TYPE_VULNERABILITIES
-                        ),
                         Decls.newFunction(
                                 FUNC_DEPENDS_ON,
                                 // project.depends_on(org.dependencytrack.policy.v1.Component{name: "foo"})
@@ -153,20 +131,20 @@ class CelPolicyLibrary implements Library {
                 ProgramOption.functions(
                         Overload.binary(
                                 FUNC_DEPENDS_ON,
-                                CelPolicyLibrary::dependsOnFunc
+                                CelCommonPolicyLibrary::dependsOnFunc
                         ),
                         Overload.binary(
                                 FUNC_IS_DEPENDENCY_OF,
-                                CelPolicyLibrary::isDependencyOfFunc
+                                CelCommonPolicyLibrary::isDependencyOfFunc
                         ),
                         Overload.binary(
                                 FUNC_MATCHES_RANGE,
-                                CelPolicyLibrary::matchesRangeFunc
+                                CelCommonPolicyLibrary::matchesRangeFunc
                         ),
                         Overload.function(FUNC_COMPARE_AGE,
-                                CelPolicyLibrary::isComponentOldFunc),
+                                CelCommonPolicyLibrary::isComponentOldFunc),
                         Overload.function(FUNC_COMPARE_VERSION_DISTANCE,
-                                CelPolicyLibrary::matchesVersionDistanceFunc)
+                                CelCommonPolicyLibrary::matchesVersionDistanceFunc)
                 )
         );
     }

--- a/src/main/java/org/dependencytrack/policy/cel/CelComponentPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelComponentPolicyLibrary.java
@@ -1,0 +1,29 @@
+package org.dependencytrack.policy.cel;
+
+import org.projectnessie.cel.EnvOption;
+import org.projectnessie.cel.Library;
+import org.projectnessie.cel.ProgramOption;
+
+import java.util.Collections;
+import java.util.List;
+
+class CelComponentPolicyLibrary implements Library {
+
+    @Override
+    public List<EnvOption> getCompileOptions() {
+        return List.of(
+                EnvOption.declarations(
+                        CelPolicyVariable.COMPONENT.declaration(),
+                        CelPolicyVariable.PROJECT.declaration(),
+                        CelPolicyVariable.VULNS.declaration(),
+                        CelPolicyVariable.NOW.declaration()
+                )
+        );
+    }
+
+    @Override
+    public List<ProgramOption> getProgramOptions() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -69,16 +69,12 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.MultiMapUtils.emptyMultiValuedMap;
 import static org.apache.commons.lang3.StringUtils.trimToEmpty;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_COMPONENT;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_LICENSE;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_LICENSE_GROUP;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_PROJECT;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_PROJECT_PROPERTY;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.TYPE_VULNERABILITY;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_COMPONENT;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_NOW;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_PROJECT;
-import static org.dependencytrack.policy.cel.CelPolicyLibrary.VAR_VULNERABILITIES;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_COMPONENT;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_LICENSE;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_LICENSE_GROUP;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_PROJECT;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_PROJECT_PROPERTY;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_VULNERABILITY;
 
 /**
  * A policy engine powered by the Common Expression Language (CEL).
@@ -112,7 +108,7 @@ public class CelPolicyEngine {
     private final CelPolicyScriptHost scriptHost;
 
     public CelPolicyEngine() {
-        this(CelPolicyScriptHost.getInstance());
+        this(CelPolicyScriptHost.getInstance(CelPolicyType.COMPONENT));
     }
 
     CelPolicyEngine(final CelPolicyScriptHost scriptHost) {
@@ -203,10 +199,10 @@ public class CelPolicyEngine {
                                 .toList();
 
                 conditionsViolated.putAll(component.id, evaluateConditions(conditionScriptPairs, Map.of(
-                        VAR_COMPONENT, protoComponent,
-                        VAR_NOW, protoNow,
-                        VAR_PROJECT, protoProject,
-                        VAR_VULNERABILITIES, protoVulns
+                        CelPolicyVariable.COMPONENT.variableName(), protoComponent,
+                        CelPolicyVariable.PROJECT.variableName(), protoProject,
+                        CelPolicyVariable.VULNS.variableName(), protoVulns,
+                        CelPolicyVariable.NOW.variableName(), protoNow
                 )));
             }
 

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyType.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyType.java
@@ -1,0 +1,34 @@
+package org.dependencytrack.policy.cel;
+
+import org.projectnessie.cel.EnvOption;
+import org.projectnessie.cel.Library;
+import org.projectnessie.cel.extension.StringsLib;
+
+import java.util.List;
+
+public enum CelPolicyType {
+
+    COMPONENT(List.of(
+            Library.StdLib(),
+            Library.Lib(new StringsLib()),
+            Library.Lib(new CelComponentPolicyLibrary()),
+            Library.Lib(new CelCommonPolicyLibrary())
+    )),
+    VULNERABILITY(List.of(
+            Library.StdLib(),
+            Library.Lib(new StringsLib()),
+            Library.Lib(new CelVulnerabilityPolicyLibrary()),
+            Library.Lib(new CelCommonPolicyLibrary())
+    ));
+
+    private final List<EnvOption> envOptions;
+
+    CelPolicyType(final List<EnvOption> envOptions) {
+        this.envOptions = envOptions;
+    }
+
+    List<EnvOption> envOptions() {
+        return envOptions;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyVariable.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyVariable.java
@@ -1,0 +1,34 @@
+package org.dependencytrack.policy.cel;
+
+import com.google.api.expr.v1alpha1.Decl;
+import com.google.api.expr.v1alpha1.Type;
+import org.dependencytrack.proto.policy.v1.Component;
+import org.dependencytrack.proto.policy.v1.Project;
+import org.dependencytrack.proto.policy.v1.Vulnerability;
+import org.projectnessie.cel.checker.Decls;
+
+enum CelPolicyVariable {
+
+    COMPONENT("component", Decls.newObjectType(Component.getDescriptor().getFullName())),
+    PROJECT("project", Decls.newObjectType(Project.getDescriptor().getFullName())),
+    VULN("vuln", Decls.newObjectType(Vulnerability.getDescriptor().getFullName())),
+    VULNS("vulns", Decls.newListType(Decls.newObjectType(Vulnerability.getDescriptor().getFullName()))),
+    NOW("now", Decls.Timestamp);
+
+    private final String name;
+    private final Type type;
+
+    CelPolicyVariable(final String name, final Type type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    String variableName() {
+        return name;
+    }
+
+    Decl declaration() {
+        return Decls.newVar(name, type);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
@@ -1,0 +1,301 @@
+package org.dependencytrack.policy.cel;
+
+import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
+import alpine.server.cache.AbstractCacheManager;
+import com.google.api.expr.v1alpha1.Type;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import io.micrometer.core.instrument.Timer;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyProvider;
+import org.dependencytrack.proto.policy.v1.Component;
+import org.dependencytrack.proto.policy.v1.Project;
+import org.dependencytrack.proto.policy.v1.Vulnerability;
+import org.projectnessie.cel.tools.ScriptCreateException;
+import org.projectnessie.cel.tools.ScriptExecutionException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_COMPONENT;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_LICENSE;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_LICENSE_GROUP;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_PROJECT;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_PROJECT_PROPERTY;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_VULNERABILITY;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.TYPE_VULNERABILITY_ALIAS;
+
+/**
+ * A {@link VulnerabilityPolicyEvaluator} capable of evaluating conditions as CEL expressions.
+ */
+public class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolicyEvaluator {
+
+    private static final Logger LOGGER = Logger.getLogger(CelVulnerabilityPolicyEvaluator.class);
+
+    private final VulnerabilityPolicyProvider policyProvider;
+    private final CelPolicyScriptHost scriptHost;
+    private final AbstractCacheManager cacheManager;
+
+    CelVulnerabilityPolicyEvaluator(final VulnerabilityPolicyProvider policyProvider,
+                                    final CelPolicyScriptHost scriptHost, final AbstractCacheManager cacheManager) {
+        this.policyProvider = policyProvider;
+        this.scriptHost = scriptHost;
+        this.cacheManager = cacheManager;
+
+        // FIXME: Caches are not initialized until the first entry is added...
+        cacheManager.put("%s-init".formatted(getClass().getSimpleName()), Project.getDefaultInstance());
+        cacheManager.put("%s-init".formatted(getClass().getSimpleName()), Component.getDefaultInstance());
+        cacheManager.put("%s-init".formatted(getClass().getSimpleName()), Vulnerability.getDefaultInstance());
+    }
+
+    @Override
+    public Map<UUID, VulnerabilityPolicy> evaluate(final Collection<Vulnerability> vulns, final Component component, final Project project) {
+        final Timer.Sample timerSample = Timer.start();
+        try {
+            return evaluateInternal(vulns, component, project);
+        } finally {
+            timerSample.stop(Timer
+                    .builder("vuln_policy_evaluation")
+                    .register(Metrics.getRegistry()));
+        }
+    }
+
+    private Map<UUID, VulnerabilityPolicy> evaluateInternal(final Collection<Vulnerability> vulns, final Component component, final Project project) {
+        requireNonNull(project, "project must not be null");
+        requireNonNull(component, "component must not be null");
+        requireNonNull(vulns, "vulns must not be null");
+
+        // UUIDs are the bare minimum, everything else can be loaded if required.
+        if (project.getUuid().isBlank()) {
+            throw new IllegalArgumentException("project must have a UUID");
+        }
+        if (component.getUuid().isBlank()) {
+            throw new IllegalArgumentException("component must have a UUID");
+        }
+        for (final Vulnerability vuln : vulns) {
+            if (vuln.getUuid().isBlank()) {
+                throw new IllegalArgumentException("vulns must have a UUID");
+            }
+        }
+
+        if (vulns.isEmpty()) {
+            LOGGER.debug("No vulnerabilities to evaluate policies for");
+            return Collections.emptyMap();
+        }
+
+        // TODO: Can this be cached? Would be good to avoid having to do a DB query for each component.
+        //   Alternatively, we can consider caching an implementation detail of the respective provider.
+        final List<VulnerabilityPolicy> applicablePolicies = policyProvider.getApplicablePolicies(project);
+        if (applicablePolicies == null || applicablePolicies.isEmpty()) {
+            LOGGER.debug("No applicable policies found");
+            return Collections.emptyMap();
+        }
+
+        // Compile condition scripts and group them by policy name.
+        // Using LinkedHashMap to preserve the order of the policies.
+        final var compiledScriptsByPolicyName = new LinkedHashMap<String, List<CelPolicyScript>>();
+        for (final VulnerabilityPolicy policy : applicablePolicies) {
+            for (final String condition : policy.conditions()) {
+                compiledScriptsByPolicyName.compute(policy.name(), (policyName, compiledScripts) -> {
+                    final CelPolicyScript compiledScript = compileConditionScript(condition);
+                    if (compiledScript == null) {
+                        return compiledScripts;
+                    }
+                    if (compiledScripts == null) {
+                        final var scripts = new ArrayList<CelPolicyScript>();
+                        scripts.add(compiledScript);
+                        return scripts;
+                    } else {
+                        compiledScripts.add(compiledScript);
+                        return compiledScripts;
+                    }
+                });
+            }
+        }
+
+        // Determine requirements across all condition scripts.
+        final MultiValuedMap<Type, String> scriptRequirements = compiledScriptsByPolicyName.values().stream()
+                .flatMap(Collection::stream)
+                .map(CelPolicyScript::getRequirements)
+                .reduce(new HashSetValuedHashMap<>(), (lhs, rhs) -> {
+                    lhs.putAll(rhs);
+                    return lhs;
+                });
+
+        final Project scriptArgProject;
+        if (scriptRequirements.containsKey(TYPE_PROJECT)) {
+            scriptArgProject = ensureRequirementsLoaded(project, scriptRequirements);
+        } else {
+            scriptArgProject = org.dependencytrack.proto.policy.v1.Project.getDefaultInstance();
+        }
+
+        final Component scriptArgComponent;
+        if (scriptRequirements.containsKey(TYPE_COMPONENT)) {
+            scriptArgComponent = ensureRequirementsLoaded(component, scriptRequirements);
+        } else {
+            scriptArgComponent = org.dependencytrack.proto.policy.v1.Component.getDefaultInstance();
+        }
+
+        final Map<String, Vulnerability> scriptArgVulns;
+        if (scriptRequirements.containsKey(TYPE_VULNERABILITY)) {
+            scriptArgVulns = ensureRequirementsLoaded(vulns, scriptRequirements);
+        } else {
+            scriptArgVulns = vulns.stream()
+                    .map(vuln -> Map.entry(vuln.getUuid(), vuln))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+
+        // Index policies by their (unique) name to make lookups easier.
+        final Map<String, VulnerabilityPolicy> policiesByName = applicablePolicies.stream()
+                .collect(Collectors.toMap(VulnerabilityPolicy::name, Function.identity()));
+
+        // Iterate over all policies IN THE ORDER THEY WERE GIVEN TO US, evaluating their conditions
+        // IN THE ORDER THEY WERE GIVEN TO US.
+        // TODO: Clean this up; Those nested for loops are hideous.
+        final var matchedPolicies = new HashMap<UUID, VulnerabilityPolicy>();
+        final Timestamp protoNow = Timestamps.now(); // Use consistent now timestamp for all evaluations.
+        for (final Vulnerability protoVuln : scriptArgVulns.values()) {
+            final var shortCircuitedPolicies = new HashSet<String>();
+
+            policyLoop:
+            for (final Map.Entry<String, List<CelPolicyScript>> policyNameAndScripts : compiledScriptsByPolicyName.entrySet()) {
+                if (shortCircuitedPolicies.contains(policyNameAndScripts.getKey())) {
+                    LOGGER.debug("Policy %s already short-circuited");
+                    continue;
+                }
+
+                for (final CelPolicyScript script : policyNameAndScripts.getValue()) {
+                    final Map<String, Object> scriptArguments = Map.ofEntries(
+                            Map.entry(CelPolicyVariable.COMPONENT.variableName(), scriptArgComponent),
+                            Map.entry(CelPolicyVariable.PROJECT.variableName(), scriptArgProject),
+                            Map.entry(CelPolicyVariable.VULN.variableName(), protoVuln),
+                            Map.entry(CelPolicyVariable.NOW.variableName(), protoNow)
+                    );
+                    try {
+                        final boolean conditionMatched = script.execute(scriptArguments);
+                        if (conditionMatched && policyNameAndScripts.getValue().lastIndexOf(script) == policyNameAndScripts.getValue().size() - 1) {
+                            matchedPolicies.put(UUID.fromString(protoVuln.getUuid()), policiesByName.get(policyNameAndScripts.getKey()));
+
+                            // We already matched a policy; We're done for this vulnerability.
+                            break policyLoop;
+                        } else if (!conditionMatched) {
+                            // If we have any other policies in the pipeline with the EXACT same condition in them,
+                            // mark them as short-circuited; They'll not yield a match.
+                            // TODO: This should be more efficient
+                            for (final Map.Entry<String, List<CelPolicyScript>> otherPolicyNameAndScripts : compiledScriptsByPolicyName.entrySet()) {
+                                if (!otherPolicyNameAndScripts.getKey().equals(policyNameAndScripts.getKey()) && otherPolicyNameAndScripts.getValue().contains(script)) {
+                                    LOGGER.debug("Short-circuiting policy %s".formatted(otherPolicyNameAndScripts.getKey()));
+                                    shortCircuitedPolicies.add(otherPolicyNameAndScripts.getKey());
+                                }
+                            }
+
+                            // Move on to the next policy in the pipeline.
+                            continue policyLoop;
+                        }
+                    } catch (ScriptExecutionException e) {
+                        LOGGER.warn("Failed to execute script for condition %s with arguments %s", e);
+                        break policyLoop; // This policy can not succeed anymore; Move on to the next.
+                    }
+                }
+            }
+        }
+
+        return matchedPolicies;
+    }
+
+    private Project ensureRequirementsLoaded(final Project project, final MultiValuedMap<Type, String> requirements) {
+        // TODO: Load fields from database that are required, but not present in the project object already.
+        //   Currently omitted to keep the change set slim-ish.
+        return cacheManager.get(Project.class, buildCacheKey(project, requirements), cacheKey -> project);
+    }
+
+    private Component ensureRequirementsLoaded(final Component component, final MultiValuedMap<Type, String> requirements) {
+        // TODO: Load fields from database that are required, but not present in the component object already.
+        //   Currently omitted to keep the change set slim-ish.
+        return cacheManager.get(Component.class, buildCacheKey(component, requirements), cacheKey -> component);
+    }
+
+    private Map<String, Vulnerability> ensureRequirementsLoaded(final Collection<Vulnerability> vulns,
+                                                                final MultiValuedMap<Type, String> requirements) {
+        return vulns.stream()
+                .map(vuln -> Map.entry(vuln.getUuid(), ensureRequirementsLoaded(vuln, requirements)))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private Vulnerability ensureRequirementsLoaded(final Vulnerability vuln, final MultiValuedMap<Type, String> requirements) {
+        // TODO: Load fields from database that are required, but not present in the vuln object already.
+        //   Currently omitted to keep the change set slim-ish.
+        return cacheManager.get(Vulnerability.class, buildCacheKey(vuln, requirements), cacheKey -> vuln);
+    }
+
+    private CelPolicyScript compileConditionScript(final String conditionScriptSrc) {
+        try {
+            return scriptHost.compile(conditionScriptSrc, CelPolicyScriptHost.CacheMode.CACHE);
+        } catch (ScriptCreateException e) {
+            LOGGER.warn("Failed to compile script %s; Condition will be skipped"
+                    .formatted(conditionScriptSrc), e);
+            return null;
+        }
+    }
+
+    private static String buildCacheKey(final Project project, final MultiValuedMap<Type, String> requirements) {
+        final var cacheKeyParts = new ArrayList<>(requirements.get(TYPE_PROJECT));
+        if (cacheKeyParts.contains("properties") && requirements.containsKey(TYPE_PROJECT_PROPERTY)) {
+            for (final String propertyFieldName : requirements.get(TYPE_PROJECT_PROPERTY)) {
+                cacheKeyParts.add("property.%s".formatted(propertyFieldName));
+            }
+        }
+
+        final String rawCacheKey = "%s|%s"
+                .formatted(project.getUuid(), cacheKeyParts.stream().sorted().collect(Collectors.joining("|")));
+        return DigestUtils.sha256Hex(rawCacheKey);
+    }
+
+    private static String buildCacheKey(final Component component, final MultiValuedMap<Type, String> requirements) {
+        final var cacheKeyParts = new ArrayList<>(requirements.get(TYPE_COMPONENT));
+        if (cacheKeyParts.contains("resolved_license") && requirements.containsKey(TYPE_LICENSE)) {
+            for (final String licenseFieldName : requirements.get(TYPE_LICENSE)) {
+                cacheKeyParts.add("license.%s".formatted(licenseFieldName));
+            }
+
+            if (requirements.get(TYPE_LICENSE).contains("groups") && requirements.containsKey(TYPE_LICENSE_GROUP)) {
+                for (final String licenseGroupFieldName : requirements.get(TYPE_LICENSE_GROUP)) {
+                    cacheKeyParts.add("licenseGroup.%s".formatted(licenseGroupFieldName));
+                }
+            }
+        }
+
+        final String rawCacheKey = "%s|%s"
+                .formatted(component.getUuid(), cacheKeyParts.stream().sorted().collect(Collectors.joining("|")));
+        return DigestUtils.sha256Hex(rawCacheKey);
+    }
+
+    private static String buildCacheKey(final Vulnerability vuln, final MultiValuedMap<Type, String> requirements) {
+        final var cacheKeyParts = new ArrayList<>(requirements.get(TYPE_VULNERABILITY));
+        if (cacheKeyParts.contains("aliases") && requirements.containsKey(TYPE_VULNERABILITY_ALIAS)) {
+            for (final String aliasFieldName : requirements.get(TYPE_VULNERABILITY_ALIAS)) {
+                cacheKeyParts.add("alias.%s".formatted(aliasFieldName));
+            }
+        }
+
+        final String rawCacheKey = "%s|%s"
+                .formatted(vuln.getUuid(), cacheKeyParts.stream().sorted().collect(Collectors.joining("|")));
+        return DigestUtils.sha256Hex(rawCacheKey);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyLibrary.java
@@ -1,0 +1,29 @@
+package org.dependencytrack.policy.cel;
+
+import org.projectnessie.cel.EnvOption;
+import org.projectnessie.cel.Library;
+import org.projectnessie.cel.ProgramOption;
+
+import java.util.Collections;
+import java.util.List;
+
+class CelVulnerabilityPolicyLibrary implements Library {
+
+    @Override
+    public List<EnvOption> getCompileOptions() {
+        return List.of(
+                EnvOption.declarations(
+                        CelPolicyVariable.COMPONENT.declaration(),
+                        CelPolicyVariable.PROJECT.declaration(),
+                        CelPolicyVariable.VULN.declaration(),
+                        CelPolicyVariable.NOW.declaration()
+                )
+        );
+    }
+
+    @Override
+    public List<ProgramOption> getProgramOptions() {
+        return Collections.emptyList();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicy.java
+++ b/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicy.java
@@ -1,0 +1,108 @@
+package org.dependencytrack.policy.vulnerability;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+public class VulnerabilityPolicy {
+
+    private String name;
+
+    private String description;
+
+    private String author;
+
+    private ZonedDateTime created;
+
+    private ZonedDateTime updated;
+
+    private ZonedDateTime validFrom;
+
+    private ZonedDateTime validUntil;
+
+    private List<String> conditions;
+
+    private VulnerabilityPolicyAnalysis analysis;
+
+    private List<VulnerabilityPolicyRating> ratings;
+
+    public String name() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String description() {
+        return description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+
+    public String author() {
+        return author;
+    }
+
+    public void setAuthor(final String author) {
+        this.author = author;
+    }
+
+    public ZonedDateTime created() {
+        return created;
+    }
+
+    public void setCreated(final ZonedDateTime created) {
+        this.created = created;
+    }
+
+    public ZonedDateTime updated() {
+        return updated;
+    }
+
+    public void setUpdated(final ZonedDateTime updated) {
+        this.updated = updated;
+    }
+
+    public ZonedDateTime validFrom() {
+        return validFrom;
+    }
+
+    public void setValidFrom(final ZonedDateTime validFrom) {
+        this.validFrom = validFrom;
+    }
+
+    public ZonedDateTime validUntil() {
+        return validUntil;
+    }
+
+    public void setValidUntil(final ZonedDateTime validUntil) {
+        this.validUntil = validUntil;
+    }
+
+    public List<String> conditions() {
+        return conditions;
+    }
+
+    public void setConditions(final List<String> conditions) {
+        this.conditions = conditions;
+    }
+
+    public VulnerabilityPolicyAnalysis analysis() {
+        return analysis;
+    }
+
+    public void setAnalysis(final VulnerabilityPolicyAnalysis analysis) {
+        this.analysis = analysis;
+    }
+
+    public List<VulnerabilityPolicyRating> ratings() {
+        return ratings;
+    }
+
+    public void setRatings(final List<VulnerabilityPolicyRating> ratings) {
+        this.ratings = ratings;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyAnalysis.java
+++ b/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyAnalysis.java
@@ -1,0 +1,83 @@
+package org.dependencytrack.policy.vulnerability;
+
+public class VulnerabilityPolicyAnalysis {
+
+    public enum State {
+        EXPLOITABLE,
+        IN_TRIAGE,
+        FALSE_POSITIVE,
+        NOT_AFFECTED,
+        RESOLVED
+    }
+
+    public enum Justification {
+        CODE_NOT_PRESENT,
+        CODE_NOT_REACHABLE,
+        REQUIRES_CONFIGURATION,
+        REQUIRES_DEPENDENCY,
+        REQUIRES_ENVIRONMENT,
+        PROTECTED_BY_COMPILER,
+        PROTECTED_AT_RUNTIME,
+        PROTECTED_AT_PERIMETER,
+        PROTECTED_BY_MITIGATING_CONTROL,
+    }
+
+    public enum Response {
+        CAN_NOT_FIX,
+        WILL_NOT_FIX,
+        UPDATE,
+        ROLLBACK,
+        WORKAROUND_AVAILABLE,
+    }
+
+    private State state;
+
+    private Justification justification;
+
+    private Response response;
+
+    private String details;
+
+    private boolean suppress;
+
+    public State state() {
+        return state;
+    }
+
+    public void setState(final State state) {
+        this.state = state;
+    }
+
+    public Justification justification() {
+        return justification;
+    }
+
+    public void setJustification(final Justification justification) {
+        this.justification = justification;
+    }
+
+    public Response response() {
+        return response;
+    }
+
+    public void setResponse(final Response response) {
+        this.response = response;
+    }
+
+    public String details() {
+        return details;
+    }
+
+    public void setDetails(final String details) {
+        this.details = details;
+    }
+
+    public boolean suppress() {
+        return suppress;
+    }
+
+    public void setSuppress(final boolean suppress) {
+        this.suppress = suppress;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyEvaluator.java
@@ -1,0 +1,26 @@
+package org.dependencytrack.policy.vulnerability;
+
+import org.dependencytrack.proto.policy.v1.Component;
+import org.dependencytrack.proto.policy.v1.Project;
+import org.dependencytrack.proto.policy.v1.Vulnerability;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Evaluator for {@link VulnerabilityPolicy}s.
+ */
+public interface VulnerabilityPolicyEvaluator {
+
+    /**
+     * Evaluate one or more {@link Vulnerability}s against all applicable {@link VulnerabilityPolicy}s.
+     *
+     * @param vulns     The {@link Vulnerability}s to evaluate policies against
+     * @param component The affected {@link Component}
+     * @param project   The {@link Project} the affected {@link Component} is part of
+     * @return A {@link Map} keyed by {@link Vulnerability} {@link UUID}s, containing matched {@link VulnerabilityPolicy}s
+     */
+    Map<UUID, VulnerabilityPolicy> evaluate(final Collection<Vulnerability> vulns, final Component component, final Project project);
+
+}

--- a/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyProvider.java
+++ b/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyProvider.java
@@ -1,0 +1,20 @@
+package org.dependencytrack.policy.vulnerability;
+
+import org.dependencytrack.proto.policy.v1.Project;
+
+import java.util.List;
+
+/**
+ * A provider for {@link VulnerabilityPolicy}s.
+ */
+public interface VulnerabilityPolicyProvider {
+
+    /**
+     * Provide zero or more {@link VulnerabilityPolicy}s applicable to a given {@link Project}.
+     *
+     * @param project The {@link Project} to get applicable {@link VulnerabilityPolicy}s for
+     * @return All applicable {@link VulnerabilityPolicy}s
+     */
+    List<VulnerabilityPolicy> getApplicablePolicies(final Project project);
+
+}

--- a/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyRating.java
+++ b/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicyRating.java
@@ -1,0 +1,59 @@
+package org.dependencytrack.policy.vulnerability;
+
+public class VulnerabilityPolicyRating {
+
+    public enum Method {
+        CVSSv2,
+        CVSSv3,
+        OWASP
+    }
+
+    public enum Severity {
+        INFO,
+        LOW,
+        MEDIUM,
+        HIGH,
+        CRITICAL
+    }
+
+    private Method method;
+
+    private Severity severity;
+
+    private String vector;
+
+    private Double score;
+
+    public Method method() {
+        return method;
+    }
+
+    public void setMethod(final Method method) {
+        this.method = method;
+    }
+
+    public Severity severity() {
+        return severity;
+    }
+
+    public void setSeverity(final Severity severity) {
+        this.severity = severity;
+    }
+
+    public String vector() {
+        return vector;
+    }
+
+    public void setVector(final String vector) {
+        this.vector = vector;
+    }
+
+    public Double score() {
+        return score;
+    }
+
+    public void setScore(final Double score) {
+        this.score = score;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyConditionResource.java
@@ -34,6 +34,7 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.policy.cel.CelPolicyScriptHost;
 import org.dependencytrack.policy.cel.CelPolicyScriptHost.CacheMode;
+import org.dependencytrack.policy.cel.CelPolicyType;
 import org.dependencytrack.resources.v1.vo.CelExpressionError;
 import org.projectnessie.cel.common.CELError;
 import org.projectnessie.cel.tools.ScriptCreateException;
@@ -166,7 +167,7 @@ public class PolicyConditionResource extends AlpineResource {
         }
 
         try {
-            CelPolicyScriptHost.getInstance().compile(policyCondition.getValue(), CacheMode.NO_CACHE);
+            CelPolicyScriptHost.getInstance(CelPolicyType.COMPONENT).compile(policyCondition.getValue(), CacheMode.NO_CACHE);
         } catch (ScriptCreateException e) {
             final var celErrors = new ArrayList<CelExpressionError>();
             for (final CELError error : e.getIssues().getErrors()) {

--- a/src/test/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluatorTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluatorTest.java
@@ -1,0 +1,193 @@
+package org.dependencytrack.policy.cel;
+
+import alpine.server.cache.AbstractCacheManager;
+import org.dependencytrack.AbstractPostgresEnabledTest;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyProvider;
+import org.dependencytrack.proto.policy.v1.Component;
+import org.dependencytrack.proto.policy.v1.Project;
+import org.dependencytrack.proto.policy.v1.Vulnerability;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+public class CelVulnerabilityPolicyEvaluatorTest extends AbstractPostgresEnabledTest {
+
+    private VulnerabilityPolicyProvider policyProviderMock;
+    private VulnerabilityPolicyEvaluator policyEvaluator;
+
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+
+        final var cacheManager = new TestCacheManager();
+        final var policyScriptHost = CelPolicyScriptHost.getInstance(CelPolicyType.VULNERABILITY);
+        policyProviderMock = mock(VulnerabilityPolicyProvider.class);
+        policyEvaluator = new CelVulnerabilityPolicyEvaluator(policyProviderMock, policyScriptHost, cacheManager);
+    }
+
+    @Test
+    public void testEvaluateWithNoApplicablePolicies() {
+        final var project = Project.newBuilder()
+                .setUuid(UUID.randomUUID().toString())
+                .setName("acme-app")
+                .build();
+        final var component = Component.newBuilder()
+                .setUuid(UUID.randomUUID().toString())
+                .setName("acme-lib")
+                .build();
+        final UUID vulnUuid = UUID.randomUUID();
+        final var vuln = Vulnerability.newBuilder()
+                .setUuid(vulnUuid.toString())
+                .setId("CVE-123")
+                .build();
+
+        doReturn(Collections.emptyList())
+                .when(policyProviderMock).getApplicablePolicies(any(Project.class));
+
+        assertThat(policyEvaluator.evaluate(List.of(vuln), component, project)).isEmpty();
+    }
+
+    @Test
+    public void testEvaluateWithNoMatchingPolicies() {
+        final var project = Project.newBuilder()
+                .setUuid(UUID.randomUUID().toString())
+                .setName("acme-app")
+                .build();
+        final var component = Component.newBuilder()
+                .setUuid(UUID.randomUUID().toString())
+                .setName("acme-lib")
+                .build();
+        final UUID vulnUuid = UUID.randomUUID();
+        final var vuln = Vulnerability.newBuilder()
+                .setUuid(vulnUuid.toString())
+                .setId("CVE-123")
+                .build();
+
+        final var policyA = new VulnerabilityPolicy();
+        policyA.setName("policyA");
+        policyA.setConditions(List.of("component.name == 'foo'"));
+        final var policyB = new VulnerabilityPolicy();
+        policyB.setName("policyB");
+        policyB.setConditions(List.of("project.name == 'bar'"));
+        final var policyC = new VulnerabilityPolicy();
+        policyC.setName("policyC");
+        policyC.setConditions(List.of("vuln.id == 'baz'"));
+
+        doReturn(List.of(policyA, policyB, policyC))
+                .when(policyProviderMock).getApplicablePolicies(any(Project.class));
+
+        assertThat(policyEvaluator.evaluate(List.of(vuln), component, project)).isEmpty();
+    }
+
+    @Test
+    public void testEvaluateWithMultipleMatchingPolicies() {
+        final var project = Project.newBuilder()
+                .setUuid(UUID.randomUUID().toString())
+                .setName("acme-app")
+                .build();
+        final var component = Component.newBuilder()
+                .setUuid(UUID.randomUUID().toString())
+                .setName("acme-lib")
+                .build();
+        final UUID vulnUuid = UUID.randomUUID();
+        final var vuln = Vulnerability.newBuilder()
+                .setUuid(vulnUuid.toString())
+                .setId("CVE-123")
+                .build();
+
+        // Create multiple policies which all match the given evaluation input.
+        final var policyA = new VulnerabilityPolicy();
+        policyA.setName("policyA");
+        policyA.setConditions(List.of("component.name == 'acme-lib'"));
+        final var policyB = new VulnerabilityPolicy();
+        policyB.setName("policyB");
+        policyB.setConditions(List.of("project.name == 'acme-app'"));
+        final var policyC = new VulnerabilityPolicy();
+        policyC.setName("policyC");
+        policyC.setConditions(List.of("vuln.id == 'CVE-123'"));
+
+        doReturn(List.of(policyA, policyB, policyC))
+                .when(policyProviderMock).getApplicablePolicies(any(Project.class));
+
+        // Policies are supposed to be evaluated in order, so policyA should be the only match.
+        assertThat(policyEvaluator.evaluate(List.of(vuln), component, project))
+                .hasEntrySatisfying(vulnUuid, policy -> {
+                    assertThat(policy.name()).isEqualTo("policyA");
+                });
+    }
+
+    @Test
+    public void testEvaluateWithAdditionalRequiredFields() {
+        final var persistentProject = new org.dependencytrack.model.Project();
+        persistentProject.setName("acme-app");
+        persistentProject.setVersion("1.0.0");
+        qm.persist(persistentProject);
+
+        final var persistentComponent = new org.dependencytrack.model.Component();
+        persistentComponent.setProject(persistentProject);
+        persistentComponent.setName("acme-lib");
+        persistentComponent.setVersion("2.0.0");
+        qm.persist(persistentComponent);
+
+        final var persistentVuln = new org.dependencytrack.model.Vulnerability();
+        persistentVuln.setVulnId("CVE-123");
+        persistentVuln.setSource(org.dependencytrack.model.Vulnerability.Source.NVD);
+        persistentVuln.setCvssV3Vector("CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:H/A:L");
+        qm.persist(persistentVuln);
+
+        final var project = Project.newBuilder()
+                .setUuid(persistentProject.getUuid().toString())
+                .setName("acme-app")
+                .build();
+        final var component = Component.newBuilder()
+                .setUuid(persistentComponent.getUuid().toString())
+                .setName("acme-lib")
+                .build();
+        final var vuln = Vulnerability.newBuilder()
+                .setUuid(persistentVuln.getUuid().toString())
+                .setId("CVE-123")
+                .build();
+
+        // Access more fields than provided in the evaluation arguments.
+        // The evaluator should load those fields from the database.
+        final var policy = new VulnerabilityPolicy();
+        policy.setName("policy");
+        policy.setConditions(List.of("""
+                project.name == "acme-app"
+                  && project.version == "1.0.0"
+                  && component.name == "acme-lib"
+                  && component.version == "2.0.0"
+                  && vuln.id == "CVE-123"
+                  && vuln.cvssv3_vector == "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:H/A:L"
+                """));
+
+        doReturn(List.of(policy))
+                .when(policyProviderMock).getApplicablePolicies(any(Project.class));
+
+        // TODO: Does not currently match because loading of additional properties is not yet implemented.
+        //   Should be:
+        //     assertThat(policyEvaluator.evaluate(List.of(vuln), component, project))
+        //             .containsOnly(Map.entry(persistentVuln.getUuid(), policy));
+        assertThat(policyEvaluator.evaluate(List.of(vuln), component, project)).isEmpty();
+    }
+
+    private static final class TestCacheManager extends AbstractCacheManager {
+
+        private TestCacheManager() {
+            super(30, TimeUnit.SECONDS, 5);
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds definitions for vulnerability policies, and implements an evaluator powered by CEL.

The evaluator currently does not dynamically load required fields from the database. Because that includes a lot more code, I decided to decouple that from this initial PR to make reviews easier.

There are now two policy types, each with their own context (only difference currently are the available variables).

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Partly addresses https://github.com/DependencyTrack/hyades/issues/937

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
