### PR TITLE
Set CEL policy container name to `org.dependencytrack.policy`

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -36,9 +36,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMPONENT;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 
 public class CelCommonPolicyLibrary implements Library {
 
@@ -53,10 +54,11 @@ public class CelCommonPolicyLibrary implements Library {
     @Override
     public List<EnvOption> getCompileOptions() {
         return List.of(
+                EnvOption.container("org.dependencytrack.policy"),
                 EnvOption.declarations(
                         Decls.newFunction(
                                 FUNC_DEPENDS_ON,
-                                // project.depends_on(org.dependencytrack.policy.v1.Component{name: "foo"})
+                                // project.depends_on(v1.Component{name: "foo"})
                                 Decls.newInstanceOverload(
                                         "project_depends_on_component_bool",
                                         List.of(TYPE_PROJECT, TYPE_COMPONENT),
@@ -65,7 +67,7 @@ public class CelCommonPolicyLibrary implements Library {
                         ),
                         Decls.newFunction(
                                 FUNC_IS_DEPENDENCY_OF,
-                                // component.is_dependency_of(org.dependencytrack.policy.v1.Component{name: "foo"})
+                                // component.is_dependency_of(v1.Component{name: "foo"})
                                 Decls.newInstanceOverload(
                                         "component_is_dependency_of_component_bool",
                                         List.of(TYPE_COMPONENT, TYPE_COMPONENT),
@@ -197,7 +199,7 @@ public class CelCommonPolicyLibrary implements Library {
         }
 
         if (lhs.value() instanceof final Project project) {
-            // project.depends_on(org.dependencytrack.policy.v1.Component{name: "foo"})
+            // project.depends_on(v1.Component{name: "foo"})
             return Types.boolOf(dependsOn(project, leafComponent));
         }
 

--- a/src/test/java/org/dependencytrack/persistence/VulnerabilityPolicyQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/VulnerabilityPolicyQueryManagerTest.java
@@ -19,7 +19,7 @@ public class VulnerabilityPolicyQueryManagerTest extends AbstractPostgresEnabled
         VulnerabilityPolicy vulnPolicy = new VulnerabilityPolicy();
         vulnPolicy.setCreated(new Date());
         vulnPolicy.setConditions(new String[]{"vuln.id == \"CVE-123\" || vuln.aliases.exists(alias, alias.id == \"CVE-123\")",
-                "component.name == \"foo\" && project.name == \"bar\" && \"internal\" in project.tags && !component.is_dependency_of(org.dependencytrack.policy.v1.Component{group: \"org.springframework.boot\"}"});
+                "component.name == \"foo\" && project.name == \"bar\" && \"internal\" in project.tags && !component.is_dependency_of(v1.Component{group: \"org.springframework.boot\"}"});
         vulnPolicy.setName("name");
         VulnerabilityPolicyAnalysis vulnerabilityPolicyAnalysis = new VulnerabilityPolicyAnalysis();
         vulnerabilityPolicyAnalysis.setState(VulnerabilityPolicyAnalysis.State.NOT_AFFECTED);

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -816,7 +816,7 @@ public class CelPolicyEngineTest extends AbstractPostgresEnabledTest {
     public void testEvaluateProjectWithFuncProjectDependsOnComponent() {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
-                project.depends_on(org.dependencytrack.policy.v1.Component{name: "acme-lib-a"})
+                project.depends_on(v1.Component{name: "acme-lib-a"})
                 """, PolicyViolation.Type.OPERATIONAL);
 
         final var project = new Project();
@@ -849,7 +849,7 @@ public class CelPolicyEngineTest extends AbstractPostgresEnabledTest {
     public void testEvaluateProjectWithFuncComponentIsDependencyOfComponent() {
         final var policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """
-                component.is_dependency_of(org.dependencytrack.policy.v1.Component{name: "acme-lib-a"})
+                component.is_dependency_of(v1.Component{name: "acme-lib-a"})
                 """, PolicyViolation.Type.OPERATIONAL);
 
         final var project = new Project();

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
@@ -63,7 +63,7 @@ public class CelPolicyScriptHostTest {
         final CelPolicyScript compiledScript = CelPolicyScriptHost.getInstance(CelPolicyType.COMPONENT).compile("""
                 component.resolved_license.groups.exists(licenseGroup, licenseGroup.name == "Permissive")
                   && vulns.exists(vuln, vuln.severity in ["HIGH", "CRITICAL"] && has(vuln.aliases))
-                  && project.depends_on(org.dependencytrack.policy.v1.Component{name: "foo"})
+                  && project.depends_on(v1.Component{name: "foo"})
                 """, CacheMode.NO_CACHE);
 
         final Map<Type, Collection<String>> requirements = compiledScript.getRequirements().asMap();

--- a/src/test/resources/unit/policy/vulnerability-policy-v1-invalid.yaml
+++ b/src/test/resources/unit/policy/vulnerability-policy-v1-invalid.yaml
@@ -13,7 +13,7 @@ conditions:
     component.name == "foo" 
       && project.name == "bar"
       && "internal" in project.tags
-      && !component.is_dependency_of(org.dependencytrack.policy.v1.Component{group: "org.springframework.boot"}
+      && !component.is_dependency_of(v1.Component{group: "org.springframework.boot"}
 analysis:
   state: NOT_AFFECTED
   justification: random-value

--- a/src/test/resources/unit/policy/vulnerability-policy-v1-valid.yaml
+++ b/src/test/resources/unit/policy/vulnerability-policy-v1-valid.yaml
@@ -13,7 +13,7 @@ conditions:
     component.name == "foo" 
       && project.name == "bar"
       && "internal" in project.tags
-      && !component.is_dependency_of(org.dependencytrack.policy.v1.Component{group: "org.springframework.boot"}
+      && !component.is_dependency_of(v1.Component{group: "org.springframework.boot"}
 analysis:
   state: NOT_AFFECTED
   justification: CODE_NOT_REACHABLE


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows for omitting of the `org.dependencytrack.policy` prefix when referring to Proto types. Foe example, referring to `Component` can now be done using `v1.Component` instead of `org.dependencytrack.policy.v1.Component`.

It would further be possible to allow a simple `Component` instead, using `EnvOptions.abbrevs`. However, if we allow that, policy conditions will not necessarily backward compatible anymore. *Some* kind of explicit versioning is required.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
