### PR TITLE
Support bearer auth for policy bundle server

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -83,7 +83,7 @@ public enum ConfigKey implements Config.Key {
     VULNERABILITY_POLICY_BUNDLE_URL("vulnerability.policy.bundle.url", null),
     VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE("vulnerability.policy.bundle.source.type", "NGINX"),
     VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME( "vulnerability.policy.bundle.auth.username", null),
-    VULNERABILITY_POLICY_BUNDLE_BEARER_TOKEN("vulnerability.policy.bundle.bearer.token", null),
+    VULNERABILITY_POLICY_BUNDLE_AUTH_BEARER_TOKEN("vulnerability.policy.bundle.auth.bearer.token", null),
     VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD( "vulnerability.policy.bundle.auth.password", null),
     VULNERABILITY_POLICY_S3_ACCESS_KEY("vulnerability.policy.s3.access.key", null),
     VULNERABILITY_POLICY_S3_SECRET_KEY("vulnerability.policy.s3.secret.key", null),

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -83,6 +83,7 @@ public enum ConfigKey implements Config.Key {
     VULNERABILITY_POLICY_BUNDLE_URL("vulnerability.policy.bundle.url", null),
     VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE("vulnerability.policy.bundle.source.type", "NGINX"),
     VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME( "vulnerability.policy.bundle.auth.username", null),
+    VULNERABILITY_POLICY_BUNDLE_BEARER_TOKEN("vulnerability.policy.bundle.bearer.token", null),
     VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD( "vulnerability.policy.bundle.auth.password", null),
     VULNERABILITY_POLICY_S3_ACCESS_KEY("vulnerability.policy.s3.access.key", null),
     VULNERABILITY_POLICY_S3_SECRET_KEY("vulnerability.policy.s3.secret.key", null),

--- a/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
+++ b/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
@@ -58,7 +58,7 @@ public class NginxStorageHandler implements BlobStorageAccessHandler {
     }
 
     private String getHeader(String username, String password, String bearerToken) {
-        if (username != null && bearerToken == null) {
+        if (username != null) {
             return HttpUtil.basicAuthHeaderValue(username, password);
         } else if (bearerToken != null) {
             return "Bearer " + bearerToken;

--- a/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
+++ b/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
@@ -57,10 +57,10 @@ public class NginxStorageHandler implements BlobStorageAccessHandler {
         return httpClient.execute(request);
     }
 
-    private String getHeader(String username, String password, String bearerToken) {
-        if (username != null) {
+    public String getHeader(String username, String password, String bearerToken) {
+        if (username != null && !(username.trim().equals(""))) {
             return HttpUtil.basicAuthHeaderValue(username, password);
-        } else if (bearerToken != null) {
+        } else if (bearerToken != null && !(bearerToken.trim().equals(""))) {
             return "Bearer " + bearerToken;
         }
         return null;

--- a/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
+++ b/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
@@ -39,8 +39,8 @@ public class NginxStorageHandler implements BlobStorageAccessHandler {
     }
 
     void setBearerToken() {
-        if (Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_BEARER_TOKEN) != null) {
-            this.bearerToken = Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_BEARER_TOKEN);
+        if (Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_AUTH_BEARER_TOKEN) != null) {
+            this.bearerToken = Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_AUTH_BEARER_TOKEN);
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
+++ b/src/main/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandler.java
@@ -1,7 +1,6 @@
 package org.dependencytrack.tasks.vulnerabilitypolicy.blobstorage;
 
 import alpine.Config;
-import alpine.common.logging.Logger;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
@@ -22,9 +21,9 @@ import java.util.zip.ZipInputStream;
 
 public class NginxStorageHandler implements BlobStorageAccessHandler {
 
-    private static final Logger LOGGER = Logger.getLogger(NginxStorageHandler.class);
     protected String username;
     protected String password;
+    protected String bearerToken;
     protected final CloseableHttpClient httpClient = HttpClientPool.getClient();
 
     void setUsername() {
@@ -39,24 +38,37 @@ public class NginxStorageHandler implements BlobStorageAccessHandler {
         }
     }
 
+    void setBearerToken() {
+        if (Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_BEARER_TOKEN) != null) {
+            this.bearerToken = Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_BEARER_TOKEN);
+        }
+    }
+
     public NginxStorageHandler() {
         setUsername();
         setPassword();
+        setBearerToken();
     }
 
     CloseableHttpResponse performHeadRequest() throws IOException {
         HttpUriRequest request = new HttpHead(Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_URL));
-        if (username != null || password != null) {
-            request.addHeader("Authorization", HttpUtil.basicAuthHeaderValue(username, password));
-        }
+        request.addHeader("Authorization", getHeader(username, password, bearerToken));
+
         return httpClient.execute(request);
+    }
+
+    private String getHeader(String username, String password, String bearerToken) {
+        if (username != null && bearerToken == null) {
+            return HttpUtil.basicAuthHeaderValue(username, password);
+        } else if (bearerToken != null) {
+            return "Bearer " + bearerToken;
+        }
+        return null;
     }
 
     CloseableHttpResponse performGetRequest() throws IOException {
         HttpUriRequest request = new HttpGet(Config.getInstance().getProperty(ConfigKey.VULNERABILITY_POLICY_BUNDLE_URL));
-        if (username != null || password != null) {
-            request.addHeader("Authorization", HttpUtil.basicAuthHeaderValue(username, password));
-        }
+        request.addHeader("Authorization", getHeader(username, password, bearerToken));
         return httpClient.execute(request);
     }
 
@@ -64,14 +76,11 @@ public class NginxStorageHandler implements BlobStorageAccessHandler {
     public boolean verifyDownloadNeeded() throws IOException {
         try (CloseableHttpResponse response = performHeadRequest()) {
             if (response.getStatusLine().getStatusCode() == HttpStatus.SC_OK) {
+                //there is a possiblility that etag header is not present in the response from policy bundle server
+                //when etag header not found, we still want to update the lastmodified hash as null
                 Header[] httpHeaders = response.getAllHeaders();
                 Optional<Header> headerOptional = Arrays.stream(httpHeaders).filter(header -> header.getName().equalsIgnoreCase("ETag")).findFirst();
-                if (headerOptional.isPresent()) {
-                    return VulnerabilityPolicyUtil.matchWithHashConfigProperty(headerOptional.get().getValue());
-                } else {
-                    LOGGER.warn("Was not able to find Etag header in the nginx request. Will proceed assuming that file needs to be downloaded");
-                    return true;
-                }
+                return headerOptional.map(header -> VulnerabilityPolicyUtil.matchWithHashConfigProperty(header.getValue())).orElseGet(() -> VulnerabilityPolicyUtil.matchWithHashConfigProperty(null));
             } else {
                 throw new IOException(("Unable to get response from resource bundle endpoint for policy." +
                         " Response code received: %s. Response messge: %s").

--- a/src/main/java/org/dependencytrack/util/VulnerabilityPolicyUtil.java
+++ b/src/main/java/org/dependencytrack/util/VulnerabilityPolicyUtil.java
@@ -123,20 +123,22 @@ public class VulnerabilityPolicyUtil {
             ConfigProperty lastModifiedHash = queryManager.getConfigProperty(ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getGroupName(),
                     ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getPropertyName());
             if (lastModifiedHash == null) {
-                //lastmodified hash property is currently not in the db
+                //lastmodified hash property is currently not in the db then it will be created and set to etag (null or not) value provided
                 queryManager.createConfigProperty(ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getGroupName(),
                         ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getPropertyName(),
                         etag,
                         ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getPropertyType(),
                         ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getDescription());
                 return true;
-            } else if (lastModifiedHash.getPropertyValue() == null ||
-                    !(etag.equals(lastModifiedHash.getPropertyValue()))) {
+            }
+            //if etag is not returned by head request then we need to return true all the time.
+            // if etag was previously not null in config and now is getting fetched as null then the config property value
+            //also needs to be set to null.
+            if (etag == null || lastModifiedHash.getPropertyValue() == null || !(etag.equals(lastModifiedHash.getPropertyValue()))) {
                 //lastmodifiedhash value is either null or different from incoming value
                 lastModifiedHash.setPropertyValue(etag);
                 return true;
             }
-            //the lastmodified hash is the same as the incoming value
             return false;
         }
     }

--- a/src/main/java/org/dependencytrack/util/VulnerabilityPolicyUtil.java
+++ b/src/main/java/org/dependencytrack/util/VulnerabilityPolicyUtil.java
@@ -52,23 +52,26 @@ public class VulnerabilityPolicyUtil {
                                                 List<VulnerabilityPolicy> updateVulnerabilityPolicyList,
                                                 List<String> policyNames) throws IOException, ScriptCreateException {
         JsonNode jsonNode = MAPPER.readTree(out.toString());
-        Set<ValidationMessage> validateMsg = schema.validate(jsonNode);
-        if (validateMsg.isEmpty()) { //yaml file provided is valid and we can proceed to validate the cel policy
-            //if cel policy is invalid, ScriptCreateException will be thrown that trickles back to inform
-            validateVulnerabilityCelPolicy(MAPPER.convertValue(jsonNode.get("conditions"), new TypeReference<>() {
-            }));
-            VulnerabilityPolicy vulnerabilityPolicy = MAPPER.convertValue(jsonNode, VulnerabilityPolicy.class);
-            if (vulnerabilityPolicy != null) {
-                if (policyNames.contains(vulnerabilityPolicy.getName())) {
-                    updateVulnerabilityPolicyList.add(vulnerabilityPolicy);
+        //this is a precheck to existing validation so that if there are other yaml files in the bundle, we ignore them
+        if (jsonNode.has("type") && jsonNode.get("type").asText().equals("Vulnerability Policy")) {
+            Set<ValidationMessage> validateMsg = schema.validate(jsonNode);
+            if (validateMsg.isEmpty()) { //yaml file provided is valid and we can proceed to validate the cel policy
+                //if cel policy is invalid, ScriptCreateException will be thrown that trickles back to inform
+                validateVulnerabilityCelPolicy(MAPPER.convertValue(jsonNode.get("conditions"), new TypeReference<>() {
+                }));
+                VulnerabilityPolicy vulnerabilityPolicy = MAPPER.convertValue(jsonNode, VulnerabilityPolicy.class);
+                if (vulnerabilityPolicy != null) {
+                    if (policyNames.contains(vulnerabilityPolicy.getName())) {
+                        updateVulnerabilityPolicyList.add(vulnerabilityPolicy);
+                    } else {
+                        createVulnerabilityPolicyList.add(vulnerabilityPolicy);
+                    }
                 } else {
-                    createVulnerabilityPolicyList.add(vulnerabilityPolicy);
+                    throw new NullPointerException("Was not able to create vulnerability policy object successfully");
                 }
             } else {
-                throw new NullPointerException("Was not able to create vulnerability policy object successfully");
+                throw new IllegalArgumentException("Schema validation failed: %s".formatted(validateMsg));
             }
-        } else {
-            throw new IllegalArgumentException("Schema validation failed: %s".formatted(validateMsg));
         }
     }
 

--- a/src/main/java/org/dependencytrack/util/VulnerabilityPolicyUtil.java
+++ b/src/main/java/org/dependencytrack/util/VulnerabilityPolicyUtil.java
@@ -135,10 +135,10 @@ public class VulnerabilityPolicyUtil {
             // if etag was previously not null in config and now is getting fetched as null then the config property value
             //also needs to be set to null.
             if (etag == null || lastModifiedHash.getPropertyValue() == null || !(etag.equals(lastModifiedHash.getPropertyValue()))) {
-                //lastmodifiedhash value is either null or different from incoming value
                 lastModifiedHash.setPropertyValue(etag);
                 return true;
             }
+            //the lastmodified hash is the same as the incoming value
             return false;
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -552,13 +552,19 @@ vulnerability.policy.bundle.url=http://localhostt:80/bundles/test.zip
 # - S3
 vulnerability.policy.bundle.source.type=NGINX
 
+#For nginx server, if username and bearer token both are provided, basic auth will be used,
+# else the auth header will be added based on the not null values
 # Optional
-# Defines the username to be used for basic authentication against the service hosting the policy bundle.
+# Defines the password to be used for basic authentication against the service hosting the policy bundle.
 vulnerability.policy.bundle.auth.password=
 
 # Optional
-# Defines the password to be used for basic authentication against the service hosting the policy bundle.
+# Defines the username to be used for basic authentication against the service hosting the policy bundle.
 vulnerability.policy.bundle.auth.username=
+
+# Optional
+# Defines the token to be used as bearerAuth against the service hosting the policy bundle.
+vulnerability.policy.bundle.bearer.token=
 
 # Optional
 # S3 related details. Access key, secret key, bucket name and bundle names are mandatory if S3 is chosen. Region is optional

--- a/src/test/java/org/dependencytrack/tasks/vulnerabilitypolicy/VulnerabilityPolicyFetchTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/vulnerabilitypolicy/VulnerabilityPolicyFetchTaskTest.java
@@ -164,10 +164,34 @@ public class VulnerabilityPolicyFetchTaskTest extends AbstractPostgresEnabledTes
             zipOutputStream.putNextEntry(new ZipEntry("invalid.yml"));
             IOUtils.copy(new StringReader("""
                     apiVersion: v1.0
-                    type: Some Other Policy
-                    name: Invalid
-                    conditions: { }
-                    """), zipOutputStream, StandardCharsets.UTF_8);
+                    type: Vulnerability Policy
+                    name: Example2
+                    description: Foo bar
+                    author: Jane Doe
+                    created: 2023-11-22T06:06:05Z
+                    updated: 2023-11-23T07:07:17Z
+                    validFrom: 2024-01-01T00:00:00Z
+                    validUntil: 2024-01-01T00:00:00Z
+                    conditions:
+                      - vuln.id == "CVE-125" || vuln.aliases.exists(alias, alias.id == "CVE-123")
+                      - |-
+                        vuln.id == "CVE-156" || vuln.aliases.exists(alias, alias.id == "CVE-156")
+                    analysis:
+                      state: test
+                      justification: CODE_NOT_REACHABLE
+                      details: Because foo bar baz
+                      suppress: true
+                      vendorResponse: CAN_NOT_FIX
+                    ratings:
+                      - method: CVSSV3
+                        vector: CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+                        severity: MEDIUM
+                        score: 6.3
+                      - method: CVSSV2
+                        vector: CVSS:2.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
+                        severity: HIGH
+                        score: 8.3
+                        """), zipOutputStream, StandardCharsets.UTF_8);
         }
 
         WireMock.stubFor(WireMock.head(WireMock.urlPathEqualTo("/bundles/bundle.zip"))

--- a/src/test/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandlerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandlerTest.java
@@ -3,6 +3,7 @@ package org.dependencytrack.tasks.vulnerabilitypolicy.blobstorage;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import org.apache.http.HttpStatus;
+import org.assertj.core.api.Assertions;
 import org.dependencytrack.AbstractPostgresEnabledTest;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.VulnerabilityPolicy;
@@ -303,7 +304,36 @@ public class NginxStorageHandlerTest extends AbstractPostgresEnabledTest {
     @After
     public void afterTest() {
         environmentVariables.clear("VULNERABILITY_POLICY_BUNDLE_URL",
-                "VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE");
+                "VULNERABILITY_POLICY_BUNDLE_SOURCE_TYPE", "VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME",
+                "VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD",
+                "VULNERABILITY_POLICY_BUNDLE_AUTH_BEARER_TOKEN");
+    }
+
+    @Test
+    public void getHeaderWithUsername() {
+        environmentVariables.set("VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME", "test");
+        environmentVariables.set("VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD", "test");
+        NginxStorageHandler nginxStorageHandler = new NginxStorageHandler();
+        String result = nginxStorageHandler.getHeader(nginxStorageHandler.username, nginxStorageHandler.password, nginxStorageHandler.bearerToken);
+        Assertions.assertThat(result).isEqualTo("Basic dGVzdDp0ZXN0");
+    }
+
+    @Test
+    public void getHeaderWithBearerToken() {
+        environmentVariables.set("VULNERABILITY_POLICY_BUNDLE_AUTH_BEARER_TOKEN", "test");
+        NginxStorageHandler nginxStorageHandler = new NginxStorageHandler();
+        String result = nginxStorageHandler.getHeader(nginxStorageHandler.username, nginxStorageHandler.password, nginxStorageHandler.bearerToken);
+        Assertions.assertThat(result).isEqualTo("Bearer test");
+    }
+
+    @Test
+    public void getHeaderWithBearerTokenAndUserName() {
+        environmentVariables.set("VULNERABILITY_POLICY_BUNDLE_AUTH_BEARER_TOKEN", "test");
+        environmentVariables.set("VULNERABILITY_POLICY_BUNDLE_AUTH_USERNAME", "test");
+        environmentVariables.set("VULNERABILITY_POLICY_BUNDLE_AUTH_PASSWORD", "test");
+        NginxStorageHandler nginxStorageHandler = new NginxStorageHandler();
+        String result = nginxStorageHandler.getHeader(nginxStorageHandler.username, nginxStorageHandler.password, nginxStorageHandler.bearerToken);
+        Assertions.assertThat(result).isEqualTo("Basic dGVzdDp0ZXN0");
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandlerTest.java
+++ b/src/test/java/org/dependencytrack/tasks/vulnerabilitypolicy/blobstorage/NginxStorageHandlerTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-public class NginxPolicyFetcherTest extends AbstractPostgresEnabledTest {
+public class NginxStorageHandlerTest extends AbstractPostgresEnabledTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());

--- a/src/test/java/org/dependencytrack/util/VulnerabilityPolicyUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/VulnerabilityPolicyUtilTest.java
@@ -108,6 +108,16 @@ public class VulnerabilityPolicyUtilTest extends AbstractPostgresEnabledTest {
     }
 
     @Test
+    public void testmatchWithEtagNullValue() {
+        qm.createConfigProperty(ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getGroupName(),
+                ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getPropertyName(),
+                "test1",
+                ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getPropertyType(),
+                ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getDescription());
+        Assertions.assertTrue(VulnerabilityPolicyUtil.matchWithHashConfigProperty(null));
+    }
+
+    @Test
     public void testmatchWithHashConfigPropertySameValue() {
         qm.createConfigProperty(ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getGroupName(),
                 ConfigPropertyConstants.VULNERABILITY_POLICY_FILE_LAST_MODIFIED_HASH.getPropertyName(),


### PR DESCRIPTION
### Description

Added support for bearer token based authentication for bundle server. 
If etag header is not provided by bundle server in head request then the policy bundle will always be downloaded and the lastModifiedHash config property would be set to null. 
If etag is returned from head request, the system would receive benefit of avoiding redundant downloads when bundle is same

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
