### PR TITLE
Add support for github meta analyzer

### DIFF
--- a/src/main/java/org/dependencytrack/model/RepositoryType.java
+++ b/src/main/java/org/dependencytrack/model/RepositoryType.java
@@ -38,6 +38,7 @@ public enum RepositoryType {
     CARGO,
     GO_MODULES,
     CPAN,
+    GITHUB,
     UNSUPPORTED;
 
     /**
@@ -67,6 +68,8 @@ public enum RepositoryType {
             return GO_MODULES;
         } else if ("cpan".equals(type)) { // Not defined in StandardTypes
             return CPAN;
+        } else if (PackageURL.StandardTypes.GITHUB.equals(type)) { // Not defined in StandardTypes
+            return GITHUB;
         }
         return UNSUPPORTED;
     }

--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -216,6 +216,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
             qm.createRepository(RepositoryType.COMPOSER, "packagist", "https://repo.packagist.org/", true, false, false, null, null);
             qm.createRepository(RepositoryType.CARGO, "crates.io", "https://crates.io", true, false, false, null, null);
             qm.createRepository(RepositoryType.GO_MODULES, "proxy.golang.org", "https://proxy.golang.org", true, false, false, null, null);
+            qm.createRepository(RepositoryType.GITHUB, "github.com", "https://github.com", true, false, false, null, null);
         }
     }
 

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -102,7 +102,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
         Method method = generator.getClass().getDeclaredMethod("loadDefaultRepositories");
         method.setAccessible(true);
         method.invoke(generator);
-        Assert.assertEquals(14, qm.getAllRepositories().size());
+        Assert.assertEquals(15, qm.getAllRepositories().size());
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -66,10 +66,10 @@ public class RepositoryResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(14), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals(String.valueOf(15), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(14, json.size());
+        Assert.assertEquals(15, json.size());
         for (int i = 0; i < json.size(); i++) {
             Assert.assertNotNull(json.getJsonObject(i).getString("type"));
             Assert.assertNotNull(json.getJsonObject(i).getString("identifier"));
@@ -194,17 +194,17 @@ public class RepositoryResourceTest extends ResourceTest {
 
         response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(15), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals(String.valueOf(16), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(15, json.size());
-        Assert.assertEquals("MAVEN", json.getJsonObject(11).getString("type"));
-        Assert.assertEquals("test", json.getJsonObject(11).getString("identifier"));
-        Assert.assertEquals("www.foobar.com", json.getJsonObject(11).getString("url"));
-        Assert.assertTrue(json.getJsonObject(11).getInt("resolutionOrder") > 0);
-        Assert.assertTrue(json.getJsonObject(11).getBoolean("authenticationRequired"));
-        Assert.assertEquals("testuser", json.getJsonObject(11).getString("username"));
-        Assert.assertTrue(json.getJsonObject(11).getBoolean("enabled"));
+        Assert.assertEquals(16, json.size());
+        Assert.assertEquals("MAVEN", json.getJsonObject(12).getString("type"));
+        Assert.assertEquals("test", json.getJsonObject(12).getString("identifier"));
+        Assert.assertEquals("www.foobar.com", json.getJsonObject(12).getString("url"));
+        Assert.assertTrue(json.getJsonObject(12).getInt("resolutionOrder") > 0);
+        Assert.assertTrue(json.getJsonObject(12).getBoolean("authenticationRequired"));
+        Assert.assertEquals("testuser", json.getJsonObject(12).getString("username"));
+        Assert.assertTrue(json.getJsonObject(12).getBoolean("enabled"));
     }
 
     @Test
@@ -223,16 +223,16 @@ public class RepositoryResourceTest extends ResourceTest {
 
         response = target(V1_REPOSITORY).request().header(X_API_KEY, apiKey).get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(15), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals(String.valueOf(16), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(15, json.size());
-        Assert.assertEquals("MAVEN", json.getJsonObject(11).getString("type"));
-        Assert.assertEquals("test", json.getJsonObject(11).getString("identifier"));
-        Assert.assertEquals("www.foobar.com", json.getJsonObject(11).getString("url"));
-        Assert.assertTrue(json.getJsonObject(11).getInt("resolutionOrder") > 0);
-        Assert.assertFalse(json.getJsonObject(11).getBoolean("authenticationRequired"));
-        Assert.assertTrue(json.getJsonObject(11).getBoolean("enabled"));
+        Assert.assertEquals(16, json.size());
+        Assert.assertEquals("MAVEN", json.getJsonObject(12).getString("type"));
+        Assert.assertEquals("test", json.getJsonObject(12).getString("identifier"));
+        Assert.assertEquals("www.foobar.com", json.getJsonObject(12).getString("url"));
+        Assert.assertTrue(json.getJsonObject(12).getInt("resolutionOrder") > 0);
+        Assert.assertFalse(json.getJsonObject(12).getBoolean("authenticationRequired"));
+        Assert.assertTrue(json.getJsonObject(12).getBoolean("enabled"));
 
     }
 


### PR DESCRIPTION
### Description

Add support for github meta analyzer, as part of back porting from upstream DT release 4.10.x

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/983

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
