### PR TITLE
Integrate vulnerability policy evaluation into scan result processing

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -82,8 +82,7 @@ public enum ConfigKey implements Config.Key {
     VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE("vulnerability.policy.bundle.source.type", "NGINX"),
     VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME( "vulnerability.policy.bundle.auth.username", null),
     VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD( "vulnerability.policy.bundle.auth.password", null),
-    RUN_MIGRATIONS("run.migrations", true),
-    VULNERABILITY_POLICY_ENABLED("vulnerability.policy.enabled", "false");
+    RUN_MIGRATIONS("run.migrations", true);
 
     private final String propertyName;
     private final Object defaultValue;

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -82,7 +82,8 @@ public enum ConfigKey implements Config.Key {
     VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE("vulnerability.policy.bundle.source.type", "NGINX"),
     VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME( "vulnerability.policy.bundle.auth.username", null),
     VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD( "vulnerability.policy.bundle.auth.password", null),
-    RUN_MIGRATIONS("run.migrations", true);
+    RUN_MIGRATIONS("run.migrations", true),
+    VULNERABILITY_POLICY_ENABLED("vulnerability.policy.enabled", "false");
 
     private final String propertyName;
     private final Object defaultValue;

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
@@ -65,9 +65,7 @@ final class KafkaEventConverter {
         return new KafkaEvent<>(KafkaTopics.REPO_META_ANALYSIS_COMMAND, event.purlCoordinates(), analysisCommand, null);
     }
 
-    static KafkaEvent<String, Notification> convert(final UUID projectUuid, final alpine.notification.Notification alpineNotification) {
-        final Notification notification = NotificationModelConverter.convert(alpineNotification);
-
+    static KafkaEvent<String, Notification> convert(final String key, final Notification notification) {
         final Topic<String, Notification> topic = switch (notification.getGroup()) {
             case GROUP_CONFIGURATION -> KafkaTopics.NOTIFICATION_CONFIGURATION;
             case GROUP_DATASOURCE_MIRRORING -> KafkaTopics.NOTIFICATION_DATASOURCE_MIRRORING;
@@ -92,10 +90,12 @@ final class KafkaEventConverter {
             return null;
         }
 
-        return new KafkaEvent<>(topic,
-                projectUuid != null ? projectUuid.toString() : null,
-                notification,
-                null);
+        return new KafkaEvent<>(topic, key, notification, null);
+    }
+
+    static KafkaEvent<String, Notification> convert(final UUID projectUuid, final alpine.notification.Notification alpineNotification) {
+        final Notification notification = NotificationModelConverter.convert(alpineNotification);
+        return convert(projectUuid != null ? projectUuid.toString() : null, notification);
     }
 
 }

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventDispatcher.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventDispatcher.java
@@ -121,6 +121,18 @@ public class KafkaEventDispatcher {
         return dispatchAsyncInternal(KafkaEventConverter.convert(projectUuid, alpineNotification), null);
     }
 
+    /**
+     * Asynchronously dispatch a given {@link org.dependencytrack.proto.notification.v1.Notification} to Kafka.
+     *
+     * @param key          The event key to use
+     * @param notification The {@link org.dependencytrack.proto.notification.v1.Notification} to dispatch
+     * @return A {@link Future} holding a {@link RecordMetadata} instance for the dispatched notification,
+     * or {@code null} when the event was not dispatched
+     */
+    public Future<RecordMetadata> dispatchAsync(final String key, final org.dependencytrack.proto.notification.v1.Notification notification) {
+        return dispatchAsyncInternal(KafkaEventConverter.convert(key, notification), null);
+    }
+
     private <K, V> Future<RecordMetadata> dispatchAsyncInternal(final KafkaEvent<K, V> event, final Callback callback) {
         if (event == null) {
             if (callback != null) {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -33,6 +33,7 @@ import org.dependencytrack.persistence.jdbi.NotificationSubjectDao;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyAnalysis;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
+import org.dependencytrack.proto.notification.v1.Group;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
@@ -66,6 +67,7 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
 import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
 import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln.convert;
@@ -328,7 +330,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     }
 
     /**
-     * Associate a given {@link Set} of {@link Vulnerability}s with a given {@link Component}.
+     * Associate a given {@link Collection} of {@link Vulnerability}s with a given {@link Component}.
      * <p>
      * If a {@link Vulnerability} was not previously associated with the {@link Component},
      * a {@link FindingAttribution} will be created for the {@link Scanner}.
@@ -353,6 +355,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     .toList();
             dao.createFindingAttributions(findingAttributions);
 
+            // Create indexes for vulnerability ID <-> UUID lookups.
             final var vulnIdByUuid = new HashMap<UUID, Long>();
             final var vulnUuidById = new HashMap<Long, UUID>();
             for (final Vulnerability vuln : vulns) {
@@ -379,54 +382,89 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 final UUID vulnUuid = vulnUuidAndPolicy.getKey();
                 final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
                 final String policyAnalysisCommenter = "[Policy] %s".formatted(policy.name());
-                final Analysis policyAnalysis = Analysis.fromPolicyAnalysis(policy.analysis());
+                final Analysis policyAnalysis = Analysis.fromPolicy(policy.analysis());
                 final Analysis existingAnalysis = existingAnalyses.get(vulnUuid);
                 if (existingAnalysis == null) {
                     policyAnalysis.setComponentId(component.id());
                     policyAnalysis.setProjectId(component.projectId());
                     policyAnalysis.setVulnId(vulnIdByUuid.get(vulnUuid));
                     policyAnalysis.setVulnUuid(vulnUuid);
+
+                    // We'll create comments for analysisId=null for now, as the Analysis we're referring
+                    // to hasn't been created yet. The analysisId is populated later, after bulk upserting
+                    // all analyses.
+                    final var commentFactory = new AnalysisCommentFactory(null, policyAnalysisCommenter);
                     if (policyAnalysis.getState() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "State: NOT_SET → %s".formatted(policyAnalysis.getState()), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("State: %s → %s"
+                                .formatted(AnalysisState.NOT_SET, policyAnalysis.getState()));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.getJustification() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Justification: NOT_SET → %s".formatted(policyAnalysis.getJustification()), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("Justification: %s → %s"
+                                .formatted(AnalysisJustification.NOT_SET, policyAnalysis.getJustification()));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.getResponse() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Response: NOT_SET → %s".formatted(policyAnalysis.response), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("Response: %s → %s"
+                                .formatted(AnalysisResponse.NOT_SET, policyAnalysis.response));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.getDetails() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Details: %s".formatted(policyAnalysis.details), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("Details: (None) → %s"
+                                .formatted(policyAnalysis.details));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.suppressed) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Suppressed", policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("Unsuppressed → Suppressed");
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     // TODO: Handle ratings
                     analysesToCreateOrUpdate.add(policyAnalysis);
                 } else {
                     boolean shouldUpdate = false;
+                    final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), policyAnalysisCommenter);
                     if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "State: %s → %s".formatted(existingAnalysis.getState(), policyAnalysis.getState()), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("State: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getState(), AnalysisState.NOT_SET),
+                                requireNonNullElse(policyAnalysis.getState(), AnalysisState.NOT_SET)));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
+
                         existingAnalysis.setState(policyAnalysis.getState());
                         shouldUpdate = true;
                     }
                     if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Justification: %s → %s".formatted(existingAnalysis.justification, policyAnalysis.getJustification()), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("Justification: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.justification, AnalysisJustification.NOT_SET),
+                                requireNonNullElse(policyAnalysis.getJustification(), AnalysisJustification.NOT_SET)));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
+
                         existingAnalysis.setJustification(policyAnalysis.getJustification());
                         shouldUpdate = true;
                     }
                     if (!Objects.equals(existingAnalysis.getResponse(), policyAnalysis.getResponse())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Response: %s → %s".formatted(existingAnalysis.response, policyAnalysis.getResponse()), policyAnalysisCommenter));
+                        final AnalysisComment comment = commentFactory.createComment("Response: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.response, AnalysisResponse.NOT_SET),
+                                requireNonNullElse(policyAnalysis.getResponse(), AnalysisResponse.NOT_SET)));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
+
                         existingAnalysis.setResponse(policyAnalysis.getResponse());
                         shouldUpdate = true;
                     }
-                    if (policy.analysis().getDetails() != null && !Objects.equals(existingAnalysis.details, policy.analysis().getDetails())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Details: %s → %s".formatted(existingAnalysis.details, policyAnalysis.getDetails()), policyAnalysisCommenter));
+                    if (!Objects.equals(existingAnalysis.details, policy.analysis().getDetails())) {
+                        final AnalysisComment comment = commentFactory.createComment("Details: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.details, "(None)"),
+                                requireNonNullElse(policyAnalysis.getDetails(), "(None)")));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
+
                         existingAnalysis.setDetails(policy.analysis().getDetails());
                         shouldUpdate = true;
                     }
                     if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policy.analysis().isSuppress())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Suppressed: %s → %s".formatted(existingAnalysis.suppressed, policyAnalysis.getSuppressed()), policyAnalysisCommenter));
+                        final String previousState = existingAnalysis.suppressed ? "Suppressed" : "Unsuppressed";
+                        final String newState = policyAnalysis.getSuppressed() ? "Suppressed" : "Unsuppressed";
+                        final AnalysisComment comment = commentFactory.createComment("%s → %s".formatted(previousState, newState));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
+
                         existingAnalysis.setSuppressed(policy.analysis().isSuppress());
                         shouldUpdate = true;
                     }
@@ -436,7 +474,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     }
                 }
 
-                // If the policy outcome is a suppression, don't report the vulnerability.
+                // If the finding was already suppressed, or the policy
                 if (Boolean.TRUE.equals(policyAnalysis.getSuppressed())) {
                     newFindingVulnIds.remove(vulnIdByUuid.get(vulnUuid));
                 }
@@ -463,6 +501,16 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         });
     }
 
+    /**
+     * Send {@link Group#GROUP_NEW_VULNERABLE_DEPENDENCY} and {@link Group#GROUP_NEW_VULNERABILITY} notifications
+     * for a given {@link Component}, <em>if it was found to have at least one non-suppressed vulnerability</em>.
+     *
+     * @param qm             The {@link QueryManager} to use
+     * @param component      The {@link Component} to send notifications for
+     * @param isNewComponent Whether {@code component} is new
+     * @param analysisLevel  The {@link VulnerabilityAnalysisLevel}
+     * @param newVulnUuids   {@link UUID}s of newly identified vulnerabilities
+     */
     private void maybeSendNotifications(final QueryManager qm, final Component component, final boolean isNewComponent,
                                         final VulnerabilityAnalysisLevel analysisLevel, final List<UUID> newVulnUuids) {
         if (newVulnUuids.isEmpty()) {
@@ -650,7 +698,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         private String details;
         private Boolean suppressed;
 
-        private static Analysis fromPolicyAnalysis(final VulnerabilityPolicyAnalysis policyAnalysis) {
+        private static Analysis fromPolicy(final VulnerabilityPolicyAnalysis policyAnalysis) {
             final var analysis = new Analysis();
             if (policyAnalysis.getState() != null) {
                 analysis.setState(switch (policyAnalysis.getState()) {
@@ -776,6 +824,14 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     }
 
     public record AnalysisComment(Long analysisId, String comment, String commenter) {
+    }
+
+    private record AnalysisCommentFactory(Long analysisId, String commenter) {
+
+        private AnalysisComment createComment(final String comment) {
+            return new AnalysisComment(this.analysisId, comment, this.commenter);
+        }
+
     }
 
     public record Component(long id, UUID uuid, long projectId, UUID projectUuid) {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -66,6 +66,8 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
+import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
 import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln.convert;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
@@ -111,6 +113,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
         final Timer.Sample timerSample = Timer.start();
         try (final var qm = new QueryManager()) {
+            // Do not unload fields upon commit (why is this even the default WTF).
+            qm.getPersistenceManager().setProperty(PROPERTY_RETAIN_VALUES, "true");
+            qm.getPersistenceManager().setProperty(PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT, "false");
+
             final Component component = jdbi(qm).withExtension(Dao.class, dao -> dao.getComponentByUuid(componentUuid));
             if (component == null) {
                 LOGGER.warn("Received result for component %s, but it does not exist (scanKey: %s)"
@@ -204,6 +210,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             }
         }
 
+        // Detach vulnerabilities from JDO persistence context.
+        // We do not want to trigger any DB interactions by accessing their fields.
+        qm.getPersistenceManager().makeTransientAll(syncedVulns);
+
         return syncedVulns;
     }
 
@@ -222,6 +232,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
      * @throws NoSuchElementException When the reported vulnerability is internal, but does not exist in the datastore
      */
     private Vulnerability syncVulnerability(final QueryManager qm, final Vulnerability vuln, final Scanner scanner) {
+        // TODO: Refactor this to use JDBI instead.
         // It is possible that the same vulnerability is reported for multiple components in parallel,
         // causing unique constraint violations when attempting to INSERT into the VULNERABILITY table.
         // In such cases, we can get away with simply retrying to SELECT or INSERT again.
@@ -367,6 +378,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
                 final UUID vulnUuid = vulnUuidAndPolicy.getKey();
                 final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
+                final String policyAnalysisCommenter = "[Policy] %s".formatted(policy.name());
                 final Analysis policyAnalysis = Analysis.fromPolicyAnalysis(policy.analysis());
                 final Analysis existingAnalysis = existingAnalyses.get(vulnUuid);
                 if (existingAnalysis == null) {
@@ -375,46 +387,46 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     policyAnalysis.setVulnId(vulnIdByUuid.get(vulnUuid));
                     policyAnalysis.setVulnUuid(vulnUuid);
                     if (policyAnalysis.getState() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "State: NOT_SET → %s".formatted(policyAnalysis.getState()), "Policy"));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "State: NOT_SET → %s".formatted(policyAnalysis.getState()), policyAnalysisCommenter));
                     }
                     if (policyAnalysis.getJustification() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Justification: NOT_SET → %s".formatted(policyAnalysis.getJustification()), "Policy"));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Justification: NOT_SET → %s".formatted(policyAnalysis.getJustification()), policyAnalysisCommenter));
                     }
                     if (policyAnalysis.getResponse() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Response: NOT_SET → %s".formatted(policyAnalysis.response), "Policy"));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Response: NOT_SET → %s".formatted(policyAnalysis.response), policyAnalysisCommenter));
                     }
                     if (policyAnalysis.getDetails() != null) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Details: %s".formatted(policyAnalysis.details), "Policy"));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Details: %s".formatted(policyAnalysis.details), policyAnalysisCommenter));
                     }
                     if (policyAnalysis.suppressed) {
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Suppressed", "Policy"));
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Suppressed", policyAnalysisCommenter));
                     }
                     // TODO: Handle ratings
                     analysesToCreateOrUpdate.add(policyAnalysis);
                 } else {
                     boolean shouldUpdate = false;
                     if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "State: %s → %s".formatted(existingAnalysis.getState(), policyAnalysis.getState()), "Policy"));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "State: %s → %s".formatted(existingAnalysis.getState(), policyAnalysis.getState()), policyAnalysisCommenter));
                         existingAnalysis.setState(policyAnalysis.getState());
                         shouldUpdate = true;
                     }
                     if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Justification: %s → %s".formatted(existingAnalysis.justification, policyAnalysis.getJustification()), "Policy"));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Justification: %s → %s".formatted(existingAnalysis.justification, policyAnalysis.getJustification()), policyAnalysisCommenter));
                         existingAnalysis.setJustification(policyAnalysis.getJustification());
                         shouldUpdate = true;
                     }
                     if (!Objects.equals(existingAnalysis.getResponse(), policyAnalysis.getResponse())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Response: %s → %s".formatted(existingAnalysis.response, policyAnalysis.getResponse()), "Policy"));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Response: %s → %s".formatted(existingAnalysis.response, policyAnalysis.getResponse()), policyAnalysisCommenter));
                         existingAnalysis.setResponse(policyAnalysis.getResponse());
                         shouldUpdate = true;
                     }
                     if (policy.analysis().getDetails() != null && !Objects.equals(existingAnalysis.details, policy.analysis().getDetails())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Details: %s → %s".formatted(existingAnalysis.details, policyAnalysis.getDetails()), "Policy"));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Details: %s → %s".formatted(existingAnalysis.details, policyAnalysis.getDetails()), policyAnalysisCommenter));
                         existingAnalysis.setDetails(policy.analysis().getDetails());
                         shouldUpdate = true;
                     }
                     if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policy.analysis().isSuppress())) {
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Suppressed: %s → %s".formatted(existingAnalysis.suppressed, policyAnalysis.getSuppressed()), "Policy"));
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Suppressed: %s → %s".formatted(existingAnalysis.suppressed, policyAnalysis.getSuppressed()), policyAnalysisCommenter));
                         existingAnalysis.setSuppressed(policy.analysis().isSuppress());
                         shouldUpdate = true;
                     }

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -1,29 +1,38 @@
 package org.dependencytrack.event.kafka.processor;
 
+import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.common.metrics.Metrics;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
+import com.google.protobuf.Any;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import io.micrometer.core.instrument.Timer;
 import org.apache.kafka.streams.processor.api.ContextualFixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.kafka.KafkaEventDispatcher;
 import org.dependencytrack.event.kafka.KafkaEventHeaders;
 import org.dependencytrack.event.kafka.KafkaUtil;
+import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
+import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.AnalyzerIdentity;
-import org.dependencytrack.model.Component;
-import org.dependencytrack.model.FindingAttribution;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
+import org.dependencytrack.model.mapping.PolicyProtoMapper;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
-import org.dependencytrack.notification.vo.NewVulnerabilityIdentified;
-import org.dependencytrack.notification.vo.NewVulnerableDependency;
 import org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.NotificationSubjectDao;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyAnalysis;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
@@ -31,20 +40,40 @@ import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
 import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
 import org.dependencytrack.util.PersistenceUtil;
 import org.dependencytrack.util.PersistenceUtil.Differ;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
+import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
 import javax.jdo.Query;
+import javax.ws.rs.core.MultivaluedHashMap;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln.convert;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABLE_DEPENDENCY;
+import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
+import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
 import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
 import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
-import static org.dependencytrack.util.NotificationUtil.generateNotificationContent;
-import static org.dependencytrack.util.NotificationUtil.generateNotificationTitle;
 import static org.dependencytrack.util.VulnerabilityUtil.canBeMirrored;
 import static org.dependencytrack.util.VulnerabilityUtil.isAuthoritativeSource;
 import static org.dependencytrack.util.VulnerabilityUtil.isMirroringEnabled;
@@ -60,6 +89,17 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             .register(Metrics.getRegistry());
 
     private final KafkaEventDispatcher eventDispatcher = new KafkaEventDispatcher();
+    private final VulnerabilityPolicyEvaluator vulnPolicyEvaluator;
+
+    public VulnerabilityScanResultProcessor() {
+        this(Config.getInstance().getPropertyAsBoolean(ConfigKey.VULNERABILITY_POLICY_ENABLED)
+                ? ServiceLoader.load(VulnerabilityPolicyEvaluator.class).findFirst().orElseThrow()
+                : null);
+    }
+
+    VulnerabilityScanResultProcessor(final VulnerabilityPolicyEvaluator vulnPolicyEvaluator) {
+        this.vulnPolicyEvaluator = vulnPolicyEvaluator;
+    }
 
     @Override
     public void process(final FixedKeyRecord<ScanKey, ScanResult> record) {
@@ -68,9 +108,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         final UUID componentUuid = UUID.fromString(scanKey.getComponentUuid());
         final VulnerabilityAnalysisLevel analysisLevel = determineAnalysisLevel(record);
         final boolean isNewComponent = determineIsComponentNew(record);
+
         final Timer.Sample timerSample = Timer.start();
-        try (final var qm = new QueryManager().withL2CacheDisabled()) {
-            final Component component = qm.getObjectByUuid(Component.class, componentUuid, List.of(Component.FetchGroup.IDENTITY.name()));
+        try (final var qm = new QueryManager()) {
+            final Component component = jdbi(qm).withExtension(Dao.class, dao -> dao.getComponentByUuid(componentUuid));
             if (component == null) {
                 LOGGER.warn("Received result for component %s, but it does not exist (scanKey: %s)"
                         .formatted(componentUuid, prettyPrint(scanKey)));
@@ -95,8 +136,8 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                                       final boolean isNewComponent) {
         if (scannerResult.getStatus() == SCAN_STATUS_FAILED) {
             final var message = "Scan of component %s with %s failed (scanKey: %s): %s"
-                    .formatted(component.getUuid(), scannerResult.getScanner(), prettyPrint(scanKey), scannerResult.getFailureReason());
-            eventDispatcher.dispatchAsync(component.getProject().getUuid(), new Notification()
+                    .formatted(component.uuid(), scannerResult.getScanner(), prettyPrint(scanKey), scannerResult.getFailureReason());
+            eventDispatcher.dispatchAsync(component.projectUuid(), new Notification()
                     .scope(NotificationScope.SYSTEM)
                     .group(NotificationGroup.ANALYZER)
                     .level(NotificationLevel.ERROR)
@@ -114,36 +155,16 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         LOGGER.debug("Synchronized %d vulnerabilities reported by %s for %s (scanKey: %s)"
                 .formatted(syncedVulns.size(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)));
 
-        //send notification if there is a new vulnerable component
-        if (isNewComponent && !syncedVulns.isEmpty()) {
-            final Component detachedComponent = qm.getPersistenceManager().detachCopy(component);
-            eventDispatcher.dispatchAsync(component.getProject().getUuid(), new Notification()
-                    .scope(NotificationScope.PORTFOLIO)
-                    .group(NotificationGroup.NEW_VULNERABLE_DEPENDENCY)
-                    .level(NotificationLevel.INFORMATIONAL)
-                    .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABLE_DEPENDENCY, detachedComponent.getProject()))
-                    .content(generateNotificationContent(component, syncedVulns))
-                    .subject(new NewVulnerableDependency(detachedComponent, syncedVulns)));
-        }
+        final Map<UUID, VulnerabilityPolicy> matchedPoliciesByVulnUuid = maybeEvaluateVulnPolicies(component, syncedVulns);
+        LOGGER.debug("Identified policy matches for %d/%d vulnerabilities (scanKey: %s)"
+                .formatted(matchedPoliciesByVulnUuid.size(), syncedVulns.size(), prettyPrint(scanKey)));
 
-
-        final Set<Vulnerability> newVulns = addVulnerabilities(qm, component, syncedVulns, scannerResult.getScanner());
+        final List<UUID> newVulnUuids = synchronizeFindingsAndAnalyses(qm, component, syncedVulns,
+                scannerResult.getScanner(), matchedPoliciesByVulnUuid);
         LOGGER.debug("Identified %d new vulnerabilities for %s with %s (scanKey: %s)"
-                .formatted(newVulns.size(), scanKey.getComponentUuid(), scannerResult.getScanner(), prettyPrint(scanKey)));
+                .formatted(newVulnUuids.size(), scanKey.getComponentUuid(), scannerResult.getScanner(), prettyPrint(scanKey)));
 
-        if (!newVulns.isEmpty()) {
-            final Component detachedComponent = qm.getPersistenceManager().detachCopy(component);
-            final Collection<Vulnerability> detachedVulns = qm.getPersistenceManager().detachCopyAll(newVulns);
-            for (final Vulnerability detachedVuln : detachedVulns) {
-                eventDispatcher.dispatchAsync(component.getProject().getUuid(), new Notification()
-                        .scope(NotificationScope.PORTFOLIO)
-                        .group(NotificationGroup.NEW_VULNERABILITY)
-                        .level(NotificationLevel.INFORMATIONAL)
-                        .title(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, detachedComponent.getProject()))
-                        .content(generateNotificationContent(detachedVuln))
-                        .subject(new NewVulnerabilityIdentified(detachedVuln, detachedComponent, analysisLevel)));
-            }
-        }
+        maybeSendNotifications(qm, component, isNewComponent, analysisLevel, newVulnUuids);
     }
 
     /**
@@ -277,6 +298,24 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         }, PersistenceUtil::isUniqueConstraintViolation);
     }
 
+    private Map<UUID, VulnerabilityPolicy> maybeEvaluateVulnPolicies(final Component component, final Collection<Vulnerability> vulns) {
+        if (vulnPolicyEvaluator == null) {
+            return Collections.emptyMap();
+        }
+
+        final var policyProject = org.dependencytrack.proto.policy.v1.Project.newBuilder()
+                .setUuid(component.projectUuid().toString())
+                .build();
+        final var policyComponent = org.dependencytrack.proto.policy.v1.Component.newBuilder()
+                .setUuid(component.uuid().toString())
+                .build();
+        final List<org.dependencytrack.proto.policy.v1.Vulnerability> policyVulns = vulns.stream()
+                .map(PolicyProtoMapper::mapToProto)
+                .toList();
+
+        return vulnPolicyEvaluator.evaluate(policyVulns, policyComponent, policyProject);
+    }
+
     /**
      * Associate a given {@link Set} of {@link Vulnerability}s with a given {@link Component}.
      * <p>
@@ -287,24 +326,166 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
      * @param component The {@link Component} to associate with
      * @param vulns     The {@link Vulnerability}s to associate with
      * @param scanner   The {@link Scanner} that identified the association
-     * @return A {@link Set} of {@link Vulnerability}s that were not previously associated with the {@link Component}
+     * @return A {@link Collection} of {@link Vulnerability}s that were not previously associated with the {@link Component}
      */
-    private Set<Vulnerability> addVulnerabilities(final QueryManager qm, final Component component,
-                                                  final Set<Vulnerability> vulns, final Scanner scanner) {
-        final var newVulns = new HashSet<Vulnerability>();
+    private List<UUID> synchronizeFindingsAndAnalyses(final QueryManager qm, final Component component,
+                                                      final Collection<Vulnerability> vulns, final Scanner scanner,
+                                                      final Map<UUID, VulnerabilityPolicy> policiesByVulnUuid) {
+        return jdbi(qm).inTransaction(jdbiHandle -> {
+            final var dao = jdbiHandle.attach(Dao.class);
 
-        for (final Vulnerability vuln : vulns) {
-            qm.runInTransaction(() -> {
-                if (!qm.contains(vuln, component)) {
-                    component.addVulnerability(vuln);
-                    qm.getPersistenceManager().makePersistent(new FindingAttribution(
-                            component, vuln, convert(scanner), null, null));
-                    newVulns.add(vuln);
+            // Bulk-create new findings and corresponding scanner attributions.
+            final List<Long> newFindingVulnIds = dao.createFindings(component, vulns);
+            final List<FindingAttribution> findingAttributions = newFindingVulnIds.stream()
+                    .map(vulnId -> new FindingAttribution(vulnId, component.id(), component.projectId(),
+                            convert(scanner).name(), UUID.randomUUID()))
+                    .toList();
+            dao.createFindingAttributions(findingAttributions);
+
+            final var vulnIdByUuid = new HashMap<UUID, Long>();
+            final var vulnUuidById = new HashMap<Long, UUID>();
+            for (final Vulnerability vuln : vulns) {
+                vulnIdByUuid.put(vuln.getUuid(), vuln.getId());
+                vulnUuidById.put(vuln.getId(), vuln.getUuid());
+            }
+
+            // Unless we have any matching vulnerability policies, there's nothing more to do!
+            if (policiesByVulnUuid.isEmpty()) {
+                return vulnUuidById.entrySet().stream()
+                        .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
+                        .map(Map.Entry::getValue)
+                        .toList();
+            }
+
+            // For all vulnerabilities with matching policies, bulk-fetch existing analyses.
+            // Index them by vulnerability UUID for more efficient access.
+            final Map<UUID, Analysis> existingAnalyses = dao.getAnalyses(component, policiesByVulnUuid.keySet()).stream()
+                    .collect(Collectors.toMap(Analysis::getVulnUuid, Function.identity()));
+
+            final var analysesToCreateOrUpdate = new ArrayList<Analysis>();
+            final var analysisCommentsByVulnId = new MultivaluedHashMap<Long, AnalysisComment>();
+            for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
+                final UUID vulnUuid = vulnUuidAndPolicy.getKey();
+                final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
+                final Analysis policyAnalysis = Analysis.fromPolicyAnalysis(policy.analysis());
+                final Analysis existingAnalysis = existingAnalyses.get(vulnUuid);
+                if (existingAnalysis == null) {
+                    policyAnalysis.setComponentId(component.id());
+                    policyAnalysis.setProjectId(component.projectId());
+                    policyAnalysis.setVulnId(vulnIdByUuid.get(vulnUuid));
+                    policyAnalysis.setVulnUuid(vulnUuid);
+                    if (policyAnalysis.getState() != null) {
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "State: NOT_SET → %s".formatted(policyAnalysis.getState()), "Policy"));
+                    }
+                    if (policyAnalysis.getJustification() != null) {
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Justification: NOT_SET → %s".formatted(policyAnalysis.getJustification()), "Policy"));
+                    }
+                    if (policyAnalysis.getResponse() != null) {
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Response: NOT_SET → %s".formatted(policyAnalysis.response), "Policy"));
+                    }
+                    if (policyAnalysis.getDetails() != null) {
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Details: %s".formatted(policyAnalysis.details), "Policy"));
+                    }
+                    if (policyAnalysis.suppressed) {
+                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), new AnalysisComment(null, "Suppressed", "Policy"));
+                    }
+                    // TODO: Handle ratings
+                    analysesToCreateOrUpdate.add(policyAnalysis);
+                } else {
+                    boolean shouldUpdate = false;
+                    if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "State: %s → %s".formatted(existingAnalysis.getState(), policyAnalysis.getState()), "Policy"));
+                        existingAnalysis.setState(policyAnalysis.getState());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Justification: %s → %s".formatted(existingAnalysis.justification, policyAnalysis.getJustification()), "Policy"));
+                        existingAnalysis.setJustification(policyAnalysis.getJustification());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getResponse(), policyAnalysis.getResponse())) {
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Response: %s → %s".formatted(existingAnalysis.response, policyAnalysis.getResponse()), "Policy"));
+                        existingAnalysis.setResponse(policyAnalysis.getResponse());
+                        shouldUpdate = true;
+                    }
+                    if (policy.analysis().getDetails() != null && !Objects.equals(existingAnalysis.details, policy.analysis().getDetails())) {
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Details: %s → %s".formatted(existingAnalysis.details, policyAnalysis.getDetails()), "Policy"));
+                        existingAnalysis.setDetails(policy.analysis().getDetails());
+                        shouldUpdate = true;
+                    }
+                    if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policy.analysis().isSuppress())) {
+                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), new AnalysisComment(existingAnalysis.getId(), "Suppressed: %s → %s".formatted(existingAnalysis.suppressed, policyAnalysis.getSuppressed()), "Policy"));
+                        existingAnalysis.setSuppressed(policy.analysis().isSuppress());
+                        shouldUpdate = true;
+                    }
+                    // TODO: Handle ratings
+                    if (shouldUpdate) {
+                        analysesToCreateOrUpdate.add(existingAnalysis);
+                    }
                 }
-            });
+
+                // If the policy outcome is a suppression, don't report the vulnerability.
+                if (Boolean.TRUE.equals(policyAnalysis.getSuppressed())) {
+                    newFindingVulnIds.remove(vulnIdByUuid.get(vulnUuid));
+                }
+            }
+
+            if (!analysesToCreateOrUpdate.isEmpty()) {
+                final List<CreatedAnalysis> createdAnalyses = dao.createOrUpdateAnalyses(analysesToCreateOrUpdate);
+
+                // Comments for new analyses do not have an analysis ID set yet, as that ID is not known prior
+                // to inserting the respective analysis record. Enrich comments with analysis IDs now that we know them.
+                for (final CreatedAnalysis createdAnalysis : createdAnalyses) {
+                    analysisCommentsByVulnId.computeIfPresent(createdAnalysis.vulnId, (vulnId, comments) -> comments.stream()
+                            .map(comment -> new AnalysisComment(createdAnalysis.id, comment.comment(), comment.commenter()))
+                            .toList());
+                }
+
+                dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
+            }
+
+            return vulnUuidById.entrySet().stream()
+                    .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
+                    .map(Map.Entry::getValue)
+                    .toList();
+        });
+    }
+
+    private void maybeSendNotifications(final QueryManager qm, final Component component, final boolean isNewComponent,
+                                        final VulnerabilityAnalysisLevel analysisLevel, final List<UUID> newVulnUuids) {
+        if (newVulnUuids.isEmpty()) {
+            return;
         }
 
-        return newVulns;
+        final Timestamp notificationTimestamp = Timestamps.now();
+        final var notifications = new ArrayList<org.dependencytrack.proto.notification.v1.Notification>();
+        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> {
+            if (isNewComponent) {
+                dao.getForNewVulnerableDependency(component.uuid())
+                        .map(subject -> org.dependencytrack.proto.notification.v1.Notification.newBuilder()
+                                .setScope(SCOPE_PORTFOLIO)
+                                .setGroup(GROUP_NEW_VULNERABLE_DEPENDENCY)
+                                .setLevel(LEVEL_INFORMATIONAL)
+                                .setTimestamp(notificationTimestamp)
+                                .setSubject(Any.pack(subject))
+                                .build())
+                        .ifPresent(notifications::add);
+            }
+
+            dao.getForNewVulnerabilities(component.uuid(), newVulnUuids, analysisLevel).stream()
+                    .map(subject -> org.dependencytrack.proto.notification.v1.Notification.newBuilder()
+                            .setScope(SCOPE_PORTFOLIO)
+                            .setGroup(GROUP_NEW_VULNERABILITY)
+                            .setLevel(LEVEL_INFORMATIONAL)
+                            .setTimestamp(notificationTimestamp)
+                            .setSubject(Any.pack(subject))
+                            .build())
+                    .forEach(notifications::add);
+        });
+
+        for (final org.dependencytrack.proto.notification.v1.Notification notification : notifications) {
+            eventDispatcher.dispatchAsync(component.projectUuid().toString(), notification);
+        }
     }
 
     private boolean canUpdateVulnerability(final Vulnerability vuln, final Scanner scanner) {
@@ -353,6 +534,242 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
     private static String prettyPrint(final ScanKey scanKey) {
         return "%s/%s".formatted(scanKey.getScanToken(), scanKey.getComponentUuid());
+    }
+
+    public interface Dao {
+
+        @SqlQuery("""
+                SELECT
+                  "C"."ID"   AS "id",
+                  "C"."UUID" AS "uuid",
+                  "P"."ID"   AS "projectId",
+                  "P"."UUID" AS "projectUuid"
+                FROM
+                  "COMPONENT" AS "C"
+                INNER JOIN
+                  "PROJECT" AS "P" ON "P"."ID" = "C"."PROJECT_ID"
+                WHERE
+                  "C"."UUID" = (:uuid)::TEXT
+                """)
+        @RegisterConstructorMapper(Component.class)
+        Component getComponentByUuid(final UUID uuid);
+
+        @SqlBatch("""
+                INSERT INTO "COMPONENTS_VULNERABILITIES"
+                  ("COMPONENT_ID", "VULNERABILITY_ID")
+                VALUES
+                  (:component.id, :vuln.id)
+                ON CONFLICT DO NOTHING
+                RETURNING "VULNERABILITY_ID"
+                """)
+        @GetGeneratedKeys("VULNERABILITY_ID")
+        List<Long> createFindings(@BindMethods("component") final Component component, @BindBean("vuln") final Iterable<Vulnerability> vuln);
+
+        @SqlBatch("""
+                INSERT INTO "FINDINGATTRIBUTION"
+                  ("VULNERABILITY_ID", "COMPONENT_ID", "PROJECT_ID", "ANALYZERIDENTITY", "ATTRIBUTED_ON", "UUID")
+                VALUES
+                  (:vulnId, :componentId, :projectId, :analyzer, NOW(), (:uuid)::TEXT)
+                ON CONFLICT ("VULNERABILITY_ID", "COMPONENT_ID") DO NOTHING
+                """)
+        void createFindingAttributions(@BindMethods final Iterable<FindingAttribution> attribution);
+
+        @SqlQuery("""
+                SELECT
+                  "V"."ID"            AS "vulnId",
+                  "V"."UUID"          AS "vulnUuid",
+                  "A"."ID"            AS "id",
+                  "A"."COMPONENT_ID"  AS "componentId",
+                  "A"."PROJECT_ID"    AS "projectId",
+                  "A"."STATE"         AS "state",
+                  "A"."JUSTIFICATION" AS "justification",
+                  "A"."RESPONSE"      AS "response",
+                  "A"."DETAILS"       AS "details",
+                  "A"."SUPPRESSED"    AS "suppressed"
+                FROM
+                  "VULNERABILITY" AS "V"
+                INNER JOIN
+                  "ANALYSIS" AS "A" ON "A"."VULNERABILITY_ID" = "V"."ID"
+                WHERE
+                  "A"."COMPONENT_ID" = :component.id
+                  AND "V"."UUID" = ANY((:vulnUuids)::TEXT[])
+                """)
+        @RegisterBeanMapper(Analysis.class)
+        List<Analysis> getAnalyses(@BindMethods("component") final Component component, final Iterable<UUID> vulnUuids);
+
+        @SqlBatch("""
+                INSERT INTO "ANALYSIS"
+                  ("VULNERABILITY_ID", "COMPONENT_ID", "PROJECT_ID", "STATE", "JUSTIFICATION", "RESPONSE", "DETAILS", "SUPPRESSED")
+                VALUES
+                  (:vulnId, :componentId, :projectId, :state, :justification, :response, :details, :suppressed)
+                ON CONFLICT ("VULNERABILITY_ID", "COMPONENT_ID", "PROJECT_ID") DO UPDATE
+                  SET
+                    "STATE" = :state,
+                    "JUSTIFICATION" = :justification,
+                    "RESPONSE" = :response,
+                    "DETAILS" = :details,
+                    "SUPPRESSED" = :suppressed
+                RETURNING "ID", "VULNERABILITY_ID"
+                """)
+        @GetGeneratedKeys({"ID", "VULNERABILITY_ID"})
+        @RegisterConstructorMapper(CreatedAnalysis.class)
+        List<CreatedAnalysis> createOrUpdateAnalyses(@BindBean final Iterable<Analysis> analysis);
+
+        @SqlBatch("""
+                INSERT INTO "ANALYSISCOMMENT"
+                  ("ANALYSIS_ID", "TIMESTAMP", "COMMENT", "COMMENTER")
+                VALUES
+                  (:analysisId, NOW(), :comment, :commenter)
+                """)
+        void createAnalysisComments(@BindMethods final Iterable<AnalysisComment> comment);
+
+    }
+
+    public static class Analysis {
+
+        private long id;
+        private long componentId;
+        private long projectId;
+        private long vulnId;
+        private UUID vulnUuid;
+        private AnalysisState state;
+        private AnalysisJustification justification;
+        private AnalysisResponse response;
+        private String details;
+        private Boolean suppressed;
+
+        private static Analysis fromPolicyAnalysis(final VulnerabilityPolicyAnalysis policyAnalysis) {
+            final var analysis = new Analysis();
+            if (policyAnalysis.getState() != null) {
+                analysis.setState(switch (policyAnalysis.getState()) {
+                    case EXPLOITABLE -> AnalysisState.EXPLOITABLE;
+                    case FALSE_POSITIVE -> AnalysisState.FALSE_POSITIVE;
+                    case IN_TRIAGE -> AnalysisState.IN_TRIAGE;
+                    case NOT_AFFECTED -> AnalysisState.NOT_AFFECTED;
+                    case RESOLVED -> AnalysisState.RESOLVED;
+                });
+            }
+            if (policyAnalysis.getJustification() != null) {
+                analysis.setJustification(switch (policyAnalysis.getJustification()) {
+                    case CODE_NOT_PRESENT -> AnalysisJustification.CODE_NOT_PRESENT;
+                    case CODE_NOT_REACHABLE -> AnalysisJustification.CODE_NOT_REACHABLE;
+                    case PROTECTED_AT_PERIMETER -> AnalysisJustification.PROTECTED_AT_PERIMETER;
+                    case PROTECTED_AT_RUNTIME -> AnalysisJustification.PROTECTED_AT_RUNTIME;
+                    case PROTECTED_BY_COMPILER -> AnalysisJustification.PROTECTED_BY_COMPILER;
+                    case PROTECTED_BY_MITIGATING_CONTROL -> AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL;
+                    case REQUIRES_CONFIGURATION -> AnalysisJustification.REQUIRES_CONFIGURATION;
+                    case REQUIRES_DEPENDENCY -> AnalysisJustification.REQUIRES_DEPENDENCY;
+                    case REQUIRES_ENVIRONMENT -> AnalysisJustification.REQUIRES_ENVIRONMENT;
+                });
+            }
+            if (policyAnalysis.getResponse() != null) {
+                analysis.setResponse(switch (policyAnalysis.getResponse()) {
+                    case CAN_NOT_FIX -> AnalysisResponse.CAN_NOT_FIX;
+                    case ROLLBACK -> AnalysisResponse.ROLLBACK;
+                    case UPDATE -> AnalysisResponse.UPDATE;
+                    case WILL_NOT_FIX -> AnalysisResponse.WILL_NOT_FIX;
+                    case WORKAROUND_AVAILABLE -> AnalysisResponse.WORKAROUND_AVAILABLE;
+                });
+            }
+            if (policyAnalysis.getDetails() != null) {
+                analysis.setDetails(policyAnalysis.getDetails());
+            }
+            analysis.setSuppressed(policyAnalysis.isSuppress());
+            return analysis;
+        }
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(final long id) {
+            this.id = id;
+        }
+
+        public long getComponentId() {
+            return componentId;
+        }
+
+        public void setComponentId(final long componentId) {
+            this.componentId = componentId;
+        }
+
+        public long getProjectId() {
+            return projectId;
+        }
+
+        public void setProjectId(final long projectId) {
+            this.projectId = projectId;
+        }
+
+        public long getVulnId() {
+            return vulnId;
+        }
+
+        public void setVulnId(final long vulnId) {
+            this.vulnId = vulnId;
+        }
+
+        public UUID getVulnUuid() {
+            return vulnUuid;
+        }
+
+        public void setVulnUuid(final UUID vulnUuid) {
+            this.vulnUuid = vulnUuid;
+        }
+
+        public AnalysisState getState() {
+            return state;
+        }
+
+        public void setState(final AnalysisState state) {
+            this.state = state;
+        }
+
+        public AnalysisJustification getJustification() {
+            return justification;
+        }
+
+        public void setJustification(final AnalysisJustification justification) {
+            this.justification = justification;
+        }
+
+        public AnalysisResponse getResponse() {
+            return response;
+        }
+
+        public void setResponse(final AnalysisResponse response) {
+            this.response = response;
+        }
+
+        public String getDetails() {
+            return details;
+        }
+
+        public void setDetails(final String details) {
+            this.details = details;
+        }
+
+        public Boolean getSuppressed() {
+            return suppressed;
+        }
+
+        public void setSuppressed(final Boolean suppressed) {
+            this.suppressed = suppressed;
+        }
+
+    }
+
+    public record CreatedAnalysis(long id, @ColumnName("VULNERABILITY_ID") long vulnId) {
+    }
+
+    public record AnalysisComment(Long analysisId, String comment, String commenter) {
+    }
+
+    public record Component(long id, UUID uuid, long projectId, UUID projectUuid) {
+    }
+
+    public record FindingAttribution(long vulnId, long componentId, long projectId, String analyzer, UUID uuid) {
     }
 
 }

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -169,7 +169,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         LOGGER.debug("Identified policy matches for %d/%d vulnerabilities (scanKey: %s)"
                 .formatted(matchedPoliciesByVulnUuid.size(), syncedVulns.size(), prettyPrint(scanKey)));
 
-        final List<UUID> newVulnUuids = synchronizeFindingsAndAnalyses(qm, component, syncedVulns,
+        final List<Vulnerability> newVulnUuids = synchronizeFindingsAndAnalyses(qm, component, syncedVulns,
                 scannerResult.getScanner(), matchedPoliciesByVulnUuid);
         LOGGER.debug("Identified %d new vulnerabilities for %s with %s (scanKey: %s)"
                 .formatted(newVulnUuids.size(), scanKey.getComponentUuid(), scannerResult.getScanner(), prettyPrint(scanKey)));
@@ -341,16 +341,17 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
      * If a {@link Vulnerability} was not previously associated with the {@link Component},
      * a {@link FindingAttribution} will be created for the {@link Scanner}.
      *
-     * @param qm        The {@link QueryManager} to use
-     * @param component The {@link Component} to associate with
-     * @param vulns     The {@link Vulnerability}s to associate with
-     * @param scanner   The {@link Scanner} that identified the association
-     * @return A {@link List} of {@link UUID}s, for {@link Vulnerability}s that were not previously
-     * associated with the {@link Component}, and which have not been suppressed via {@link VulnerabilityPolicy}.
+     * @param qm                 The {@link QueryManager} to use
+     * @param component          The {@link Component} to associate with
+     * @param vulns              The {@link Vulnerability}s to associate with
+     * @param scanner            The {@link Scanner} that identified the association
+     * @param policiesByVulnUuid Matched {@link VulnerabilityPolicy}s grouped by {@link Vulnerability#getUuid()}
+     * @return A {@link List} of {@link Vulnerability}s, that were not previously associated with the {@link Component},
+     * and which have not been suppressed via {@link VulnerabilityPolicy}.
      */
-    private List<UUID> synchronizeFindingsAndAnalyses(final QueryManager qm, final Component component,
-                                                      final Collection<Vulnerability> vulns, final Scanner scanner,
-                                                      final Map<UUID, VulnerabilityPolicy> policiesByVulnUuid) {
+    private List<Vulnerability> synchronizeFindingsAndAnalyses(final QueryManager qm, final Component component,
+                                                               final Collection<Vulnerability> vulns, final Scanner scanner,
+                                                               final Map<UUID, VulnerabilityPolicy> policiesByVulnUuid) {
         return jdbi(qm).inTransaction(jdbiHandle -> {
             final var dao = jdbiHandle.attach(Dao.class);
 
@@ -362,236 +363,249 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     .toList();
             dao.createFindingAttributions(findingAttributions);
 
-            // Index vulnerabilities by ID and UUID for more efficient lookups.
-            final var vulnById = new HashMap<Long, Vulnerability>();
-            final var vulnByUuid = new HashMap<UUID, Vulnerability>();
-            for (final Vulnerability vuln : vulns) {
-                vulnById.put(vuln.getId(), vuln);
-                vulnByUuid.put(vuln.getUuid(), vuln);
-            }
-
-            // Unless we have any matching vulnerability policies, there's nothing more to do!
-            if (policiesByVulnUuid.isEmpty()) {
-                return vulnById.entrySet().stream()
-                        .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
-                        .map(Map.Entry::getValue)
-                        .map(Vulnerability::getUuid)
-                        .toList();
-            }
-
-            // For all vulnerabilities with matching policies, bulk-fetch existing analyses.
-            // Index them by vulnerability UUID for more efficient access.
-            final Map<UUID, Analysis> existingAnalyses = dao.getAnalyses(component, policiesByVulnUuid.keySet()).stream()
-                    .collect(Collectors.toMap(Analysis::getVulnUuid, Function.identity()));
-
-            final var analysesToCreateOrUpdate = new ArrayList<Analysis>();
-            final var analysisCommentsByVulnId = new MultivaluedHashMap<Long, AnalysisComment>();
-            for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
-                final Vulnerability vuln = vulnByUuid.get(vulnUuidAndPolicy.getKey());
-                final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
-                final Analysis policyAnalysis;
-                try {
-                    policyAnalysis = Analysis.fromPolicy(policy);
-                } catch (IllegalArgumentException e) {
-                    LOGGER.warn("Unable to apply policy %s as it was found to be invalid".formatted(policy.name()), e);
-                    continue;
-                }
-
-                final Analysis existingAnalysis = existingAnalyses.get(vuln.getUuid());
-                if (existingAnalysis == null) {
-                    policyAnalysis.setComponentId(component.id());
-                    policyAnalysis.setProjectId(component.projectId());
-                    policyAnalysis.setVulnId(vuln.getId());
-                    policyAnalysis.setVulnUuid(vuln.getUuid());
-
-                    // We'll create comments for analysisId=null for now, as the Analysis we're referring
-                    // to hasn't been created yet. The analysisId is populated later, after bulk upserting
-                    // all analyses.
-                    final var commentFactory = new AnalysisCommentFactory(null, createPolicyAnalysisCommenter(policy));
-                    if (policyAnalysis.getState() != null) {
-                        commentFactory.createComment("State: %s → %s"
-                                .formatted(AnalysisState.NOT_SET, policyAnalysis.getState()));
-                    }
-                    if (policyAnalysis.getJustification() != null) {
-                        commentFactory.createComment("Justification: %s → %s"
-                                .formatted(AnalysisJustification.NOT_SET, policyAnalysis.getJustification()));
-                    }
-                    if (policyAnalysis.getResponse() != null) {
-                        commentFactory.createComment("Response: %s → %s"
-                                .formatted(AnalysisResponse.NOT_SET, policyAnalysis.response));
-                    }
-                    if (policyAnalysis.getDetails() != null) {
-                        commentFactory.createComment("Details: (None) → %s"
-                                .formatted(policyAnalysis.details));
-                    }
-                    if (policyAnalysis.getSuppressed()) {
-                        commentFactory.createComment("Unsuppressed → Suppressed");
-                    }
-                    if (policyAnalysis.getSeverity() != null) {
-                        commentFactory.createComment("Severity: %s → %s"
-                                .formatted(vuln.getSeverity(), policyAnalysis.getSeverity()));
-                    }
-                    if (policyAnalysis.getCvssV2Vector() != null) {
-                        commentFactory.createComment("CVSSv2 Vector: %s → %s"
-                                .formatted(requireNonNullElse(vuln.getCvssV2Vector(), "(None)"), policyAnalysis.getCvssV2Vector()));
-                    }
-                    if (policyAnalysis.getCvssV2Score() != null) {
-                        commentFactory.createComment("CVSSv2 Score: %s → %s"
-                                .formatted(requireNonNullElse(vuln.getCvssV2BaseScore(), "(None)"), policyAnalysis.getCvssV2Score()));
-                    }
-                    if (policyAnalysis.getCvssV3Vector() != null) {
-                        commentFactory.createComment("CVSSv3 Vector: %s → %s"
-                                .formatted(requireNonNullElse(vuln.getCvssV3Vector(), "(None)"), policyAnalysis.getCvssV3Vector()));
-                    }
-                    if (policyAnalysis.getCvssV3Score() != null) {
-                        commentFactory.createComment("CVSSv3 Score: %s → %s"
-                                .formatted(requireNonNullElse(vuln.getCvssV3BaseScore(), "(None)"), policyAnalysis.getCvssV3Score()));
-                    }
-                    if (policyAnalysis.getOwaspVector() != null) {
-                        commentFactory.createComment("OWASP Vector: %s → %s"
-                                .formatted(requireNonNullElse(vuln.getOwaspRRVector(), "(None)"), policyAnalysis.getOwaspVector()));
-                    }
-                    if (policyAnalysis.getOwaspScore() != null) {
-                        commentFactory.createComment("OWASP Score: %s → %s"
-                                .formatted(requireNonNullElse(vuln.getOwaspRRLikelihoodScore(), "(None)"), policyAnalysis.getOwaspScore()));
-                    }
-                    analysesToCreateOrUpdate.add(policyAnalysis);
-                    analysisCommentsByVulnId.addAll(policyAnalysis.getVulnId(), commentFactory.getComments());
-                } else {
-                    boolean shouldUpdate = false;
-                    final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), createPolicyAnalysisCommenter(policy));
-                    if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
-                        commentFactory.createComment("State: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getState(), AnalysisState.NOT_SET),
-                                requireNonNullElse(policyAnalysis.getState(), AnalysisState.NOT_SET)));
-
-                        existingAnalysis.setState(policyAnalysis.getState());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
-                        commentFactory.createComment("Justification: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.justification, AnalysisJustification.NOT_SET),
-                                requireNonNullElse(policyAnalysis.getJustification(), AnalysisJustification.NOT_SET)));
-
-                        existingAnalysis.setJustification(policyAnalysis.getJustification());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getResponse(), policyAnalysis.getResponse())) {
-                        commentFactory.createComment("Response: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.response, AnalysisResponse.NOT_SET),
-                                requireNonNullElse(policyAnalysis.getResponse(), AnalysisResponse.NOT_SET)));
-
-                        existingAnalysis.setResponse(policyAnalysis.getResponse());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.details, policyAnalysis.getDetails())) {
-                        commentFactory.createComment("Details: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.details, "(None)"),
-                                requireNonNullElse(policyAnalysis.getDetails(), "(None)")));
-
-                        existingAnalysis.setDetails(policy.analysis().getDetails());
-                        shouldUpdate = true;
-                    }
-                    if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policyAnalysis.getSuppressed())) {
-                        final String previousState = existingAnalysis.suppressed ? "Suppressed" : "Unsuppressed";
-                        final String newState = policyAnalysis.getSuppressed() ? "Suppressed" : "Unsuppressed";
-                        commentFactory.createComment("%s → %s".formatted(previousState, newState));
-
-                        existingAnalysis.setSuppressed(policy.analysis().isSuppress());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getSeverity(), policyAnalysis.getSeverity())) {
-                        commentFactory.createComment("Severity: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getSeverity(), Severity.UNASSIGNED),
-                                requireNonNullElse(policyAnalysis.getSeverity(), Severity.UNASSIGNED)));
-
-                        existingAnalysis.setSeverity(policyAnalysis.getSeverity());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getCvssV2Vector(), policyAnalysis.getCvssV2Vector())) {
-                        commentFactory.createComment("CVSSv2 Vector: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getCvssV2Vector(), "(None)"),
-                                requireNonNullElse(policyAnalysis.getCvssV2Vector(), "(None)")));
-
-                        existingAnalysis.setCvssV2Vector(policyAnalysis.getCvssV2Vector());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getCvssV2Score(), policyAnalysis.getCvssV2Score())) {
-                        commentFactory.createComment("CVSSv2 Score: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getCvssV2Score(), "(None)"),
-                                requireNonNullElse(policyAnalysis.getCvssV2Score(), "(None)")));
-
-                        existingAnalysis.setCvssV2Score(policyAnalysis.getCvssV2Score());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getCvssV3Vector(), policyAnalysis.getCvssV3Vector())) {
-                        commentFactory.createComment("CVSSv3 Vector: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getCvssV3Vector(), "(None)"),
-                                requireNonNullElse(policyAnalysis.getCvssV3Vector(), "(None)")));
-
-                        existingAnalysis.setCvssV3Vector(policyAnalysis.getCvssV3Vector());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getCvssV3Score(), policyAnalysis.getCvssV3Score())) {
-                        commentFactory.createComment("CVSSv3 Score: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getCvssV3Score(), "(None)"),
-                                requireNonNullElse(policyAnalysis.getCvssV3Score(), "(None)")));
-
-                        existingAnalysis.setCvssV3Score(policyAnalysis.getCvssV3Score());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getOwaspVector(), policyAnalysis.getOwaspVector())) {
-                        commentFactory.createComment("OWASP Vector: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getOwaspVector(), "(None)"),
-                                requireNonNullElse(policyAnalysis.getOwaspVector(), "(None)")));
-
-                        existingAnalysis.setOwaspVector(policyAnalysis.getCvssV2Vector());
-                        shouldUpdate = true;
-                    }
-                    if (!Objects.equals(existingAnalysis.getOwaspScore(), policyAnalysis.getOwaspScore())) {
-                        commentFactory.createComment("OWASP Score: %s → %s".formatted(
-                                requireNonNullElse(existingAnalysis.getOwaspScore(), "(None)"),
-                                requireNonNullElse(policyAnalysis.getOwaspScore(), "(None)")));
-
-                        existingAnalysis.setOwaspScore(policyAnalysis.getOwaspScore());
-                        shouldUpdate = true;
-                    }
-                    if (shouldUpdate) {
-                        analysesToCreateOrUpdate.add(existingAnalysis);
-                        analysisCommentsByVulnId.addAll(existingAnalysis.getVulnId(), commentFactory.getComments());
-                    }
-                }
-
-                // If the finding was suppressed, do not report it as new.
-                if (Boolean.TRUE.equals(policyAnalysis.getSuppressed())) {
-                    newFindingVulnIds.remove(vuln.getId());
-                }
-            }
-
-            if (!analysesToCreateOrUpdate.isEmpty()) {
-                final List<CreatedAnalysis> createdAnalyses = dao.createOrUpdateAnalyses(analysesToCreateOrUpdate);
-                // TODO: Construct notifications for PROJECT_AUDIT_CHANGE, but do not dispatch them here!
-                //  They should be dispatched together with NEW_VULNERABILITY and NEW_VULNERABLE_DEPENDENCY
-                //  notifications, AFTER this database transaction completed successfully.
-
-                // Comments for new analyses do not have an analysis ID set yet, as that ID was not known prior
-                // to inserting the respective analysis record. Enrich comments with analysis IDs now that we know them.
-                for (final CreatedAnalysis createdAnalysis : createdAnalyses) {
-                    analysisCommentsByVulnId.computeIfPresent(createdAnalysis.vulnId(),
-                            (vulnId, comments) -> comments.stream()
-                                    .map(comment -> new AnalysisComment(createdAnalysis.id(), comment.comment(), comment.commenter()))
-                                    .toList());
-                }
-
-                dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
-            }
-
-            return vulnById.entrySet().stream()
-                    .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
-                    .map(Map.Entry::getValue)
-                    .map(Vulnerability::getUuid)
-                    .toList();
+            return maybeApplyPolicyAnalyses(dao, component, vulns, newFindingVulnIds, policiesByVulnUuid);
         });
+    }
+
+    /**
+     * Apply analyses of matched {@link VulnerabilityPolicy}s. Do nothing when no policies matched.
+     *
+     * @param dao                The {@link Dao} to use for persistence operations
+     * @param component          The {@link Component} to apply analyses for
+     * @param vulns              The {@link Vulnerability}s identified for the {@link Component}
+     * @param newFindingVulnIds  IDs of {@link Vulnerability}s that newly affect the {@link Component}
+     * @param policiesByVulnUuid Matched {@link VulnerabilityPolicy}s grouped by {@link Vulnerability#getUuid()}
+     * @return A {@link List} of {@link Vulnerability}s, that were not previously associated with the {@link Component},
+     * and which have not been suppressed via {@link VulnerabilityPolicy}.
+     */
+    private List<Vulnerability> maybeApplyPolicyAnalyses(final Dao dao, final Component component, final Collection<Vulnerability> vulns,
+                                                         final List<Long> newFindingVulnIds, final Map<UUID, VulnerabilityPolicy> policiesByVulnUuid) {
+        // Unless we have any matching vulnerability policies, there's nothing to do!
+        if (policiesByVulnUuid.isEmpty()) {
+            return vulns.stream()
+                    .filter(vuln -> newFindingVulnIds.contains(vuln.getId()))
+                    .toList();
+        }
+
+        // Index vulnerabilities by ID and UUID for more efficient lookups.
+        final var vulnById = new HashMap<Long, Vulnerability>();
+        final var vulnByUuid = new HashMap<UUID, Vulnerability>();
+        for (final Vulnerability vuln : vulns) {
+            vulnById.put(vuln.getId(), vuln);
+            vulnByUuid.put(vuln.getUuid(), vuln);
+        }
+
+        // For all vulnerabilities with matching policies, bulk-fetch existing analyses.
+        // Index them by vulnerability UUID for more efficient access.
+        final Map<UUID, Analysis> existingAnalyses = dao.getAnalyses(component, policiesByVulnUuid.keySet()).stream()
+                .collect(Collectors.toMap(Analysis::getVulnUuid, Function.identity()));
+
+        final var analysesToCreateOrUpdate = new ArrayList<Analysis>();
+        final var analysisCommentsByVulnId = new MultivaluedHashMap<Long, AnalysisComment>();
+        for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
+            final Vulnerability vuln = vulnByUuid.get(vulnUuidAndPolicy.getKey());
+            final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
+            final Analysis policyAnalysis;
+            try {
+                policyAnalysis = Analysis.fromPolicy(policy);
+            } catch (IllegalArgumentException e) {
+                LOGGER.warn("Unable to apply policy %s as it was found to be invalid".formatted(policy.name()), e);
+                continue;
+            }
+
+            final Analysis existingAnalysis = existingAnalyses.get(vuln.getUuid());
+            if (existingAnalysis == null) {
+                policyAnalysis.setComponentId(component.id());
+                policyAnalysis.setProjectId(component.projectId());
+                policyAnalysis.setVulnId(vuln.getId());
+                policyAnalysis.setVulnUuid(vuln.getUuid());
+
+                // We'll create comments for analysisId=null for now, as the Analysis we're referring
+                // to hasn't been created yet. The analysisId is populated later, after bulk upserting
+                // all analyses.
+                final var commentFactory = new AnalysisCommentFactory(null, createPolicyAnalysisCommenter(policy));
+                if (policyAnalysis.getState() != null) {
+                    commentFactory.createComment("State: %s → %s"
+                            .formatted(AnalysisState.NOT_SET, policyAnalysis.getState()));
+                }
+                if (policyAnalysis.getJustification() != null) {
+                    commentFactory.createComment("Justification: %s → %s"
+                            .formatted(AnalysisJustification.NOT_SET, policyAnalysis.getJustification()));
+                }
+                if (policyAnalysis.getResponse() != null) {
+                    commentFactory.createComment("Response: %s → %s"
+                            .formatted(AnalysisResponse.NOT_SET, policyAnalysis.response));
+                }
+                if (policyAnalysis.getDetails() != null) {
+                    commentFactory.createComment("Details: (None) → %s"
+                            .formatted(policyAnalysis.details));
+                }
+                if (policyAnalysis.getSuppressed()) {
+                    commentFactory.createComment("Unsuppressed → Suppressed");
+                }
+                if (policyAnalysis.getSeverity() != null) {
+                    commentFactory.createComment("Severity: %s → %s"
+                            .formatted(vuln.getSeverity(), policyAnalysis.getSeverity()));
+                }
+                if (policyAnalysis.getCvssV2Vector() != null) {
+                    commentFactory.createComment("CVSSv2 Vector: %s → %s"
+                            .formatted(requireNonNullElse(vuln.getCvssV2Vector(), "(None)"), policyAnalysis.getCvssV2Vector()));
+                }
+                if (policyAnalysis.getCvssV2Score() != null) {
+                    commentFactory.createComment("CVSSv2 Score: %s → %s"
+                            .formatted(requireNonNullElse(vuln.getCvssV2BaseScore(), "(None)"), policyAnalysis.getCvssV2Score()));
+                }
+                if (policyAnalysis.getCvssV3Vector() != null) {
+                    commentFactory.createComment("CVSSv3 Vector: %s → %s"
+                            .formatted(requireNonNullElse(vuln.getCvssV3Vector(), "(None)"), policyAnalysis.getCvssV3Vector()));
+                }
+                if (policyAnalysis.getCvssV3Score() != null) {
+                    commentFactory.createComment("CVSSv3 Score: %s → %s"
+                            .formatted(requireNonNullElse(vuln.getCvssV3BaseScore(), "(None)"), policyAnalysis.getCvssV3Score()));
+                }
+                if (policyAnalysis.getOwaspVector() != null) {
+                    commentFactory.createComment("OWASP Vector: %s → %s"
+                            .formatted(requireNonNullElse(vuln.getOwaspRRVector(), "(None)"), policyAnalysis.getOwaspVector()));
+                }
+                if (policyAnalysis.getOwaspScore() != null) {
+                    commentFactory.createComment("OWASP Score: %s → %s"
+                            .formatted(requireNonNullElse(vuln.getOwaspRRLikelihoodScore(), "(None)"), policyAnalysis.getOwaspScore()));
+                }
+                analysesToCreateOrUpdate.add(policyAnalysis);
+                analysisCommentsByVulnId.addAll(policyAnalysis.getVulnId(), commentFactory.getComments());
+            } else {
+                boolean shouldUpdate = false;
+                final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), createPolicyAnalysisCommenter(policy));
+                if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
+                    commentFactory.createComment("State: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getState(), AnalysisState.NOT_SET),
+                            requireNonNullElse(policyAnalysis.getState(), AnalysisState.NOT_SET)));
+
+                    existingAnalysis.setState(policyAnalysis.getState());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
+                    commentFactory.createComment("Justification: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.justification, AnalysisJustification.NOT_SET),
+                            requireNonNullElse(policyAnalysis.getJustification(), AnalysisJustification.NOT_SET)));
+
+                    existingAnalysis.setJustification(policyAnalysis.getJustification());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getResponse(), policyAnalysis.getResponse())) {
+                    commentFactory.createComment("Response: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.response, AnalysisResponse.NOT_SET),
+                            requireNonNullElse(policyAnalysis.getResponse(), AnalysisResponse.NOT_SET)));
+
+                    existingAnalysis.setResponse(policyAnalysis.getResponse());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.details, policyAnalysis.getDetails())) {
+                    commentFactory.createComment("Details: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.details, "(None)"),
+                            requireNonNullElse(policyAnalysis.getDetails(), "(None)")));
+
+                    existingAnalysis.setDetails(policy.analysis().getDetails());
+                    shouldUpdate = true;
+                }
+                if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policyAnalysis.getSuppressed())) {
+                    final String previousState = existingAnalysis.suppressed ? "Suppressed" : "Unsuppressed";
+                    final String newState = policyAnalysis.getSuppressed() ? "Suppressed" : "Unsuppressed";
+                    commentFactory.createComment("%s → %s".formatted(previousState, newState));
+
+                    existingAnalysis.setSuppressed(policy.analysis().isSuppress());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getSeverity(), policyAnalysis.getSeverity())) {
+                    commentFactory.createComment("Severity: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getSeverity(), Severity.UNASSIGNED),
+                            requireNonNullElse(policyAnalysis.getSeverity(), Severity.UNASSIGNED)));
+
+                    existingAnalysis.setSeverity(policyAnalysis.getSeverity());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getCvssV2Vector(), policyAnalysis.getCvssV2Vector())) {
+                    commentFactory.createComment("CVSSv2 Vector: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getCvssV2Vector(), "(None)"),
+                            requireNonNullElse(policyAnalysis.getCvssV2Vector(), "(None)")));
+
+                    existingAnalysis.setCvssV2Vector(policyAnalysis.getCvssV2Vector());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getCvssV2Score(), policyAnalysis.getCvssV2Score())) {
+                    commentFactory.createComment("CVSSv2 Score: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getCvssV2Score(), "(None)"),
+                            requireNonNullElse(policyAnalysis.getCvssV2Score(), "(None)")));
+
+                    existingAnalysis.setCvssV2Score(policyAnalysis.getCvssV2Score());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getCvssV3Vector(), policyAnalysis.getCvssV3Vector())) {
+                    commentFactory.createComment("CVSSv3 Vector: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getCvssV3Vector(), "(None)"),
+                            requireNonNullElse(policyAnalysis.getCvssV3Vector(), "(None)")));
+
+                    existingAnalysis.setCvssV3Vector(policyAnalysis.getCvssV3Vector());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getCvssV3Score(), policyAnalysis.getCvssV3Score())) {
+                    commentFactory.createComment("CVSSv3 Score: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getCvssV3Score(), "(None)"),
+                            requireNonNullElse(policyAnalysis.getCvssV3Score(), "(None)")));
+
+                    existingAnalysis.setCvssV3Score(policyAnalysis.getCvssV3Score());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getOwaspVector(), policyAnalysis.getOwaspVector())) {
+                    commentFactory.createComment("OWASP Vector: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getOwaspVector(), "(None)"),
+                            requireNonNullElse(policyAnalysis.getOwaspVector(), "(None)")));
+
+                    existingAnalysis.setOwaspVector(policyAnalysis.getCvssV2Vector());
+                    shouldUpdate = true;
+                }
+                if (!Objects.equals(existingAnalysis.getOwaspScore(), policyAnalysis.getOwaspScore())) {
+                    commentFactory.createComment("OWASP Score: %s → %s".formatted(
+                            requireNonNullElse(existingAnalysis.getOwaspScore(), "(None)"),
+                            requireNonNullElse(policyAnalysis.getOwaspScore(), "(None)")));
+
+                    existingAnalysis.setOwaspScore(policyAnalysis.getOwaspScore());
+                    shouldUpdate = true;
+                }
+                if (shouldUpdate) {
+                    analysesToCreateOrUpdate.add(existingAnalysis);
+                    analysisCommentsByVulnId.addAll(existingAnalysis.getVulnId(), commentFactory.getComments());
+                }
+            }
+
+            // If the finding was suppressed, do not report it as new.
+            if (Boolean.TRUE.equals(policyAnalysis.getSuppressed())) {
+                newFindingVulnIds.remove(vuln.getId());
+            }
+        }
+
+        if (!analysesToCreateOrUpdate.isEmpty()) {
+            final List<CreatedAnalysis> createdAnalyses = dao.createOrUpdateAnalyses(analysesToCreateOrUpdate);
+            // TODO: Construct notifications for PROJECT_AUDIT_CHANGE, but do not dispatch them here!
+            //  They should be dispatched together with NEW_VULNERABILITY and NEW_VULNERABLE_DEPENDENCY
+            //  notifications, AFTER this database transaction completed successfully.
+
+            // Comments for new analyses do not have an analysis ID set yet, as that ID was not known prior
+            // to inserting the respective analysis record. Enrich comments with analysis IDs now that we know them.
+            for (final CreatedAnalysis createdAnalysis : createdAnalyses) {
+                analysisCommentsByVulnId.computeIfPresent(createdAnalysis.vulnId(),
+                        (vulnId, comments) -> comments.stream()
+                                .map(comment -> new AnalysisComment(createdAnalysis.id(), comment.comment(), comment.commenter()))
+                                .toList());
+            }
+
+            dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
+        }
+
+        return vulnById.entrySet().stream()
+                .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
+                .map(Map.Entry::getValue)
+                .toList();
     }
 
     /**
@@ -602,11 +616,11 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
      * @param component      The {@link Component} to send notifications for
      * @param isNewComponent Whether {@code component} is new
      * @param analysisLevel  The {@link VulnerabilityAnalysisLevel}
-     * @param newVulnUuids   {@link UUID}s of newly identified vulnerabilities
+     * @param newVulns       Newly identified {@link Vulnerability}s
      */
     private void maybeSendNotifications(final QueryManager qm, final Component component, final boolean isNewComponent,
-                                        final VulnerabilityAnalysisLevel analysisLevel, final List<UUID> newVulnUuids) {
-        if (newVulnUuids.isEmpty()) {
+                                        final VulnerabilityAnalysisLevel analysisLevel, final List<Vulnerability> newVulns) {
+        if (newVulns.isEmpty()) {
             return;
         }
 
@@ -625,7 +639,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                         .ifPresent(notifications::add);
             }
 
-            dao.getForNewVulnerabilities(component.uuid(), newVulnUuids, analysisLevel).stream()
+            dao.getForNewVulnerabilities(component.uuid(), newVulns.stream().map(Vulnerability::getUuid).toList(), analysisLevel).stream()
                     .map(subject -> org.dependencytrack.proto.notification.v1.Notification.newBuilder()
                             .setScope(SCOPE_PORTFOLIO)
                             .setGroup(GROUP_NEW_VULNERABILITY)
@@ -655,12 +669,12 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         // it should be able to update it. This will be the case for the OSS Index scanner
         // and sonatype-XXX vulnerabilities for example.
         canUpdate &= isAuthoritativeSource(vuln, convert(scanner))
-                // Alternatively, if the vulnerability could be mirrored, but mirroring
-                // is disabled, it is OK to override any existing data.
-                //
-                // Ideally, we'd track the data from all sources instead of just overriding
-                // it, but for now this will have to do it.
-                || (canBeMirrored(vuln) && !isMirroringEnabled(vuln));
+                     // Alternatively, if the vulnerability could be mirrored, but mirroring
+                     // is disabled, it is OK to override any existing data.
+                     //
+                     // Ideally, we'd track the data from all sources instead of just overriding
+                     // it, but for now this will have to do it.
+                     || (canBeMirrored(vuln) && !isMirroringEnabled(vuln));
 
         return canUpdate;
     }

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -68,6 +68,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNullElse;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
 import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
 import static org.dependencytrack.common.ConfigKey.VULNERABILITY_POLICY_ANALYSIS_ENABLED;
@@ -215,6 +216,9 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
         // Detach vulnerabilities from JDO persistence context.
         // We do not want to trigger any DB interactions by accessing their fields.
+        // Note that even PersistenceManager#detachCopy will load / unload fields based
+        // on the current FetchPlan. But we just want to keep the data we already have,
+        // and #makeTransientAll does exactly that.
         qm.getPersistenceManager().makeTransientAll(syncedVulns);
 
         return syncedVulns;
@@ -331,7 +335,8 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     }
 
     /**
-     * Associate a given {@link Collection} of {@link Vulnerability}s with a given {@link Component}.
+     * Associate a given {@link Collection} of {@link Vulnerability}s with a given {@link Component},
+     * evaluate applicable {@link VulnerabilityPolicy}s, and apply the resulting analyses.
      * <p>
      * If a {@link Vulnerability} was not previously associated with the {@link Component},
      * a {@link FindingAttribution} will be created for the {@link Scanner}.
@@ -340,7 +345,8 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
      * @param component The {@link Component} to associate with
      * @param vulns     The {@link Vulnerability}s to associate with
      * @param scanner   The {@link Scanner} that identified the association
-     * @return A {@link Collection} of {@link Vulnerability}s that were not previously associated with the {@link Component}
+     * @return A {@link List} of {@link UUID}s, for {@link Vulnerability}s that were not previously
+     * associated with the {@link Component}, and which have not been suppressed via {@link VulnerabilityPolicy}.
      */
     private List<UUID> synchronizeFindingsAndAnalyses(final QueryManager qm, final Component component,
                                                       final Collection<Vulnerability> vulns, final Scanner scanner,
@@ -383,7 +389,6 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
                 final Vulnerability vuln = vulnByUuid.get(vulnUuidAndPolicy.getKey());
                 final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
-                final String policyAnalysisCommenter = "[Policy] %s".formatted(policy.name());
                 final Analysis policyAnalysis;
                 try {
                     policyAnalysis = Analysis.fromPolicy(policy);
@@ -391,6 +396,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     LOGGER.warn("Unable to apply policy %s as it was found to be invalid".formatted(policy.name()), e);
                     continue;
                 }
+
                 final Analysis existingAnalysis = existingAnalyses.get(vuln.getUuid());
                 if (existingAnalysis == null) {
                     policyAnalysis.setComponentId(component.id());
@@ -401,7 +407,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     // We'll create comments for analysisId=null for now, as the Analysis we're referring
                     // to hasn't been created yet. The analysisId is populated later, after bulk upserting
                     // all analyses.
-                    final var commentFactory = new AnalysisCommentFactory(null, policyAnalysisCommenter);
+                    final var commentFactory = new AnalysisCommentFactory(null, createPolicyAnalysisCommenter(policy));
                     if (policyAnalysis.getState() != null) {
                         commentFactory.createComment("State: %s → %s"
                                 .formatted(AnalysisState.NOT_SET, policyAnalysis.getState()));
@@ -453,7 +459,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     analysisCommentsByVulnId.addAll(policyAnalysis.getVulnId(), commentFactory.getComments());
                 } else {
                     boolean shouldUpdate = false;
-                    final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), policyAnalysisCommenter);
+                    final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), createPolicyAnalysisCommenter(policy));
                     if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
                         commentFactory.createComment("State: %s → %s".formatted(
                                 requireNonNullElse(existingAnalysis.getState(), AnalysisState.NOT_SET),
@@ -556,7 +562,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     }
                 }
 
-                // If the finding was already suppressed, or the policy
+                // If the finding was suppressed, do not report it as new.
                 if (Boolean.TRUE.equals(policyAnalysis.getSuppressed())) {
                     newFindingVulnIds.remove(vuln.getId());
                 }
@@ -568,12 +574,13 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 //  They should be dispatched together with NEW_VULNERABILITY and NEW_VULNERABLE_DEPENDENCY
                 //  notifications, AFTER this database transaction completed successfully.
 
-                // Comments for new analyses do not have an analysis ID set yet, as that ID is not known prior
+                // Comments for new analyses do not have an analysis ID set yet, as that ID was not known prior
                 // to inserting the respective analysis record. Enrich comments with analysis IDs now that we know them.
                 for (final CreatedAnalysis createdAnalysis : createdAnalyses) {
-                    analysisCommentsByVulnId.computeIfPresent(createdAnalysis.vulnId, (vulnId, comments) -> comments.stream()
-                            .map(comment -> new AnalysisComment(createdAnalysis.id, comment.comment(), comment.commenter()))
-                            .toList());
+                    analysisCommentsByVulnId.computeIfPresent(createdAnalysis.vulnId(),
+                            (vulnId, comments) -> comments.stream()
+                                    .map(comment -> new AnalysisComment(createdAnalysis.id(), comment.comment(), comment.commenter()))
+                                    .toList());
                 }
 
                 dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
@@ -680,6 +687,14 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
     private static String prettyPrint(final ScanKey scanKey) {
         return "%s/%s".formatted(scanKey.getScanToken(), scanKey.getComponentUuid());
+    }
+
+    private static String createPolicyAnalysisCommenter(final VulnerabilityPolicy policy) {
+        if (isNotBlank(policy.author())) {
+            return "[Policy{Name=%s, Author=%s}]".formatted(policy.name(), policy.author());
+        }
+
+        return "[Policy{Name=%s}]".formatted(policy.name());
     }
 
     public interface Dao {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -12,7 +12,6 @@ import io.micrometer.core.instrument.Timer;
 import org.apache.kafka.streams.processor.api.ContextualFixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.ContextualProcessor;
 import org.apache.kafka.streams.processor.api.FixedKeyRecord;
-import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.kafka.KafkaEventDispatcher;
 import org.dependencytrack.event.kafka.KafkaEventHeaders;
 import org.dependencytrack.event.kafka.KafkaUtil;
@@ -71,6 +70,7 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNullElse;
 import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
 import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
+import static org.dependencytrack.common.ConfigKey.VULNERABILITY_POLICY_ANALYSIS_ENABLED;
 import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln.convert;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
@@ -97,7 +97,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     private final VulnerabilityPolicyEvaluator vulnPolicyEvaluator;
 
     public VulnerabilityScanResultProcessor() {
-        this(Config.getInstance().getPropertyAsBoolean(ConfigKey.VULNERABILITY_POLICY_ENABLED)
+        this(Config.getInstance().getPropertyAsBoolean(VULNERABILITY_POLICY_ANALYSIS_ENABLED)
                 ? ServiceLoader.load(VulnerabilityPolicyEvaluator.class).findFirst().orElseThrow()
                 : null);
     }
@@ -564,6 +564,9 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
             if (!analysesToCreateOrUpdate.isEmpty()) {
                 final List<CreatedAnalysis> createdAnalyses = dao.createOrUpdateAnalyses(analysesToCreateOrUpdate);
+                // TODO: Construct notifications for PROJECT_AUDIT_CHANGE, but do not dispatch them here!
+                //  They should be dispatched together with NEW_VULNERABILITY and NEW_VULNERABLE_DEPENDENCY
+                //  notifications, AFTER this database transaction completed successfully.
 
                 // Comments for new analyses do not have an analysis ID set yet, as that ID is not known prior
                 // to inserting the respective analysis record. Enrich comments with analysis IDs now that we know them.

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -20,6 +20,7 @@ import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.AnalyzerIdentity;
+import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
@@ -31,8 +32,8 @@ import org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.NotificationSubjectDao;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
-import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyAnalysis;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyRating;
 import org.dependencytrack.proto.notification.v1.Group;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
@@ -355,19 +356,20 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     .toList();
             dao.createFindingAttributions(findingAttributions);
 
-            // Create indexes for vulnerability ID <-> UUID lookups.
-            final var vulnIdByUuid = new HashMap<UUID, Long>();
-            final var vulnUuidById = new HashMap<Long, UUID>();
+            // Index vulnerabilities by ID and UUID for more efficient lookups.
+            final var vulnById = new HashMap<Long, Vulnerability>();
+            final var vulnByUuid = new HashMap<UUID, Vulnerability>();
             for (final Vulnerability vuln : vulns) {
-                vulnIdByUuid.put(vuln.getUuid(), vuln.getId());
-                vulnUuidById.put(vuln.getId(), vuln.getUuid());
+                vulnById.put(vuln.getId(), vuln);
+                vulnByUuid.put(vuln.getUuid(), vuln);
             }
 
             // Unless we have any matching vulnerability policies, there's nothing more to do!
             if (policiesByVulnUuid.isEmpty()) {
-                return vulnUuidById.entrySet().stream()
+                return vulnById.entrySet().stream()
                         .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
                         .map(Map.Entry::getValue)
+                        .map(Vulnerability::getUuid)
                         .toList();
             }
 
@@ -379,104 +381,184 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             final var analysesToCreateOrUpdate = new ArrayList<Analysis>();
             final var analysisCommentsByVulnId = new MultivaluedHashMap<Long, AnalysisComment>();
             for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
-                final UUID vulnUuid = vulnUuidAndPolicy.getKey();
+                final Vulnerability vuln = vulnByUuid.get(vulnUuidAndPolicy.getKey());
                 final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
                 final String policyAnalysisCommenter = "[Policy] %s".formatted(policy.name());
-                final Analysis policyAnalysis = Analysis.fromPolicy(policy.analysis());
-                final Analysis existingAnalysis = existingAnalyses.get(vulnUuid);
+                final Analysis policyAnalysis;
+                try {
+                    policyAnalysis = Analysis.fromPolicy(policy);
+                } catch (IllegalArgumentException e) {
+                    LOGGER.warn("Unable to apply policy %s as it was found to be invalid".formatted(policy.name()), e);
+                    continue;
+                }
+                final Analysis existingAnalysis = existingAnalyses.get(vuln.getUuid());
                 if (existingAnalysis == null) {
                     policyAnalysis.setComponentId(component.id());
                     policyAnalysis.setProjectId(component.projectId());
-                    policyAnalysis.setVulnId(vulnIdByUuid.get(vulnUuid));
-                    policyAnalysis.setVulnUuid(vulnUuid);
+                    policyAnalysis.setVulnId(vuln.getId());
+                    policyAnalysis.setVulnUuid(vuln.getUuid());
 
                     // We'll create comments for analysisId=null for now, as the Analysis we're referring
                     // to hasn't been created yet. The analysisId is populated later, after bulk upserting
                     // all analyses.
                     final var commentFactory = new AnalysisCommentFactory(null, policyAnalysisCommenter);
                     if (policyAnalysis.getState() != null) {
-                        final AnalysisComment comment = commentFactory.createComment("State: %s → %s"
+                        commentFactory.createComment("State: %s → %s"
                                 .formatted(AnalysisState.NOT_SET, policyAnalysis.getState()));
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.getJustification() != null) {
-                        final AnalysisComment comment = commentFactory.createComment("Justification: %s → %s"
+                        commentFactory.createComment("Justification: %s → %s"
                                 .formatted(AnalysisJustification.NOT_SET, policyAnalysis.getJustification()));
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.getResponse() != null) {
-                        final AnalysisComment comment = commentFactory.createComment("Response: %s → %s"
+                        commentFactory.createComment("Response: %s → %s"
                                 .formatted(AnalysisResponse.NOT_SET, policyAnalysis.response));
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
                     if (policyAnalysis.getDetails() != null) {
-                        final AnalysisComment comment = commentFactory.createComment("Details: (None) → %s"
+                        commentFactory.createComment("Details: (None) → %s"
                                 .formatted(policyAnalysis.details));
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
                     }
-                    if (policyAnalysis.suppressed) {
-                        final AnalysisComment comment = commentFactory.createComment("Unsuppressed → Suppressed");
-                        analysisCommentsByVulnId.add(policyAnalysis.getVulnId(), comment);
+                    if (policyAnalysis.getSuppressed()) {
+                        commentFactory.createComment("Unsuppressed → Suppressed");
                     }
-                    // TODO: Handle ratings
+                    if (policyAnalysis.getSeverity() != null) {
+                        commentFactory.createComment("Severity: %s → %s"
+                                .formatted(vuln.getSeverity(), policyAnalysis.getSeverity()));
+                    }
+                    if (policyAnalysis.getCvssV2Vector() != null) {
+                        commentFactory.createComment("CVSSv2 Vector: %s → %s"
+                                .formatted(requireNonNullElse(vuln.getCvssV2Vector(), "(None)"), policyAnalysis.getCvssV2Vector()));
+                    }
+                    if (policyAnalysis.getCvssV2Score() != null) {
+                        commentFactory.createComment("CVSSv2 Score: %s → %s"
+                                .formatted(requireNonNullElse(vuln.getCvssV2BaseScore(), "(None)"), policyAnalysis.getCvssV2Score()));
+                    }
+                    if (policyAnalysis.getCvssV3Vector() != null) {
+                        commentFactory.createComment("CVSSv3 Vector: %s → %s"
+                                .formatted(requireNonNullElse(vuln.getCvssV3Vector(), "(None)"), policyAnalysis.getCvssV3Vector()));
+                    }
+                    if (policyAnalysis.getCvssV3Score() != null) {
+                        commentFactory.createComment("CVSSv3 Score: %s → %s"
+                                .formatted(requireNonNullElse(vuln.getCvssV3BaseScore(), "(None)"), policyAnalysis.getCvssV3Score()));
+                    }
+                    if (policyAnalysis.getOwaspVector() != null) {
+                        commentFactory.createComment("OWASP Vector: %s → %s"
+                                .formatted(requireNonNullElse(vuln.getOwaspRRVector(), "(None)"), policyAnalysis.getOwaspVector()));
+                    }
+                    if (policyAnalysis.getOwaspScore() != null) {
+                        commentFactory.createComment("OWASP Score: %s → %s"
+                                .formatted(requireNonNullElse(vuln.getOwaspRRLikelihoodScore(), "(None)"), policyAnalysis.getOwaspScore()));
+                    }
                     analysesToCreateOrUpdate.add(policyAnalysis);
+                    analysisCommentsByVulnId.addAll(policyAnalysis.getVulnId(), commentFactory.getComments());
                 } else {
                     boolean shouldUpdate = false;
                     final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), policyAnalysisCommenter);
                     if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
-                        final AnalysisComment comment = commentFactory.createComment("State: %s → %s".formatted(
+                        commentFactory.createComment("State: %s → %s".formatted(
                                 requireNonNullElse(existingAnalysis.getState(), AnalysisState.NOT_SET),
                                 requireNonNullElse(policyAnalysis.getState(), AnalysisState.NOT_SET)));
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
 
                         existingAnalysis.setState(policyAnalysis.getState());
                         shouldUpdate = true;
                     }
                     if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
-                        final AnalysisComment comment = commentFactory.createComment("Justification: %s → %s".formatted(
+                        commentFactory.createComment("Justification: %s → %s".formatted(
                                 requireNonNullElse(existingAnalysis.justification, AnalysisJustification.NOT_SET),
                                 requireNonNullElse(policyAnalysis.getJustification(), AnalysisJustification.NOT_SET)));
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
 
                         existingAnalysis.setJustification(policyAnalysis.getJustification());
                         shouldUpdate = true;
                     }
                     if (!Objects.equals(existingAnalysis.getResponse(), policyAnalysis.getResponse())) {
-                        final AnalysisComment comment = commentFactory.createComment("Response: %s → %s".formatted(
+                        commentFactory.createComment("Response: %s → %s".formatted(
                                 requireNonNullElse(existingAnalysis.response, AnalysisResponse.NOT_SET),
                                 requireNonNullElse(policyAnalysis.getResponse(), AnalysisResponse.NOT_SET)));
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
 
                         existingAnalysis.setResponse(policyAnalysis.getResponse());
                         shouldUpdate = true;
                     }
-                    if (!Objects.equals(existingAnalysis.details, policy.analysis().getDetails())) {
-                        final AnalysisComment comment = commentFactory.createComment("Details: %s → %s".formatted(
+                    if (!Objects.equals(existingAnalysis.details, policyAnalysis.getDetails())) {
+                        commentFactory.createComment("Details: %s → %s".formatted(
                                 requireNonNullElse(existingAnalysis.details, "(None)"),
                                 requireNonNullElse(policyAnalysis.getDetails(), "(None)")));
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
 
                         existingAnalysis.setDetails(policy.analysis().getDetails());
                         shouldUpdate = true;
                     }
-                    if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policy.analysis().isSuppress())) {
+                    if (existingAnalysis.getSuppressed() == null || (existingAnalysis.getSuppressed() != policyAnalysis.getSuppressed())) {
                         final String previousState = existingAnalysis.suppressed ? "Suppressed" : "Unsuppressed";
                         final String newState = policyAnalysis.getSuppressed() ? "Suppressed" : "Unsuppressed";
-                        final AnalysisComment comment = commentFactory.createComment("%s → %s".formatted(previousState, newState));
-                        analysisCommentsByVulnId.add(existingAnalysis.getVulnId(), comment);
+                        commentFactory.createComment("%s → %s".formatted(previousState, newState));
 
                         existingAnalysis.setSuppressed(policy.analysis().isSuppress());
                         shouldUpdate = true;
                     }
-                    // TODO: Handle ratings
+                    if (!Objects.equals(existingAnalysis.getSeverity(), policyAnalysis.getSeverity())) {
+                        commentFactory.createComment("Severity: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getSeverity(), Severity.UNASSIGNED),
+                                requireNonNullElse(policyAnalysis.getSeverity(), Severity.UNASSIGNED)));
+
+                        existingAnalysis.setSeverity(policyAnalysis.getSeverity());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getCvssV2Vector(), policyAnalysis.getCvssV2Vector())) {
+                        commentFactory.createComment("CVSSv2 Vector: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getCvssV2Vector(), "(None)"),
+                                requireNonNullElse(policyAnalysis.getCvssV2Vector(), "(None)")));
+
+                        existingAnalysis.setCvssV2Vector(policyAnalysis.getCvssV2Vector());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getCvssV2Score(), policyAnalysis.getCvssV2Score())) {
+                        commentFactory.createComment("CVSSv2 Score: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getCvssV2Score(), "(None)"),
+                                requireNonNullElse(policyAnalysis.getCvssV2Score(), "(None)")));
+
+                        existingAnalysis.setCvssV2Score(policyAnalysis.getCvssV2Score());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getCvssV3Vector(), policyAnalysis.getCvssV3Vector())) {
+                        commentFactory.createComment("CVSSv3 Vector: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getCvssV3Vector(), "(None)"),
+                                requireNonNullElse(policyAnalysis.getCvssV3Vector(), "(None)")));
+
+                        existingAnalysis.setCvssV3Vector(policyAnalysis.getCvssV3Vector());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getCvssV3Score(), policyAnalysis.getCvssV3Score())) {
+                        commentFactory.createComment("CVSSv3 Score: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getCvssV3Score(), "(None)"),
+                                requireNonNullElse(policyAnalysis.getCvssV3Score(), "(None)")));
+
+                        existingAnalysis.setCvssV3Score(policyAnalysis.getCvssV3Score());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getOwaspVector(), policyAnalysis.getOwaspVector())) {
+                        commentFactory.createComment("OWASP Vector: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getOwaspVector(), "(None)"),
+                                requireNonNullElse(policyAnalysis.getOwaspVector(), "(None)")));
+
+                        existingAnalysis.setOwaspVector(policyAnalysis.getCvssV2Vector());
+                        shouldUpdate = true;
+                    }
+                    if (!Objects.equals(existingAnalysis.getOwaspScore(), policyAnalysis.getOwaspScore())) {
+                        commentFactory.createComment("OWASP Score: %s → %s".formatted(
+                                requireNonNullElse(existingAnalysis.getOwaspScore(), "(None)"),
+                                requireNonNullElse(policyAnalysis.getOwaspScore(), "(None)")));
+
+                        existingAnalysis.setOwaspScore(policyAnalysis.getOwaspScore());
+                        shouldUpdate = true;
+                    }
                     if (shouldUpdate) {
                         analysesToCreateOrUpdate.add(existingAnalysis);
+                        analysisCommentsByVulnId.addAll(existingAnalysis.getVulnId(), commentFactory.getComments());
                     }
                 }
 
                 // If the finding was already suppressed, or the policy
                 if (Boolean.TRUE.equals(policyAnalysis.getSuppressed())) {
-                    newFindingVulnIds.remove(vulnIdByUuid.get(vulnUuid));
+                    newFindingVulnIds.remove(vuln.getId());
                 }
             }
 
@@ -494,9 +576,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
             }
 
-            return vulnUuidById.entrySet().stream()
+            return vulnById.entrySet().stream()
                     .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
                     .map(Map.Entry::getValue)
+                    .map(Vulnerability::getUuid)
                     .toList();
         });
     }
@@ -645,7 +728,14 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                   "A"."JUSTIFICATION" AS "justification",
                   "A"."RESPONSE"      AS "response",
                   "A"."DETAILS"       AS "details",
-                  "A"."SUPPRESSED"    AS "suppressed"
+                  "A"."SUPPRESSED"    AS "suppressed",
+                  "A"."SEVERITY"      AS "severity",
+                  "A"."CVSSV2VECTOR"  AS "cvssV2Vector",
+                  "A"."CVSSV2SCORE"   AS "cvssV2Score",
+                  "A"."CVSSV3VECTOR"  AS "cvssV3Vector",
+                  "A"."CVSSV3SCORE"   AS "cvssV3Score",
+                  "A"."OWASPVECTOR"   AS "owaspVector",
+                  "A"."OWASPSCORE"    AS "owaspScore"
                 FROM
                   "VULNERABILITY" AS "V"
                 INNER JOIN
@@ -659,16 +749,25 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
         @SqlBatch("""
                 INSERT INTO "ANALYSIS"
-                  ("VULNERABILITY_ID", "COMPONENT_ID", "PROJECT_ID", "STATE", "JUSTIFICATION", "RESPONSE", "DETAILS", "SUPPRESSED")
+                  ("VULNERABILITY_ID", "COMPONENT_ID", "PROJECT_ID", "STATE", "JUSTIFICATION", "RESPONSE", "DETAILS",
+                   "SUPPRESSED", "SEVERITY", "CVSSV2VECTOR", "CVSSV2SCORE", "CVSSV3VECTOR", "CVSSV3SCORE", "OWASPVECTOR", "OWASPSCORE")
                 VALUES
-                  (:vulnId, :componentId, :projectId, :state, :justification, :response, :details, :suppressed)
+                  (:vulnId, :componentId, :projectId, :state, :justification, :response, :details, :suppressed,
+                   :severity, :cvssV2Vector, :cvssV2Score, :cvssV3Vector, :cvssV3Score, :owaspVector, :owaspScore)
                 ON CONFLICT ("VULNERABILITY_ID", "COMPONENT_ID", "PROJECT_ID") DO UPDATE
                   SET
-                    "STATE" = :state,
+                    "STATE"         = :state,
                     "JUSTIFICATION" = :justification,
-                    "RESPONSE" = :response,
-                    "DETAILS" = :details,
-                    "SUPPRESSED" = :suppressed
+                    "RESPONSE"      = :response,
+                    "DETAILS"       = :details,
+                    "SUPPRESSED"    = :suppressed,
+                    "SEVERITY"      = :severity,
+                    "CVSSV2VECTOR"  = :cvssV2Vector,
+                    "CVSSV2SCORE"   = :cvssV2Score,
+                    "CVSSV3VECTOR"  = :cvssV3Vector,
+                    "CVSSV3SCORE"   = :cvssV3Score,
+                    "OWASPVECTOR"   = :owaspVector,
+                    "OWASPSCORE"    = :owaspScore
                 RETURNING "ID", "VULNERABILITY_ID"
                 """)
         @GetGeneratedKeys({"ID", "VULNERABILITY_ID"})
@@ -697,20 +796,29 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
         private AnalysisResponse response;
         private String details;
         private Boolean suppressed;
+        private Severity severity;
+        private String cvssV2Vector;
+        private Double cvssV2Score;
+        private String cvssV3Vector;
+        private Double cvssV3Score;
+        private String owaspVector;
+        private Double owaspScore;
 
-        private static Analysis fromPolicy(final VulnerabilityPolicyAnalysis policyAnalysis) {
+        private static Analysis fromPolicy(final VulnerabilityPolicy policy) {
             final var analysis = new Analysis();
-            if (policyAnalysis.getState() != null) {
-                analysis.setState(switch (policyAnalysis.getState()) {
+            if (policy.analysis().getState() != null) {
+                analysis.setState(switch (policy.analysis().getState()) {
                     case EXPLOITABLE -> AnalysisState.EXPLOITABLE;
                     case FALSE_POSITIVE -> AnalysisState.FALSE_POSITIVE;
                     case IN_TRIAGE -> AnalysisState.IN_TRIAGE;
                     case NOT_AFFECTED -> AnalysisState.NOT_AFFECTED;
                     case RESOLVED -> AnalysisState.RESOLVED;
                 });
+            } else {
+                throw new IllegalArgumentException("Analysis of policy does not define a state");
             }
-            if (policyAnalysis.getJustification() != null) {
-                analysis.setJustification(switch (policyAnalysis.getJustification()) {
+            if (policy.analysis().getJustification() != null) {
+                analysis.setJustification(switch (policy.analysis().getJustification()) {
                     case CODE_NOT_PRESENT -> AnalysisJustification.CODE_NOT_PRESENT;
                     case CODE_NOT_REACHABLE -> AnalysisJustification.CODE_NOT_REACHABLE;
                     case PROTECTED_AT_PERIMETER -> AnalysisJustification.PROTECTED_AT_PERIMETER;
@@ -722,8 +830,8 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     case REQUIRES_ENVIRONMENT -> AnalysisJustification.REQUIRES_ENVIRONMENT;
                 });
             }
-            if (policyAnalysis.getResponse() != null) {
-                analysis.setResponse(switch (policyAnalysis.getResponse()) {
+            if (policy.analysis().getVendorResponse() != null) {
+                analysis.setResponse(switch (policy.analysis().getVendorResponse()) {
                     case CAN_NOT_FIX -> AnalysisResponse.CAN_NOT_FIX;
                     case ROLLBACK -> AnalysisResponse.ROLLBACK;
                     case UPDATE -> AnalysisResponse.UPDATE;
@@ -731,10 +839,55 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     case WORKAROUND_AVAILABLE -> AnalysisResponse.WORKAROUND_AVAILABLE;
                 });
             }
-            if (policyAnalysis.getDetails() != null) {
-                analysis.setDetails(policyAnalysis.getDetails());
+            if (policy.analysis().getDetails() != null) {
+                analysis.setDetails(policy.analysis().getDetails());
             }
-            analysis.setSuppressed(policyAnalysis.isSuppress());
+            analysis.setSuppressed(policy.analysis().isSuppress());
+
+            if (policy.ratings() != null && !policy.ratings().isEmpty()) {
+                if (policy.ratings().size() > 3) {
+                    throw new IllegalArgumentException("Policy defines more than three ratings");
+                }
+
+                final var methodsSeen = new HashSet<VulnerabilityPolicyRating.Method>();
+                for (final VulnerabilityPolicyRating policyRating : policy.ratings()) {
+                    if (policyRating.getMethod() == null) {
+                        throw new IllegalArgumentException("Rating #%d does not define a method"
+                                .formatted(policy.ratings().indexOf(policyRating)));
+                    }
+                    if (!methodsSeen.add(policyRating.getMethod())) {
+                        throw new IllegalArgumentException("Rating method %s is defined more than once"
+                                .formatted(policyRating.getMethod()));
+                    }
+                    if (policyRating.getSeverity() == null) {
+                        throw new IllegalArgumentException("Rating #%d (%s) does not define a severity"
+                                .formatted(policy.ratings().indexOf(policyRating), policyRating.getMethod()));
+                    }
+
+                    analysis.setSeverity(switch (policyRating.getSeverity()) {
+                        case INFO -> Severity.INFO;
+                        case LOW -> Severity.LOW;
+                        case MEDIUM -> Severity.MEDIUM;
+                        case HIGH -> Severity.HIGH;
+                        case CRITICAL -> Severity.CRITICAL;
+                    });
+                    switch (policyRating.getMethod()) {
+                        case CVSSV2 -> {
+                            analysis.setCvssV2Vector(policyRating.getVector());
+                            analysis.setCvssV2Score(policyRating.getScore());
+                        }
+                        case CVSSV3 -> {
+                            analysis.setCvssV3Vector(policyRating.getVector());
+                            analysis.setCvssV3Score(policyRating.getScore());
+                        }
+                        case OWASP -> {
+                            analysis.setOwaspVector(policyRating.getVector());
+                            analysis.setOwaspScore(policyRating.getScore());
+                        }
+                    }
+                }
+            }
+
             return analysis;
         }
 
@@ -818,6 +971,62 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
             this.suppressed = suppressed;
         }
 
+        public Severity getSeverity() {
+            return severity;
+        }
+
+        public void setSeverity(final Severity severity) {
+            this.severity = severity;
+        }
+
+        public String getCvssV2Vector() {
+            return cvssV2Vector;
+        }
+
+        public void setCvssV2Vector(final String cvssV2Vector) {
+            this.cvssV2Vector = cvssV2Vector;
+        }
+
+        public Double getCvssV2Score() {
+            return cvssV2Score;
+        }
+
+        public void setCvssV2Score(final Double cvssV2Score) {
+            this.cvssV2Score = cvssV2Score;
+        }
+
+        public String getCvssV3Vector() {
+            return cvssV3Vector;
+        }
+
+        public void setCvssV3Vector(final String cvssV3Vector) {
+            this.cvssV3Vector = cvssV3Vector;
+        }
+
+        public Double getCvssV3Score() {
+            return cvssV3Score;
+        }
+
+        public void setCvssV3Score(final Double cvssV3Score) {
+            this.cvssV3Score = cvssV3Score;
+        }
+
+        public String getOwaspVector() {
+            return owaspVector;
+        }
+
+        public void setOwaspVector(final String owaspVector) {
+            this.owaspVector = owaspVector;
+        }
+
+        public Double getOwaspScore() {
+            return owaspScore;
+        }
+
+        public void setOwaspScore(final Double owaspScore) {
+            this.owaspScore = owaspScore;
+        }
+
     }
 
     public record CreatedAnalysis(long id, @ColumnName("VULNERABILITY_ID") long vulnId) {
@@ -826,10 +1035,24 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     public record AnalysisComment(Long analysisId, String comment, String commenter) {
     }
 
-    private record AnalysisCommentFactory(Long analysisId, String commenter) {
+    private static final class AnalysisCommentFactory {
 
-        private AnalysisComment createComment(final String comment) {
-            return new AnalysisComment(this.analysisId, comment, this.commenter);
+        private final Long analysisId;
+        private final String commenter;
+        private final List<AnalysisComment> comments;
+
+        private AnalysisCommentFactory(final Long analysisId, final String commenter) {
+            this.analysisId = analysisId;
+            this.commenter = commenter;
+            this.comments = new ArrayList<>();
+        }
+
+        private void createComment(final String comment) {
+            comments.add(new AnalysisComment(this.analysisId, comment, this.commenter));
+        }
+
+        private List<AnalysisComment> getComments() {
+            return comments;
         }
 
     }

--- a/src/main/java/org/dependencytrack/model/mapping/PolicyProtoMapper.java
+++ b/src/main/java/org/dependencytrack/model/mapping/PolicyProtoMapper.java
@@ -1,0 +1,101 @@
+package org.dependencytrack.model.mapping;
+
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAlias;
+
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.Date;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
+
+public class PolicyProtoMapper {
+
+    public static org.dependencytrack.proto.policy.v1.Vulnerability mapToProto(final Vulnerability vuln) {
+        if (vuln == null) {
+            return org.dependencytrack.proto.policy.v1.Vulnerability.getDefaultInstance();
+        }
+
+        // An object attached to a persistence context could do lazy loading of fields when accessing them.
+        // Ensure this can't happen, as it could cause massive performance degradation.
+        assertNonPersistent(vuln, "vuln must not be persistent");
+
+        final org.dependencytrack.proto.policy.v1.Vulnerability.Builder protoBuilder =
+                org.dependencytrack.proto.policy.v1.Vulnerability.newBuilder();
+        maybeSet(asString(vuln.getUuid()), protoBuilder::setUuid);
+        maybeSet(vuln::getVulnId, protoBuilder::setId);
+        maybeSet(vuln::getSource, protoBuilder::setSource);
+        maybeSet(() -> vuln.getAliases() != null
+                ? vuln.getAliases().stream().flatMap(PolicyProtoMapper::mapToProtos).distinct().toList()
+                : Collections.emptyList(), protoBuilder::addAllAliases);
+        maybeSet(vuln::getCwes, protoBuilder::addAllCwes);
+        maybeSet(asTimestamp(vuln.getCreated()), protoBuilder::setCreated);
+        maybeSet(asTimestamp(vuln.getPublished()), protoBuilder::setPublished);
+        maybeSet(asTimestamp(vuln.getUpdated()), protoBuilder::setUpdated);
+        maybeSet(asString(vuln.getSeverity()), protoBuilder::setSeverity);
+        maybeSet(asDouble(vuln.getCvssV2BaseScore()), protoBuilder::setCvssv2BaseScore);
+        maybeSet(asDouble(vuln.getCvssV2ImpactSubScore()), protoBuilder::setCvssv2ImpactSubscore);
+        maybeSet(asDouble(vuln.getCvssV2ExploitabilitySubScore()), protoBuilder::setCvssv2ExploitabilitySubscore);
+        maybeSet(vuln::getCvssV2Vector, protoBuilder::setCvssv2Vector);
+        maybeSet(asDouble(vuln.getCvssV3BaseScore()), protoBuilder::setCvssv3BaseScore);
+        maybeSet(asDouble(vuln.getCvssV3ImpactSubScore()), protoBuilder::setCvssv3ImpactSubscore);
+        maybeSet(asDouble(vuln.getCvssV3ExploitabilitySubScore()), protoBuilder::setCvssv3ExploitabilitySubscore);
+        maybeSet(vuln::getCvssV3Vector, protoBuilder::setCvssv3Vector);
+        maybeSet(asDouble(vuln.getOwaspRRBusinessImpactScore()), protoBuilder::setOwaspRrBusinessImpactScore);
+        maybeSet(asDouble(vuln.getOwaspRRLikelihoodScore()), protoBuilder::setOwaspRrLikelihoodScore);
+        maybeSet(asDouble(vuln.getOwaspRRTechnicalImpactScore()), protoBuilder::setOwaspRrTechnicalImpactScore);
+        maybeSet(vuln::getOwaspRRVector, protoBuilder::setOwaspRrVector);
+        maybeSet(asDouble(vuln.getEpssScore()), protoBuilder::setEpssScore);
+        maybeSet(asDouble(vuln.getEpssPercentile()), protoBuilder::setEpssPercentile);
+
+        return protoBuilder.build();
+    }
+
+    private static Stream<org.dependencytrack.proto.policy.v1.Vulnerability.Alias> mapToProtos(final VulnerabilityAlias alias) {
+        if (alias == null) {
+            return Stream.empty();
+        }
+
+        // An object attached to a persistence context could do lazy loading of fields when accessing them.
+        // Ensure this can't happen, as it could cause massive performance degradation.
+        assertNonPersistent(alias, "alias must not be persistent");
+
+        return alias.getAllBySource().entrySet().stream()
+                .map(aliasEntry -> org.dependencytrack.proto.policy.v1.Vulnerability.Alias.newBuilder()
+                        .setSource(aliasEntry.getKey().name())
+                        .setId(aliasEntry.getValue())
+                        .build());
+    }
+
+    private static <V> void maybeSet(final Supplier<V> getter, final Consumer<V> setter) {
+        final V modelValue = getter.get();
+        if (modelValue == null) {
+            return;
+        }
+
+        setter.accept(modelValue);
+    }
+
+    private static Supplier<Double> asDouble(final BigDecimal bigDecimal) {
+        return () -> bigDecimal != null ? bigDecimal.doubleValue() : null;
+    }
+
+    private static Supplier<String> asString(final Enum<?> enumInstance) {
+        return () -> enumInstance != null ? enumInstance.name() : null;
+    }
+
+    private static Supplier<String> asString(final UUID uuid) {
+        return () -> uuid != null ? uuid.toString() : null;
+    }
+
+    private static Supplier<Timestamp> asTimestamp(final Date date) {
+        return () -> date != null ? Timestamps.fromDate(date) : null;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/model/mapping/PolicyProtoMapper.java
+++ b/src/main/java/org/dependencytrack/model/mapping/PolicyProtoMapper.java
@@ -15,6 +15,9 @@ import java.util.stream.Stream;
 
 import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
 
+/**
+ * Utility class to map objects from Dependency-Track's internal data model to Policy protocol buffers.
+ */
 public class PolicyProtoMapper {
 
     public static org.dependencytrack.proto.policy.v1.Vulnerability mapToProto(final Vulnerability vuln) {
@@ -32,8 +35,9 @@ public class PolicyProtoMapper {
         maybeSet(vuln::getVulnId, protoBuilder::setId);
         maybeSet(vuln::getSource, protoBuilder::setSource);
         maybeSet(() -> vuln.getAliases() != null
-                ? vuln.getAliases().stream().flatMap(PolicyProtoMapper::mapToProtos).distinct().toList()
-                : Collections.emptyList(), protoBuilder::addAllAliases);
+                        ? vuln.getAliases().stream().flatMap(PolicyProtoMapper::mapToProtos).distinct().toList()
+                        : Collections.emptyList(),
+                protoBuilder::addAllAliases);
         maybeSet(vuln::getCwes, protoBuilder::addAllCwes);
         maybeSet(asTimestamp(vuln.getCreated()), protoBuilder::setCreated);
         maybeSet(asTimestamp(vuln.getPublished()), protoBuilder::setPublished);

--- a/src/main/java/org/dependencytrack/util/PersistenceUtil.java
+++ b/src/main/java/org/dependencytrack/util/PersistenceUtil.java
@@ -121,14 +121,24 @@ public final class PersistenceUtil {
      * @see <a href="https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#lifecycle">Object Lifecycle</a>
      */
     public static void assertPersistent(final Object object, final String message) {
-        final ObjectState objectState = JDOHelper.getObjectState(object);
-        if (objectState != PERSISTENT_CLEAN
-                && objectState != PERSISTENT_DIRTY
-                && objectState != PERSISTENT_NEW
-                && objectState != PERSISTENT_NONTRANSACTIONAL_DIRTY
-                && objectState != HOLLOW_PERSISTENT_NONTRANSACTIONAL) {
+        if (!isPersistent(object)) {
             throw new IllegalStateException(message != null ? message : "Object must be persistent");
         }
+    }
+
+    public static void assertNonPersistent(final Object object, final String message) {
+        if (isPersistent(object)) {
+            throw new IllegalStateException(message != null ? message : "Object must not be persistent");
+        }
+    }
+
+    private static boolean isPersistent(final Object object) {
+        final ObjectState objectState = JDOHelper.getObjectState(object);
+        return objectState == PERSISTENT_CLEAN
+                || objectState == PERSISTENT_DIRTY
+                || objectState == PERSISTENT_NEW
+                || objectState == PERSISTENT_NONTRANSACTIONAL_DIRTY
+                || objectState == HOLLOW_PERSISTENT_NONTRANSACTIONAL;
     }
 
 }

--- a/src/main/java/org/dependencytrack/util/PersistenceUtil.java
+++ b/src/main/java/org/dependencytrack/util/PersistenceUtil.java
@@ -84,19 +84,6 @@ public final class PersistenceUtil {
         return false;
     }
 
-    public static <T, V> boolean applyIfNonNullAndChanged(final T existingObject, final T newObject,
-                                                          final Function<T, V> getter, final Consumer<V> setter) {
-        final V existingValue = getter.apply(existingObject);
-        final V newValue = getter.apply(newObject);
-
-        if (newValue != null && !Objects.equals(existingValue, newValue)) {
-            setter.accept(newValue);
-            return true;
-        }
-
-        return false;
-    }
-
     public static boolean isUniqueConstraintViolation(final Throwable throwable) {
         // TODO: DataNucleus doesn't map constraint violation exceptions very well,
         // so we have to depend on the exception of the underlying JDBC driver to
@@ -126,6 +113,13 @@ public final class PersistenceUtil {
         }
     }
 
+    /**
+     * Utility method to ensure that a given object is <strong>not</strong> in a persistent state.
+     *
+     * @param object  The object to check the state of
+     * @param message Message to use for the exception, if object is persistent
+     * @see #assertPersistent(Object, String)
+     */
     public static void assertNonPersistent(final Object object, final String message) {
         if (isPersistent(object)) {
             throw new IllegalStateException(message != null ? message : "Object must not be persistent");

--- a/src/main/resources/migration/changelog-v5.3.0.xml
+++ b/src/main/resources/migration/changelog-v5.3.0.xml
@@ -2367,4 +2367,17 @@
             <column name="SEVERITY" type="VARCHAR(255)"/>
         </addColumn>
     </changeSet>
+
+    <changeSet id="v5.3.0-7" author="nscuro@protonmail.com">
+        <dropIndex tableName="FINDINGATTRIBUTION" indexName="FINDINGATTRIBUTION_COMPOUND_IDX"/>
+        <createIndex tableName="FINDINGATTRIBUTION" indexName="FINDINGATTRIBUTION_COMPOUND_IDX" unique="true">
+            <column name="COMPONENT_ID"/>
+            <column name="VULNERABILITY_ID"/>
+        </createIndex>
+
+        <createIndex indexName="COMPONENTS_VULNERABILITIES_COMPOSITE_IDX" tableName="COMPONENTS_VULNERABILITIES" unique="true">
+            <column name="COMPONENT_ID"/>
+            <column name="VULNERABILITY_ID"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migration/changelog-v5.3.0.xml
+++ b/src/main/resources/migration/changelog-v5.3.0.xml
@@ -2369,12 +2369,14 @@
     </changeSet>
 
     <changeSet id="v5.3.0-7" author="nscuro@protonmail.com">
+        <!-- The existing index does not enforce uniqueness, but it is required for batch upserts. -->
         <dropIndex tableName="FINDINGATTRIBUTION" indexName="FINDINGATTRIBUTION_COMPOUND_IDX"/>
         <createIndex tableName="FINDINGATTRIBUTION" indexName="FINDINGATTRIBUTION_COMPOUND_IDX" unique="true">
             <column name="COMPONENT_ID"/>
             <column name="VULNERABILITY_ID"/>
         </createIndex>
 
+        <!-- The unique index is required to support batch upserts. -->
         <createIndex indexName="COMPONENTS_VULNERABILITIES_COMPOSITE_IDX" tableName="COMPONENTS_VULNERABILITIES" unique="true">
             <column name="COMPONENT_ID"/>
             <column name="VULNERABILITY_ID"/>

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -24,6 +24,7 @@ import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerde;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisComment;
 import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
@@ -598,7 +599,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
     }
 
     @Test
-    public void analysisThroughPolicyTest() {
+    public void analysisThroughPolicyNewAnalysisTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -614,55 +615,28 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         final var newVuln = new Vulnerability();
         newVuln.setVulnId("CVE-100");
         newVuln.setSource(Vulnerability.Source.NVD);
+        newVuln.setSeverity(Severity.CRITICAL);
         qm.persist(newVuln);
 
-        // Create a vulnerability that was previously reported, but has a different
-        // analysis than what is defined in the policy.
-        final var existingVulnWithDifferentAnalysis = new Vulnerability();
-        existingVulnWithDifferentAnalysis.setVulnId("CVE-200");
-        existingVulnWithDifferentAnalysis.setSource(Vulnerability.Source.NVD);
-        qm.persist(existingVulnWithDifferentAnalysis);
-        qm.addVulnerability(existingVulnWithDifferentAnalysis, component, AnalyzerIdentity.INTERNAL_ANALYZER);
-        final Analysis existingVulnWithDifferentAnalysisAnalysis = qm.makeAnalysis(component, existingVulnWithDifferentAnalysis,
-                AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Old Details", false);
-        existingVulnWithDifferentAnalysisAnalysis.setSeverity(Severity.LOW);
-        existingVulnWithDifferentAnalysisAnalysis.setCvssV3Score(BigDecimal.valueOf(2.5));
-        qm.persist(existingVulnWithDifferentAnalysisAnalysis);
-
-        // Create a vulnerability that was previously reported, and has an identical
-        // analysis to what is defined in the policy.
-        final var existingVulnWithIdenticalAnalysis = new Vulnerability();
-        existingVulnWithIdenticalAnalysis.setVulnId("CVE-300");
-        existingVulnWithIdenticalAnalysis.setSource(Vulnerability.Source.NVD);
-        qm.persist(existingVulnWithIdenticalAnalysis);
-        qm.addVulnerability(existingVulnWithIdenticalAnalysis, component, AnalyzerIdentity.INTERNAL_ANALYZER);
-        final Analysis existingVulnWithIdenticalAnalysisAnalysis = qm.makeAnalysis(component, existingVulnWithIdenticalAnalysis,
-                AnalysisState.FALSE_POSITIVE, null, null, "FP", true);
-        existingVulnWithIdenticalAnalysisAnalysis.setSeverity(Severity.INFO);
-        existingVulnWithIdenticalAnalysisAnalysis.setCvssV3Score(BigDecimal.valueOf(0.1));
-        qm.persist(existingVulnWithIdenticalAnalysisAnalysis);
-
-        // Create a policy that suppresses any finding as false positive,
-        // and have it apply to all vulnerabilities.
+        // Create a policy that marks any finding as NOT_AFFECTED, and downgrades the severity to LOW.
         final var policyAnalysis = new VulnerabilityPolicyAnalysis();
-        policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.FALSE_POSITIVE);
-        policyAnalysis.setDetails("FP");
-        policyAnalysis.setSuppress(true);
+        policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.NOT_AFFECTED);
+        policyAnalysis.setJustification(VulnerabilityPolicyAnalysis.Justification.CODE_NOT_REACHABLE);
+        policyAnalysis.setVendorResponse(VulnerabilityPolicyAnalysis.Response.WILL_NOT_FIX);
+        policyAnalysis.setDetails("Because I say so.");
         final var policyRating = new VulnerabilityPolicyRating();
         policyRating.setMethod(VulnerabilityPolicyRating.Method.CVSSV3);
-        policyRating.setSeverity(VulnerabilityPolicyRating.Severity.INFO);
-        policyRating.setScore(0.1);
+        policyRating.setSeverity(VulnerabilityPolicyRating.Severity.LOW);
+        policyRating.setVector("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+        policyRating.setScore(1.6);
         final var policy = new VulnerabilityPolicy();
-        policy.setName("foo");
+        policy.setName("Foo");
         policy.setAnalysis(policyAnalysis);
         policy.setRatings(List.of(policyRating));
         Mockito.reset(policyEvaluatorMock);
-        Mockito.doReturn(Map.ofEntries(Map.entry(newVuln.getUuid(), policy),
-                        Map.entry(existingVulnWithDifferentAnalysis.getUuid(), policy),
-                        Map.entry(existingVulnWithIdenticalAnalysis.getUuid(), policy)))
+        doReturn(Map.of(newVuln.getUuid(), policy))
                 .when(policyEvaluatorMock).evaluate(any(), any(), any());
 
-        // Have all three vulnerabilities reported by the internal vulnerability scanner.
         final var componentUuid = component.getUuid();
         final var scanToken = UUID.randomUUID().toString();
         final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(componentUuid.toString()).build();
@@ -672,9 +646,106 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         .setScanner(SCANNER_INTERNAL)
                         .setStatus(SCAN_STATUS_SUCCESSFUL)
                         .setBom(Bom.newBuilder().addAllVulnerabilities(List.of(
-                                createVuln(newVuln.getVulnId(), newVuln.getSource()),
-                                createVuln(existingVulnWithDifferentAnalysis.getVulnId(), existingVulnWithDifferentAnalysis.getSource()),
-                                createVuln(existingVulnWithIdenticalAnalysis.getVulnId(), existingVulnWithIdenticalAnalysis.getSource())
+                                createVuln(newVuln.getVulnId(), newVuln.getSource())
+                        ))))
+                .build();
+        inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult));
+        assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(component.getVulnerabilities()).satisfiesExactly(
+                v -> {
+                    assertThat(v.getVulnId()).isEqualTo("CVE-100");
+                    assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
+                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.NOT_AFFECTED);
+                        assertThat(analysis.getAnalysisJustification()).isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE);
+                        assertThat(analysis.getAnalysisResponse()).isEqualTo(AnalysisResponse.WILL_NOT_FIX);
+                        assertThat(analysis.getAnalysisDetails()).isEqualTo("Because I say so.");
+                        assertThat(analysis.isSuppressed()).isFalse();
+                        assertThat(analysis.getSeverity()).isEqualTo(Severity.LOW);
+                        assertThat(analysis.getCvssV2Vector()).isNull();
+                        assertThat(analysis.getCvssV2Score()).isNull();
+                        assertThat(analysis.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("1.6");
+                        assertThat(analysis.getOwaspVector()).isNull();
+                        assertThat(analysis.getOwaspScore()).isNull();
+
+                        // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
+                        // the same timestamp as they were created in the same database transaction. Ordering in this
+                        // test might not be stable, hence the check for "in any order".
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy] Foo");
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
+                                "State: NOT_SET → NOT_AFFECTED",
+                                "Justification: NOT_SET → CODE_NOT_REACHABLE",
+                                "Response: NOT_SET → WILL_NOT_FIX",
+                                "Details: (None) → Because I say so.",
+                                "Severity: CRITICAL → LOW",
+                                "CVSSv3 Vector: (None) → CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
+                                "CVSSv3 Score: (None) → 1.6"
+                        );
+                    });
+                });
+
+        // TODO: There should be PROJECT_AUDIT_CHANGE notifications.
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(
+                record -> {
+                    assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_NEW_VULNERABILITY.name());
+                    final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_NEW_VULNERABILITY, record);
+                    assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+                    assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                    assertThat(notification.getGroup()).isEqualTo(GROUP_NEW_VULNERABILITY);
+                    assertThat(notification.getSubject().is(NewVulnerabilitySubject.class)).isTrue();
+                    final var subject = notification.getSubject().unpack(NewVulnerabilitySubject.class);
+                    assertThat(subject.getVulnerability().getVulnId()).isEqualTo("CVE-100");
+                    assertThat(subject.getVulnerability().getSource()).isEqualTo("NVD");
+                    // TODO: Update these assertions once https://github.com/DependencyTrack/hyades/issues/967 is fixed.
+                    assertThat(subject.getVulnerability().getSeverity()).isEqualTo("CRITICAL"); // FIXME: This should be LOW due to overwrite
+                    assertThat(subject.getVulnerability().getCvssV3()).isEqualTo(0.0); // FIXME: This should be 1.6 due to overwrite
+                }
+        );
+    }
+
+    @Test
+    public void analysisThroughPolicyNewAnalysisSuppressionTest() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-lib");
+        component.setVersion("1.1.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        // Create a vulnerability that was not previously reported for the component.
+        final var newVuln = new Vulnerability();
+        newVuln.setVulnId("CVE-100");
+        newVuln.setSource(Vulnerability.Source.NVD);
+        newVuln.setSeverity(Severity.CRITICAL);
+        qm.persist(newVuln);
+
+        // Create a policy that marks any finding as FALSE_POSITIVE, and suppresses it.
+        final var policyAnalysis = new VulnerabilityPolicyAnalysis();
+        policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.FALSE_POSITIVE);
+        policyAnalysis.setSuppress(true);
+        final var policy = new VulnerabilityPolicy();
+        policy.setName("Foo");
+        policy.setAnalysis(policyAnalysis);
+        Mockito.reset(policyEvaluatorMock);
+        doReturn(Map.of(newVuln.getUuid(), policy))
+                .when(policyEvaluatorMock).evaluate(any(), any(), any());
+
+        final var componentUuid = component.getUuid();
+        final var scanToken = UUID.randomUUID().toString();
+        final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(componentUuid.toString()).build();
+        final var scanResult = ScanResult.newBuilder()
+                .setKey(scanKey)
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_INTERNAL)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .setBom(Bom.newBuilder().addAllVulnerabilities(List.of(
+                                createVuln(newVuln.getVulnId(), newVuln.getSource())
                         ))))
                 .build();
         inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult));
@@ -688,81 +759,228 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
                         assertThat(analysis.getAnalysisJustification()).isNull();
                         assertThat(analysis.getAnalysisResponse()).isNull();
-                        assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
+                        assertThat(analysis.getAnalysisDetails()).isNull();
                         assertThat(analysis.isSuppressed()).isTrue();
-                        assertThat(analysis.getSeverity()).isEqualTo(Severity.INFO);
+                        assertThat(analysis.getSeverity()).isNull();
                         assertThat(analysis.getCvssV2Vector()).isNull();
                         assertThat(analysis.getCvssV2Score()).isNull();
                         assertThat(analysis.getCvssV3Vector()).isNull();
-                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("0.1");
+                        assertThat(analysis.getCvssV3Score()).isNull();
                         assertThat(analysis.getOwaspVector()).isNull();
                         assertThat(analysis.getOwaspScore()).isNull();
 
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
                         // test might not be stable, hence the check for "in any order".
-                        assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(
-                                comment -> assertThat(comment.getComment()).isEqualTo("State: NOT_SET → FALSE_POSITIVE"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Details: (None) → FP"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Severity: UNASSIGNED → INFO"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("CVSSv3 Score: (None) → 0.1")
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy] Foo");
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
+                                "State: NOT_SET → FALSE_POSITIVE",
+                                "Unsuppressed → Suppressed"
                         );
                     });
-                },
+                });
+
+        // The vulnerability was suppressed, so no notifications to be expected.
+        // TODO: There should be PROJECT_AUDIT_CHANGE notifications.
+        assertThat(kafkaMockProducer.history()).isEmpty();
+    }
+
+    @Test
+    public void analysisThroughPolicyExistingDifferentAnalysisTest() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-lib");
+        component.setVersion("1.1.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        // Create an existing vulnerability, for which the analysis is entirely different
+        // over what's defined in the policy.
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-100");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.CRITICAL);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        final Analysis vulnAnalysis = qm.makeAnalysis(component, vuln, AnalysisState.FALSE_POSITIVE,
+                AnalysisJustification.NOT_SET, AnalysisResponse.CAN_NOT_FIX, "oldDetails", true);
+        vulnAnalysis.setSeverity(Severity.INFO);
+        vulnAnalysis.setCvssV2Vector("oldCvssV2Vector");
+        vulnAnalysis.setCvssV2Score(BigDecimal.ZERO);
+        vulnAnalysis.setCvssV3Vector("oldCvssV3Vector");
+        vulnAnalysis.setCvssV3Score(BigDecimal.ZERO);
+        vulnAnalysis.setOwaspVector("oldOwaspVector");
+        vulnAnalysis.setOwaspScore(BigDecimal.ZERO);
+        qm.persist(vulnAnalysis);
+
+        // Create a policy that marks any finding as NOT_AFFECTED, and downgrades the severity to LOW.
+        final var policyAnalysis = new VulnerabilityPolicyAnalysis();
+        policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.NOT_AFFECTED);
+        policyAnalysis.setJustification(VulnerabilityPolicyAnalysis.Justification.CODE_NOT_REACHABLE);
+        policyAnalysis.setVendorResponse(VulnerabilityPolicyAnalysis.Response.WILL_NOT_FIX);
+        policyAnalysis.setDetails("Because I say so.");
+        final var policyRating = new VulnerabilityPolicyRating();
+        policyRating.setMethod(VulnerabilityPolicyRating.Method.CVSSV3);
+        policyRating.setSeverity(VulnerabilityPolicyRating.Severity.LOW);
+        policyRating.setVector("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+        policyRating.setScore(1.6);
+        final var policy = new VulnerabilityPolicy();
+        policy.setName("Foo");
+        policy.setAnalysis(policyAnalysis);
+        policy.setRatings(List.of(policyRating));
+        Mockito.reset(policyEvaluatorMock);
+        doReturn(Map.of(vuln.getUuid(), policy))
+                .when(policyEvaluatorMock).evaluate(any(), any(), any());
+
+        final var componentUuid = component.getUuid();
+        final var scanToken = UUID.randomUUID().toString();
+        final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(componentUuid.toString()).build();
+        final var scanResult = ScanResult.newBuilder()
+                .setKey(scanKey)
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_INTERNAL)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .setBom(Bom.newBuilder().addAllVulnerabilities(List.of(
+                                createVuln(vuln.getVulnId(), vuln.getSource())
+                        ))))
+                .build();
+        inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult));
+        assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(component.getVulnerabilities()).satisfiesExactly(
                 v -> {
-                    assertThat(v.getVulnId()).isEqualTo("CVE-200");
+                    assertThat(v.getVulnId()).isEqualTo("CVE-100");
                     assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
-                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
-                        assertThat(analysis.getAnalysisJustification()).isNull();
-                        assertThat(analysis.getAnalysisResponse()).isNull();
-                        assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
-                        assertThat(analysis.isSuppressed()).isTrue();
-                        assertThat(analysis.getSeverity()).isEqualTo(Severity.INFO);
+                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.NOT_AFFECTED);
+                        assertThat(analysis.getAnalysisJustification()).isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE);
+                        assertThat(analysis.getAnalysisResponse()).isEqualTo(AnalysisResponse.WILL_NOT_FIX);
+                        assertThat(analysis.getAnalysisDetails()).isEqualTo("Because I say so.");
+                        assertThat(analysis.isSuppressed()).isFalse();
+                        assertThat(analysis.getSeverity()).isEqualTo(Severity.LOW);
                         assertThat(analysis.getCvssV2Vector()).isNull();
                         assertThat(analysis.getCvssV2Score()).isNull();
-                        assertThat(analysis.getCvssV3Vector()).isNull();
-                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("0.1");
+                        assertThat(analysis.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("1.6");
                         assertThat(analysis.getOwaspVector()).isNull();
                         assertThat(analysis.getOwaspScore()).isNull();
 
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
                         // test might not be stable, hence the check for "in any order".
-                        assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(
-                                comment -> assertThat(comment.getComment()).isEqualTo("State: NOT_AFFECTED → FALSE_POSITIVE"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Justification: CODE_NOT_REACHABLE → NOT_SET"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Response: WILL_NOT_FIX → NOT_SET"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Details: Old Details → FP"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Severity: LOW → INFO"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("CVSSv3 Score: 2.5 → 0.1")
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy] Foo");
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
+                                "State: FALSE_POSITIVE → NOT_AFFECTED",
+                                "Justification: NOT_SET → CODE_NOT_REACHABLE",
+                                "Response: CAN_NOT_FIX → WILL_NOT_FIX",
+                                "Details: oldDetails → Because I say so.",
+                                "Suppressed → Unsuppressed",
+                                "Severity: INFO → LOW",
+                                "CVSSv2 Vector: oldCvssV2Vector → (None)",
+                                "CVSSv2 Score: 0.0 → (None)",
+                                "CVSSv3 Vector: oldCvssV3Vector → CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L",
+                                "CVSSv3 Score: 0.0 → 1.6",
+                                "OWASP Vector: oldOwaspVector → (None)",
+                                "OWASP Score: 0.0 → (None)"
                         );
                     });
-                },
+                });
+
+        // The vulnerability already existed, so no notifications to be expected.
+        // TODO: There should be PROJECT_AUDIT_CHANGE notifications.
+        assertThat(kafkaMockProducer.history()).isEmpty();
+    }
+
+    @Test
+    public void analysisThroughPolicyExistingEqualAnalysisTest() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-lib");
+        component.setVersion("1.1.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        // Create an existing vulnerability, for which the analysis is completely
+        // identical to what's defined in the policy.
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-100");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.CRITICAL);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        final Analysis vulnAnalysis = qm.makeAnalysis(component, vuln, AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Because I say so.", false);
+        vulnAnalysis.setSeverity(Severity.LOW);
+        vulnAnalysis.setCvssV3Vector("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+        vulnAnalysis.setCvssV3Score(BigDecimal.valueOf(1.6));
+        qm.persist(vulnAnalysis);
+
+        // Create a policy that marks any finding as NOT_AFFECTED, and downgrades the severity to LOW.
+        final var policyAnalysis = new VulnerabilityPolicyAnalysis();
+        policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.NOT_AFFECTED);
+        policyAnalysis.setJustification(VulnerabilityPolicyAnalysis.Justification.CODE_NOT_REACHABLE);
+        policyAnalysis.setVendorResponse(VulnerabilityPolicyAnalysis.Response.WILL_NOT_FIX);
+        policyAnalysis.setDetails("Because I say so.");
+        final var policyRating = new VulnerabilityPolicyRating();
+        policyRating.setMethod(VulnerabilityPolicyRating.Method.CVSSV3);
+        policyRating.setSeverity(VulnerabilityPolicyRating.Severity.LOW);
+        policyRating.setVector("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+        policyRating.setScore(1.6);
+        final var policy = new VulnerabilityPolicy();
+        policy.setName("Foo");
+        policy.setAnalysis(policyAnalysis);
+        policy.setRatings(List.of(policyRating));
+        Mockito.reset(policyEvaluatorMock);
+        doReturn(Map.of(vuln.getUuid(), policy))
+                .when(policyEvaluatorMock).evaluate(any(), any(), any());
+
+        final var componentUuid = component.getUuid();
+        final var scanToken = UUID.randomUUID().toString();
+        final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(componentUuid.toString()).build();
+        final var scanResult = ScanResult.newBuilder()
+                .setKey(scanKey)
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_INTERNAL)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .setBom(Bom.newBuilder().addAllVulnerabilities(List.of(
+                                createVuln(vuln.getVulnId(), vuln.getSource())
+                        ))))
+                .build();
+        inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult));
+        assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(component.getVulnerabilities()).satisfiesExactly(
                 v -> {
-                    assertThat(v.getVulnId()).isEqualTo("CVE-300");
+                    assertThat(v.getVulnId()).isEqualTo("CVE-100");
                     assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
-                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
-                        assertThat(analysis.getAnalysisJustification()).isNull();
-                        assertThat(analysis.getAnalysisResponse()).isNull();
-                        assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
-                        assertThat(analysis.isSuppressed()).isTrue();
-                        assertThat(analysis.getSeverity()).isEqualTo(Severity.INFO);
+                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.NOT_AFFECTED);
+                        assertThat(analysis.getAnalysisJustification()).isEqualTo(AnalysisJustification.CODE_NOT_REACHABLE);
+                        assertThat(analysis.getAnalysisResponse()).isEqualTo(AnalysisResponse.WILL_NOT_FIX);
+                        assertThat(analysis.getAnalysisDetails()).isEqualTo("Because I say so.");
+                        assertThat(analysis.isSuppressed()).isFalse();
+                        assertThat(analysis.getSeverity()).isEqualTo(Severity.LOW);
                         assertThat(analysis.getCvssV2Vector()).isNull();
                         assertThat(analysis.getCvssV2Score()).isNull();
-                        assertThat(analysis.getCvssV3Vector()).isNull();
-                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("0.1");
+                        assertThat(analysis.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:P/AC:H/PR:H/UI:R/S:U/C:N/I:N/A:L");
+                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("1.6");
                         assertThat(analysis.getOwaspVector()).isNull();
                         assertThat(analysis.getOwaspScore()).isNull();
 
-                        // As the analysis was in the desired state already,
-                        // no additional audit trail entries should've been created.
+                        // As no changes were made, no analysis comments should've been created.
                         assertThat(analysis.getAnalysisComments()).isEmpty();
                     });
                 });
 
-        // No notifications must have been sent, due to the findings being suppressed.
+        // The vulnerability already existed, so no notifications to be expected.
         assertThat(kafkaMockProducer.history()).isEmpty();
     }
 

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -631,6 +631,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         policyRating.setScore(1.6);
         final var policy = new VulnerabilityPolicy();
         policy.setName("Foo");
+        policy.setAuthor("Jane Doe");
         policy.setAnalysis(policyAnalysis);
         policy.setRatings(List.of(policyRating));
         Mockito.reset(policyEvaluatorMock);
@@ -673,7 +674,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
                         // test might not be stable, hence the check for "in any order".
-                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy] Foo");
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy{Name=Foo, Author=Jane Doe}]");
                         assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
                                 "State: NOT_SET → NOT_AFFECTED",
                                 "Justification: NOT_SET → CODE_NOT_REACHABLE",
@@ -731,6 +732,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         policyAnalysis.setSuppress(true);
         final var policy = new VulnerabilityPolicy();
         policy.setName("Foo");
+        policy.setAuthor("Jane Doe");
         policy.setAnalysis(policyAnalysis);
         Mockito.reset(policyEvaluatorMock);
         doReturn(Map.of(newVuln.getUuid(), policy))
@@ -772,7 +774,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
                         // test might not be stable, hence the check for "in any order".
-                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy] Foo");
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy{Name=Foo, Author=Jane Doe}]");
                         assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
                                 "State: NOT_SET → FALSE_POSITIVE",
                                 "Unsuppressed → Suppressed"
@@ -830,6 +832,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         policyRating.setScore(1.6);
         final var policy = new VulnerabilityPolicy();
         policy.setName("Foo");
+        policy.setAuthor("Jane Doe");
         policy.setAnalysis(policyAnalysis);
         policy.setRatings(List.of(policyRating));
         Mockito.reset(policyEvaluatorMock);
@@ -872,7 +875,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
                         // test might not be stable, hence the check for "in any order".
-                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy] Foo");
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy{Name=Foo, Author=Jane Doe}]");
                         assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
                                 "State: FALSE_POSITIVE → NOT_AFFECTED",
                                 "Justification: NOT_SET → CODE_NOT_REACHABLE",

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -23,6 +23,7 @@ import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerde;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
+import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
@@ -40,6 +41,7 @@ import org.dependencytrack.persistence.CweImporter;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyAnalysis;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyRating;
 import org.dependencytrack.proto.notification.v1.NewVulnerabilitySubject;
 import org.dependencytrack.proto.notification.v1.NewVulnerableDependencySubject;
 import org.dependencytrack.proto.notification.v1.Notification;
@@ -596,7 +598,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
     }
 
     @Test
-    public void suppressionThroughPolicyTest() {
+    public void analysisThroughPolicyTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -621,8 +623,11 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         existingVulnWithDifferentAnalysis.setSource(Vulnerability.Source.NVD);
         qm.persist(existingVulnWithDifferentAnalysis);
         qm.addVulnerability(existingVulnWithDifferentAnalysis, component, AnalyzerIdentity.INTERNAL_ANALYZER);
-        qm.makeAnalysis(component, existingVulnWithDifferentAnalysis, AnalysisState.NOT_AFFECTED,
-                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Old Details", false);
+        final Analysis existingVulnWithDifferentAnalysisAnalysis = qm.makeAnalysis(component, existingVulnWithDifferentAnalysis,
+                AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Old Details", false);
+        existingVulnWithDifferentAnalysisAnalysis.setSeverity(Severity.LOW);
+        existingVulnWithDifferentAnalysisAnalysis.setCvssV3Score(BigDecimal.valueOf(2.5));
+        qm.persist(existingVulnWithDifferentAnalysisAnalysis);
 
         // Create a vulnerability that was previously reported, and has an identical
         // analysis to what is defined in the policy.
@@ -631,7 +636,11 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         existingVulnWithIdenticalAnalysis.setSource(Vulnerability.Source.NVD);
         qm.persist(existingVulnWithIdenticalAnalysis);
         qm.addVulnerability(existingVulnWithIdenticalAnalysis, component, AnalyzerIdentity.INTERNAL_ANALYZER);
-        qm.makeAnalysis(component, existingVulnWithIdenticalAnalysis, AnalysisState.FALSE_POSITIVE, null, null, "FP", true);
+        final Analysis existingVulnWithIdenticalAnalysisAnalysis = qm.makeAnalysis(component, existingVulnWithIdenticalAnalysis,
+                AnalysisState.FALSE_POSITIVE, null, null, "FP", true);
+        existingVulnWithIdenticalAnalysisAnalysis.setSeverity(Severity.INFO);
+        existingVulnWithIdenticalAnalysisAnalysis.setCvssV3Score(BigDecimal.valueOf(0.1));
+        qm.persist(existingVulnWithIdenticalAnalysisAnalysis);
 
         // Create a policy that suppresses any finding as false positive,
         // and have it apply to all vulnerabilities.
@@ -639,9 +648,14 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.FALSE_POSITIVE);
         policyAnalysis.setDetails("FP");
         policyAnalysis.setSuppress(true);
+        final var policyRating = new VulnerabilityPolicyRating();
+        policyRating.setMethod(VulnerabilityPolicyRating.Method.CVSSV3);
+        policyRating.setSeverity(VulnerabilityPolicyRating.Severity.INFO);
+        policyRating.setScore(0.1);
         final var policy = new VulnerabilityPolicy();
         policy.setName("foo");
         policy.setAnalysis(policyAnalysis);
+        policy.setRatings(List.of(policyRating));
         Mockito.reset(policyEvaluatorMock);
         Mockito.doReturn(Map.ofEntries(Map.entry(newVuln.getUuid(), policy),
                         Map.entry(existingVulnWithDifferentAnalysis.getUuid(), policy),
@@ -676,6 +690,13 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getAnalysisResponse()).isNull();
                         assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
                         assertThat(analysis.isSuppressed()).isTrue();
+                        assertThat(analysis.getSeverity()).isEqualTo(Severity.INFO);
+                        assertThat(analysis.getCvssV2Vector()).isNull();
+                        assertThat(analysis.getCvssV2Score()).isNull();
+                        assertThat(analysis.getCvssV3Vector()).isNull();
+                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("0.1");
+                        assertThat(analysis.getOwaspVector()).isNull();
+                        assertThat(analysis.getOwaspScore()).isNull();
 
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
@@ -683,7 +704,9 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(
                                 comment -> assertThat(comment.getComment()).isEqualTo("State: NOT_SET → FALSE_POSITIVE"),
                                 comment -> assertThat(comment.getComment()).isEqualTo("Details: (None) → FP"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed")
+                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Severity: UNASSIGNED → INFO"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("CVSSv3 Score: (None) → 0.1")
                         );
                     });
                 },
@@ -695,6 +718,13 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getAnalysisResponse()).isNull();
                         assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
                         assertThat(analysis.isSuppressed()).isTrue();
+                        assertThat(analysis.getSeverity()).isEqualTo(Severity.INFO);
+                        assertThat(analysis.getCvssV2Vector()).isNull();
+                        assertThat(analysis.getCvssV2Score()).isNull();
+                        assertThat(analysis.getCvssV3Vector()).isNull();
+                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("0.1");
+                        assertThat(analysis.getOwaspVector()).isNull();
+                        assertThat(analysis.getOwaspScore()).isNull();
 
                         // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
                         // the same timestamp as they were created in the same database transaction. Ordering in this
@@ -704,7 +734,9 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                                 comment -> assertThat(comment.getComment()).isEqualTo("Justification: CODE_NOT_REACHABLE → NOT_SET"),
                                 comment -> assertThat(comment.getComment()).isEqualTo("Response: WILL_NOT_FIX → NOT_SET"),
                                 comment -> assertThat(comment.getComment()).isEqualTo("Details: Old Details → FP"),
-                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed")
+                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Severity: LOW → INFO"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("CVSSv3 Score: 2.5 → 0.1")
                         );
                     });
                 },
@@ -716,6 +748,13 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getAnalysisResponse()).isNull();
                         assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
                         assertThat(analysis.isSuppressed()).isTrue();
+                        assertThat(analysis.getSeverity()).isEqualTo(Severity.INFO);
+                        assertThat(analysis.getCvssV2Vector()).isNull();
+                        assertThat(analysis.getCvssV2Score()).isNull();
+                        assertThat(analysis.getCvssV3Vector()).isNull();
+                        assertThat(analysis.getCvssV3Score()).isEqualByComparingTo("0.1");
+                        assertThat(analysis.getOwaspVector()).isNull();
+                        assertThat(analysis.getOwaspScore()).isNull();
 
                         // As the analysis was in the desired state already,
                         // no additional audit trail entries should've been created.

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -23,6 +23,7 @@ import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerde;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
+import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -34,6 +35,9 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.persistence.CweImporter;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyAnalysis;
+import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
 import org.dependencytrack.proto.notification.v1.NewVulnerabilitySubject;
 import org.dependencytrack.proto.notification.v1.NewVulnerableDependencySubject;
 import org.dependencytrack.proto.notification.v1.Notification;
@@ -45,11 +49,14 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +77,9 @@ import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL
 import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_OSSINDEX;
 import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_SNYK;
 import static org.dependencytrack.util.KafkaTestUtil.deserializeValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 @RunWith(JUnitParamsRunner.class)
 public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnabledTest {
@@ -77,16 +87,20 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
     private TopologyTestDriver testDriver;
     private TestInputTopic<ScanKey, ScanResult> inputTopic;
     private TestOutputTopic<ScanKey, ScanResult> outputTopic;
+    private VulnerabilityPolicyEvaluator policyEvaluatorMock;
 
     @Before
     public void setUp() throws Exception {
         super.setUp();
 
+        policyEvaluatorMock = mock(VulnerabilityPolicyEvaluator.class);
+        doReturn(Collections.emptyMap()).when(policyEvaluatorMock).evaluate(any(), any(), any());
+
         final var streamsBuilder = new StreamsBuilder();
         streamsBuilder
                 .stream("input-topic", Consumed
                         .with(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser())))
-                .processValues(VulnerabilityScanResultProcessor::new)
+                .processValues(() -> new VulnerabilityScanResultProcessor(policyEvaluatorMock))
                 .to("output-topic", Produced
                         .with(new KafkaProtobufSerde<>(ScanKey.parser()), new KafkaProtobufSerde<>(ScanResult.parser())));
 
@@ -577,6 +591,65 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         assertThat(vulnerability.getPatchedVersions()).isNull();
         assertThat(vulnerability.getEpssScore()).isEqualByComparingTo("5.1");
         assertThat(vulnerability.getEpssPercentile()).isEqualByComparingTo("5.2");
+    }
+
+    @Test
+    public void suppressionThroughPolicyTest() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-lib");
+        component.setVersion("1.1.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-123");
+        vuln.setSource(Vulnerability.Source.NVD);
+        qm.persist(vuln);
+
+        final var policyAnalysis = new VulnerabilityPolicyAnalysis();
+        policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.FALSE_POSITIVE);
+        policyAnalysis.setDetails("Foobar");
+        policyAnalysis.setSuppress(true);
+        final var policy = new VulnerabilityPolicy();
+        policy.setName("foo");
+        policy.setAnalysis(policyAnalysis);
+        Mockito.reset(policyEvaluatorMock);
+        doReturn(Map.of(vuln.getUuid(), policy)).when(policyEvaluatorMock).evaluate(any(), any(), any());
+
+        final var componentUuid = component.getUuid();
+        final var scanToken = UUID.randomUUID().toString();
+        final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(componentUuid.toString()).build();
+        final var scanResult = ScanResult.newBuilder()
+                .setKey(scanKey)
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_INTERNAL)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .setBom(Bom.newBuilder().addAllVulnerabilities(List.of(
+                                createVuln(vuln.getVulnId(), vuln.getSource())
+                        ))))
+                .build();
+
+        inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult));
+
+        assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(component.getVulnerabilities()).satisfiesExactly(v -> {
+            assertThat(v.getVulnId()).isEqualTo("CVE-123");
+            assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
+                assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
+                assertThat(analysis.getAnalysisDetails()).isEqualTo("Foobar");
+                assertThat(analysis.isSuppressed()).isTrue();
+            });
+        });
+
+        // No notifications must have been sent, due to the finding being suppressed.
+        assertThat(kafkaMockProducer.history()).isEmpty();
     }
 
     private org.cyclonedx.proto.v1_4.Vulnerability createVuln(final String id, final String source) {

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -17,7 +17,7 @@ import org.cyclonedx.proto.v1_4.Bom;
 import org.cyclonedx.proto.v1_4.Property;
 import org.cyclonedx.proto.v1_4.Source;
 import org.cyclonedx.proto.v1_4.VulnerabilityRating;
-import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.AbstractPostgresEnabledTest;
 import org.dependencytrack.event.kafka.KafkaEventHeaders;
 import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
@@ -72,7 +72,7 @@ import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_SNYK;
 import static org.dependencytrack.util.KafkaTestUtil.deserializeValue;
 
 @RunWith(JUnitParamsRunner.class)
-public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest {
+public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnabledTest {
 
     private TopologyTestDriver testDriver;
     private TestInputTopic<ScanKey, ScanResult> inputTopic;
@@ -80,6 +80,8 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
 
     @Before
     public void setUp() throws Exception {
+        super.setUp();
+
         final var streamsBuilder = new StreamsBuilder();
         streamsBuilder
                 .stream("input-topic", Consumed
@@ -102,6 +104,8 @@ public class VulnerabilityScanResultProcessorTest extends PersistenceCapableTest
         if (testDriver != null) {
             testDriver.close();
         }
+
+        super.tearDown();
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -23,6 +23,8 @@ import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerde;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
+import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
@@ -296,10 +298,10 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                     assertThat(notification.getGroup()).isEqualTo(GROUP_NEW_VULNERABLE_DEPENDENCY);
                     assertThat(notification.getSubject().is(NewVulnerableDependencySubject.class)).isTrue();
                     final var subject = notification.getSubject().unpack(NewVulnerableDependencySubject.class);
-                    assertThat(subject.getComponent().getName().equals("acme-lib"));
-                    assertThat(subject.getComponent().getVersion().equals("1.1.0"));
-                    assertThat(subject.getProject().getName().equals("acme-app"));
-                    assertThat(subject.getProject().getVersion().equals("1.1.0"));
+                    assertThat(subject.getComponent().getName()).isEqualTo("acme-lib");
+                    assertThat(subject.getComponent().getVersion()).isEqualTo("1.1.0");
+                    assertThat(subject.getProject().getName()).isEqualTo("acme-app");
+                    assertThat(subject.getProject().getVersion()).isEqualTo("1.0.0");
                     assertThat(subject.getVulnerabilitiesCount()).isEqualTo(2);
                 },
                 record -> {
@@ -606,21 +608,47 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         component.setProject(project);
         qm.persist(component);
 
-        final var vuln = new Vulnerability();
-        vuln.setVulnId("CVE-123");
-        vuln.setSource(Vulnerability.Source.NVD);
-        qm.persist(vuln);
+        // Create a vulnerability that was not previously reported for the component.
+        final var newVuln = new Vulnerability();
+        newVuln.setVulnId("CVE-100");
+        newVuln.setSource(Vulnerability.Source.NVD);
+        qm.persist(newVuln);
 
+        // Create a vulnerability that was previously reported, but has a different
+        // analysis than what is defined in the policy.
+        final var existingVulnWithDifferentAnalysis = new Vulnerability();
+        existingVulnWithDifferentAnalysis.setVulnId("CVE-200");
+        existingVulnWithDifferentAnalysis.setSource(Vulnerability.Source.NVD);
+        qm.persist(existingVulnWithDifferentAnalysis);
+        qm.addVulnerability(existingVulnWithDifferentAnalysis, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        qm.makeAnalysis(component, existingVulnWithDifferentAnalysis, AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Old Details", false);
+
+        // Create a vulnerability that was previously reported, and has an identical
+        // analysis to what is defined in the policy.
+        final var existingVulnWithIdenticalAnalysis = new Vulnerability();
+        existingVulnWithIdenticalAnalysis.setVulnId("CVE-300");
+        existingVulnWithIdenticalAnalysis.setSource(Vulnerability.Source.NVD);
+        qm.persist(existingVulnWithIdenticalAnalysis);
+        qm.addVulnerability(existingVulnWithIdenticalAnalysis, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        qm.makeAnalysis(component, existingVulnWithIdenticalAnalysis, AnalysisState.FALSE_POSITIVE, null, null, "FP", true);
+
+        // Create a policy that suppresses any finding as false positive,
+        // and have it apply to all vulnerabilities.
         final var policyAnalysis = new VulnerabilityPolicyAnalysis();
         policyAnalysis.setState(VulnerabilityPolicyAnalysis.State.FALSE_POSITIVE);
-        policyAnalysis.setDetails("Foobar");
+        policyAnalysis.setDetails("FP");
         policyAnalysis.setSuppress(true);
         final var policy = new VulnerabilityPolicy();
         policy.setName("foo");
         policy.setAnalysis(policyAnalysis);
         Mockito.reset(policyEvaluatorMock);
-        doReturn(Map.of(vuln.getUuid(), policy)).when(policyEvaluatorMock).evaluate(any(), any(), any());
+        Mockito.doReturn(Map.ofEntries(Map.entry(newVuln.getUuid(), policy),
+                        Map.entry(existingVulnWithDifferentAnalysis.getUuid(), policy),
+                        Map.entry(existingVulnWithIdenticalAnalysis.getUuid(), policy)))
+                .when(policyEvaluatorMock).evaluate(any(), any(), any());
 
+        // Have all three vulnerabilities reported by the internal vulnerability scanner.
         final var componentUuid = component.getUuid();
         final var scanToken = UUID.randomUUID().toString();
         final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(componentUuid.toString()).build();
@@ -630,25 +658,72 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         .setScanner(SCANNER_INTERNAL)
                         .setStatus(SCAN_STATUS_SUCCESSFUL)
                         .setBom(Bom.newBuilder().addAllVulnerabilities(List.of(
-                                createVuln(vuln.getVulnId(), vuln.getSource())
+                                createVuln(newVuln.getVulnId(), newVuln.getSource()),
+                                createVuln(existingVulnWithDifferentAnalysis.getVulnId(), existingVulnWithDifferentAnalysis.getSource()),
+                                createVuln(existingVulnWithIdenticalAnalysis.getVulnId(), existingVulnWithIdenticalAnalysis.getSource())
                         ))))
                 .build();
-
         inputTopic.pipeInput(new TestRecord<>(scanKey, scanResult));
-
         assertThat(outputTopic.readValuesToList()).containsOnly(scanResult);
 
         qm.getPersistenceManager().evictAll();
-        assertThat(component.getVulnerabilities()).satisfiesExactly(v -> {
-            assertThat(v.getVulnId()).isEqualTo("CVE-123");
-            assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
-                assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
-                assertThat(analysis.getAnalysisDetails()).isEqualTo("Foobar");
-                assertThat(analysis.isSuppressed()).isTrue();
-            });
-        });
+        assertThat(component.getVulnerabilities()).satisfiesExactly(
+                v -> {
+                    assertThat(v.getVulnId()).isEqualTo("CVE-100");
+                    assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
+                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
+                        assertThat(analysis.getAnalysisJustification()).isNull();
+                        assertThat(analysis.getAnalysisResponse()).isNull();
+                        assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
+                        assertThat(analysis.isSuppressed()).isTrue();
 
-        // No notifications must have been sent, due to the finding being suppressed.
+                        // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
+                        // the same timestamp as they were created in the same database transaction. Ordering in this
+                        // test might not be stable, hence the check for "in any order".
+                        assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(
+                                comment -> assertThat(comment.getComment()).isEqualTo("State: NOT_SET → FALSE_POSITIVE"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Details: (None) → FP"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed")
+                        );
+                    });
+                },
+                v -> {
+                    assertThat(v.getVulnId()).isEqualTo("CVE-200");
+                    assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
+                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
+                        assertThat(analysis.getAnalysisJustification()).isNull();
+                        assertThat(analysis.getAnalysisResponse()).isNull();
+                        assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
+                        assertThat(analysis.isSuppressed()).isTrue();
+
+                        // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
+                        // the same timestamp as they were created in the same database transaction. Ordering in this
+                        // test might not be stable, hence the check for "in any order".
+                        assertThat(analysis.getAnalysisComments()).satisfiesExactlyInAnyOrder(
+                                comment -> assertThat(comment.getComment()).isEqualTo("State: NOT_AFFECTED → FALSE_POSITIVE"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Justification: CODE_NOT_REACHABLE → NOT_SET"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Response: WILL_NOT_FIX → NOT_SET"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Details: Old Details → FP"),
+                                comment -> assertThat(comment.getComment()).isEqualTo("Unsuppressed → Suppressed")
+                        );
+                    });
+                },
+                v -> {
+                    assertThat(v.getVulnId()).isEqualTo("CVE-300");
+                    assertThat(qm.getAnalysis(component, v)).satisfies(analysis -> {
+                        assertThat(analysis.getAnalysisState()).isEqualTo(AnalysisState.FALSE_POSITIVE);
+                        assertThat(analysis.getAnalysisJustification()).isNull();
+                        assertThat(analysis.getAnalysisResponse()).isNull();
+                        assertThat(analysis.getAnalysisDetails()).isEqualTo("FP");
+                        assertThat(analysis.isSuppressed()).isTrue();
+
+                        // As the analysis was in the desired state already,
+                        // no additional audit trail entries should've been created.
+                        assertThat(analysis.getAnalysisComments()).isEmpty();
+                    });
+                });
+
+        // No notifications must have been sent, due to the findings being suppressed.
         assertThat(kafkaMockProducer.history()).isEmpty();
     }
 

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -569,9 +569,9 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
         assertThat(vulnerability.getCvssV3ExploitabilitySubScore()).isEqualTo("3.9");
         assertThat(vulnerability.getCvssV3ImpactSubScore()).isEqualTo("6.0");
         assertThat(vulnerability.getCvssV3Vector()).isEqualTo("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H");
-        assertThat(vulnerability.getOwaspRRLikelihoodScore()).isEqualTo("4.4");
+        assertThat(vulnerability.getOwaspRRLikelihoodScore()).isEqualTo("4.375");
         assertThat(vulnerability.getOwaspRRTechnicalImpactScore()).isEqualTo("4.0");
-        assertThat(vulnerability.getOwaspRRBusinessImpactScore()).isEqualTo("5.8");
+        assertThat(vulnerability.getOwaspRRBusinessImpactScore()).isEqualTo("5.75");
         assertThat(vulnerability.getOwaspRRVector()).isEqualTo("SL:1/M:4/O:4/S:9/ED:7/EE:3/A:4/ID:3/LC:9/LI:1/LAV:5/LAC:1/FD:3/RD:4/NC:7/PV:9");
         assertThat(vulnerability.getVulnerableVersions()).isNull();
         assertThat(vulnerability.getPatchedVersions()).isNull();

--- a/src/test/java/org/dependencytrack/model/mapping/PolicyProtoMapperTest.java
+++ b/src/test/java/org/dependencytrack/model/mapping/PolicyProtoMapperTest.java
@@ -1,0 +1,131 @@
+package org.dependencytrack.model.mapping;
+
+import com.google.protobuf.util.JsonFormat;
+import net.javacrumbs.jsonunit.core.Option;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Severity;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityAlias;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class PolicyProtoMapperTest extends PersistenceCapableTest {
+
+    @Test
+    public void testMapVulnerabilityToProto() throws Exception {
+        final var vulnAlias = new VulnerabilityAlias();
+        vulnAlias.setCveId("CVE-100");
+        vulnAlias.setGhsaId("GHSA-100");
+        vulnAlias.setSnykId("SNYK-100");
+
+        final var vuln = new Vulnerability();
+        vuln.setUuid(UUID.fromString("4702f182-3b24-426a-a469-118dbe61bab7"));
+        vuln.setVulnId("CVE-100");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setAliases(List.of(vulnAlias));
+        vuln.setCwes(List.of(666, 777));
+        vuln.setCreated(Date.from(Instant.ofEpochSecond(666)));
+        vuln.setPublished(Date.from(Instant.ofEpochSecond(777)));
+        vuln.setUpdated(Date.from(Instant.ofEpochSecond(888)));
+        vuln.setSeverity(Severity.MEDIUM);
+        vuln.setCvssV2Vector("cvssV2Vector");
+        vuln.setCvssV2BaseScore(BigDecimal.valueOf(1.1));
+        vuln.setCvssV2ExploitabilitySubScore(BigDecimal.valueOf(2.2));
+        vuln.setCvssV2ImpactSubScore(BigDecimal.valueOf(3.3));
+        vuln.setCvssV3Vector("cvssV2Vector");
+        vuln.setCvssV3BaseScore(BigDecimal.valueOf(4.4));
+        vuln.setCvssV3ExploitabilitySubScore(BigDecimal.valueOf(5.5));
+        vuln.setCvssV3ImpactSubScore(BigDecimal.valueOf(6.6));
+        vuln.setOwaspRRVector("owaspRrVector");
+        vuln.setOwaspRRBusinessImpactScore(BigDecimal.valueOf(7.7));
+        vuln.setOwaspRRLikelihoodScore(BigDecimal.valueOf(8.8));
+        vuln.setOwaspRRTechnicalImpactScore(BigDecimal.valueOf(9.9));
+        vuln.setEpssScore(BigDecimal.valueOf(0.6));
+        vuln.setEpssPercentile(BigDecimal.valueOf(0.7));
+
+        assertThatJson(JsonFormat.printer().print(PolicyProtoMapper.mapToProto(vuln)))
+                .withOptions(Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo("""
+                        {
+                          "uuid": "4702f182-3b24-426a-a469-118dbe61bab7",
+                          "id": "CVE-100",
+                          "source": "NVD",
+                          "aliases": [
+                            {
+                              "id": "CVE-100",
+                              "source": "NVD"
+                            },
+                            {
+                              "id": "SNYK-100",
+                              "source": "SNYK"
+                            },
+                            {
+                              "id": "GHSA-100",
+                              "source": "GITHUB"
+                            }
+                          ],
+                          "cwes": [
+                            666,
+                            777
+                          ],
+                          "created": "1970-01-01T00:11:06Z",
+                          "published": "1970-01-01T00:12:57Z",
+                          "updated": "1970-01-01T00:14:48Z",
+                          "severity": "MEDIUM",
+                          "cvssv2BaseScore": 1.1,
+                          "cvssv2ImpactSubscore": 3.3,
+                          "cvssv2ExploitabilitySubscore": 2.2,
+                          "cvssv2Vector": "cvssV2Vector",
+                          "cvssv3BaseScore": 4.4,
+                          "cvssv3ImpactSubscore": 6.6,
+                          "cvssv3ExploitabilitySubscore": 5.5,
+                          "cvssv3Vector": "cvssV2Vector",
+                          "owaspRrLikelihoodScore": 8.8,
+                          "owaspRrTechnicalImpactScore": 9.9,
+                          "owaspRrBusinessImpactScore": 7.7,
+                          "owaspRrVector": "owaspRrVector",
+                          "epssScore": 0.6,
+                          "epssPercentile": 0.7
+                        }
+                        """);
+    }
+
+    @Test
+    public void testMapVulnerabilityWithNoFieldsSet() throws Exception {
+        assertThatJson(JsonFormat.printer().print(PolicyProtoMapper.mapToProto(new Vulnerability())))
+                // Oddity of the Vulnerability behavior: getSeverity never returns null, but UNASSIGNED instead.
+                .isEqualTo("""
+                        {
+                          "severity": "UNASSIGNED"
+                        }
+                        """);
+    }
+
+    @Test
+    public void testMapVulnerabilityToProtoWhenNull() {
+        assertThat(PolicyProtoMapper.mapToProto(null))
+                .isEqualTo(org.dependencytrack.proto.policy.v1.Vulnerability.getDefaultInstance());
+    }
+
+    @Test
+    public void testMapVulnerabilityToProtoWhenPersistent() {
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-100");
+        vuln.setSource(Vulnerability.Source.NVD);
+        qm.persist(vuln);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> PolicyProtoMapper.mapToProto(vuln))
+                .withMessage("vuln must not be persistent");
+    }
+
+}

--- a/src/test/java/org/dependencytrack/util/PersistenceUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/PersistenceUtilTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
 
 public class PersistenceUtilTest extends PersistenceCapableTest {
@@ -67,6 +68,50 @@ public class PersistenceUtilTest extends PersistenceCapableTest {
 
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> assertPersistent(pm.detachCopy(project), null));
+    }
+
+    @Test
+    public void testAssertNonPersistentTx() {
+        final Transaction trx = pm.currentTransaction();
+        try {
+            trx.begin();
+
+            final var project = new Project();
+            project.setName("foo");
+            pm.makePersistent(project);
+
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(() -> assertNonPersistent(project, null));
+        } finally {
+            trx.rollback();
+        }
+    }
+
+    @Test
+    public void testAssertNonPersistentNonTx() {
+        final var project = new Project();
+        project.setName("foo");
+        pm.makePersistent(project);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> assertNonPersistent(project, null));
+    }
+
+    @Test
+    public void testAssertNonPersistentWhenTransient() {
+        final var project = new Project();
+        assertThatNoException()
+                .isThrownBy(() -> assertNonPersistent(project, null));
+    }
+
+    @Test
+    public void testAssertNonPersistentWhenDetached() {
+        final var project = new Project();
+        project.setName("foo");
+        pm.makePersistent(project);
+
+        assertThatNoException()
+                .isThrownBy(() -> assertNonPersistent(pm.detachCopy(project), null));
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR integrates the evaluation *and application* of vulnerability policies into the vulnerability scan result processing logic. The application includes both analyses and custom ratings, as well as according population of the audit trail.

In order to reduce the performance hit for doing this, the code has been *slightly* refactored to utilize batched SQL statements wherever possible. The majority of the logic has been migrated to use JDBI instead of DataNucleus, which again results in performance gains due to less ORM overhead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/940

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

* There's quite a bit of code in `VulnerabilityScanResultProcessor` that could theoretically be moved to separate classes. I left it there for now, as it is kind of specific to what the processor needs. It may not be applicable to other areas of the codebase.
* `PROJECT_AUDIT_CHANGE` notifications are currently not sent for analyses applied via policy. I added `TODO`s in the code and raised https://github.com/DependencyTrack/hyades/issues/968 to implement that.
* `NEW_VULNERABILITY` and `NEW_VULNERABLE_DEPENDENCY` notifications do not currently reflect the rating overwrites applied via policy. I added `FIXME`s in the code and raised https://github.com/DependencyTrack/hyades/issues/967 to address that.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
