### PR TITLE
Add capability to use regular expressions and `vers` ranges in dependency graph traversal

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVersValidationVisitor.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVersValidationVisitor.java
@@ -1,0 +1,144 @@
+package org.dependencytrack.policy.cel;
+
+import alpine.common.logging.Logger;
+import com.google.api.expr.v1alpha1.Constant;
+import com.google.api.expr.v1alpha1.Expr;
+import io.github.nscuro.versatile.Vers;
+import io.github.nscuro.versatile.VersException;
+import org.dependencytrack.proto.policy.v1.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+class CelPolicyScriptVersValidationVisitor {
+
+    private static final Logger LOGGER = Logger.getLogger(CelPolicyScriptVersValidationVisitor.class);
+    private static final Set<String> COMPONENT_FILTER_FIELDS = Set.of("group", "name", "classifier", "cpe", "purl", "swid_tag_id");
+    private static final List<String> COMPONENT_FILTER_FIELDS_SORTED = COMPONENT_FILTER_FIELDS.stream().sorted().toList();
+
+    record VersValidationError(RuntimeException exception, Integer position) {
+    }
+
+    private final Map<Long, Integer> positions;
+    private final List<VersValidationError> errors;
+
+    CelPolicyScriptVersValidationVisitor(final Map<Long, Integer> positions) {
+        this.positions = positions;
+        this.errors = new ArrayList<>();
+    }
+
+    void visit(final Expr expr) {
+        switch (expr.getExprKindCase()) {
+            case CALL_EXPR -> visitCall(expr);
+            case COMPREHENSION_EXPR -> visitComprehension(expr);
+            case LIST_EXPR -> visitList(expr);
+            case SELECT_EXPR -> visitSelect(expr);
+            case EXPRKIND_NOT_SET -> LOGGER.debug("Unknown expression: %s".formatted(expr));
+        }
+    }
+
+    private void visitCall(final Expr expr) {
+        final Expr.Call callExpr = expr.getCallExpr();
+        if ("matches_range".equals(callExpr.getFunction())) {
+            maybeValidateVers(callExpr.getArgs(0));
+            return;
+        } else if (("depends_on".equals(callExpr.getFunction()) || "is_dependency_of".equals(callExpr.getFunction())) && callExpr.getArgsCount() == 1) {
+            maybeValidateComponentStruct(callExpr.getArgs(0));
+            return;
+        }
+
+        visit(callExpr.getTarget());
+        for (final Expr argExpr : callExpr.getArgsList()) {
+            visit(argExpr);
+        }
+    }
+
+    private void visitComprehension(final Expr expr) {
+        final Expr.Comprehension comprehensionExpr = expr.getComprehensionExpr();
+
+        visit(comprehensionExpr.getAccuInit());
+        visit(comprehensionExpr.getIterRange());
+        visit(comprehensionExpr.getLoopStep());
+        visit(comprehensionExpr.getLoopCondition());
+        visit(comprehensionExpr.getResult());
+    }
+
+    private void visitList(final Expr expr) {
+        final Expr.CreateList listExpr = expr.getListExpr();
+        for (final Expr elementExpr : listExpr.getElementsList()) {
+            visit(elementExpr);
+        }
+    }
+
+    private void visitSelect(final Expr expr) {
+        final Expr.Select selectExpr = expr.getSelectExpr();
+        visit(selectExpr.getOperand());
+    }
+
+    private void maybeValidateComponentStruct(final Expr expr) {
+        if (expr.getExprKindCase() != Expr.ExprKindCase.STRUCT_EXPR) {
+            // Should've been catched in type checking phase.
+            return;
+        }
+
+        final Expr.CreateStruct structExpr = expr.getStructExpr();
+        if (!Component.getDescriptor().getFullName().equals(structExpr.getMessageName())) {
+            // Should've been catched in type checking phase.
+            return;
+        }
+
+        Expr.CreateStruct.Entry versionEntryExpr = null;
+        boolean hasQualifiers = false;
+        for (final Expr.CreateStruct.Entry structEntryExpr : structExpr.getEntriesList()) {
+            if ("version".equals(structEntryExpr.getFieldKey())) {
+                versionEntryExpr = structEntryExpr;
+            } else if (COMPONENT_FILTER_FIELDS.contains(structEntryExpr.getFieldKey())) {
+                hasQualifiers = true;
+            }
+        }
+        if (versionEntryExpr == null) {
+            return;
+        }
+
+        final String version = versionEntryExpr.getValue().getConstExpr().getStringValue();
+        if (!version.startsWith("vers:")) {
+            // It's a version literal, nothing to validate here.
+            return;
+        }
+
+        if (!hasQualifiers) {
+            final var exception = new RuntimeException("""
+                    Querying by version range without providing an additional field to filter on is not allowed. \
+                    Possible fields to filter on are: %s""".formatted(COMPONENT_FILTER_FIELDS_SORTED));
+            errors.add(new VersValidationError(exception, positions.get(expr.getId())));
+        }
+
+        maybeValidateVers(versionEntryExpr.getValue());
+    }
+
+    private void maybeValidateVers(final Expr expr) {
+        if (expr.getExprKindCase() != Expr.ExprKindCase.CONST_EXPR) {
+            return;
+        }
+
+        final Constant constExpr = expr.getConstExpr();
+        if (constExpr.getConstantKindCase() != Constant.ConstantKindCase.STRING_VALUE) {
+            return;
+        }
+
+        try {
+            final Vers vers = Vers.parse(constExpr.getStringValue());
+            vers.validate();
+        } catch (VersException e) {
+            errors.add(new VersValidationError(e, positions.get(expr.getId())));
+        }
+    }
+
+    List<VersValidationError> getErrors() {
+        return Collections.unmodifiableList(errors);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVersValidationVisitor.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVersValidationVisitor.java
@@ -16,7 +16,7 @@ import java.util.Set;
 class CelPolicyScriptVersValidationVisitor {
 
     private static final Logger LOGGER = Logger.getLogger(CelPolicyScriptVersValidationVisitor.class);
-    private static final Set<String> COMPONENT_FILTER_FIELDS = Set.of("group", "name", "classifier", "cpe", "purl", "swid_tag_id");
+    private static final Set<String> COMPONENT_FILTER_FIELDS = Set.of("group", "name", "cpe", "purl", "swid_tag_id");
     private static final List<String> COMPONENT_FILTER_FIELDS_SORTED = COMPONENT_FILTER_FIELDS.stream().sorted().toList();
 
     record VersValidationError(RuntimeException exception, Integer position) {

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyScriptHostTest.java
@@ -88,7 +88,7 @@ public class CelPolicyScriptHostTest {
                 Failed to check script: ERROR: <input>:1:48: vers string does not contain a versioning scheme separator
                  | project.name == "foo" && project.matches_range("vers:generic<1")
                  | ...............................................^
-                ERROR: <input>:2:37: Querying by version range without providing an additional field to filter on is not allowed. Possible fields to filter on are: [classifier, cpe, group, name, purl, swid_tag_id]
+                ERROR: <input>:2:37: Querying by version range without providing an additional field to filter on is not allowed. Possible fields to filter on are: [cpe, group, name, purl, swid_tag_id]
                  |   && project.depends_on(v1.Component{
                  | ....................................^
                 ERROR: <input>:3:17: Invalid range vers:maven/>0|>1: A > or >= comparator must only be followed by a < or <= comparator, but got: >


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds the capability to use regular expressions and `vers` ranges in dependency graph traversal functions.

Regular expressions must be prefixed with `re:`, e.g.

```js
component.is_dependency_of(v1.Component{
  name: "re:spring-.*"
})
```

> [!NOTE]
> The following fields support regular expressions:
> 
> * `group`
> * `name`
> * `version`
> * `cpe`
> * `purl`
> * `swid_tag_id`

The `version` field optionally accepts a `vers` version range, e.g.:

```js
component.is_dependency_of(v1.Component{
  name: "spring-core",
  version: "vers:maven/>=1.1.1|<2"
}
```

> [!WARNING]
> To limit the performance impact of version range lookups, their usage requires at least one additional
> filter on any of the following fields:
> * `group`
> * `name`
> * `cpe`
> * `purl`
> * `swid_tag_id`
>
> This is enforced during script compilation. The following would **not** compile:
> ```js
> component.is_dependency_of(v1.Component{
>   version: "vers:maven/>=1.1.1|<2"
> })
> ```

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

https://github.com/DependencyTrack/hyades/issues/1005

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Regular expressions are executed in the database, using [PostgreSQL's native `~` operator](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP).

Version ranges are evaluated in-memory out of necessity. Hence, using this feature has an additional performance penalty.

The validation logic has been updated to:

* Handle `vers` ranges specified via `Component.version`
* Handle multiple validation failures in the same script
* Provide exact locations for each failure

Example screenshots:

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/4bb30c22-a7b2-4dbc-8588-78f00c893acb)

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/d1dea7a9-659b-4168-901b-84251ffd212e)

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/f497fc82-480b-4c64-829c-d7656520c64c)

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/01d60f2e-571b-489d-8dc0-aa98c0590bcf)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
