### PR TITLE
Fix `is_dependency_of` query template

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -408,7 +408,7 @@ public class CelCommonPolicyLibrary implements Library {
                         -- Do not consider other leaf nodes (typically the majority of components).
                         -- Because we're looking for parent nodes, they MUST have direct dependencies defined.
                         AND "DIRECT_DEPENDENCIES" IS NOT NULL
-                        AND <filters>
+                        AND ${filters}
                     ),
                     "CTE_DEPENDENCIES" ("UUID", "PROJECT_ID", "FOUND", "PATH") AS (
                       SELECT

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -845,37 +845,37 @@ public class CelPolicyEngineTest extends AbstractPostgresEnabledTest {
         assertThat(qm.getAllPolicyViolations(componentB)).hasSize(1);
     }
 
-//    @Test
-//    public void testEvaluateProjectWithFuncComponentIsDependencyOfComponent() {
-//        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
-//        qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
-//                component.is_dependency_of(org.dependencytrack.policy.v1.Component{name: "acme-lib-a"})
-//                """, PolicyViolation.Type.OPERATIONAL);
-//
-//        final var project = new Project();
-//        project.setName("acme-app");
-//        qm.persist(project);
-//
-//        final var componentA = new Component();
-//        componentA.setProject(project);
-//        componentA.setName("acme-lib-a");
-//        qm.persist(componentA);
-//
-//        final var componentB = new Component();
-//        componentB.setProject(project);
-//        componentB.setName("acme-lib-b");
-//        qm.persist(componentB);
-//
-//        project.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentA).toJSON()));
-//        qm.persist(project);
-//        componentA.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentB).toJSON()));
-//        qm.persist(componentA);
-//
-//        new CelPolicyEngine().evaluateProject(project.getUuid());
-//
-//        assertThat(qm.getAllPolicyViolations(componentA)).isEmpty();
-//        assertThat(qm.getAllPolicyViolations(componentB)).hasSize(1);
-//    }
+    @Test
+    public void testEvaluateProjectWithFuncComponentIsDependencyOfComponent() {
+        final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
+        qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
+                component.is_dependency_of(org.dependencytrack.policy.v1.Component{name: "acme-lib-a"})
+                """, PolicyViolation.Type.OPERATIONAL);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var componentA = new Component();
+        componentA.setProject(project);
+        componentA.setName("acme-lib-a");
+        qm.persist(componentA);
+
+        final var componentB = new Component();
+        componentB.setProject(project);
+        componentB.setName("acme-lib-b");
+        qm.persist(componentB);
+
+        project.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentA).toJSON()));
+        qm.persist(project);
+        componentA.setDirectDependencies("[%s]".formatted(new ComponentIdentity(componentB).toJSON()));
+        qm.persist(componentA);
+
+        new CelPolicyEngine().evaluateProject(project.getUuid());
+
+        assertThat(qm.getAllPolicyViolations(componentA)).isEmpty();
+        assertThat(qm.getAllPolicyViolations(componentB)).hasSize(1);
+    }
 
     @Test
     public void testEvaluateProjectWithFuncMatchesRange() {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The query template (https://jdbi.org/#query-templating) engine was changed from the default (which uses `<>` for interpolation) to Freemarker (which uses `${}`) in #465.

The `is_dependency_of` query uses templating for dynamic filter conditions.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
