### PR TITLE
Implement `is_exclusive_dependency_of` function for CEL expressions

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptHost.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptHost.java
@@ -32,6 +32,7 @@ import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_COMPARE
 import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_COMPARE_VERSION_DISTANCE;
 import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_DEPENDS_ON;
 import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_DEPENDENCY_OF;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_EXCLUSIVE_DEPENDENCY_OF;
 import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_MATCHES_RANGE;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMPONENT;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
@@ -153,7 +154,7 @@ public class CelPolicyScriptHost {
         // TODO: This should be restructured to be more generic.
         for (final FunctionSignature functionSignature : visitor.getUsedFunctionSignatures()) {
             switch (functionSignature.function()) {
-                case FUNC_DEPENDS_ON, FUNC_IS_DEPENDENCY_OF -> {
+                case FUNC_DEPENDS_ON, FUNC_IS_DEPENDENCY_OF, FUNC_IS_EXCLUSIVE_DEPENDENCY_OF -> {
                     if (TYPE_PROJECT.equals(functionSignature.targetType())) {
                         requirements.put(TYPE_PROJECT, "uuid");
                     } else if (TYPE_COMPONENT.equals(functionSignature.targetType())) {

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVersValidationVisitor.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptVersValidationVisitor.java
@@ -13,6 +13,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_DEPENDS_ON;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_DEPENDENCY_OF;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_EXCLUSIVE_DEPENDENCY_OF;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_MATCHES_RANGE;
+
 class CelPolicyScriptVersValidationVisitor {
 
     private static final Logger LOGGER = Logger.getLogger(CelPolicyScriptVersValidationVisitor.class);
@@ -42,10 +47,14 @@ class CelPolicyScriptVersValidationVisitor {
 
     private void visitCall(final Expr expr) {
         final Expr.Call callExpr = expr.getCallExpr();
-        if ("matches_range".equals(callExpr.getFunction())) {
+        final String functionName = callExpr.getFunction();
+        if (FUNC_MATCHES_RANGE.equals(functionName)) {
             maybeValidateVers(callExpr.getArgs(0));
             return;
-        } else if (("depends_on".equals(callExpr.getFunction()) || "is_dependency_of".equals(callExpr.getFunction())) && callExpr.getArgsCount() == 1) {
+        } else if ((FUNC_DEPENDS_ON.equals(functionName)
+                    || FUNC_IS_DEPENDENCY_OF.equals(functionName)
+                    || FUNC_IS_EXCLUSIVE_DEPENDENCY_OF.equals(functionName))
+                   && callExpr.getArgsCount() == 1) {
             maybeValidateComponentStruct(callExpr.getArgs(0));
             return;
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR adds a capability to CEL expressions, that allows to determine whether a component is *only* introduced transitively through another component.

It differs from the existing `is_dependency_of` function, in that `is_dependency_of` matches as long as *any* path matches, whereas the new functionality requires *all* of them to match.

Refer to https://github.com/DependencyTrack/hyades/issues/1025 for covered scenarios.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1025

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
