### PR TITLE
Add PROJECT_AUDIT_CHANGE notification on policy eval

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -76,6 +76,7 @@ import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABLE_DEPENDENCY;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_AUDIT_CHANGE;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
 import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
@@ -372,13 +373,14 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     .toList();
             dao.createFindingAttributions(findingAttributions);
 
-            return maybeApplyPolicyAnalyses(dao, component, vulns, newFindingVulnIds, policiesByVulnUuid);
+            return maybeApplyPolicyAnalyses(qm, dao, component, vulns, newFindingVulnIds, policiesByVulnUuid);
         });
     }
 
     /**
      * Apply analyses of matched {@link VulnerabilityPolicy}s. Do nothing when no policies matched.
      *
+     * @param qm
      * @param dao                The {@link Dao} to use for persistence operations
      * @param component          The {@link Component} to apply analyses for
      * @param vulns              The {@link Vulnerability}s identified for the {@link Component}
@@ -387,7 +389,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
      * @return A {@link List} of {@link Vulnerability}s, that were not previously associated with the {@link Component},
      * and which have not been suppressed via {@link VulnerabilityPolicy}.
      */
-    private List<Vulnerability> maybeApplyPolicyAnalyses(final Dao dao, final Component component, final Collection<Vulnerability> vulns,
+    private List<Vulnerability> maybeApplyPolicyAnalyses(QueryManager qm, final Dao dao, final Component component, final Collection<Vulnerability> vulns,
                                                          final List<Long> newFindingVulnIds, final Map<UUID, VulnerabilityPolicy> policiesByVulnUuid) {
         // Unless we have any matching vulnerability policies, there's nothing to do!
         if (policiesByVulnUuid.isEmpty()) {
@@ -411,6 +413,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
         final var analysesToCreateOrUpdate = new ArrayList<Analysis>();
         final var analysisCommentsByVulnId = new MultivaluedHashMap<Long, AnalysisComment>();
+
         for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
             final Vulnerability vuln = vulnByUuid.get(vulnUuidAndPolicy.getKey());
             final VulnerabilityPolicy policy = vulnUuidAndPolicy.getValue();
@@ -421,7 +424,6 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 LOGGER.warn("Unable to apply policy %s as it was found to be invalid".formatted(policy.name()), e);
                 continue;
             }
-
             final Analysis existingAnalysis = existingAnalyses.get(vuln.getUuid());
             if (existingAnalysis == null) {
                 policyAnalysis.setComponentId(component.id());
@@ -595,10 +597,6 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
         if (!analysesToCreateOrUpdate.isEmpty()) {
             final List<CreatedAnalysis> createdAnalyses = dao.createOrUpdateAnalyses(analysesToCreateOrUpdate);
-            // TODO: Construct notifications for PROJECT_AUDIT_CHANGE, but do not dispatch them here!
-            //  They should be dispatched together with NEW_VULNERABILITY and NEW_VULNERABLE_DEPENDENCY
-            //  notifications, AFTER this database transaction completed successfully.
-
             // Comments for new analyses do not have an analysis ID set yet, as that ID was not known prior
             // to inserting the respective analysis record. Enrich comments with analysis IDs now that we know them.
             for (final CreatedAnalysis createdAnalysis : createdAnalyses) {
@@ -607,8 +605,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                                 .map(comment -> new AnalysisComment(createdAnalysis.id(), comment.comment(), comment.commenter()))
                                 .toList());
             }
-
             dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
+
+            // dispatch PROJECT_AUDIT_CHANGE notifications
+            maybeSendProjectAuditChangeNotification(qm, component, createdAnalyses.stream().map(CreatedAnalysis::vulnId).toList());
         }
 
         return vulnById.entrySet().stream()
@@ -663,6 +663,31 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                     .forEach(notifications::add);
         });
 
+        for (final org.dependencytrack.proto.notification.v1.Notification notification : notifications) {
+            eventDispatcher.dispatchAsync(component.projectUuid().toString(), notification);
+        }
+    }
+
+
+    private void maybeSendProjectAuditChangeNotification(final QueryManager qm, final Component component, List<Long> vulnIds) {
+        if (vulnIds.isEmpty()) {
+            return;
+        }
+        final Timestamp notificationTimestamp = Timestamps.now();
+        final var notifications = new ArrayList<org.dependencytrack.proto.notification.v1.Notification>();
+        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> {
+        dao.getForProjectAuditChange(component.uuid(), vulnIds).stream()
+                    .map(subject -> org.dependencytrack.proto.notification.v1.Notification.newBuilder()
+                            .setScope(SCOPE_PORTFOLIO)
+                            .setGroup(GROUP_PROJECT_AUDIT_CHANGE)
+                            .setLevel(LEVEL_INFORMATIONAL)
+                            .setTimestamp(notificationTimestamp)
+                            .setTitle(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, subject.getProject())) // TODO
+                            .setContent(generateNotificationContent(subject.getVulnerability())) // TODO
+                            .setSubject(Any.pack(subject))
+                            .build())
+                    .forEach(notifications::add);
+        });
         for (final org.dependencytrack.proto.notification.v1.Notification notification : notifications) {
             eventDispatcher.dispatchAsync(component.projectUuid().toString(), notification);
         }

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -77,6 +77,7 @@ import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABLE_DEPENDENCY;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_AUDIT_CHANGE;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
 import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
@@ -626,12 +627,12 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
     private org.dependencytrack.proto.notification.v1.Notification createAndAddProjectAuditChangeNotification(QueryManager qm, Component component, Vulnerability vuln, Analysis policyAnalysis, boolean analysisStateChange, boolean suppressionChange) {
         final Timestamp notificationTimestamp = Timestamps.now();
-        AtomicReference<org.dependencytrack.proto.notification.v1.Notification> notification = null;
-        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> dao.getForProjectAuditChange(component.uuid(), vuln.getUuid())
+        AtomicReference<org.dependencytrack.proto.notification.v1.Notification> notification = new AtomicReference<>();
+        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> dao.getForProjectAuditChange(component.uuid(), vuln.getUuid(), policyAnalysis.state, policyAnalysis.suppressed)
                     .map(subject -> {
                         notification.set(org.dependencytrack.proto.notification.v1.Notification.newBuilder()
                                 .setScope(SCOPE_PORTFOLIO)
-                                .setGroup(GROUP_NEW_VULNERABILITY)
+                                .setGroup(GROUP_PROJECT_AUDIT_CHANGE)
                                 .setLevel(LEVEL_INFORMATIONAL)
                                 .setTimestamp(notificationTimestamp)
                                 .setTitle(generateTitle(policyAnalysis.getState(), policyAnalysis.getSuppressed(), analysisStateChange, suppressionChange))

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -64,6 +64,7 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -76,13 +77,13 @@ import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABLE_DEPENDENCY;
-import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_AUDIT_CHANGE;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
 import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
 import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
 import static org.dependencytrack.util.NotificationUtil.generateNotificationContent;
 import static org.dependencytrack.util.NotificationUtil.generateNotificationTitle;
+import static org.dependencytrack.util.NotificationUtil.generateTitle;
 import static org.dependencytrack.util.VulnerabilityUtil.canBeMirrored;
 import static org.dependencytrack.util.VulnerabilityUtil.isAuthoritativeSource;
 import static org.dependencytrack.util.VulnerabilityUtil.isMirroringEnabled;
@@ -412,6 +413,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 .collect(Collectors.toMap(Analysis::getVulnUuid, Function.identity()));
 
         final var analysesToCreateOrUpdate = new ArrayList<Analysis>();
+        final var projectAuditChangeNotifications = new ArrayList<org.dependencytrack.proto.notification.v1.Notification>();
         final var analysisCommentsByVulnId = new MultivaluedHashMap<Long, AnalysisComment>();
 
         for (final Map.Entry<UUID, VulnerabilityPolicy> vulnUuidAndPolicy : policiesByVulnUuid.entrySet()) {
@@ -486,6 +488,8 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 analysisCommentsByVulnId.addAll(policyAnalysis.getVulnId(), commentFactory.getComments());
             } else {
                 boolean shouldUpdate = false;
+                boolean analysisStateChange = false;
+                boolean suppressionChange = false;
                 final var commentFactory = new AnalysisCommentFactory(existingAnalysis.getId(), policy);
                 if (!Objects.equals(existingAnalysis.getState(), policyAnalysis.getState())) {
                     commentFactory.createComment("State: %s → %s".formatted(
@@ -494,6 +498,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
                     existingAnalysis.setState(policyAnalysis.getState());
                     shouldUpdate = true;
+                    analysisStateChange = true;
                 }
                 if (!Objects.equals(existingAnalysis.getJustification(), policyAnalysis.getJustification())) {
                     commentFactory.createComment("Justification: %s → %s".formatted(
@@ -526,6 +531,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
                     existingAnalysis.setSuppressed(policy.analysis().isSuppress());
                     shouldUpdate = true;
+                    suppressionChange = true;
                 }
                 if (!Objects.equals(existingAnalysis.getSeverity(), policyAnalysis.getSeverity())) {
                     commentFactory.createComment("Severity: %s → %s".formatted(
@@ -586,6 +592,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 if (shouldUpdate) {
                     analysesToCreateOrUpdate.add(existingAnalysis);
                     analysisCommentsByVulnId.addAll(existingAnalysis.getVulnId(), commentFactory.getComments());
+                    projectAuditChangeNotifications.add(createAndAddProjectAuditChangeNotification(qm, component, vuln, policyAnalysis, analysisStateChange, suppressionChange));
                 }
             }
 
@@ -606,15 +613,34 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                                 .toList());
             }
             dao.createAnalysisComments(analysisCommentsByVulnId.values().stream().flatMap(Collection::stream).toList());
-
-            // dispatch PROJECT_AUDIT_CHANGE notifications
-            maybeSendProjectAuditChangeNotification(qm, component, createdAnalyses.stream().map(CreatedAnalysis::vulnId).toList());
         }
+
+        // dispatch PROJECT_AUDIT_CHANGE notifications
+        maybeSendProjectAuditChangeNotification(component.projectUuid, projectAuditChangeNotifications);
 
         return vulnById.entrySet().stream()
                 .filter(entry -> newFindingVulnIds.contains(entry.getKey()))
                 .map(Map.Entry::getValue)
                 .toList();
+    }
+
+    private org.dependencytrack.proto.notification.v1.Notification createAndAddProjectAuditChangeNotification(QueryManager qm, Component component, Vulnerability vuln, Analysis policyAnalysis, boolean analysisStateChange, boolean suppressionChange) {
+        final Timestamp notificationTimestamp = Timestamps.now();
+        AtomicReference<org.dependencytrack.proto.notification.v1.Notification> notification = null;
+        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> dao.getForProjectAuditChange(component.uuid(), vuln.getUuid())
+                    .map(subject -> {
+                        notification.set(org.dependencytrack.proto.notification.v1.Notification.newBuilder()
+                                .setScope(SCOPE_PORTFOLIO)
+                                .setGroup(GROUP_NEW_VULNERABILITY)
+                                .setLevel(LEVEL_INFORMATIONAL)
+                                .setTimestamp(notificationTimestamp)
+                                .setTitle(generateTitle(policyAnalysis.getState(), policyAnalysis.getSuppressed(), analysisStateChange, suppressionChange))
+                                .setContent(generateNotificationContent(policyAnalysis))
+                                .setSubject(Any.pack(subject))
+                                .build());
+                        return null;
+                    }));
+        return notification.get();
     }
 
     /**
@@ -669,27 +695,12 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
     }
 
 
-    private void maybeSendProjectAuditChangeNotification(final QueryManager qm, final Component component, List<Long> vulnIds) {
-        if (vulnIds.isEmpty()) {
+    private void maybeSendProjectAuditChangeNotification(final UUID projectUuid, final ArrayList<org.dependencytrack.proto.notification.v1.Notification> projectAuditChangeNotifications) {
+        if (projectAuditChangeNotifications.isEmpty()) {
             return;
         }
-        final Timestamp notificationTimestamp = Timestamps.now();
-        final var notifications = new ArrayList<org.dependencytrack.proto.notification.v1.Notification>();
-        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> {
-        dao.getForProjectAuditChange(component.uuid(), vulnIds).stream()
-                    .map(subject -> org.dependencytrack.proto.notification.v1.Notification.newBuilder()
-                            .setScope(SCOPE_PORTFOLIO)
-                            .setGroup(GROUP_PROJECT_AUDIT_CHANGE)
-                            .setLevel(LEVEL_INFORMATIONAL)
-                            .setTimestamp(notificationTimestamp)
-                            .setTitle(generateNotificationTitle(NotificationConstants.Title.NEW_VULNERABILITY, subject.getProject())) // TODO
-                            .setContent(generateNotificationContent(subject.getVulnerability())) // TODO
-                            .setSubject(Any.pack(subject))
-                            .build())
-                    .forEach(notifications::add);
-        });
-        for (final org.dependencytrack.proto.notification.v1.Notification notification : notifications) {
-            eventDispatcher.dispatchAsync(component.projectUuid().toString(), notification);
+        for (final var notification : projectAuditChangeNotifications) {
+            eventDispatcher.dispatchAsync(projectUuid.toString(), notification);
         }
     }
 

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -64,7 +64,6 @@ import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -593,7 +592,10 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                 if (shouldUpdate) {
                     analysesToCreateOrUpdate.add(existingAnalysis);
                     analysisCommentsByVulnId.addAll(existingAnalysis.getVulnId(), commentFactory.getComments());
-                    projectAuditChangeNotifications.add(createAndAddProjectAuditChangeNotification(qm, component, vuln, policyAnalysis, analysisStateChange, suppressionChange));
+                    var projectAuditChangeNotification = createAndAddProjectAuditChangeNotification(qm, component, vuln, policyAnalysis, analysisStateChange, suppressionChange);
+                    if (projectAuditChangeNotification != null) {
+                        projectAuditChangeNotifications.add(projectAuditChangeNotification);
+                    }
                 }
             }
 
@@ -627,21 +629,19 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
 
     private org.dependencytrack.proto.notification.v1.Notification createAndAddProjectAuditChangeNotification(QueryManager qm, Component component, Vulnerability vuln, Analysis policyAnalysis, boolean analysisStateChange, boolean suppressionChange) {
         final Timestamp notificationTimestamp = Timestamps.now();
-        AtomicReference<org.dependencytrack.proto.notification.v1.Notification> notification = new AtomicReference<>();
-        jdbi(qm).useExtension(NotificationSubjectDao.class, dao -> dao.getForProjectAuditChange(component.uuid(), vuln.getUuid(), policyAnalysis.state, policyAnalysis.suppressed)
-                    .map(subject -> {
-                        notification.set(org.dependencytrack.proto.notification.v1.Notification.newBuilder()
-                                .setScope(SCOPE_PORTFOLIO)
-                                .setGroup(GROUP_PROJECT_AUDIT_CHANGE)
-                                .setLevel(LEVEL_INFORMATIONAL)
-                                .setTimestamp(notificationTimestamp)
-                                .setTitle(generateTitle(policyAnalysis.getState(), policyAnalysis.getSuppressed(), analysisStateChange, suppressionChange))
-                                .setContent(generateNotificationContent(policyAnalysis))
-                                .setSubject(Any.pack(subject))
-                                .build());
-                        return null;
-                    }));
-        return notification.get();
+        final var optionalSubject = jdbi(qm).withExtension(NotificationSubjectDao.class, dao -> dao.getForProjectAuditChange(component.uuid(), vuln.getUuid(), policyAnalysis.state, policyAnalysis.suppressed));
+        if (optionalSubject.isPresent()) {
+            return org.dependencytrack.proto.notification.v1.Notification.newBuilder()
+                    .setScope(SCOPE_PORTFOLIO)
+                    .setGroup(GROUP_PROJECT_AUDIT_CHANGE)
+                    .setLevel(LEVEL_INFORMATIONAL)
+                    .setTimestamp(notificationTimestamp)
+                    .setTitle(generateTitle(policyAnalysis.getState(), policyAnalysis.getSuppressed(), analysisStateChange, suppressionChange))
+                    .setContent(generateNotificationContent(policyAnalysis))
+                    .setSubject(Any.pack(optionalSubject.get()))
+                    .build();
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -338,8 +338,8 @@ public interface NotificationSubjectDao {
                   OR ("V"."SOURCE" = 'VULNDB' AND "VA"."VULNDB_ID" = "V"."VULNID")
             ) AS "vulnAliases" ON TRUE
             WHERE
-              "C"."UUID" = (:componentUuid)::TEXT AND "V"."ID" = ANY((:vulnIds)::BIGINT[])
+              "C"."UUID" = (:componentUuid)::TEXT AND "V"."UUID" = (:vulnUuid)::TEXT
             """)
     @RegisterRowMapper(NotificationSubjectProjectAuditChangeRowMapper.class)
-    List<VulnerabilityAnalysisDecisionChangeSubject> getForProjectAuditChange(final UUID componentUuid, final Collection<Long> vulnIds);
+    Optional<VulnerabilityAnalysisDecisionChangeSubject> getForProjectAuditChange(final UUID componentUuid, final UUID vulnUuid);
 }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -1,5 +1,6 @@
 package org.dependencytrack.persistence.jdbi;
 
+import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.VulnerabilityAnalysisLevel;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationComponentRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationProjectRowMapper;
@@ -299,8 +300,8 @@ public interface NotificationSubjectDao {
               )                    AS "vulnSeverity",
               STRING_TO_ARRAY("V"."CWES", ',') AS "vulnCwes",
               "vulnAliasesJson",
-              "A"."SUPPRESSED"             AS "isVulnAnalysisSuppressed",
-              "A"."STATE"             AS "vulnAnalysisState",
+              :isSuppressed              AS "isVulnAnalysisSuppressed",
+              :analysisState             AS "vulnAnalysisState",
               '/api/v1/vulnerability/source/' || "V"."SOURCE" || '/vuln/' || "V"."VULNID" || '/projects' AS "affectedProjectsApiUrl",
               '/vulnerabilities/' || "V"."SOURCE" || '/' || "V"."VULNID" || '/affectedProjects'          AS "affectedProjectsFrontendUrl"
             FROM
@@ -341,5 +342,6 @@ public interface NotificationSubjectDao {
               "C"."UUID" = (:componentUuid)::TEXT AND "V"."UUID" = (:vulnUuid)::TEXT
             """)
     @RegisterRowMapper(NotificationSubjectProjectAuditChangeRowMapper.class)
-    Optional<VulnerabilityAnalysisDecisionChangeSubject> getForProjectAuditChange(final UUID componentUuid, final UUID vulnUuid);
+
+    Optional<VulnerabilityAnalysisDecisionChangeSubject> getForProjectAuditChange(final UUID componentUuid, final UUID vulnUuid, AnalysisState analysisState, boolean isSuppressed);
 }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -5,9 +5,11 @@ import org.dependencytrack.persistence.jdbi.mapping.NotificationComponentRowMapp
 import org.dependencytrack.persistence.jdbi.mapping.NotificationProjectRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectNewVulnerabilityRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectNewVulnerableDependencyRowReducer;
+import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectProjectAuditChangeRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationVulnerabilityRowMapper;
 import org.dependencytrack.proto.notification.v1.NewVulnerabilitySubject;
 import org.dependencytrack.proto.notification.v1.NewVulnerableDependencySubject;
+import org.dependencytrack.proto.notification.v1.VulnerabilityAnalysisDecisionChangeSubject;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMappers;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -235,4 +237,109 @@ public interface NotificationSubjectDao {
     @UseRowReducer(NotificationSubjectNewVulnerableDependencyRowReducer.class)
     Optional<NewVulnerableDependencySubject> getForNewVulnerableDependency(final UUID componentUuid);
 
+    @SqlQuery("""
+            SELECT
+              "C"."UUID"                       AS "componentUuid",
+              "C"."GROUP"                      AS "componentGroup",
+              "C"."NAME"                       AS "componentName",
+              "C"."VERSION"                    AS "componentVersion",
+              "C"."PURL"                       AS "componentPurl",
+              "C"."MD5"                        AS "componentMd5",
+              "C"."SHA1"                       AS "componentSha1",
+              "C"."SHA_256"                    AS "componentSha256",
+              "C"."SHA_512"                    AS "componentSha512",
+              "P"."UUID"                       AS "projectUuid",
+              "P"."NAME"                       AS "projectName",
+              "P"."VERSION"                    AS "projectVersion",
+              "P"."DESCRIPTION"                AS "projectDescription",
+              "P"."PURL"                       AS "projectPurl",
+              (SELECT
+                 ARRAY_AGG(DISTINCT "T"."NAME")
+               FROM
+                 "TAG" AS "T"
+               INNER JOIN
+                 "PROJECTS_TAGS" AS "PT" ON "PT"."TAG_ID" = "T"."ID"
+               WHERE
+                 "PT"."PROJECT_ID" = "P"."ID"
+              )                                AS "projectTags",
+              "V"."UUID"                       AS "vulnUuid",
+              "V"."VULNID"                     AS "vulnId",
+              "V"."SOURCE"                     AS "vulnSource",
+              "V"."TITLE"                      AS "vulnTitle",
+              "V"."SUBTITLE"                   AS "vulnSubTitle",
+              "V"."DESCRIPTION"                AS "vulnDescription",
+              "V"."RECOMMENDATION"             AS "vulnRecommendation",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV2SCORE"
+                ELSE "V"."CVSSV2BASESCORE"
+              END                              AS "vulnCvssV2BaseScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3SCORE"
+                ELSE "V"."CVSSV3BASESCORE"
+              END                              AS "vulnCvssV3BaseScore",
+              -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
+              --  How to handle this?
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPSCORE"
+                ELSE "V"."OWASPRRBUSINESSIMPACTSCORE"
+              END                              AS "vulnOwaspRrBusinessImpactScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPSCORE"
+                ELSE "V"."OWASPRRLIKELIHOODSCORE"
+              END                              AS "vulnOwaspRrLikelihoodScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPSCORE"
+                ELSE "V"."OWASPRRTECHNICALIMPACTSCORE"
+              END                              AS "vulnOwaspRrTechnicalImpactScore",
+              "CALC_SEVERITY"(
+                "V"."SEVERITY",
+                "A"."SEVERITY",
+                "V"."CVSSV3BASESCORE",
+                "V"."CVSSV2BASESCORE"
+              )                    AS "vulnSeverity",
+              STRING_TO_ARRAY("V"."CWES", ',') AS "vulnCwes",
+              "vulnAliasesJson",
+              "A"."SUPPRESSED"             AS "isVulnAnalysisSuppressed",
+              "A"."STATE"             AS "vulnAnalysisState",
+              '/api/v1/vulnerability/source/' || "V"."SOURCE" || '/vuln/' || "V"."VULNID" || '/projects' AS "affectedProjectsApiUrl",
+              '/vulnerabilities/' || "V"."SOURCE" || '/' || "V"."VULNID" || '/affectedProjects'          AS "affectedProjectsFrontendUrl"
+            FROM
+              "COMPONENT" AS "C"
+            INNER JOIN
+              "PROJECT" AS "P" ON "P"."ID" = "C"."PROJECT_ID"
+            INNER JOIN
+              "COMPONENTS_VULNERABILITIES" AS "CV" ON "CV"."COMPONENT_ID" = "C"."ID"
+            INNER JOIN
+              "VULNERABILITY" AS "V" ON "V"."ID" = "CV"."VULNERABILITY_ID"
+            LEFT JOIN
+              "ANALYSIS" AS "A" ON "A"."COMPONENT_ID" = "C"."ID" AND "A"."VULNERABILITY_ID" = "V"."ID"
+            LEFT JOIN LATERAL (
+              SELECT
+                CAST(JSONB_AGG(DISTINCT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
+                  'cveId',      "VA"."CVE_ID",
+                  'ghsaId',     "VA"."GHSA_ID",
+                  'gsdId',      "VA"."GSD_ID",
+                  'internalId', "VA"."INTERNAL_ID",
+                  'osvId',      "VA"."OSV_ID",
+                  'sonatypeId', "VA"."SONATYPE_ID",
+                  'snykId',     "VA"."SNYK_ID",
+                  'vulnDbId',   "VA"."VULNDB_ID"
+                ))) AS TEXT) AS "vulnAliasesJson"
+              FROM
+                "VULNERABILITYALIAS" AS "VA"
+              WHERE
+                ("V"."SOURCE" = 'NVD' AND "VA"."CVE_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'GITHUB' AND "VA"."GHSA_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'GSD' AND "VA"."GSD_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'INTERNAL' AND "VA"."INTERNAL_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'OSV' AND "VA"."OSV_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'SONATYPE' AND "VA"."SONATYPE_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'SNYK' AND "VA"."SNYK_ID" = "V"."VULNID")
+                  OR ("V"."SOURCE" = 'VULNDB' AND "VA"."VULNDB_ID" = "V"."VULNID")
+            ) AS "vulnAliases" ON TRUE
+            WHERE
+              "C"."UUID" = (:componentUuid)::TEXT AND "V"."ID" = ANY((:vulnIds)::BIGINT[])
+            """)
+    @RegisterRowMapper(NotificationSubjectProjectAuditChangeRowMapper.class)
+    List<VulnerabilityAnalysisDecisionChangeSubject> getForProjectAuditChange(final UUID componentUuid, final Collection<Long> vulnIds);
 }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationSubjectProjectAuditChangeRowMapper.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationSubjectProjectAuditChangeRowMapper.java
@@ -1,0 +1,37 @@
+package org.dependencytrack.persistence.jdbi.mapping;
+
+import org.dependencytrack.proto.notification.v1.Component;
+import org.dependencytrack.proto.notification.v1.Project;
+import org.dependencytrack.proto.notification.v1.Vulnerability;
+import org.dependencytrack.proto.notification.v1.VulnerabilityAnalysis;
+import org.dependencytrack.proto.notification.v1.VulnerabilityAnalysisDecisionChangeSubject;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.dependencytrack.persistence.jdbi.mapping.RowMapperUtil.maybeSet;
+
+public class NotificationSubjectProjectAuditChangeRowMapper implements RowMapper<VulnerabilityAnalysisDecisionChangeSubject> {
+
+    @Override
+    public VulnerabilityAnalysisDecisionChangeSubject map(final ResultSet rs, final StatementContext ctx) throws SQLException {
+        final RowMapper<Component> componentRowMapper = ctx.findRowMapperFor(Component.class).orElseThrow();
+        final RowMapper<Project> projectRowMapper = ctx.findRowMapperFor(Project.class).orElseThrow();
+        final RowMapper<Vulnerability> vulnRowMapper = ctx.findRowMapperFor(Vulnerability.class).orElseThrow();
+        final VulnerabilityAnalysis.Builder vulnAnalysisBuilder = VulnerabilityAnalysis.newBuilder()
+                .setComponent(componentRowMapper.map(rs, ctx))
+                .setProject(projectRowMapper.map(rs, ctx))
+                .setVulnerability(vulnRowMapper.map(rs, ctx));
+        maybeSet(rs, "vulnAnalysisState", ResultSet::getString, vulnAnalysisBuilder::setState);
+        maybeSet(rs, "isVulnAnalysisSuppressed", ResultSet::getBoolean, vulnAnalysisBuilder::setSuppressed);
+        final VulnerabilityAnalysisDecisionChangeSubject.Builder builder = VulnerabilityAnalysisDecisionChangeSubject.newBuilder()
+                .setComponent(componentRowMapper.map(rs, ctx))
+                .setProject(projectRowMapper.map(rs, ctx))
+                .setVulnerability(vulnRowMapper.map(rs, ctx))
+                .setAnalysis(vulnAnalysisBuilder);
+        return builder.build();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -52,6 +52,7 @@ import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyRating;
 import org.dependencytrack.proto.notification.v1.NewVulnerabilitySubject;
 import org.dependencytrack.proto.notification.v1.NewVulnerableDependencySubject;
 import org.dependencytrack.proto.notification.v1.Notification;
+import org.dependencytrack.proto.notification.v1.VulnerabilityAnalysisDecisionChangeSubject;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
 import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
@@ -75,6 +76,7 @@ import static org.cyclonedx.proto.v1_4.ScoreMethod.SCORE_METHOD_OWASP;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_ANALYZER;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABLE_DEPENDENCY;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_AUDIT_CHANGE;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_ERROR;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
@@ -895,8 +897,19 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                 });
 
         // The vulnerability already existed, so no notifications to be expected.
-        // TODO: There should be PROJECT_AUDIT_CHANGE notifications.
-        assertThat(kafkaMockProducer.history()).isEmpty();
+        // There should be PROJECT_AUDIT_CHANGE notification.
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(
+                record -> {
+                    assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
+                    final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+                    assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+                    assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                    assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
+                    assertThat(notification.getSubject().is(VulnerabilityAnalysisDecisionChangeSubject.class)).isTrue();
+                    final var subject = notification.getSubject().unpack(VulnerabilityAnalysisDecisionChangeSubject.class);
+                    assertThat(subject.getAnalysis().getState()).isEqualTo("NOT_AFFECTED");
+                }
+        );
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -491,28 +491,20 @@ public class NotificationSubjectDaoTest extends AbstractPostgresEnabledTest {
         vulnA.setCwes(List.of(666, 777));
         qm.persist(vulnA);
 
-        final var vulnB = new Vulnerability();
-        vulnB.setVulnId("CVE-200");
-        vulnB.setSource(Vulnerability.Source.NVD);
-        qm.persist(vulnB);
-
         final var vulnAlias = new VulnerabilityAlias();
         vulnAlias.setCveId("CVE-100");
         vulnAlias.setGhsaId("GHSA-100");
         qm.synchronizeVulnerabilityAlias(vulnAlias);
 
         qm.addVulnerability(vulnA, component, AnalyzerIdentity.INTERNAL_ANALYZER);
-        qm.addVulnerability(vulnB, component, AnalyzerIdentity.INTERNAL_ANALYZER);
 
         // Suppress vulnB, it should not appear in the query results.
-        qm.makeAnalysis(component, vulnB, AnalysisState.FALSE_POSITIVE, null, null, null, true);
         qm.makeAnalysis(component, vulnA, AnalysisState.NOT_AFFECTED, null, null, null, false);
 
-        final List<VulnerabilityAnalysisDecisionChangeSubject> subjects = JdbiFactory.jdbi(qm).withExtension(NotificationSubjectDao.class,
-                dao -> dao.getForProjectAuditChange(component.getUuid(), List.of(vulnA.getId(), vulnB.getId())));
+        final Optional<VulnerabilityAnalysisDecisionChangeSubject> optionalSubject = JdbiFactory.jdbi(qm).withExtension(NotificationSubjectDao.class,
+                dao -> dao.getForProjectAuditChange(component.getUuid(), vulnA.getUuid()));
 
-        assertThat(subjects.size()).isEqualTo(2);
-        assertThat(subjects.get(0)).satisfies(subject ->
+        assertThat(optionalSubject.get()).satisfies(subject ->
                 assertThatJson(JsonFormat.printer().print(subject))
                         .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                         .withMatcher("componentUuid", equalTo(component.getUuid().toString()))

--- a/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -499,10 +499,10 @@ public class NotificationSubjectDaoTest extends AbstractPostgresEnabledTest {
         qm.addVulnerability(vulnA, component, AnalyzerIdentity.INTERNAL_ANALYZER);
 
         // Suppress vulnB, it should not appear in the query results.
-        qm.makeAnalysis(component, vulnA, AnalysisState.NOT_AFFECTED, null, null, null, false);
+        var policyAnalysis = qm.makeAnalysis(component, vulnA, AnalysisState.NOT_AFFECTED, null, null, null, false);
 
         final Optional<VulnerabilityAnalysisDecisionChangeSubject> optionalSubject = JdbiFactory.jdbi(qm).withExtension(NotificationSubjectDao.class,
-                dao -> dao.getForProjectAuditChange(component.getUuid(), vulnA.getUuid()));
+                dao -> dao.getForProjectAuditChange(component.getUuid(), vulnA.getUuid(), policyAnalysis.getAnalysisState(), policyAnalysis.isSuppressed()));
 
         assertThat(optionalSubject.get()).satisfies(subject ->
                 assertThatJson(JsonFormat.printer().print(subject))


### PR DESCRIPTION
### Description

We do not currently send PROJECT_AUDIT_CHANGE notifications for analyses that were applied via vulnerability policy.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/968 

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
