### PR TITLE
Use `ResultSet#getTimestamp` over `ResultSet#getDate` when mapping vuln policies

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityPolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityPolicyQueryManager.java
@@ -87,15 +87,15 @@ public class VulnerabilityPolicyQueryManager extends QueryManager implements IQu
                 vulnerabilityPolicy.setAuthor(rs.getString("AUTHOR"));
                 Array conditions = rs.getArray("CONDITIONS");
                 vulnerabilityPolicy.setConditions((String[]) conditions.getArray());
-                vulnerabilityPolicy.setCreated(rs.getDate("CREATED"));
+                vulnerabilityPolicy.setCreated(rs.getTimestamp("CREATED"));
                 vulnerabilityPolicy.setDescription(rs.getString("DESCRIPTION"));
                 vulnerabilityPolicy.setName(rs.getString("NAME"));
                 JSONArray ratingsJson = new JSONArray(rs.getString("RATINGS"));
                 vulnerabilityPolicy.setRatings(MAPPER.convertValue(ratingsJson, new TypeReference<>() {
                 }));
-                vulnerabilityPolicy.setUpdated(rs.getDate("UPDATED"));
-                vulnerabilityPolicy.setValidFrom(rs.getDate("VALID_FROM"));
-                vulnerabilityPolicy.setValidUntil(rs.getDate("VALID_UNTIL"));
+                vulnerabilityPolicy.setUpdated(rs.getTimestamp("UPDATED"));
+                vulnerabilityPolicy.setValidFrom(rs.getTimestamp("VALID_FROM"));
+                vulnerabilityPolicy.setValidUntil(rs.getTimestamp("VALID_UNTIL"));
                 vulnerabilityPolicies.add(vulnerabilityPolicy);
             }
         } catch (Exception ex) {
@@ -129,15 +129,15 @@ public class VulnerabilityPolicyQueryManager extends QueryManager implements IQu
                 vulnerabilityPolicy.setAuthor(rs.getString("AUTHOR"));
                 Array conditions = rs.getArray("CONDITIONS");
                 vulnerabilityPolicy.setConditions((String[]) conditions.getArray());
-                vulnerabilityPolicy.setCreated(rs.getDate("CREATED"));
+                vulnerabilityPolicy.setCreated(rs.getTimestamp("CREATED"));
                 vulnerabilityPolicy.setDescription(rs.getString("DESCRIPTION"));
                 vulnerabilityPolicy.setName(rs.getString("NAME"));
                 JSONArray ratingsJson = new JSONArray(rs.getString("RATINGS"));
                 vulnerabilityPolicy.setRatings(MAPPER.convertValue(ratingsJson, new TypeReference<>() {
                 }));
-                vulnerabilityPolicy.setUpdated(rs.getDate("UPDATED"));
-                vulnerabilityPolicy.setValidFrom(rs.getDate("VALID_FROM"));
-                vulnerabilityPolicy.setValidUntil(rs.getDate("VALID_UNTIL"));
+                vulnerabilityPolicy.setUpdated(rs.getTimestamp("UPDATED"));
+                vulnerabilityPolicy.setValidFrom(rs.getTimestamp("VALID_FROM"));
+                vulnerabilityPolicy.setValidUntil(rs.getTimestamp("VALID_UNTIL"));
             }
         } catch (Exception ex) {
             LOGGER.error("error in executing workflow state cte query to update states", ex);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

`getDate` returns `java.sql.Date` which as per documentation does not have a time component, and throws when `toInstant` is being called on it (https://docs.oracle.com/javase/8/docs/api/java/sql/Date.html#toInstant--).

The database columns being mapped do have a time component, and `toInstant` is important for conversions to other datetime formats like `ZonedDateTime`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
