### PR TITLE
Update component metrics in project metrics update procedure

### DIFF
--- a/src/main/java/org/dependencytrack/event/ProjectMetricsUpdateEvent.java
+++ b/src/main/java/org/dependencytrack/event/ProjectMetricsUpdateEvent.java
@@ -32,26 +32,13 @@ import java.util.UUID;
 public class ProjectMetricsUpdateEvent extends AbstractChainableEvent {
 
     private final UUID uuid;
-    private final boolean forceRefresh;
 
     public ProjectMetricsUpdateEvent(final UUID uuid) {
-        this(uuid, true);
-    }
-
-    /**
-     * @param uuid {@link UUID} of the {@link Project} to update metrics for
-     */
-    public ProjectMetricsUpdateEvent(final UUID uuid, final boolean forceRefresh) {
         this.uuid = uuid;
-        this.forceRefresh = forceRefresh;
     }
 
     public UUID getUuid() {
         return uuid;
-    }
-
-    public boolean isForceRefresh() {
-        return forceRefresh;
     }
 
 }

--- a/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
@@ -24,20 +24,12 @@ import alpine.event.framework.Subscriber;
 import io.micrometer.core.instrument.Timer;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.metrics.Metrics;
-import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.WorkflowState;
-import org.dependencytrack.model.WorkflowStatus;
 import org.dependencytrack.model.WorkflowStep;
 import org.dependencytrack.persistence.QueryManager;
 
-import javax.jdo.PersistenceManager;
-import javax.jdo.Query;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
-import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 /**
@@ -56,7 +48,7 @@ public class ProjectMetricsUpdateTask implements Subscriber {
             try (final var qm = new QueryManager()) {
                 metricsUpdateState = qm.updateStartTimeIfWorkflowStateExists(event.getChainIdentifier(), WorkflowStep.METRICS_UPDATE);
                 try {
-                    updateMetrics(event.getUuid(), event.isForceRefresh());
+                    updateMetrics(event.getUuid());
                     qm.updateWorkflowStateToComplete(metricsUpdateState);
                 } catch (Exception ex) {
                     qm.updateWorkflowStateToFailed(metricsUpdateState, ex.getMessage());
@@ -66,16 +58,11 @@ public class ProjectMetricsUpdateTask implements Subscriber {
         }
     }
 
-    private static void updateMetrics(final UUID uuid, final boolean forceRefresh) throws Exception {
+    private static void updateMetrics(final UUID uuid) {
         LOGGER.debug("Executing metrics update for project " + uuid);
         final Timer.Sample timerSample = Timer.start();
 
         try {
-            if (forceRefresh) {
-                LOGGER.debug("Refreshing component metrics for project " + uuid);
-                refreshComponentMetrics(uuid);
-            }
-
             Metrics.updateProjectMetrics(uuid);
         } finally {
             final long durationNanos = timerSample.stop(Timer
@@ -86,57 +73,4 @@ public class ProjectMetricsUpdateTask implements Subscriber {
         }
     }
 
-    private static void refreshComponentMetrics(final UUID uuid) throws Exception {
-        try (final QueryManager qm = new QueryManager().withL2CacheDisabled()) {
-            final PersistenceManager pm = qm.getPersistenceManager();
-
-            final Project project = qm.getObjectByUuid(Project.class, uuid, List.of(Project.FetchGroup.METRICS_UPDATE.name()));
-            if (project == null) {
-                throw new NoSuchElementException("Project " + uuid + " does not exist");
-            }
-
-            LOGGER.debug("Fetching first components page for project " + uuid);
-            List<ComponentProjection> components = fetchNextComponentsPage(pm, project, null);
-
-            while (!components.isEmpty()) {
-                for (final ComponentProjection component : components) {
-                    final Timer.Sample componentTimerSample = Timer.start();
-                    try {
-                        Metrics.updateComponentMetrics(component.uuid());
-                    } catch (Exception ex) {
-                        LOGGER.error("An unexpected error occurred while updating metrics of component " + component.uuid(), ex);
-                    } finally {
-                        componentTimerSample.stop(Timer
-                                .builder("metrics_update")
-                                .tag("target", "component")
-                                .register(alpine.common.metrics.Metrics.getRegistry()));
-                    }
-                }
-
-                LOGGER.debug("Fetching next components page for project " + uuid);
-                final long lastId = components.get(components.size() - 1).id();
-                components = fetchNextComponentsPage(pm, project, lastId);
-            }
-        }
-    }
-
-    private static List<ComponentProjection> fetchNextComponentsPage(final PersistenceManager pm, final Project project,
-                                                                     final Long lastId) throws Exception {
-        try (final Query<Component> query = pm.newQuery(Component.class)) {
-            if (lastId == null) {
-                query.setFilter("project == :project");
-                query.setParameters(project);
-            } else {
-                query.setFilter("project == :project && id < :lastId");
-                query.setParameters(project, lastId);
-            }
-            query.setOrdering("id DESC");
-            query.setRange(0, 1000);
-            query.setResult("id, uuid");
-            return List.copyOf(query.executeResultList(ComponentProjection.class));
-        }
-    }
-
-    public record ComponentProjection(long id, UUID uuid) {
-    }
 }

--- a/src/main/resources/migration/procedures/procedure_update-project-metrics.sql
+++ b/src/main/resources/migration/procedures/procedure_update-project-metrics.sql
@@ -6,6 +6,7 @@ AS
 $$
 DECLARE
   "v_project_id"                              BIGINT;
+  "v_component_uuid"                          TEXT;
   "v_components"                              INT; -- Total number of components in the project
   "v_vulnerable_components"                   INT; -- Number of vulnerable components in the project
   "v_vulnerabilities"                         INT; -- Total number of vulnerabilities
@@ -40,6 +41,11 @@ BEGIN
   IF "v_project_id" IS NULL THEN
     RAISE EXCEPTION 'Project with UUID % does not exist', "project_uuid";
   END IF;
+
+  FOR "v_component_uuid" IN SELECT "UUID" FROM "COMPONENT" WHERE "PROJECT_ID" = "v_project_id"
+  LOOP
+    CALL "UPDATE_COMPONENT_METRICS"("v_component_uuid");
+  END LOOP;
 
   -- Aggregate over all most recent DEPENDENCYMETRICS.
   -- NOTE: SUM returns NULL when no rows match the query, but COUNT returns 0.

--- a/src/test/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTaskTest.java
@@ -40,11 +40,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.WorkflowStatus.COMPLETED;
-import static org.dependencytrack.model.WorkflowStatus.FAILED;
 import static org.dependencytrack.model.WorkflowStep.METRICS_UPDATE;
 
 @RunWith(Parameterized.class)
@@ -329,22 +327,4 @@ public class ProjectMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest 
         assertThat(componentSuppressed.getLastInheritedRiskScore()).isZero();
     }
 
-    @Test
-    public void testWorkflowStateOnProjectMetricsUpdateFailure() {
-        var projectUuid = UUID.randomUUID();
-        var projectMetricsUpdateEvent = new ProjectMetricsUpdateEvent(projectUuid);
-        qm.createWorkflowSteps(projectMetricsUpdateEvent.getChainIdentifier());
-        //trigger metrics for project that does not exist
-        new ProjectMetricsUpdateTask().inform(projectMetricsUpdateEvent);
-        String failureReason = "Project " + projectUuid + " does not exist";
-        assertThat(qm.getWorkflowStateByTokenAndStep(projectMetricsUpdateEvent.getChainIdentifier(), METRICS_UPDATE)).satisfies(
-                workflowState -> {
-                    assertThat(workflowState.getStatus()).isEqualTo(FAILED);
-                    assertThat(workflowState.getStartedAt()).isNotNull();
-                    assertThat(workflowState.getParent()).isNotNull();
-                    assertThat(workflowState.getUpdatedAt()).isBefore(Date.from(Instant.now()));
-                    assertThat(workflowState.getFailureReason()).isEqualTo(failureReason);
-                }
-        );
-    }
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Updates component metrics in the project metrics update procedure.

Instead of fetching component UUIDs first, then calling the `UPDATE_COMPONENT_METRICS` procedure for every single UUID individually, and *then* updating the project metrics.

The previous approach resulted in:

* At least one `SELECT` query to fetch all N component UUIDs
* N calls to `UPDATE_COMPONENT_METRICS`
* N transactions, because each stored procedure call runs in its own transaction
* One call to `UPDATE_PROJECT_METRICS`

Which resulted in lots of wasted resources.

Refreshing metrics for all projects in a portfolio with 400 total projects completes in 5s instead of 20s on my machine. I expect the difference to be even more drastic in deployments where the database is running on a different machine, and network latency plays a bigger role.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
