### PR TITLE
Fix inconsistent `AnalysisComment` ordering in case of equal `timestamp` values

### DIFF
--- a/src/main/java/org/dependencytrack/model/Analysis.java
+++ b/src/main/java/org/dependencytrack/model/Analysis.java
@@ -89,7 +89,7 @@ public class Analysis implements Serializable {
     private String analysisDetails;
 
     @Persistent(mappedBy = "analysis", defaultFetchGroup = "true")
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "timestamp ASC"))
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "timestamp ASC, id ASC"))
     private List<AnalysisComment> analysisComments;
 
     @Persistent

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -672,11 +672,8 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getOwaspVector()).isNull();
                         assertThat(analysis.getOwaspScore()).isNull();
 
-                        // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
-                        // the same timestamp as they were created in the same database transaction. Ordering in this
-                        // test might not be stable, hence the check for "in any order".
                         assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy{Name=Foo, Author=Jane Doe}]");
-                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactly(
                                 "Matched on condition(s):\n- has(component.name)\n- project.version != \"\"",
                                 "State: NOT_SET → NOT_AFFECTED",
                                 "Justification: NOT_SET → CODE_NOT_REACHABLE",
@@ -771,11 +768,8 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getOwaspVector()).isNull();
                         assertThat(analysis.getOwaspScore()).isNull();
 
-                        // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
-                        // the same timestamp as they were created in the same database transaction. Ordering in this
-                        // test might not be stable, hence the check for "in any order".
                         assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy{Name=Foo, Author=Jane Doe}]");
-                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactly(
                                 "Matched on condition(s):\n- has(component.name)\n- project.version != \"\"",
                                 "State: NOT_SET → FALSE_POSITIVE",
                                 "Unsuppressed → Suppressed"
@@ -872,11 +866,8 @@ public class VulnerabilityScanResultProcessorTest extends AbstractPostgresEnable
                         assertThat(analysis.getOwaspVector()).isNull();
                         assertThat(analysis.getOwaspScore()).isNull();
 
-                        // Note: getAnalysisComments returns comments ordered by timestamp, but all comments have
-                        // the same timestamp as they were created in the same database transaction. Ordering in this
-                        // test might not be stable, hence the check for "in any order".
                         assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getCommenter).containsOnly("[Policy{Name=Foo, Author=Jane Doe}]");
-                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactlyInAnyOrder(
+                        assertThat(analysis.getAnalysisComments()).extracting(AnalysisComment::getComment).containsExactly(
                                 "Matched on condition(s):\n- has(component.name)\n- project.version != \"\"",
                                 "State: FALSE_POSITIVE → NOT_AFFECTED",
                                 "Justification: NOT_SET → CODE_NOT_REACHABLE",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes inconsistent `AnalysisComment` ordering in case of equal `timestamp` values

As of recently, multiple `AnalysisComments` are created with the same `timestamp` (due to the creation happening in a single transaction). This messes with the default ordering of comments.

In addition to `timestamp`, also sort by `id` to retain the intended ordering.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
