### PR TITLE
Implement foundational API for parallel-consumer based Kafka processors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
         <lib.kafka-junit.version>3.6.0</lib.kafka-junit.version>
         <lib.micrometer-jvm-extras.version>0.2.2</lib.micrometer-jvm-extras.version>
         <lib.packageurl.version>1.4.1</lib.packageurl.version>
+        <lib.parallel-consumer.version>0.5.2.8</lib.parallel-consumer.version>
         <lib.pebble.version>3.2.0</lib.pebble.version>
         <lib.protobuf-java.version>3.25.2</lib.protobuf-java.version>
         <lib.testcontainers.version>1.18.3</lib.testcontainers.version>
@@ -299,6 +300,13 @@
             <artifactId>packageurl-java</artifactId>
             <version>${lib.packageurl.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.confluent.parallelconsumer</groupId>
+            <artifactId>parallel-consumer-core</artifactId>
+            <version>${lib.parallel-consumer.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>

--- a/src/main/java/org/dependencytrack/common/MdcKeys.java
+++ b/src/main/java/org/dependencytrack/common/MdcKeys.java
@@ -1,0 +1,16 @@
+package org.dependencytrack.common;
+
+/**
+ * Common fields for use with SLF4J's {@link org.slf4j.MDC}.
+ */
+public final class MdcKeys {
+
+    public static final String MDC_KAFKA_RECORD_TOPIC = "kafkaRecordTopic";
+    public static final String MDC_KAFKA_RECORD_PARTITION = "kafkaRecordPartition";
+    public static final String MDC_KAFKA_RECORD_OFFSET = "kafkaRecordOffset";
+    public static final String MDC_KAFKA_RECORD_KEY = "kafkaRecordKey";
+
+    private MdcKeys() {
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/ProcessorInitializer.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/ProcessorInitializer.java
@@ -1,0 +1,30 @@
+package org.dependencytrack.event.kafka.processor;
+
+import alpine.common.logging.Logger;
+import org.dependencytrack.event.kafka.processor.api.ProcessorManager;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class ProcessorInitializer implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(ProcessorInitializer.class);
+
+    static final ProcessorManager PROCESSOR_MANAGER = new ProcessorManager();
+
+    @Override
+    public void contextInitialized(final ServletContextEvent event) {
+        LOGGER.info("Initializing processors");
+
+        // TODO: Register processor here!
+
+        PROCESSOR_MANAGER.startAll();
+    }
+
+    @Override
+    public void contextDestroyed(final ServletContextEvent event) {
+        LOGGER.info("Stopping processors");
+        PROCESSOR_MANAGER.close();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/ProcessorsHealthCheck.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/ProcessorsHealthCheck.java
@@ -1,0 +1,17 @@
+package org.dependencytrack.event.kafka.processor;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.Liveness;
+
+import static org.dependencytrack.event.kafka.processor.ProcessorInitializer.PROCESSOR_MANAGER;
+
+@Liveness
+public class ProcessorsHealthCheck implements HealthCheck {
+
+    @Override
+    public HealthCheckResponse call() {
+        return PROCESSOR_MANAGER.probeHealth();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/AbstractProcessingStrategy.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/AbstractProcessingStrategy.java
@@ -1,0 +1,87 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.http.conn.ConnectTimeoutException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serde;
+import org.datanucleus.api.jdo.exceptions.ConnectionInUseException;
+import org.datanucleus.store.query.QueryInterruptedException;
+import org.dependencytrack.event.kafka.processor.exception.RetryableProcessingException;
+import org.postgresql.util.PSQLState;
+
+import javax.jdo.JDOOptimisticVerificationException;
+import java.net.SocketTimeoutException;
+import java.sql.SQLException;
+import java.sql.SQLTransientConnectionException;
+import java.sql.SQLTransientException;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * An abstract {@link ProcessingStrategy} that provides various shared functionality.
+ *
+ * @param <K> Type of the {@link ConsumerRecord} key
+ * @param <V> Type of the {@link ConsumerRecord} value
+ */
+abstract class AbstractProcessingStrategy<K, V> implements ProcessingStrategy {
+
+    private final Serde<K> keySerde;
+    private final Serde<V> valueSerde;
+
+    AbstractProcessingStrategy(final Serde<K> keySerde, final Serde<V> valueSerde) {
+        this.keySerde = keySerde;
+        this.valueSerde = valueSerde;
+    }
+
+    /**
+     * @param record The {@link ConsumerRecord} to deserialize key and value of
+     * @return A {@link ConsumerRecord} with deserialized key and value
+     * @throws SerializationException When deserializing the {@link ConsumerRecord} failed
+     */
+    ConsumerRecord<K, V> deserialize(final ConsumerRecord<byte[], byte[]> record) {
+        final K deserializedKey;
+        final V deserializedValue;
+        try {
+            deserializedKey = keySerde.deserializer().deserialize(record.topic(), record.key());
+            deserializedValue = valueSerde.deserializer().deserialize(record.topic(), record.value());
+        } catch (RuntimeException e) {
+            if (e instanceof SerializationException) {
+                throw e;
+            }
+
+            throw new SerializationException(e);
+        }
+
+        return new ConsumerRecord<>(record.topic(), record.partition(), record.offset(),
+                record.timestamp(), record.timestampType(), record.serializedKeySize(), record.serializedValueSize(),
+                deserializedKey, deserializedValue, record.headers(), record.leaderEpoch());
+    }
+
+    private static final List<Class<? extends Exception>> KNOWN_TRANSIENT_EXCEPTIONS = List.of(
+            ConnectTimeoutException.class,
+            ConnectionInUseException.class,
+            JDOOptimisticVerificationException.class,
+            QueryInterruptedException.class,
+            SocketTimeoutException.class,
+            SQLTransientException.class,
+            SQLTransientConnectionException.class,
+            TimeoutException.class
+    );
+
+    boolean isRetryableException(final Throwable throwable) {
+        if (throwable instanceof RetryableProcessingException) {
+            return true;
+        }
+
+        final boolean isKnownTransientException = ExceptionUtils.getThrowableList(throwable).stream()
+                .anyMatch(cause -> KNOWN_TRANSIENT_EXCEPTIONS.contains(cause.getClass()));
+        if (isKnownTransientException) {
+            return true;
+        }
+
+        return ExceptionUtils.getRootCause(throwable) instanceof final SQLException se
+               && PSQLState.isConnectionError(se.getSQLState());
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/BatchProcessingStrategy.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/BatchProcessingStrategy.java
@@ -1,0 +1,69 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import alpine.common.logging.Logger;
+import io.confluent.parallelconsumer.PCRetriableException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serde;
+import org.dependencytrack.common.MdcKeys;
+import org.dependencytrack.event.kafka.processor.exception.ProcessingException;
+import org.slf4j.MDC;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A {@link ProcessingStrategy} that processes records in batches.
+ *
+ * @param <K> Type of the {@link ConsumerRecord} key
+ * @param <V> Type of the {@link ConsumerRecord} value
+ */
+class BatchProcessingStrategy<K, V> extends AbstractProcessingStrategy<K, V> {
+
+    private static final Logger LOGGER = Logger.getLogger(BatchProcessingStrategy.class);
+
+    private final BatchProcessor<K, V> batchProcessor;
+
+    BatchProcessingStrategy(final BatchProcessor<K, V> batchProcessor,
+                            final Serde<K> keySerde, final Serde<V> valueSerde) {
+        super(keySerde, valueSerde);
+        this.batchProcessor = batchProcessor;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void processRecords(final List<ConsumerRecord<byte[], byte[]>> records) {
+        final var deserializedRecords = new ArrayList<ConsumerRecord<K, V>>(records.size());
+        for (final ConsumerRecord<byte[], byte[]> record : records) {
+            try (var ignoredMdcKafkaRecordTopic = MDC.putCloseable(MdcKeys.MDC_KAFKA_RECORD_TOPIC, record.topic());
+                 var ignoredMdcKafkaRecordPartition = MDC.putCloseable(MdcKeys.MDC_KAFKA_RECORD_PARTITION, String.valueOf(record.partition()));
+                 var ignoredMdcKafkaRecordOffset = MDC.putCloseable(MdcKeys.MDC_KAFKA_RECORD_OFFSET, String.valueOf(record.offset()))) {
+                deserializedRecords.add(deserialize(record));
+            } catch (SerializationException e) {
+                // TODO: Consider supporting error handlers, e.g. to send record to DLT.
+                LOGGER.error("Failed to deserialize record; Skipping", e);
+            }
+        }
+
+        if (deserializedRecords.isEmpty()) {
+            LOGGER.warn("All of the %d records in this batch failed to be deserialized".formatted(records.size()));
+            return;
+        }
+
+        try {
+            batchProcessor.process(deserializedRecords);
+        } catch (ProcessingException | RuntimeException e) {
+            if (isRetryableException(e)) {
+                LOGGER.warn("Encountered retryable exception while processing %d records".formatted(deserializedRecords.size()), e);
+                throw new PCRetriableException(e);
+            }
+
+            LOGGER.error("Encountered non-retryable exception while processing %d records; Skipping".formatted(deserializedRecords.size()), e);
+            // TODO: Consider supporting error handlers, e.g. to send records to DLT.
+            // Skip records to avoid poison-pill scenario.
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/BatchProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/BatchProcessor.java
@@ -1,0 +1,26 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.dependencytrack.event.kafka.processor.exception.ProcessingException;
+
+import java.util.List;
+
+/**
+ * A processor of {@link ConsumerRecord} batches.
+ *
+ * @param <K> Type of the {@link ConsumerRecord} key
+ * @param <V> Type of the {@link ConsumerRecord} value
+ */
+public interface BatchProcessor<K, V> {
+
+    /**
+     * Process a batch of {@link ConsumerRecord}s.
+     * <p>
+     * This method may be called by multiple threads concurrently and thus MUST be thread safe!
+     *
+     * @param records Batch of {@link ConsumerRecord}s to process
+     * @throws ProcessingException When consuming the batch of {@link ConsumerRecord}s failed
+     */
+    void process(final List<ConsumerRecord<K, V>> records) throws ProcessingException;
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessingStrategy.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessingStrategy.java
@@ -1,0 +1,16 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.util.List;
+
+interface ProcessingStrategy {
+
+    /**
+     * Process zero or more {@link ConsumerRecord}s.
+     *
+     * @param records The {@link ConsumerRecord}s to process
+     */
+    void processRecords(final List<ConsumerRecord<byte[], byte[]>> records);
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/Processor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/Processor.java
@@ -1,0 +1,24 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.dependencytrack.event.kafka.processor.exception.ProcessingException;
+
+/**
+ * A processor of individual {@link ConsumerRecord}s.
+ *
+ * @param <K> Type of the {@link ConsumerRecord} key
+ * @param <V> Type of the {@link ConsumerRecord} value
+ */
+public interface Processor<K, V> {
+
+    /**
+     * Process a {@link ConsumerRecord}.
+     * <p>
+     * This method may be called by multiple threads concurrently and thus MUST be thread safe!
+     *
+     * @param record The {@link ConsumerRecord} to process
+     * @throws ProcessingException When processing the {@link ConsumerRecord} failed
+     */
+    void process(final ConsumerRecord<K, V> record) throws ProcessingException;
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessorManager.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessorManager.java
@@ -1,0 +1,406 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import alpine.Config;
+import alpine.common.logging.Logger;
+import alpine.common.metrics.Metrics;
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
+import io.confluent.parallelconsumer.ParallelEoSStreamProcessor;
+import io.confluent.parallelconsumer.ParallelStreamProcessor;
+import io.github.resilience4j.core.IntervalFunction;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.dependencytrack.common.ConfigKey;
+import org.dependencytrack.event.kafka.KafkaTopics.Topic;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.clients.CommonClientConfigs.CLIENT_ID_CONFIG;
+import static org.apache.kafka.clients.CommonClientConfigs.SECURITY_PROTOCOL_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG;
+import static org.apache.kafka.common.config.SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+import static org.dependencytrack.common.ConfigKey.KAFKA_BOOTSTRAP_SERVERS;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_MAX_BATCH_SIZE;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_MAX_BATCH_SIZE_DEFAULT;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_MAX_CONCURRENCY;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_MAX_CONCURRENCY_DEFAULT;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_PROCESSING_ORDER;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_PROCESSING_ORDER_DEFAULT;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_INITIAL_DELAY_MS;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_INITIAL_DELAY_MS_DEFAULT;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_MAX_DELAY_MS;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_MAX_DELAY_MS_DEFAULT;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_MULTIPLIER;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_MULTIPLIER_DEFAULT;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_RANDOMIZATION_FACTOR;
+import static org.dependencytrack.event.kafka.processor.api.ProcessorProperties.PROPERTY_RETRY_RANDOMIZATION_FACTOR_DEFAULT;
+
+public class ProcessorManager implements AutoCloseable {
+
+    private static final Logger LOGGER = Logger.getLogger(ProcessorManager.class);
+    private static final Pattern PROCESSOR_NAME_PATTERN = Pattern.compile("^[a-z.]+$");
+
+    private final Map<String, ManagedProcessor> managedProcessors = new LinkedHashMap<>();
+    private final UUID instanceId;
+    private final Config config;
+    private final AdminClient adminClient;
+
+    public ProcessorManager() {
+        this(UUID.randomUUID(), Config.getInstance());
+    }
+
+    public ProcessorManager(final UUID instanceId, final Config config) {
+        this.instanceId = instanceId;
+        this.config = config;
+        this.adminClient = createAdminClient();
+    }
+
+    /**
+     * Register a new {@link Processor}.
+     *
+     * @param name      Name of the processor to register
+     * @param processor The processor to register
+     * @param topic     The topic to have the processor subscribe to
+     * @param <K>       Type of record keys in the topic
+     * @param <V>       Type of record values in the topic
+     */
+    public <K, V> void registerProcessor(final String name, final Topic<K, V> topic, final Processor<K, V> processor) {
+        requireValidProcessorName(name);
+        final var processingStrategy = new SingleRecordProcessingStrategy<>(processor, topic.keySerde(), topic.valueSerde());
+        final ParallelStreamProcessor<byte[], byte[]> parallelConsumer = createParallelConsumer(name, topic, false);
+        managedProcessors.put(name, new ManagedProcessor(parallelConsumer, processingStrategy, topic.name()));
+    }
+
+    /**
+     * Register a new {@link BatchProcessor}.
+     *
+     * @param name      Name of the processor to register
+     * @param processor The processor to register
+     * @param topic     The topic to have the processor subscribe to
+     * @param <K>       Type of record keys in the topic
+     * @param <V>       Type of record values in the topic
+     */
+    public <K, V> void registerBatchProcessor(final String name, final Topic<K, V> topic, final BatchProcessor<K, V> processor) {
+        requireValidProcessorName(name);
+        final var processingStrategy = new BatchProcessingStrategy<>(processor, topic.keySerde(), topic.valueSerde());
+        final ParallelStreamProcessor<byte[], byte[]> parallelConsumer = createParallelConsumer(name, topic, true);
+        managedProcessors.put(name, new ManagedProcessor(parallelConsumer, processingStrategy, topic.name()));
+    }
+
+    @SuppressWarnings("resource")
+    public void startAll() {
+        ensureTopicsExist();
+
+        for (final Map.Entry<String, ManagedProcessor> entry : managedProcessors.entrySet()) {
+            final String processorName = entry.getKey();
+            final ManagedProcessor managedProcessor = entry.getValue();
+
+            LOGGER.info("Starting processor %s to consume from topic %s".formatted(processorName, managedProcessor.topic()));
+            managedProcessor.parallelConsumer().subscribe(List.of(managedProcessor.topic()));
+            managedProcessor.parallelConsumer().poll(pollCtx -> {
+                // NB: Unless batching is enabled, the below list only ever contains a single record.
+                final List<ConsumerRecord<byte[], byte[]>> polledRecords = pollCtx.getConsumerRecordsFlattened();
+                managedProcessor.processingStrategy().processRecords(polledRecords);
+            });
+        }
+    }
+
+    public HealthCheckResponse probeHealth() {
+        final var responseBuilder = HealthCheckResponse.named("kafka-processors");
+
+        boolean isUp = true;
+        for (final Map.Entry<String, ManagedProcessor> entry : managedProcessors.entrySet()) {
+            final String processorName = entry.getKey();
+            final ParallelStreamProcessor<?, ?> parallelConsumer = entry.getValue().parallelConsumer();
+            final boolean isProcessorUp = !parallelConsumer.isClosedOrFailed();
+
+            responseBuilder.withData(processorName, isProcessorUp
+                    ? HealthCheckResponse.Status.UP.name()
+                    : HealthCheckResponse.Status.DOWN.name());
+            if (isProcessorUp
+                && parallelConsumer instanceof final ParallelEoSStreamProcessor<?, ?> concreteParallelConsumer
+                && concreteParallelConsumer.getFailureCause() != null) {
+                responseBuilder.withData("%s_failure_reason".formatted(processorName),
+                        concreteParallelConsumer.getFailureCause().getMessage());
+            }
+
+            isUp &= isProcessorUp;
+        }
+
+        return responseBuilder.status(isUp).build();
+    }
+
+    @Override
+    @SuppressWarnings("resource")
+    public void close() {
+        if (adminClient != null) {
+            LOGGER.debug("Closing admin client");
+            adminClient.close();
+        }
+
+        for (final Map.Entry<String, ManagedProcessor> entry : managedProcessors.entrySet()) {
+            final String processorName = entry.getKey();
+            final ManagedProcessor managedProcessor = entry.getValue();
+
+            LOGGER.info("Stopping processor %s".formatted(processorName));
+            managedProcessor.parallelConsumer().closeDontDrainFirst();
+        }
+    }
+
+    private void ensureTopicsExist() {
+        final List<String> topicNames = managedProcessors.values().stream().map(ManagedProcessor::topic).toList();
+        LOGGER.debug("Ensuring existence of topics: %s".formatted(topicNames));
+
+        final DescribeTopicsResult topicsResult = adminClient.describeTopics(topicNames);
+        final var exceptionsByTopicName = new HashMap<String, Throwable>();
+        for (final Map.Entry<String, KafkaFuture<TopicDescription>> entry : topicsResult.topicNameValues().entrySet()) {
+            final String topicName = entry.getKey();
+            try {
+                entry.getValue().get();
+            } catch (ExecutionException e) {
+                exceptionsByTopicName.put(topicName, e.getCause());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("""
+                        Thread was interrupted while waiting for broker response. \
+                        The existence of topic %s can not be determined.""".formatted(topicName), e);
+            }
+        }
+
+        if (!exceptionsByTopicName.isEmpty()) {
+            final String exceptionSummary = exceptionsByTopicName.entrySet().stream()
+                    .map(entry -> "{topic=%s, error=%s}".formatted(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.joining(", ", "[", "]"));
+            throw new IllegalStateException("Existence of %d topic(s) could not be verified: %s"
+                    .formatted(exceptionsByTopicName.size(), exceptionSummary));
+        }
+    }
+
+    private int getTopicPartitionCount(final String topicName) {
+        LOGGER.debug("Determining partition count of topic %s".formatted(topicName));
+        final DescribeTopicsResult topicsResult = adminClient.describeTopics(List.of(topicName));
+        final KafkaFuture<TopicDescription> topicDescriptionFuture = topicsResult.topicNameValues().get(topicName);
+
+        try {
+            final TopicDescription topicDescription = topicDescriptionFuture.get();
+            return topicDescription.partitions().size();
+        } catch (ExecutionException e) {
+            throw new IllegalStateException("Failed to determine partition count of topic %s".formatted(topicName), e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("""
+                    Thread was interrupted while waiting for broker response. \
+                    The partition count of topic %s can not be determined.""".formatted(topicName), e);
+        }
+    }
+
+    private ParallelStreamProcessor<byte[], byte[]> createParallelConsumer(final String processorName, final Topic<?, ?> topic, final boolean isBatch) {
+        final var optionsBuilder = ParallelConsumerOptions.<byte[], byte[]>builder()
+                .consumer(createConsumer(processorName));
+
+        final Map<String, String> properties = getPassThroughProperties(processorName.toLowerCase());
+
+        final ProcessingOrder processingOrder = Optional.ofNullable(properties.get(PROPERTY_PROCESSING_ORDER))
+                .map(String::toUpperCase)
+                .map(ProcessingOrder::valueOf)
+                .orElse(PROPERTY_PROCESSING_ORDER_DEFAULT);
+        optionsBuilder.ordering(processingOrder);
+
+        final int maxConcurrency = Optional.ofNullable(properties.get(PROPERTY_MAX_CONCURRENCY))
+                .map(Integer::parseInt)
+                .orElse(PROPERTY_MAX_CONCURRENCY_DEFAULT);
+        if (maxConcurrency == -1) {
+            final int numTopicPartitions = getTopicPartitionCount(topic.name());
+            LOGGER.debug("""
+                    Max concurrency of processor %s is configured to match the partition count of topic %s (%d)\
+                    """.formatted(processorName, topic.name(), numTopicPartitions));
+            optionsBuilder.maxConcurrency(numTopicPartitions);
+        } else {
+            optionsBuilder.maxConcurrency(maxConcurrency);
+        }
+
+        final Optional<String> optionalMaxBatchSizeProperty = Optional.ofNullable(properties.get(PROPERTY_MAX_BATCH_SIZE));
+        if (isBatch) {
+            if (processingOrder == ProcessingOrder.PARTITION) {
+                LOGGER.warn("""
+                        Processor %s is configured to use batching with processing order %s; \
+                        Batch sizes are limited by the number of partitions in the topic, \
+                        and may thus not yield the desired effect \
+                        (https://github.com/confluentinc/parallel-consumer/issues/551)\
+                        """.formatted(processorName, processingOrder));
+            }
+
+            final int maxBatchSize = optionalMaxBatchSizeProperty
+                    .map(Integer::parseInt)
+                    .orElse(PROPERTY_MAX_BATCH_SIZE_DEFAULT);
+            optionsBuilder.batchSize(maxBatchSize);
+        } else if (optionalMaxBatchSizeProperty.isPresent()) {
+            LOGGER.warn("Processor %s is configured with %s, but it is not a batch processor; Ignoring property"
+                    .formatted(processorName, PROPERTY_MAX_BATCH_SIZE));
+        }
+
+        final IntervalFunction retryIntervalFunction = getRetryIntervalFunction(properties);
+        optionsBuilder.retryDelayProvider(recordCtx -> {
+            final long delayMillis = retryIntervalFunction.apply(recordCtx.getNumberOfFailedAttempts());
+            return Duration.ofMillis(delayMillis);
+        });
+
+        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
+            optionsBuilder
+                    .meterRegistry(Metrics.getRegistry())
+                    .pcInstanceTag(processorName);
+        }
+
+        final ParallelConsumerOptions<byte[], byte[]> options = optionsBuilder.build();
+        LOGGER.debug("Creating parallel consumer for processor %s with options %s".formatted(processorName, options));
+        return ParallelStreamProcessor.createEosStreamProcessor(options);
+    }
+
+    private Consumer<byte[], byte[]> createConsumer(final String processorName) {
+        final var consumerConfig = new HashMap<String, Object>();
+        consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, config.getProperty(KAFKA_BOOTSTRAP_SERVERS));
+        consumerConfig.put(CLIENT_ID_CONFIG, "%s-%s-consumer".formatted(instanceId, processorName));
+        consumerConfig.put(GROUP_ID_CONFIG, processorName);
+        consumerConfig.putAll(getGlobalTlsConfig());
+
+        final String propertyPrefix = "%s.consumer".formatted(processorName.toLowerCase());
+        final Map<String, String> properties = getPassThroughProperties(propertyPrefix);
+        for (final Map.Entry<String, String> property : properties.entrySet()) {
+            if (!ConsumerConfig.configNames().contains(property.getKey())) {
+                LOGGER.warn("Consumer property %s was set for processor %s, but is unknown; Ignoring"
+                        .formatted(property.getKey(), processorName));
+                continue;
+            }
+
+            consumerConfig.put(property.getKey(), property.getValue());
+        }
+
+        // Properties that MUST NOT be overwritten under any circumstance have to be applied
+        // AFTER pass-through properties.
+        consumerConfig.put(KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerConfig.put(VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getName());
+        consumerConfig.put(ENABLE_AUTO_COMMIT_CONFIG, false); // Commits are managed by parallel consumer
+
+        LOGGER.debug("Creating consumer for processor %s with options %s".formatted(processorName, consumerConfig));
+        final var consumer = new KafkaConsumer<byte[], byte[]>(consumerConfig);
+
+        if (config.getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
+            new KafkaClientMetrics(consumer).bindTo(Metrics.getRegistry());
+        }
+
+        return consumer;
+    }
+
+    private AdminClient createAdminClient() {
+        final var adminClientConfig = new HashMap<String, Object>();
+        adminClientConfig.put(BOOTSTRAP_SERVERS_CONFIG, config.getProperty(KAFKA_BOOTSTRAP_SERVERS));
+        adminClientConfig.put(CLIENT_ID_CONFIG, "%s-admin-client".formatted(instanceId));
+        adminClientConfig.putAll(getGlobalTlsConfig());
+
+        LOGGER.debug("Creating admin client with options %s".formatted(adminClientConfig));
+        return AdminClient.create(adminClientConfig);
+    }
+
+    private Map<String, Object> getGlobalTlsConfig() {
+        if (!config.getPropertyAsBoolean(ConfigKey.KAFKA_TLS_ENABLED)) {
+            return Collections.emptyMap();
+        }
+
+        final var tlsConfig = new HashMap<String, Object>();
+        tlsConfig.put(SECURITY_PROTOCOL_CONFIG, config.getProperty(ConfigKey.KAFKA_TLS_PROTOCOL));
+        tlsConfig.put(SSL_TRUSTSTORE_LOCATION_CONFIG, config.getProperty(ConfigKey.TRUST_STORE_PATH));
+        tlsConfig.put(SSL_TRUSTSTORE_PASSWORD_CONFIG, config.getProperty(ConfigKey.TRUST_STORE_PASSWORD));
+
+        if (config.getPropertyAsBoolean(ConfigKey.KAFKA_MTLS_ENABLED)) {
+            tlsConfig.put(SSL_KEYSTORE_LOCATION_CONFIG, config.getProperty(ConfigKey.KEY_STORE_PATH));
+            tlsConfig.put(SSL_KEYSTORE_PASSWORD_CONFIG, config.getProperty(ConfigKey.KEY_STORE_PASSWORD));
+        }
+
+        return tlsConfig;
+    }
+
+    private Map<String, String> getPassThroughProperties(final String prefix) {
+        final String fullPrefix = "kafka.processor.%s".formatted(prefix);
+        final Pattern fullPrefixPattern = Pattern.compile(Pattern.quote("%s.".formatted(fullPrefix)));
+
+        final Map<String, String> properties = config.getPassThroughProperties(fullPrefix);
+        if (properties.isEmpty()) {
+            return properties;
+        }
+
+        final var trimmedProperties = new HashMap<String, String>(properties.size());
+        for (final Map.Entry<String, String> property : properties.entrySet()) {
+            final String trimmedKey = fullPrefixPattern.matcher(property.getKey()).replaceFirst("");
+            trimmedProperties.put(trimmedKey, property.getValue());
+        }
+
+        return trimmedProperties;
+    }
+
+    /**
+     * Validate a given {@link Processor} name.
+     * <p>
+     * Due to how Alpine's {@link Config} is resolved, {@link Processor} names must have a specific
+     * format in order to be able to resolve properties for them.
+     *
+     * @param name The {@link Processor} name to validate.
+     */
+    private static void requireValidProcessorName(final String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name must not be null");
+        }
+        if (!PROCESSOR_NAME_PATTERN.matcher(name).matches()) {
+            throw new IllegalArgumentException("name is invalid; names must match the regular expression %s"
+                    .formatted(PROCESSOR_NAME_PATTERN.pattern()));
+        }
+    }
+
+    private static IntervalFunction getRetryIntervalFunction(final Map<String, String> properties) {
+        final long initialDelayMs = Optional.ofNullable(properties.get(PROPERTY_RETRY_INITIAL_DELAY_MS))
+                .map(Long::parseLong)
+                .orElse(PROPERTY_RETRY_INITIAL_DELAY_MS_DEFAULT);
+        final long maxDelayMs = Optional.ofNullable(properties.get(PROPERTY_RETRY_MAX_DELAY_MS))
+                .map(Long::parseLong)
+                .orElse(PROPERTY_RETRY_MAX_DELAY_MS_DEFAULT);
+        final int multiplier = Optional.ofNullable(properties.get(PROPERTY_RETRY_MULTIPLIER))
+                .map(Integer::parseInt)
+                .orElse(PROPERTY_RETRY_MULTIPLIER_DEFAULT);
+        final double randomizationFactor = Optional.ofNullable(properties.get(PROPERTY_RETRY_RANDOMIZATION_FACTOR))
+                .map(Double::parseDouble)
+                .orElse(PROPERTY_RETRY_RANDOMIZATION_FACTOR_DEFAULT);
+
+        return IntervalFunction.ofExponentialRandomBackoff(Duration.ofMillis(initialDelayMs),
+                multiplier, randomizationFactor, Duration.ofMillis(maxDelayMs));
+    }
+
+    private record ManagedProcessor(ParallelStreamProcessor<byte[], byte[]> parallelConsumer,
+                                    ProcessingStrategy processingStrategy, String topic) {
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessorProperties.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessorProperties.java
@@ -1,0 +1,25 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
+
+final class ProcessorProperties {
+
+    static final String PROPERTY_MAX_BATCH_SIZE = "max.batch.size";
+    static final int PROPERTY_MAX_BATCH_SIZE_DEFAULT = 10;
+    static final String PROPERTY_MAX_CONCURRENCY = "max.concurrency";
+    static final int PROPERTY_MAX_CONCURRENCY_DEFAULT = 1;
+    static final String PROPERTY_PROCESSING_ORDER = "processing.order";
+    static final ProcessingOrder PROPERTY_PROCESSING_ORDER_DEFAULT = ProcessingOrder.PARTITION;
+    static final String PROPERTY_RETRY_INITIAL_DELAY_MS = "retry.initial.delay.ms";
+    static final long PROPERTY_RETRY_INITIAL_DELAY_MS_DEFAULT = 1000; // 1s
+    static final String PROPERTY_RETRY_MULTIPLIER = "retry.multiplier";
+    static final int PROPERTY_RETRY_MULTIPLIER_DEFAULT = 1;
+    static final String PROPERTY_RETRY_RANDOMIZATION_FACTOR = "retry.randomization.factor";
+    static final double PROPERTY_RETRY_RANDOMIZATION_FACTOR_DEFAULT = 0.3;
+    static final String PROPERTY_RETRY_MAX_DELAY_MS = "retry.max.delay.ms";
+    static final long PROPERTY_RETRY_MAX_DELAY_MS_DEFAULT = 60 * 1000; // 60s
+
+    private ProcessorProperties() {
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/SingleRecordProcessingStrategy.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/SingleRecordProcessingStrategy.java
@@ -1,0 +1,81 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import alpine.common.logging.Logger;
+import io.confluent.parallelconsumer.PCRetriableException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serde;
+import org.dependencytrack.event.kafka.processor.exception.ProcessingException;
+import org.slf4j.MDC;
+
+import java.util.List;
+
+import static org.dependencytrack.common.MdcKeys.MDC_KAFKA_RECORD_KEY;
+import static org.dependencytrack.common.MdcKeys.MDC_KAFKA_RECORD_OFFSET;
+import static org.dependencytrack.common.MdcKeys.MDC_KAFKA_RECORD_PARTITION;
+import static org.dependencytrack.common.MdcKeys.MDC_KAFKA_RECORD_TOPIC;
+
+/**
+ * A {@link ProcessingStrategy} that processes records individually.
+ *
+ * @param <K> Type of the {@link ConsumerRecord} key
+ * @param <V> Type of the {@link ConsumerRecord} value
+ */
+class SingleRecordProcessingStrategy<K, V> extends AbstractProcessingStrategy<K, V> {
+
+    private static final Logger LOGGER = Logger.getLogger(SingleRecordProcessingStrategy.class);
+
+    private final Processor<K, V> processor;
+
+    SingleRecordProcessingStrategy(final Processor<K, V> processor,
+                                   final Serde<K> keySerde, final Serde<V> valueSerde) {
+        super(keySerde, valueSerde);
+        this.processor = processor;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void processRecords(final List<ConsumerRecord<byte[], byte[]>> records) {
+        if (records.isEmpty()) {
+            return;
+        }
+        if (records.size() > 1) {
+            throw new IllegalArgumentException("Expected at most one record, but received %d".formatted(records.size()));
+        }
+
+        final ConsumerRecord<byte[], byte[]> record = records.get(0);
+
+        try (var ignoredMdcKafkaRecordTopic = MDC.putCloseable(MDC_KAFKA_RECORD_TOPIC, record.topic());
+             var ignoredMdcKafkaRecordPartition = MDC.putCloseable(MDC_KAFKA_RECORD_PARTITION, String.valueOf(record.partition()));
+             var ignoredMdcKafkaRecordOffset = MDC.putCloseable(MDC_KAFKA_RECORD_OFFSET, String.valueOf(record.offset()))) {
+            processRecord(record);
+        }
+    }
+
+    private void processRecord(final ConsumerRecord<byte[], byte[]> record) {
+        final ConsumerRecord<K, V> deserializedRecord;
+        try {
+            deserializedRecord = deserialize(record);
+        } catch (SerializationException e) {
+            LOGGER.error("Failed to deserialize consumer record %s; Skipping", e);
+            // TODO: Consider supporting error handlers, e.g. to send record to DLT.
+            return; // Skip record to avoid poison-pill scenario.
+        }
+
+        try (var ignoredMdcKafkaRecordKey = MDC.putCloseable(MDC_KAFKA_RECORD_KEY, String.valueOf(deserializedRecord.key()))) {
+            processor.process(deserializedRecord);
+        } catch (ProcessingException | RuntimeException e) {
+            if (isRetryableException(e)) {
+                LOGGER.warn("Encountered retryable exception while processing record", e);
+                throw new PCRetriableException(e);
+            }
+
+            LOGGER.error("Encountered non-retryable exception while processing record; Skipping", e);
+            // TODO: Consider supporting error handlers, e.g. to send record to DLT.
+            // Skip record to avoid poison-pill scenario.
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/exception/ProcessingException.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/exception/ProcessingException.java
@@ -1,0 +1,29 @@
+package org.dependencytrack.event.kafka.processor.exception;
+
+/**
+ * An {@link Exception} indicating an error during record processing.
+ */
+public class ProcessingException extends Exception {
+
+    /**
+     * {@inheritDoc}
+     */
+    public ProcessingException(final String message) {
+        super(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ProcessingException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ProcessingException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/processor/exception/RetryableProcessingException.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/exception/RetryableProcessingException.java
@@ -1,0 +1,29 @@
+package org.dependencytrack.event.kafka.processor.exception;
+
+/**
+ * A {@link ProcessingException} indicating a retryable error.
+ */
+public class RetryableProcessingException extends ProcessingException {
+
+    /**
+     * {@inheritDoc}
+     */
+    public RetryableProcessingException(final String message) {
+        super(message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RetryableProcessingException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public RetryableProcessingException(final Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/event/kafka/streams/KafkaStreamsInitializer.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/KafkaStreamsInitializer.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka;
+package org.dependencytrack.event.kafka.streams;
 
 import alpine.Config;
 import alpine.common.logging.Logger;
@@ -11,9 +11,9 @@ import org.apache.kafka.common.record.CompressionType;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
 import org.dependencytrack.common.ConfigKey;
-import org.dependencytrack.event.kafka.exception.KafkaStreamsDeserializationExceptionHandler;
-import org.dependencytrack.event.kafka.exception.KafkaStreamsProductionExceptionHandler;
-import org.dependencytrack.event.kafka.exception.KafkaStreamsUncaughtExceptionHandler;
+import org.dependencytrack.event.kafka.streams.exception.KafkaStreamsDeserializationExceptionHandler;
+import org.dependencytrack.event.kafka.streams.exception.KafkaStreamsProductionExceptionHandler;
+import org.dependencytrack.event.kafka.streams.exception.KafkaStreamsUncaughtExceptionHandler;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/KafkaStreamsTopologyFactory.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/KafkaStreamsTopologyFactory.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka;
+package org.dependencytrack.event.kafka.streams;
 
 import alpine.Config;
 import alpine.common.logging.Logger;
@@ -21,10 +21,11 @@ import org.dependencytrack.event.ComponentPolicyEvaluationEvent;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
-import org.dependencytrack.event.kafka.processor.DelayedBomProcessedNotificationProcessor;
-import org.dependencytrack.event.kafka.processor.MirrorVulnerabilityProcessor;
-import org.dependencytrack.event.kafka.processor.RepositoryMetaResultProcessor;
-import org.dependencytrack.event.kafka.processor.VulnerabilityScanResultProcessor;
+import org.dependencytrack.event.kafka.KafkaTopics;
+import org.dependencytrack.event.kafka.streams.processor.DelayedBomProcessedNotificationProcessor;
+import org.dependencytrack.event.kafka.streams.processor.MirrorVulnerabilityProcessor;
+import org.dependencytrack.event.kafka.streams.processor.RepositoryMetaResultProcessor;
+import org.dependencytrack.event.kafka.streams.processor.VulnerabilityScanResultProcessor;
 import org.dependencytrack.model.VulnerabilityScan;
 import org.dependencytrack.model.WorkflowState;
 import org.dependencytrack.model.WorkflowStatus;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/exception/AbstractThresholdBasedExceptionHandler.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/exception/AbstractThresholdBasedExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import java.time.Clock;
 import java.time.Duration;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsDeserializationExceptionHandler.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsDeserializationExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import alpine.Config;
 import alpine.common.logging.Logger;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsProductionExceptionHandler.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsProductionExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import alpine.Config;
 import alpine.common.logging.Logger;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsUncaughtExceptionHandler.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsUncaughtExceptionHandler.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import alpine.Config;
 import alpine.common.logging.Logger;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/processor/DelayedBomProcessedNotificationProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/processor/DelayedBomProcessedNotificationProcessor.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import alpine.common.logging.Logger;
 import alpine.notification.NotificationLevel;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/processor/MirrorVulnerabilityProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/processor/MirrorVulnerabilityProcessor.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import alpine.common.logging.Logger;
 import alpine.common.metrics.Metrics;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/processor/RepositoryMetaResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/processor/RepositoryMetaResultProcessor.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import alpine.common.logging.Logger;
 import alpine.common.metrics.Metrics;

--- a/src/main/java/org/dependencytrack/event/kafka/streams/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/streams/processor/VulnerabilityScanResultProcessor.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import alpine.Config;
 import alpine.common.logging.Logger;
@@ -625,7 +625,7 @@ public class VulnerabilityScanResultProcessor extends ContextualFixedKeyProcesso
                         .setLevel(LEVEL_INFORMATIONAL)
                         .setTimestamp(Timestamps.now())
                         .setTitle(generateTitle(policyAnalysis.getState(), policyAnalysis.getSuppressed(), analysisStateChange, suppressionChange))
-                        .setContent(generateNotificationContent(policyAnalysis))
+                        .setContent("An analysis decision was made to a finding affecting a project")
                         .setSubject(Any.pack(subject))
                         .build())
                 .orElse(null);

--- a/src/main/java/org/dependencytrack/health/KafkaStreamsHealthCheck.java
+++ b/src/main/java/org/dependencytrack/health/KafkaStreamsHealthCheck.java
@@ -1,7 +1,7 @@
 package org.dependencytrack.health;
 
 import org.apache.kafka.streams.KafkaStreams;
-import org.dependencytrack.event.kafka.KafkaStreamsInitializer;
+import org.dependencytrack.event.kafka.streams.KafkaStreamsInitializer;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Liveness;

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -24,7 +24,6 @@ import alpine.notification.NotificationLevel;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.event.kafka.KafkaEventDispatcher;
-import org.dependencytrack.event.kafka.processor.VulnerabilityScanResultProcessor;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
@@ -427,10 +426,6 @@ public final class NotificationUtil {
             return messageType + " on Project: [" + project.toString() + "]";
         }
         return messageType;
-    }
-
-    public static String generateNotificationContent(final VulnerabilityScanResultProcessor.Analysis analysis) {
-        return "An analysis decision was made to a finding affecting a project";
     }
 
     public static String generateNotificationTitle(final String messageType, final org.dependencytrack.proto.notification.v1.Project project) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -434,6 +434,42 @@ kafka.streams.production.exception.threshold.interval=PT30M
 kafka.streams.transient.processing.exception.threshold.count=50
 kafka.streams.transient.processing.exception.threshold.interval=PT30M
 
+# Optional
+# Defines the order in which records are being processed.
+# Valid options are:
+#  * partition
+#  * key
+#  * unordered
+# alpine.kafka.processor.<name>.processing.order=partition
+
+# Optional
+# Defines the maximum size of record batches being processed.
+# Batch sizes are further limited by the configured processing order:
+#  * partition: Number of partitions assigned to this processor
+#  * key:       Number of distinct record keys in current consumer poll
+#  * unordered: Potentially unlimited
+# Will be ignored when the processor is not a batch processor.
+# alpine.kafka.processor.<name>.max.batch.size=10
+
+# Optional
+# Defines the maximum concurrency with which records are being processed.
+# For batch processors, a smaller number can improve efficiency and throughput.
+# A value of -1 indicates that the maximum concurrency should be equal to
+# the number of partitions in the topic being consumed from.
+# alpine.kafka.processor.<name>.max.concurrency=1
+
+# Optional
+# Allows for customization of the processor's retry behavior.
+# alpine.kafka.processor.<name>.retry.initial.delay.ms=1000
+# alpine.kafka.processor.<name>.retry.multiplier=1
+# alpine.kafka.processor.<name>.retry.randomization.factor=0.3
+# alpine.kafka.processor.<name>.retry.max.delay.ms=60000
+
+# Optional
+# Allows for customization of the underlying Kafka consumer.
+# Refer to https://kafka.apache.org/documentation/#consumerconfigs for available options.
+# alpine.kafka.processor.<name>.consumer.<consumer.config.name>=
+
 # Scheduling tasks after 3 minutes (3*60*1000) of starting application
 task.scheduler.initial.delay=180000
 

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -48,6 +48,9 @@
         <listener-class>org.dependencytrack.event.EventSubsystemInitializer</listener-class>
     </listener>
     <listener>
+        <listener-class>org.dependencytrack.event.kafka.processor.ProcessorInitializer</listener-class>
+    </listener>
+    <listener>
         <listener-class>org.dependencytrack.event.kafka.streams.KafkaStreamsInitializer</listener-class>
     </listener>
     <listener>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -48,7 +48,7 @@
         <listener-class>org.dependencytrack.event.EventSubsystemInitializer</listener-class>
     </listener>
     <listener>
-        <listener-class>org.dependencytrack.event.kafka.KafkaStreamsInitializer</listener-class>
+        <listener-class>org.dependencytrack.event.kafka.streams.KafkaStreamsInitializer</listener-class>
     </listener>
     <listener>
         <listener-class>org.dependencytrack.event.PurlMigrator</listener-class>

--- a/src/test/java/org/dependencytrack/event/kafka/processor/AbstractProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/AbstractProcessorTest.java
@@ -1,0 +1,59 @@
+package org.dependencytrack.event.kafka.processor;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.dependencytrack.AbstractPostgresEnabledTest;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNullElseGet;
+
+abstract class AbstractProcessorTest extends AbstractPostgresEnabledTest {
+
+    static <K, V> ConsumerRecordBuilder<K, V> aConsumerRecord(final K key, final V value) {
+        return new ConsumerRecordBuilder<>(key, value);
+    }
+
+    static final class ConsumerRecordBuilder<K, V> {
+
+        private final K key;
+        private final V value;
+        private Instant timestamp;
+        private Headers headers;
+
+        private ConsumerRecordBuilder(final K key, final V value) {
+            this.key = key;
+            this.value = value;
+        }
+
+        ConsumerRecordBuilder<K, V> withTimestamp(final Instant timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        ConsumerRecordBuilder<K, V> withHeaders(final Headers headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        ConsumerRecord<K, V> build() {
+            final Instant timestamp = requireNonNullElseGet(this.timestamp, Instant::now);
+            final Headers headers = requireNonNullElseGet(this.headers, RecordHeaders::new);
+            return new ConsumerRecord<>(
+                    "topicName",
+                    /* partition */ 0,
+                    /* offset */ 1,
+                    timestamp.toEpochMilli(), TimestampType.CREATE_TIME,
+                    /* serializedKeySize */ -1,
+                    /* serializedValueSize */ -1,
+                    this.key, this.value,
+                    headers,
+                    /* leaderEpoch */ Optional.empty());
+        }
+
+    }
+
+}

--- a/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
@@ -1,0 +1,297 @@
+package org.dependencytrack.event.kafka.processor.api;
+
+import alpine.Config;
+import net.mguenther.kafka.junit.ExternalKafkaCluster;
+import net.mguenther.kafka.junit.KeyValue;
+import net.mguenther.kafka.junit.SendKeyValues;
+import net.mguenther.kafka.junit.TopicConfig;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.dependencytrack.common.ConfigKey;
+import org.dependencytrack.event.kafka.KafkaTopics.Topic;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.redpanda.RedpandaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class ProcessorManagerTest {
+
+    @Rule
+    public RedpandaContainer kafkaContainer = new RedpandaContainer(DockerImageName
+            .parse("docker.redpanda.com/vectorized/redpanda:v23.3.3"));
+
+    private ExternalKafkaCluster kafka;
+    private Config configMock;
+
+    @Before
+    public void setUp() {
+        kafka = ExternalKafkaCluster.at(kafkaContainer.getBootstrapServers());
+
+        configMock = mock(Config.class);
+        when(configMock.getProperty(eq(ConfigKey.KAFKA_BOOTSTRAP_SERVERS)))
+                .thenReturn(kafkaContainer.getBootstrapServers());
+    }
+
+    @Test
+    public void testSingleRecordProcessor() throws Exception {
+        final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
+        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+
+        final var recordsProcessed = new AtomicInteger(0);
+
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo.consumer")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.processing.order", "key",
+                        "kafka.processor.foo.max.concurrency", "5",
+                        "kafka.processor.foo.consumer.auto.offset.reset", "earliest"
+                ));
+
+        final Processor<String, String> processor =
+                record -> recordsProcessed.incrementAndGet();
+
+        try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
+            processorManager.registerProcessor("foo", inputTopic, processor);
+
+            for (int i = 0; i < 100; i++) {
+                kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo" + i, "bar" + i)))
+                        .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                        .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+            }
+
+            processorManager.startAll();
+
+            await("Record Processing")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(recordsProcessed).hasValue(100));
+        }
+    }
+
+    @Test
+    public void testSingleRecordProcessorRetry() throws Exception {
+        final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
+        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+
+        final var attemptsCounter = new AtomicInteger(0);
+
+        final var objectSpy = spy(new Object());
+        when(objectSpy.toString())
+                .thenThrow(new RuntimeException(new TimeoutException()))
+                .thenThrow(new RuntimeException(new TimeoutException()))
+                .thenThrow(new RuntimeException(new TimeoutException()))
+                .thenReturn("done");
+
+        final Processor<String, String> processor = record -> {
+            attemptsCounter.incrementAndGet();
+            var ignored = objectSpy.toString();
+        };
+
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.retry.initial.delay.ms", "5",
+                        "kafka.processor.foo.retry.multiplier", "1",
+                        "kafka.processor.foo.retry.max.delay.ms", "10"
+                ));
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo.consumer")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.consumer.auto.offset.reset", "earliest"
+                ));
+
+        try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
+            processorManager.registerProcessor("foo", inputTopic, processor);
+
+            kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo", "bar")))
+                    .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                    .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+
+            processorManager.startAll();
+
+            await("Record Processing")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(attemptsCounter).hasValue(4));
+        }
+    }
+
+    @Test
+    public void testBatchProcessor() throws Exception {
+        final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
+        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+
+        final var recordsProcessed = new AtomicInteger(0);
+        final var actualBatchSizes = new ConcurrentLinkedQueue<>();
+
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.processing.order", "key",
+                        "kafka.processor.foo.max.batch.size", "100"
+                ));
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo.consumer")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.consumer.auto.offset.reset", "earliest"
+                ));
+
+        final BatchProcessor<String, String> recordProcessor = records -> {
+            recordsProcessed.addAndGet(records.size());
+            actualBatchSizes.add(records.size());
+        };
+
+        try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
+            processorManager.registerBatchProcessor("foo", inputTopic, recordProcessor);
+
+            for (int i = 0; i < 1_000; i++) {
+                kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo" + i, "bar" + i)))
+                        .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                        .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+            }
+
+            processorManager.startAll();
+
+            await("Record Processing")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(recordsProcessed).hasValue(1_000));
+
+            assertThat(actualBatchSizes).containsOnly(100);
+        }
+    }
+
+    @Test
+    public void testWithMaxConcurrencyMatchingPartitionCount() throws Exception {
+        final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
+
+        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(12));
+
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.processing.order", "partition",
+                        "kafka.processor.foo.max.concurrency", "-1"
+                ));
+        when(configMock.getPassThroughProperties(eq("kafka.processor.foo.consumer")))
+                .thenReturn(Map.of(
+                        "kafka.processor.foo.consumer.auto.offset.reset", "earliest"
+                ));
+
+        final var threadNames = new ArrayBlockingQueue<String>(100);
+        final Processor<String, String> processor = record -> {
+            threadNames.add(Thread.currentThread().getName());
+        };
+
+        try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
+            processorManager.registerProcessor("foo", inputTopic, processor);
+
+            for (int i = 0; i < 100; i++) {
+                kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo" + i, "bar" + i)))
+                        .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
+                        .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+            }
+
+            processorManager.startAll();
+
+            await("Record Processing")
+                    .atMost(Duration.ofSeconds(5))
+                    .untilAsserted(() -> assertThat(threadNames).hasSize(100));
+
+            assertThat(threadNames.stream().distinct()).hasSize(12);
+        }
+    }
+
+    @Test
+    public void testStartAllWithMissingTopics() {
+        final var inputTopicA = new Topic<>("input-a", Serdes.String(), Serdes.String());
+        final var inputTopicB = new Topic<>("input-b", Serdes.String(), Serdes.String());
+
+        kafka.createTopic(TopicConfig.withName(inputTopicA.name()).withNumberOfPartitions(3));
+
+        final Processor<String, String> processor = record -> {
+        };
+
+        try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
+            processorManager.registerProcessor("a", inputTopicA, processor);
+            processorManager.registerProcessor("b", inputTopicB, processor);
+
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(processorManager::startAll)
+                    .withMessage("""
+                            Existence of 1 topic(s) could not be verified: \
+                            [{topic=input-b, error=org.apache.kafka.common.errors.UnknownTopicOrPartitionException: \
+                            This server does not host this topic-partition.}]""");
+        }
+    }
+
+    @Test
+    public void testProbeHealth() {
+        final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
+        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+
+        final Processor<String, String> processor = record -> {
+        };
+
+        try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
+            processorManager.registerProcessor("foo", inputTopic, processor);
+
+            {
+                final HealthCheckResponse healthCheckResponse = processorManager.probeHealth();
+                assertThat(healthCheckResponse.getName()).isEqualTo("kafka-processors");
+                assertThat(healthCheckResponse.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+                assertThat(healthCheckResponse.getData()).isPresent();
+                assertThatJson(healthCheckResponse.getData().get())
+                        .isEqualTo("""
+                                {
+                                  "foo": "UP"
+                                }
+                                """);
+            }
+
+            processorManager.startAll();
+
+            {
+                final HealthCheckResponse healthCheckResponse = processorManager.probeHealth();
+                assertThat(healthCheckResponse.getName()).isEqualTo("kafka-processors");
+                assertThat(healthCheckResponse.getStatus()).isEqualTo(HealthCheckResponse.Status.UP);
+                assertThat(healthCheckResponse.getData()).isPresent();
+                assertThatJson(healthCheckResponse.getData().get())
+                        .isEqualTo("""
+                                {
+                                  "foo": "UP"
+                                }
+                                """);
+            }
+
+            processorManager.close();
+
+            {
+                final HealthCheckResponse healthCheckResponse = processorManager.probeHealth();
+                assertThat(healthCheckResponse.getName()).isEqualTo("kafka-processors");
+                assertThat(healthCheckResponse.getStatus()).isEqualTo(HealthCheckResponse.Status.DOWN);
+                assertThat(healthCheckResponse.getData()).isPresent();
+                assertThatJson(healthCheckResponse.getData().get())
+                        .isEqualTo("""
+                                {
+                                  "foo": "DOWN"
+                                }
+                                """);
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsDelayedBomProcessedNotificationTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsDelayedBomProcessedNotificationTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka;
+package org.dependencytrack.event.kafka.streams;
 
 import net.mguenther.kafka.junit.KeyValue;
 import net.mguenther.kafka.junit.ReadKeyValues;
@@ -6,6 +6,7 @@ import net.mguenther.kafka.junit.SendKeyValues;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.VulnerabilityScan;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsPostgresTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsPostgresTest.java
@@ -1,10 +1,14 @@
-package org.dependencytrack.event.kafka;
+package org.dependencytrack.event.kafka.streams;
 
 import net.mguenther.kafka.junit.ExternalKafkaCluster;
 import net.mguenther.kafka.junit.TopicConfig;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
-import org.dependencytrack.PersistenceCapableTest;
+import org.apache.kafka.streams.Topology;
+import org.dependencytrack.AbstractPostgresEnabledTest;
+import org.dependencytrack.event.kafka.KafkaTopics;
+import org.dependencytrack.event.kafka.serialization.KafkaProtobufDeserializer;
+import org.dependencytrack.proto.notification.v1.Notification;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -14,10 +18,11 @@ import org.testcontainers.utility.DockerImageName;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.function.Supplier;
 
 import static org.dependencytrack.assertion.Assertions.assertConditionWithTimeout;
 
-abstract class KafkaStreamsTest extends PersistenceCapableTest {
+abstract class KafkaStreamsPostgresTest extends AbstractPostgresEnabledTest {
 
     @Rule
     public RedpandaContainer container = new RedpandaContainer(DockerImageName
@@ -25,10 +30,20 @@ abstract class KafkaStreamsTest extends PersistenceCapableTest {
 
     KafkaStreams kafkaStreams;
     ExternalKafkaCluster kafka;
+    private final Supplier<Topology> topologySupplier;
     private Path kafkaStreamsStateDirectory;
+
+    protected KafkaStreamsPostgresTest() {
+        this(new KafkaStreamsTopologyFactory()::createTopology);
+    }
+
+    protected KafkaStreamsPostgresTest(final Supplier<Topology> topologySupplier) {
+        this.topologySupplier = topologySupplier;
+    }
 
     @Before
     public void setUp() throws Exception {
+        super.setUp();
         kafka = ExternalKafkaCluster.at(container.getBootstrapServers());
 
         kafka.createTopic(TopicConfig
@@ -56,7 +71,7 @@ abstract class KafkaStreamsTest extends PersistenceCapableTest {
         streamsConfig.put(StreamsConfig.STATE_DIR_CONFIG, kafkaStreamsStateDirectory.toString());
         streamsConfig.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, "3");
 
-        kafkaStreams = new KafkaStreams(new KafkaStreamsTopologyFactory().createTopology(), streamsConfig);
+        kafkaStreams = new KafkaStreams(topologySupplier.get(), streamsConfig);
         kafkaStreams.start();
 
         assertConditionWithTimeout(() -> KafkaStreams.State.RUNNING == kafkaStreams.state(), Duration.ofSeconds(5));
@@ -70,6 +85,15 @@ abstract class KafkaStreamsTest extends PersistenceCapableTest {
         if (kafkaStreamsStateDirectory != null) {
             kafkaStreamsStateDirectory.toFile().delete();
         }
+        super.tearDown();
+    }
+
+    public static class NotificationDeserializer extends KafkaProtobufDeserializer<Notification> {
+
+        public NotificationDeserializer() {
+            super(Notification.parser());
+        }
+
     }
 
 }

--- a/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsTopologyTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsTopologyTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka;
+package org.dependencytrack.event.kafka.streams;
 
 import alpine.event.framework.Event;
 import alpine.event.framework.EventService;
@@ -19,6 +19,7 @@ import org.cyclonedx.proto.v1_4.VulnerabilityRating;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.event.ProjectPolicyEvaluationEvent;
+import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.kafka.serialization.KafkaProtobufSerializer;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsDeserializationExceptionHandlerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsDeserializationExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.errors.SerializationException;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsProductionExceptionHandlerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsProductionExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.RecordTooLargeException;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsUncaughtExceptionHandlerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/exception/KafkaStreamsUncaughtExceptionHandlerTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.exception;
+package org.dependencytrack.event.kafka.streams.exception;
 
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
 import org.junit.Test;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/processor/MirrorVulnerabilityProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/processor/MirrorVulnerabilityProcessorTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/processor/RepositoryMetaResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/processor/RepositoryMetaResultProcessorTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import com.google.protobuf.Timestamp;
 import org.apache.kafka.common.serialization.StringDeserializer;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/processor/VulnerabilityScanResultProcessorTest.java
@@ -1,4 +1,4 @@
-package org.dependencytrack.event.kafka.processor;
+package org.dependencytrack.event.kafka.streams.processor;
 
 import com.google.protobuf.Timestamp;
 import junitparams.JUnitParamsRunner;


### PR DESCRIPTION
### Description

Implements foundational API for parallel-consumer based Kafka processors.

Decoupled from https://github.com/DependencyTrack/hyades-apiserver/pull/509

This merely adds an API on top of which processors can be implemented. We can migrate processors one-by-one from Kafka Streams to this API. Majority of this work was already done in https://github.com/DependencyTrack/hyades-apiserver/pull/509, but got out of date due to changed priorities. At the very least said PR is good to take inspiration from.

The API surface is minimal, yet abstract enough that we can switch out Confluent Parallel Consumer for another library, or a custom implementation in the future if needed.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/346
Relates to https://github.com/DependencyTrack/hyades/issues/901
Relates to https://github.com/DependencyTrack/hyades/issues/907

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
