### PR TITLE
Allow usage of separate database user for running migrations

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -89,6 +89,9 @@ public enum ConfigKey implements Config.Key {
     VULNERABILITY_POLICY_S3_BUCKET_NAME("vulnerability.policy.s3.bucket.name", null),
     VULNERABILITY_POLICY_S3_BUNDLE_NAME("vulnerability.policy.s3.bundle.name", null),
     VULNERABILITY_POLICY_S3_REGION("vulnerability.policy.s3.region", null),
+    DATABASE_MIGRATION_URL("database.migration.url", null),
+    DATABASE_MIGRATION_USERNAME("database.migration.username", null),
+    DATABASE_MIGRATION_PASSWORD("database.migration.password", null),
     RUN_MIGRATIONS("run.migrations", true);
 
     private final String propertyName;

--- a/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
@@ -20,8 +20,10 @@ import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.sql.DataSource;
 import java.util.HashMap;
+import java.util.Optional;
 
 public class MigrationInitializer implements ServletContextListener {
+
     private static final Logger LOGGER = Logger.getLogger(MigrationInitializer.class);
 
     private final Config config;
@@ -68,11 +70,18 @@ public class MigrationInitializer implements ServletContextListener {
     }
 
     private HikariDataSource createDataSource() {
+        final String jdbcUrl = Optional.ofNullable(config.getProperty(ConfigKey.DATABASE_MIGRATION_URL))
+                .orElseGet(() -> config.getProperty(Config.AlpineKey.DATABASE_URL));
+        final String username = Optional.ofNullable(config.getProperty(ConfigKey.DATABASE_MIGRATION_USERNAME))
+                .orElseGet(() -> config.getProperty(Config.AlpineKey.DATABASE_USERNAME));
+        final String password = Optional.ofNullable(config.getProperty(ConfigKey.DATABASE_MIGRATION_PASSWORD))
+                .orElseGet(() -> config.getProperty(Config.AlpineKey.DATABASE_PASSWORD));
+
         final var hikariCfg = new HikariConfig();
-        hikariCfg.setJdbcUrl(config.getProperty(Config.AlpineKey.DATABASE_URL));
+        hikariCfg.setJdbcUrl(jdbcUrl);
         hikariCfg.setDriverClassName(config.getProperty(Config.AlpineKey.DATABASE_DRIVER));
-        hikariCfg.setUsername(config.getProperty(Config.AlpineKey.DATABASE_USERNAME));
-        hikariCfg.setPassword(config.getProperty(Config.AlpineKey.DATABASE_PASSWORD));
+        hikariCfg.setUsername(username);
+        hikariCfg.setPassword(password);
         hikariCfg.setMaximumPoolSize(1);
         hikariCfg.setMinimumIdle(1);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -147,6 +147,27 @@ alpine.database.pool.max.lifetime=600000
 # DO NOT CHANGE UNLESS THERE IS A GOOD REASON TO.
 alpine.datanucleus.cache.level2.type=none
 
+# Optional
+# Defines whether database migrations should be executed on startup.
+run.migrations=true
+
+# Optional
+# Defines the database JDBC URL to use when executing migrations.
+# If not set, the value of alpine.database.url will be used.
+# Should generally not be set, unless TLS authentication is used,
+# and custom connection variables are required.
+# database.migration.url=
+
+# Optional
+# Defines the database user for executing migrations.
+# If not set, the value of alpine.database.username will be used.
+# database.migration.username=
+
+# Optional
+# Defines the database password for executing migrations.
+# If not set, the value of alpine.database.password will be used.
+# database.migration.password=
+
 # Required
 # Specifies the number of bcrypt rounds to use when hashing a users password.
 # The higher the number the more secure the password, at the expense of

--- a/src/test/java/org/dependencytrack/persistence/migration/MigrationInitializerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/migration/MigrationInitializerTest.java
@@ -1,6 +1,7 @@
 package org.dependencytrack.persistence.migration;
 
 import alpine.Config;
+import org.dependencytrack.common.ConfigKey;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,21 +31,28 @@ public class MigrationInitializerTest {
 
     @Test
     public void test() {
-        final Config configMock = createConfigMock(postgresContainer.getJdbcUrl(),
-                postgresContainer.getDriverClassName(),
-                postgresContainer.getUsername(),
-                postgresContainer.getPassword());
+        final var configMock = mock(Config.class);
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_URL))).thenReturn(postgresContainer.getJdbcUrl());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(postgresContainer.getDriverClassName());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn(postgresContainer.getUsername());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn(postgresContainer.getPassword());
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.RUN_MIGRATIONS))).thenReturn(true);
+
         new MigrationInitializer(configMock).contextInitialized(null);
     }
 
-
-    private static Config createConfigMock(final String jdbcUrl, final String driverClassName,
-                                           final String username, final String password) {
+    @Test
+    public void testWithMigrationCredentials() {
         final var configMock = mock(Config.class);
-        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_URL))).thenReturn(jdbcUrl);
-        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(driverClassName);
-        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn(username);
-        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn(password);
-        return configMock;
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_URL))).thenReturn(postgresContainer.getJdbcUrl());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(postgresContainer.getDriverClassName());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn("username");
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn("password");
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.RUN_MIGRATIONS))).thenReturn(true);
+        when(configMock.getProperty(eq(ConfigKey.DATABASE_MIGRATION_USERNAME))).thenReturn(postgresContainer.getUsername());
+        when(configMock.getProperty(eq(ConfigKey.DATABASE_MIGRATION_PASSWORD))).thenReturn(postgresContainer.getPassword());
+
+        new MigrationInitializer(configMock).contextInitialized(null);
     }
+
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows usage of a separate database user for running migrations.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Follow-up to https://github.com/DependencyTrack/hyades-apiserver/pull/551#discussion_r1481217615

Relates to https://github.com/DependencyTrack/dependency-track/issues/2377

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

This is similar to how the Liquibase integration works in Spring: https://contribute.liquibase.com/extensions-integrations/directory/integration-docs/springboot/springboot/

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
