### PR TITLE
Improve performance of `is_dependency_of` query

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -15,6 +15,7 @@ import org.dependencytrack.proto.policy.v1.License;
 import org.dependencytrack.proto.policy.v1.Project;
 import org.dependencytrack.proto.policy.v1.Vulnerability;
 import org.dependencytrack.util.VersionDistance;
+import org.jdbi.v3.core.Handle;
 import org.projectnessie.cel.EnvOption;
 import org.projectnessie.cel.Library;
 import org.projectnessie.cel.ProgramOption;
@@ -26,10 +27,6 @@ import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.interpreter.functions.Overload;
 
 import javax.jdo.Query;
-import javax.jdo.datastore.JDOConnection;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
@@ -40,6 +37,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 
 class CelCommonPolicyLibrary implements Library {
 
@@ -342,125 +341,124 @@ class CelCommonPolicyLibrary implements Library {
             return false;
         }
 
-        final var filters = new ArrayList<String>();
-        final var params = new HashMap<Integer, Object>();
-        var paramPosition = 1;
+        final var queryFilters = new ArrayList<String>();
+        final var queryParams = new HashMap<String, Object>();
+        queryParams.put("leafComponentUuid", leafComponent.getUuid());
         if (!rootComponent.getUuid().isBlank()) {
-            filters.add("\"C\".\"UUID\" = ?");
-            params.put(paramPosition++, rootComponent.getUuid());
+            queryFilters.add("\"UUID\" = :uuid");
+            queryParams.put("uuid", rootComponent.getUuid());
         }
         if (!rootComponent.getGroup().isBlank()) {
-            filters.add("\"C\".\"GROUP\" = ?");
-            params.put(paramPosition++, rootComponent.getGroup());
+            queryFilters.add("\"GROUP\" = :group");
+            queryParams.put("group", rootComponent.getGroup());
         }
         if (!rootComponent.getName().isBlank()) {
-            filters.add("\"C\".\"NAME\" = ?");
-            params.put(paramPosition++, rootComponent.getName());
+            queryFilters.add("\"NAME\" = :name");
+            queryParams.put("name", rootComponent.getName());
         }
         if (!rootComponent.getVersion().isBlank()) {
-            filters.add("\"C\".\"VERSION\" = ?");
-            params.put(paramPosition++, rootComponent.getVersion());
+            queryFilters.add("\"VERSION\" = :version");
+            queryParams.put("version", rootComponent.getVersion());
         }
         if (!rootComponent.getClassifier().isBlank()) {
-            filters.add("\"C\".\"CLASSIFIER\" = ?");
-            params.put(paramPosition++, rootComponent.getClassifier());
+            queryFilters.add("\"CLASSIFIER\" = :classifier");
+            queryParams.put("classifier", rootComponent.getClassifier());
         }
         if (!rootComponent.getCpe().isBlank()) {
-            filters.add("\"C\".\"CPE\" = ?");
-            params.put(paramPosition++, rootComponent.getCpe());
+            queryFilters.add("\"CPE\" = :cpe");
+            queryParams.put("cpe", rootComponent.getCpe());
         }
         if (!rootComponent.getPurl().isBlank()) {
-            filters.add("\"C\".\"PURL\" = ?");
-            params.put(paramPosition++, rootComponent.getPurl());
+            queryFilters.add("\"PURL\" = :purl");
+            queryParams.put("purl", rootComponent.getPurl());
         }
         if (!rootComponent.getSwidTagId().isBlank()) {
-            filters.add("\"C\".\"SWIDTAGID\" = ?");
-            params.put(paramPosition++, rootComponent.getSwidTagId());
+            queryFilters.add("\"SWIDTAGID\" = :swidTagId");
+            queryParams.put("swidTagId", rootComponent.getSwidTagId());
         }
         if (rootComponent.hasIsInternal()) {
             if (rootComponent.getIsInternal()) {
-                filters.add("\"C\".\"INTERNAL\" = ?");
-                params.put(paramPosition++, true);
+                queryFilters.add("\"INTERNAL\" = TRUE");
             } else {
-                filters.add("(\"C\".\"INTERNAL\" IS NULL OR \"C\".\"INTERNAL\" = ?)");
-                params.put(paramPosition++, false);
+                queryFilters.add("(\"INTERNAL\" IS NULL OR \"INTERNAL\" = FALSE)");
             }
         }
 
-        if (filters.isEmpty()) {
+        if (queryFilters.isEmpty()) {
             LOGGER.warn("""
                     %s: Unable to construct filter expression from root component %s; \
                     Unable to evaluate, returning false""".formatted(FUNC_IS_DEPENDENCY_OF, rootComponent));
             return false;
         }
 
-        final String sqlFilter = String.join(" AND ", filters);
-
-        final var query = """
-                WITH RECURSIVE
-                "CTE_DEPENDENCIES" ("UUID", "PROJECT_ID", "FOUND", "COMPONENTS_SEEN") AS (
-                  SELECT
-                    "C"."UUID",
-                    "C"."PROJECT_ID",
-                    CASE WHEN (%s) THEN TRUE ELSE FALSE END AS "FOUND",
-                    ARRAY []::BIGINT[] AS "COMPONENTS_SEEN"
-                  FROM
-                    "COMPONENT" AS "C"
-                    WHERE
-                      -- TODO: Need to get project ID from somewhere to speed up
-                      --   this initial query for the CTE.
-                      -- "PROJECT_ID" = ?
-                        "C"."DIRECT_DEPENDENCIES" IS NOT NULL
-                        AND "C"."DIRECT_DEPENDENCIES" LIKE ?
-                  UNION ALL
-                  SELECT
-                    "C"."UUID"       AS "UUID",
-                    "C"."PROJECT_ID" AS "PROJECT_ID",
-                    CASE WHEN (%s) THEN TRUE ELSE FALSE END AS "FOUND",
-                    ARRAY_APPEND("COMPONENTS_SEEN", "C"."ID")
-                  FROM
-                    "COMPONENT" AS "C"
-                  INNER JOIN
-                    "CTE_DEPENDENCIES"
-                      ON "C"."PROJECT_ID" = "CTE_DEPENDENCIES"."PROJECT_ID"
-                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%%"' || "CTE_DEPENDENCIES"."UUID" || '"%%')
-                  WHERE
-                    "C"."PROJECT_ID" = "CTE_DEPENDENCIES"."PROJECT_ID"
-                    AND (
-                      "FOUND" OR "C"."DIRECT_DEPENDENCIES" IS NOT NULL
+        try (final var qm = new QueryManager();
+             final Handle jdbiHandle = jdbi(qm).open()) {
+            final org.jdbi.v3.core.statement.Query query = jdbiHandle.createQuery("""
+                    -- Determine the project the given leaf component is part of.
+                    WITH RECURSIVE
+                    "CTE_PROJECT" AS (
+                      SELECT
+                        "PROJECT_ID" AS "ID"
+                      FROM
+                        "COMPONENT"
+                      WHERE
+                        "UUID" = :leafComponentUuid
+                    ),
+                    -- Identify the IDs of all components in the project that
+                    -- match the desired criteria.
+                    "CTE_MATCHES" AS (
+                      SELECT
+                        "ID"
+                      FROM
+                        "COMPONENT"
+                      WHERE
+                        "PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
+                        -- Do not consider other leaf nodes (typically the majority of components).
+                        -- Because we're looking for parent nodes, they MUST have direct dependencies defined.
+                        AND "DIRECT_DEPENDENCIES" IS NOT NULL
+                        AND <filters>
+                    ),
+                    "CTE_DEPENDENCIES" ("UUID", "PROJECT_ID", "FOUND", "PATH") AS (
+                      SELECT
+                        "C"."UUID"                                       AS "UUID",
+                        "C"."PROJECT_ID"                                 AS "PROJECT_ID",
+                        ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND",
+                        ARRAY ["C"."ID"]::BIGINT[]                       AS "PATH"
+                      FROM
+                        "COMPONENT" AS "C"
+                      WHERE
+                        -- Short-circuit the recursive query if we don't have any matches at all.
+                        EXISTS(SELECT 1 FROM "CTE_MATCHES")
+                        -- Otherwise, find components of which the given leaf component is a direct dependency.
+                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || :leafComponentUuid || '%')
+                      UNION ALL
+                      SELECT
+                        "C"."UUID"                                       AS "UUID",
+                        "C"."PROJECT_ID"                                 AS "PROJECT_ID",
+                        ("C"."ID" = ANY(SELECT "ID" FROM "CTE_MATCHES")) AS "FOUND",
+                        ARRAY_APPEND("PREVIOUS"."PATH", "C"."ID")        AS "PATH"
+                      FROM
+                        "COMPONENT" AS "C"
+                      INNER JOIN
+                        "CTE_DEPENDENCIES" AS "PREVIOUS" ON "PREVIOUS"."PROJECT_ID" = "C"."PROJECT_ID"
+                      WHERE
+                        -- If the previous row was a match already, we're done.
+                        NOT "PREVIOUS"."FOUND"
+                        -- Also, ensure we haven't seen this component before, to prevent cycles.
+                        AND NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
+                        -- Otherwise, the previous component must appear in the current direct dependencies.
+                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || "PREVIOUS"."UUID" || '%')
                     )
-                )
-                SELECT BOOL_OR("FOUND") FROM "CTE_DEPENDENCIES";
-                """.formatted(sqlFilter, sqlFilter);
+                    SELECT BOOL_OR("FOUND") FROM "CTE_DEPENDENCIES";
+                    """);
 
-        try (final var qm = new QueryManager()) {
-            final JDOConnection jdoConnection = qm.getPersistenceManager().getDataStoreConnection();
-            try {
-                final var connection = (Connection) jdoConnection.getNativeConnection();
-                final var preparedStatement = connection.prepareStatement(query);
-                // Params need to be set twice because the rootComponent filter
-                // appears twice in the query... This needs improvement.
-                for (final Map.Entry<Integer, Object> param : params.entrySet()) {
-                    preparedStatement.setObject(param.getKey(), param.getValue());
-                }
-                preparedStatement.setString(params.size() + 1, "%" + leafComponent.getUuid() + "%");
-                for (final Map.Entry<Integer, Object> param : params.entrySet()) {
-                    preparedStatement.setObject((params.size() + 1) + param.getKey(), param.getValue());
-                }
-
-                try (final ResultSet rs = preparedStatement.executeQuery()) {
-                    if (rs.next()) {
-                        return rs.getBoolean(1);
-                    }
-                }
-            } catch (SQLException e) {
-                LOGGER.warn("%s: Failed to execute query: %s".formatted(FUNC_IS_DEPENDENCY_OF, query), e);
-            } finally {
-                jdoConnection.close();
-            }
+            return query
+                    .define("filters", String.join(" AND ", queryFilters))
+                    .bindMap(queryParams)
+                    .mapTo(Boolean.class)
+                    .findOne()
+                    .orElse(false);
         }
-
-        return false;
     }
 
     private static boolean matchesRange(final String version, final String versStr) {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

It is generally to be expected that the vast majority of components will *not* match the search criteria of `is_dependency_of`. Thus, it makes sense to optimize for the negative case.

The following additions were made:
* Perform a pre-flight check whether any component in the project matches the search criteria at all; The old query would traverse the entire graph even though no component could ever match
* Stop recursing once a match is found; The old query would keep note of when a component matched, but not abort the recursion, causing unnecessary queries to be performed
* Replace raw JDBC usage with JDBI :)

Queries where *no* component in the project matches the desired criteria complete in less than a millisecond.

Execution times of queries where at least one component matches the criteria now directly correlates with how "close" to the leaf node those components are.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

I did some testing, using a portfolio of 2000 projects ~700'000 components in total.
I used the [`bloated.bom.json`](https://github.com/DependencyTrack/hyades/blob/main/load-tests/fixtures/boms/bloated.bom.json) as test subject.

For testing positive matches, I selected `is-ci@2.0.0` as leaf node, and `miguelcostero-ng2-toasty@0.0.0-semantically-released` as root node. The distance between those components is 11. The query plan for both old and new query can be found below:

<details>
<summary>Old (114.858 ms)</summary>
<pre>
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Aggregate  (cost=38180.43..38180.44 rows=1 width=1) (actual time=114.789..114.790 rows=1 loops=1)                                                                                        |
|  CTE CTE_DEPENDENCIES                                                                                                                                                                   |
|    ->  Recursive Union  (cost=231.53..38143.71 rows=1632 width=78) (actual time=10.248..114.770 rows=11 loops=1)                                                                        |
|          ->  Bitmap Heap Scan on "COMPONENT" "C"  (cost=231.53..262.65 rows=12 width=78) (actual time=10.247..10.650 rows=1 loops=1)                                                    |
|                Recheck Cond: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                                                  |
|                Rows Removed by Index Recheck: 1                                                                                                                                         |
|                Heap Blocks: exact=2                                                                                                                                                     |
|                ->  Bitmap Index Scan on idx_gin  (cost=0.00..231.53 rows=28 width=0) (actual time=10.237..10.237 rows=2 loops=1)                                                        |
|                      Index Cond: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                                              |
|          ->  Nested Loop  (cost=29.28..3786.47 rows=162 width=78) (actual time=9.352..9.463 rows=1 loops=11)                                                                            |
|                ->  WorkTable Scan on "CTE_DEPENDENCIES" "CTE_DEPENDENCIES_1"  (cost=0.00..2.40 rows=120 width=131) (actual time=0.000..0.000 rows=1 loops=11)                           |
|                ->  Bitmap Heap Scan on "COMPONENT" "C_1"  (cost=29.28..31.52 rows=1 width=674) (actual time=9.343..9.454 rows=1 loops=11)                                               |
|                      Recheck Cond: (("CTE_DEPENDENCIES_1"."PROJECT_ID" = "PROJECT_ID") AND ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("CTE_DEPENDENCIES_1"."UUID")::text) || '%'::text)))|
|                      Rows Removed by Index Recheck: 1                                                                                                                                   |
|                      Heap Blocks: exact=18                                                                                                                                              |
|                      ->  BitmapAnd  (cost=29.28..29.28 rows=2 width=0) (actual time=9.123..9.123 rows=0 loops=11)                                                                       |
|                            ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.33 rows=379 width=0) (actual time=0.212..0.212 rows=9056 loops=11)                        |
|                                  Index Cond: ("PROJECT_ID" = "CTE_DEPENDENCIES_1"."PROJECT_ID")                                                                                         |
|                            ->  Bitmap Index Scan on idx_gin  (cost=0.00..24.70 rows=3409 width=0) (actual time=8.871..8.871 rows=2 loops=11)                                            |
|                                  Index Cond: ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("CTE_DEPENDENCIES_1"."UUID")::text) || '%'::text))                                               |
|  ->  CTE Scan on "CTE_DEPENDENCIES"  (cost=0.00..32.64 rows=1632 width=1) (actual time=10.249..114.778 rows=11 loops=1)                                                                 |
|Planning Time: 0.462 ms                                                                                                                                                                  |
|Execution Time: 114.858 ms                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
</pre>
</details>

<details>
<summary>New (111.331 ms)</summary>
<pre>
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                           |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|CTE Scan on "CTE_DEPENDENCIES"  (cost=1782.44..1784.26 rows=91 width=131) (actual time=4.648..111.203 rows=11 loops=1)                                               |
|  CTE CTE_PROJECT                                                                                                                                                    |
|    ->  Index Scan using "COMPONENT_UUID_IDX" on "COMPONENT" "C"  (cost=0.42..2.64 rows=1 width=8) (actual time=0.016..0.017 rows=1 loops=1)                         |
|          Index Cond: (("UUID")::text = '89dc699b-1518-49f9-ba74-04a8d0234400'::text)                                                                                |
|  CTE CTE_MATCHES                                                                                                                                                    |
|    ->  Bitmap Heap Scan on "COMPONENT"  (cost=6.61..7.73 rows=1 width=8) (actual time=0.585..0.586 rows=1 loops=1)                                                  |
|          Recheck Cond: ((("NAME")::text = 'miguelcostero-ng2-toasty'::text) AND ("PROJECT_ID" = $1))                                                                |
|          Filter: ("DIRECT_DEPENDENCIES" IS NOT NULL)                                                                                                                |
|          Heap Blocks: exact=1                                                                                                                                       |
|          InitPlan 2 (returns $1)                                                                                                                                    |
|            ->  CTE Scan on "CTE_PROJECT"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.018..0.018 rows=1 loops=1)                                                |
|          ->  BitmapAnd  (cost=6.59..6.59 rows=1 width=0) (actual time=0.579..0.580 rows=0 loops=1)                                                                  |
|                ->  Bitmap Index Scan on "COMPONENT_NAME_IDX"  (cost=0.00..1.98 rows=60 width=0) (actual time=0.021..0.021 rows=1 loops=1)                           |
|                      Index Cond: (("NAME")::text = 'miguelcostero-ng2-toasty'::text)                                                                                |
|                ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.37 rows=379 width=0) (actual time=0.557..0.557 rows=9056 loops=1)                 |
|                      Index Cond: ("PROJECT_ID" = $1)                                                                                                                |
|  CTE CTE_DEPENDENCIES                                                                                                                                               |
|    ->  Recursive Union  (cost=0.49..1772.07 rows=91 width=78) (actual time=4.646..111.191 rows=11 loops=1)                                                          |
|          ->  Result  (cost=0.49..174.76 rows=1 width=78) (actual time=4.645..12.423 rows=1 loops=1)                                                                 |
|                One-Time Filter: $5                                                                                                                                  |
|                InitPlan 5 (returns $5)                                                                                                                              |
|                  ->  CTE Scan on "CTE_MATCHES" "CTE_MATCHES_1"  (cost=0.00..0.02 rows=1 width=0) (actual time=0.586..0.586 rows=1 loops=1)                          |
|                InitPlan 6 (returns $6)                                                                                                                              |
|                  ->  CTE Scan on "CTE_PROJECT" "CTE_PROJECT_1"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.000..0.000 rows=1 loops=1)                          |
|                ->  Index Scan using "COMPONENT_PROJECT_ID_IDX" on "COMPONENT" "C_1"  (cost=0.42..174.70 rows=1 width=53) (actual time=4.043..11.819 rows=1 loops=1) |
|                      Index Cond: ("PROJECT_ID" = $6)                                                                                                                |
|                      Filter: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                              |
|                      Rows Removed by Filter: 9055                                                                                                                   |
|                SubPlan 4                                                                                                                                            |
|                  ->  CTE Scan on "CTE_MATCHES"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.001..0.002 rows=1 loops=1)                                          |
|          ->  Nested Loop  (cost=29.61..159.64 rows=9 width=78) (actual time=8.875..8.976 rows=1 loops=11)                                                           |
|                ->  WorkTable Scan on "CTE_DEPENDENCIES" "PREVIOUS"  (cost=0.00..0.20 rows=5 width=130) (actual time=0.001..0.001 rows=1 loops=11)                   |
|                      Filter: (NOT "FOUND")                                                                                                                          |
|                      Rows Removed by Filter: 0                                                                                                                      |
|                ->  Bitmap Heap Scan on "COMPONENT" "C_2"  (cost=29.59..31.85 rows=2 width=661) (actual time=9.744..9.856 rows=1 loops=10)                           |
|                      Recheck Cond: (("PREVIOUS"."PROJECT_ID" = "PROJECT_ID") AND ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("PREVIOUS"."UUID")::text) || '%'::text)))|
|                      Rows Removed by Index Recheck: 1                                                                                                               |
|                      Filter: ("ID" <> ALL ("PREVIOUS"."PATH"))                                                                                                      |
|                      Heap Blocks: exact=17                                                                                                                          |
|                      ->  BitmapAnd  (cost=29.59..29.59 rows=2 width=0) (actual time=9.573..9.573 rows=0 loops=10)                                                   |
|                            ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.37 rows=379 width=0) (actual time=0.251..0.251 rows=9056 loops=10)    |
|                                  Index Cond: ("PROJECT_ID" = "PREVIOUS"."PROJECT_ID")                                                                               |
|                            ->  Bitmap Index Scan on idx_gin  (cost=0.00..24.97 rows=3409 width=0) (actual time=9.285..9.285 rows=2 loops=10)                        |
|                                  Index Cond: ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("PREVIOUS"."UUID")::text) || '%'::text))                                     |
|                SubPlan 7                                                                                                                                            |
|                  ->  CTE Scan on "CTE_MATCHES" "CTE_MATCHES_2"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.001..0.001 rows=1 loops=1)                          |
|Planning Time: 0.874 ms                                                                                                                                              |
|Execution Time: 111.331 ms                                                                                                                                           |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
</pre>
</details>

For testing negative matches, I kept `is-ci@2.0.0` as leaf node. I misspelled the root node's name to emulate a no-match.

<details>
<summary>Old (113.563 ms)</summary>
<pre>
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Aggregate  (cost=38180.43..38180.44 rows=1 width=1) (actual time=113.510..113.512 rows=1 loops=1)                                                                                        |
|  CTE CTE_DEPENDENCIES                                                                                                                                                                   |
|    ->  Recursive Union  (cost=231.53..38143.71 rows=1632 width=78) (actual time=10.409..113.490 rows=11 loops=1)                                                                        |
|          ->  Bitmap Heap Scan on "COMPONENT" "C"  (cost=231.53..262.65 rows=12 width=78) (actual time=10.408..10.781 rows=1 loops=1)                                                    |
|                Recheck Cond: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                                                  |
|                Rows Removed by Index Recheck: 1                                                                                                                                         |
|                Heap Blocks: exact=2                                                                                                                                                     |
|                ->  Bitmap Index Scan on idx_gin  (cost=0.00..231.53 rows=28 width=0) (actual time=10.397..10.397 rows=2 loops=1)                                                        |
|                      Index Cond: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                                              |
|          ->  Nested Loop  (cost=29.28..3786.47 rows=162 width=78) (actual time=9.227..9.335 rows=1 loops=11)                                                                            |
|                ->  WorkTable Scan on "CTE_DEPENDENCIES" "CTE_DEPENDENCIES_1"  (cost=0.00..2.40 rows=120 width=131) (actual time=0.000..0.000 rows=1 loops=11)                           |
|                ->  Bitmap Heap Scan on "COMPONENT" "C_1"  (cost=29.28..31.52 rows=1 width=674) (actual time=9.211..9.319 rows=1 loops=11)                                               |
|                      Recheck Cond: (("CTE_DEPENDENCIES_1"."PROJECT_ID" = "PROJECT_ID") AND ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("CTE_DEPENDENCIES_1"."UUID")::text) || '%'::text)))|
|                      Rows Removed by Index Recheck: 1                                                                                                                                   |
|                      Heap Blocks: exact=18                                                                                                                                              |
|                      ->  BitmapAnd  (cost=29.28..29.28 rows=2 width=0) (actual time=9.022..9.022 rows=0 loops=11)                                                                       |
|                            ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.33 rows=379 width=0) (actual time=0.211..0.211 rows=9056 loops=11)                        |
|                                  Index Cond: ("PROJECT_ID" = "CTE_DEPENDENCIES_1"."PROJECT_ID")                                                                                         |
|                            ->  Bitmap Index Scan on idx_gin  (cost=0.00..24.70 rows=3409 width=0) (actual time=8.774..8.774 rows=2 loops=11)                                            |
|                                  Index Cond: ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("CTE_DEPENDENCIES_1"."UUID")::text) || '%'::text))                                               |
|  ->  CTE Scan on "CTE_DEPENDENCIES"  (cost=0.00..32.64 rows=1632 width=1) (actual time=10.410..113.500 rows=11 loops=1)                                                                 |
|Planning Time: 0.318 ms                                                                                                                                                                  |
|Execution Time: 113.563 ms                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
</pre>
</details>

<details>
<summary>New (0.045 ms)</summary>
<pre>
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                           |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|CTE Scan on "CTE_DEPENDENCIES"  (cost=1782.44..1784.26 rows=91 width=131) (actual time=0.013..0.014 rows=0 loops=1)                                                  |
|  CTE CTE_PROJECT                                                                                                                                                    |
|    ->  Index Scan using "COMPONENT_UUID_IDX" on "COMPONENT" "C"  (cost=0.42..2.64 rows=1 width=8) (never executed)                                                  |
|          Index Cond: (("UUID")::text = '89dc699b-1518-49f9-ba74-04a8d0234400'::text)                                                                                |
|  CTE CTE_MATCHES                                                                                                                                                    |
|    ->  Bitmap Heap Scan on "COMPONENT"  (cost=6.61..7.73 rows=1 width=8) (actual time=0.012..0.012 rows=0 loops=1)                                                  |
|          Recheck Cond: ((("NAME")::text = 'miguelcostero-ng2-toast'::text) AND ("PROJECT_ID" = $1))                                                                 |
|          Filter: ("DIRECT_DEPENDENCIES" IS NOT NULL)                                                                                                                |
|          InitPlan 2 (returns $1)                                                                                                                                    |
|            ->  CTE Scan on "CTE_PROJECT"  (cost=0.00..0.02 rows=1 width=8) (never executed)                                                                         |
|          ->  BitmapAnd  (cost=6.59..6.59 rows=1 width=0) (actual time=0.011..0.012 rows=0 loops=1)                                                                  |
|                ->  Bitmap Index Scan on "COMPONENT_NAME_IDX"  (cost=0.00..1.98 rows=60 width=0) (actual time=0.011..0.011 rows=0 loops=1)                           |
|                      Index Cond: (("NAME")::text = 'miguelcostero-ng2-toast'::text)                                                                                 |
|                ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.37 rows=379 width=0) (never executed)                                             |
|                      Index Cond: ("PROJECT_ID" = $1)                                                                                                                |
|  CTE CTE_DEPENDENCIES                                                                                                                                               |
|    ->  Recursive Union  (cost=0.49..1772.07 rows=91 width=78) (actual time=0.013..0.013 rows=0 loops=1)                                                             |
|          ->  Result  (cost=0.49..174.76 rows=1 width=78) (actual time=0.012..0.012 rows=0 loops=1)                                                                  |
|                One-Time Filter: $5                                                                                                                                  |
|                InitPlan 5 (returns $5)                                                                                                                              |
|                  ->  CTE Scan on "CTE_MATCHES" "CTE_MATCHES_1"  (cost=0.00..0.02 rows=1 width=0) (actual time=0.012..0.012 rows=0 loops=1)                          |
|                InitPlan 6 (returns $6)                                                                                                                              |
|                  ->  CTE Scan on "CTE_PROJECT" "CTE_PROJECT_1"  (cost=0.00..0.02 rows=1 width=8) (never executed)                                                   |
|                ->  Index Scan using "COMPONENT_PROJECT_ID_IDX" on "COMPONENT" "C_1"  (cost=0.42..174.70 rows=1 width=53) (never executed)                           |
|                      Index Cond: ("PROJECT_ID" = $6)                                                                                                                |
|                      Filter: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                              |
|                SubPlan 4                                                                                                                                            |
|                  ->  CTE Scan on "CTE_MATCHES"  (cost=0.00..0.02 rows=1 width=8) (never executed)                                                                   |
|          ->  Nested Loop  (cost=29.61..159.64 rows=9 width=78) (actual time=0.000..0.001 rows=0 loops=1)                                                            |
|                ->  WorkTable Scan on "CTE_DEPENDENCIES" "PREVIOUS"  (cost=0.00..0.20 rows=5 width=130) (actual time=0.000..0.000 rows=0 loops=1)                    |
|                      Filter: (NOT "FOUND")                                                                                                                          |
|                ->  Bitmap Heap Scan on "COMPONENT" "C_2"  (cost=29.59..31.85 rows=2 width=661) (never executed)                                                     |
|                      Recheck Cond: (("PREVIOUS"."PROJECT_ID" = "PROJECT_ID") AND ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("PREVIOUS"."UUID")::text) || '%'::text)))|
|                      Filter: ("ID" <> ALL ("PREVIOUS"."PATH"))                                                                                                      |
|                      ->  BitmapAnd  (cost=29.59..29.59 rows=2 width=0) (never executed)                                                                             |
|                            ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.37 rows=379 width=0) (never executed)                                 |
|                                  Index Cond: ("PROJECT_ID" = "PREVIOUS"."PROJECT_ID")                                                                               |
|                            ->  Bitmap Index Scan on idx_gin  (cost=0.00..24.97 rows=3409 width=0) (never executed)                                                  |
|                                  Index Cond: ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("PREVIOUS"."UUID")::text) || '%'::text))                                     |
|                SubPlan 7                                                                                                                                            |
|                  ->  CTE Scan on "CTE_MATCHES" "CTE_MATCHES_2"  (cost=0.00..0.02 rows=1 width=8) (never executed)                                                   |
|Planning Time: 0.398 ms                                                                                                                                              |
|Execution Time: 0.045 ms                                                                                                                                             |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
</pre>
</details>

Finally, I changed the root node to `jest-cli`, which is only 7 nodes away from `is-ci@2.0.0`.

<details>
<summary>Old (135.584 ms)</summary>
<pre>
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|Aggregate  (cost=38180.43..38180.44 rows=1 width=1) (actual time=135.498..135.500 rows=1 loops=1)                                                                                        |
|  CTE CTE_DEPENDENCIES                                                                                                                                                                   |
|    ->  Recursive Union  (cost=231.53..38143.71 rows=1632 width=78) (actual time=27.063..135.476 rows=11 loops=1)                                                                        |
|          ->  Bitmap Heap Scan on "COMPONENT" "C"  (cost=231.53..262.65 rows=12 width=78) (actual time=27.061..27.428 rows=1 loops=1)                                                    |
|                Recheck Cond: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                                                  |
|                Rows Removed by Index Recheck: 1                                                                                                                                         |
|                Heap Blocks: exact=2                                                                                                                                                     |
|                ->  Bitmap Index Scan on idx_gin  (cost=0.00..231.53 rows=28 width=0) (actual time=27.049..27.049 rows=2 loops=1)                                                        |
|                      Index Cond: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                                              |
|          ->  Nested Loop  (cost=29.28..3786.47 rows=162 width=78) (actual time=9.706..9.821 rows=1 loops=11)                                                                            |
|                ->  WorkTable Scan on "CTE_DEPENDENCIES" "CTE_DEPENDENCIES_1"  (cost=0.00..2.40 rows=120 width=131) (actual time=0.000..0.000 rows=1 loops=11)                           |
|                ->  Bitmap Heap Scan on "COMPONENT" "C_1"  (cost=29.28..31.52 rows=1 width=674) (actual time=9.690..9.804 rows=1 loops=11)                                               |
|                      Recheck Cond: (("CTE_DEPENDENCIES_1"."PROJECT_ID" = "PROJECT_ID") AND ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("CTE_DEPENDENCIES_1"."UUID")::text) || '%'::text)))|
|                      Rows Removed by Index Recheck: 1                                                                                                                                   |
|                      Heap Blocks: exact=18                                                                                                                                              |
|                      ->  BitmapAnd  (cost=29.28..29.28 rows=2 width=0) (actual time=9.488..9.489 rows=0 loops=11)                                                                       |
|                            ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.33 rows=379 width=0) (actual time=0.209..0.209 rows=9056 loops=11)                        |
|                                  Index Cond: ("PROJECT_ID" = "CTE_DEPENDENCIES_1"."PROJECT_ID")                                                                                         |
|                            ->  Bitmap Index Scan on idx_gin  (cost=0.00..24.70 rows=3409 width=0) (actual time=9.242..9.242 rows=2 loops=11)                                            |
|                                  Index Cond: ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("CTE_DEPENDENCIES_1"."UUID")::text) || '%'::text))                                               |
|  ->  CTE Scan on "CTE_DEPENDENCIES"  (cost=0.00..32.64 rows=1632 width=1) (actual time=27.065..135.486 rows=11 loops=1)                                                                 |
|Planning Time: 0.955 ms                                                                                                                                                                  |
|Execution Time: 135.584 ms                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
</pre>
</details>

<details>
<summary>New (80.121 ms)</summary>
<pre>
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|QUERY PLAN                                                                                                                                                           |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
|CTE Scan on "CTE_DEPENDENCIES"  (cost=1782.44..1784.26 rows=91 width=131) (actual time=4.647..80.023 rows=7 loops=1)                                                 |
|  CTE CTE_PROJECT                                                                                                                                                    |
|    ->  Index Scan using "COMPONENT_UUID_IDX" on "COMPONENT" "C"  (cost=0.42..2.64 rows=1 width=8) (actual time=0.017..0.017 rows=1 loops=1)                         |
|          Index Cond: (("UUID")::text = '89dc699b-1518-49f9-ba74-04a8d0234400'::text)                                                                                |
|  CTE CTE_MATCHES                                                                                                                                                    |
|    ->  Bitmap Heap Scan on "COMPONENT"  (cost=6.61..7.73 rows=1 width=8) (actual time=0.536..0.540 rows=4 loops=1)                                                  |
|          Recheck Cond: ((("NAME")::text = 'jest-cli'::text) AND ("PROJECT_ID" = $1))                                                                                |
|          Filter: ("DIRECT_DEPENDENCIES" IS NOT NULL)                                                                                                                |
|          Heap Blocks: exact=4                                                                                                                                       |
|          InitPlan 2 (returns $1)                                                                                                                                    |
|            ->  CTE Scan on "CTE_PROJECT"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.018..0.019 rows=1 loops=1)                                                |
|          ->  BitmapAnd  (cost=6.59..6.59 rows=1 width=0) (actual time=0.531..0.531 rows=0 loops=1)                                                                  |
|                ->  Bitmap Index Scan on "COMPONENT_NAME_IDX"  (cost=0.00..1.98 rows=60 width=0) (actual time=0.024..0.024 rows=4 loops=1)                           |
|                      Index Cond: (("NAME")::text = 'jest-cli'::text)                                                                                                |
|                ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.37 rows=379 width=0) (actual time=0.504..0.504 rows=9056 loops=1)                 |
|                      Index Cond: ("PROJECT_ID" = $1)                                                                                                                |
|  CTE CTE_DEPENDENCIES                                                                                                                                               |
|    ->  Recursive Union  (cost=0.49..1772.07 rows=91 width=78) (actual time=4.645..80.014 rows=7 loops=1)                                                            |
|          ->  Result  (cost=0.49..174.76 rows=1 width=78) (actual time=4.644..10.821 rows=1 loops=1)                                                                 |
|                One-Time Filter: $5                                                                                                                                  |
|                InitPlan 5 (returns $5)                                                                                                                              |
|                  ->  CTE Scan on "CTE_MATCHES" "CTE_MATCHES_1"  (cost=0.00..0.02 rows=1 width=0) (actual time=0.536..0.536 rows=1 loops=1)                          |
|                InitPlan 6 (returns $6)                                                                                                                              |
|                  ->  CTE Scan on "CTE_PROJECT" "CTE_PROJECT_1"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.000..0.000 rows=1 loops=1)                          |
|                ->  Index Scan using "COMPONENT_PROJECT_ID_IDX" on "COMPONENT" "C_1"  (cost=0.42..174.70 rows=1 width=53) (actual time=4.086..10.261 rows=1 loops=1) |
|                      Index Cond: ("PROJECT_ID" = $6)                                                                                                                |
|                      Filter: ("DIRECT_DEPENDENCIES" ~~ '%89dc699b-1518-49f9-ba74-04a8d0234400%'::text)                                                              |
|                      Rows Removed by Filter: 9055                                                                                                                   |
|                SubPlan 4                                                                                                                                            |
|                  ->  CTE Scan on "CTE_MATCHES"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.000..0.005 rows=4 loops=1)                                          |
|          ->  Nested Loop  (cost=29.61..159.64 rows=9 width=78) (actual time=9.749..9.883 rows=1 loops=7)                                                            |
|                ->  WorkTable Scan on "CTE_DEPENDENCIES" "PREVIOUS"  (cost=0.00..0.20 rows=5 width=130) (actual time=0.001..0.001 rows=1 loops=7)                    |
|                      Filter: (NOT "FOUND")                                                                                                                          |
|                      Rows Removed by Filter: 0                                                                                                                      |
|                ->  Bitmap Heap Scan on "COMPONENT" "C_2"  (cost=29.59..31.85 rows=2 width=661) (actual time=11.355..11.510 rows=1 loops=6)                          |
|                      Recheck Cond: (("PREVIOUS"."PROJECT_ID" = "PROJECT_ID") AND ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("PREVIOUS"."UUID")::text) || '%'::text)))|
|                      Rows Removed by Index Recheck: 1                                                                                                               |
|                      Filter: ("ID" <> ALL ("PREVIOUS"."PATH"))                                                                                                      |
|                      Heap Blocks: exact=11                                                                                                                          |
|                      ->  BitmapAnd  (cost=29.59..29.59 rows=2 width=0) (actual time=11.091..11.091 rows=0 loops=6)                                                  |
|                            ->  Bitmap Index Scan on "COMPONENT_PROJECT_ID_IDX"  (cost=0.00..4.37 rows=379 width=0) (actual time=0.281..0.281 rows=9056 loops=6)     |
|                                  Index Cond: ("PROJECT_ID" = "PREVIOUS"."PROJECT_ID")                                                                               |
|                            ->  Bitmap Index Scan on idx_gin  (cost=0.00..24.97 rows=3409 width=0) (actual time=10.767..10.767 rows=2 loops=6)                       |
|                                  Index Cond: ("DIRECT_DEPENDENCIES" ~~ (('%'::text || ("PREVIOUS"."UUID")::text) || '%'::text))                                     |
|                SubPlan 7                                                                                                                                            |
|                  ->  CTE Scan on "CTE_MATCHES" "CTE_MATCHES_2"  (cost=0.00..0.02 rows=1 width=8) (actual time=0.001..0.001 rows=4 loops=1)                          |
|Planning Time: 0.975 ms                                                                                                                                              |
|Execution Time: 80.121 ms                                                                                                                                            |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------+
</details>

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
