### PR TITLE
Create GIN index on `"COMPONENT"."DIRECT_DEPENDENCIES"` to support dependency graph traversal

### DIFF
--- a/src/main/resources/migration/changelog-v5.3.0.xml
+++ b/src/main/resources/migration/changelog-v5.3.0.xml
@@ -2444,4 +2444,23 @@
     <changeSet id="v5.3.0-12" author="sahibamittal">
         <dropTable tableName="CPE"/>
     </changeSet>
+
+    <changeSet id="v5.3.0-13" author="nscuro@protonmail.com">
+        <sql>
+            CREATE EXTENSION IF NOT EXISTS PG_TRGM;
+        </sql>
+    </changeSet>
+
+    <changeSet id="v5.3.0-14" author="nscuro@protonmail.com" runInTransaction="false">
+        <!--
+          Create a GIN index to support LIKE '%foo%' queries for dependency graph traversal.
+          Creating this index on an existing database might take a while, so do it concurrently
+          to not block writes on the "COMPONENT" table. Index creation cannot run in a transaction
+          when using CONCURRENTLY.
+        -->
+        <sql>
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "COMPONENT_DIRECT_DEPENDENCIES_GIN_IDX"
+                ON "COMPONENT" USING GIN ("DIRECT_DEPENDENCIES" GIN_TRGM_OPS);
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migration/changelog-v5.3.0.xml
+++ b/src/main/resources/migration/changelog-v5.3.0.xml
@@ -2446,6 +2446,13 @@
     </changeSet>
 
     <changeSet id="v5.3.0-13" author="nscuro@protonmail.com">
+        <!--
+          CREATE EXTENSION requires SUPERUSER (Postgres < 13) or CREATE privileges (Postgres >= 13).
+          Either configure a migration user with sufficient privileges via database.migration.username
+          and database.migration.password, or create the extension manually. The below statement will
+          not fail if the extension already exists, even though the user might now have sufficient
+          privileges to create it.
+        -->
         <sql>
             CREATE EXTENSION IF NOT EXISTS PG_TRGM;
         </sql>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Creates a GIN index on `"COMPONENT"."DIRECT_DEPENDENCIES"` to support dependency graph traversal.

Traversal is performed using recursive CTEs, with conditions such as:

```sql
WHERE "DIRECT_DEPENDENCIES" LIKE ('%' || :componentUuid || '%')
```

`"DIRECT_DEPENDENCIES"` is a JSON array containing zero or more JSON objects. Because `LIKE` is used with wildcards in before and after the UUID, a `BTREE` index cannot be used.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
