### PR TITLE
Fix failure to delete `PolicyViolation`s when they have an audit trail

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <lib.testcontainers.version>1.18.3</lib.testcontainers.version>
         <lib.resilience4j.version>2.1.0</lib.resilience4j.version>
         <lib.snappy-java.version>1.1.10.5</lib.snappy-java.version>
-        <lib.versatile.version>0.4.0</lib.versatile.version>
+        <lib.versatile.version>0.4.1</lib.versatile.version>
         <lib.woodstox.version>6.4.0</lib.woodstox.version>
         <lib.junit-params.version>1.1.1</lib.junit-params.version>
         <lib.log4j-over-slf4j.version>2.0.12</lib.log4j-over-slf4j.version>

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -226,51 +226,6 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
     }
 
     /**
-     * Intelligently adds dependencies for components that are not already a dependency
-     * of the specified project and removes the dependency relationship for components
-     * that are not in the list of specified components.
-     * @param component the project to bind components to
-     * @param policyViolations the complete list of existing dependent components
-     */
-    public synchronized void reconcilePolicyViolations(final Component component, final List<PolicyViolation> policyViolations) {
-        // Removes violations as dependencies to the project for all
-        // components not included in the list provided
-        List<PolicyViolation> markedForDeletion = new ArrayList<>();
-        for (final PolicyViolation existingViolation: getAllPolicyViolations(component)) {
-            boolean keep = false;
-            for (final PolicyViolation violation: policyViolations) {
-                if (violation.getType() == existingViolation.getType()
-                        && violation.getPolicyCondition().getId() == existingViolation.getPolicyCondition().getId()
-                        && violation.getComponent().getId() == existingViolation.getComponent().getId())
-                {
-                    keep = true;
-                    break;
-                }
-            }
-            if (!keep) {
-                markedForDeletion.add(existingViolation);
-            }
-        }
-        if (!markedForDeletion.isEmpty()) {
-            delete(markedForDeletion);
-        }
-    }
-
-    /**
-     * Adds a policy violation
-     * @param pv the policy violation to add
-     */
-    public synchronized PolicyViolation addPolicyViolationIfNotExist(final PolicyViolation pv) {
-        final Query<PolicyViolation> query = pm.newQuery(PolicyViolation.class, "type == :type && component == :component && policyCondition == :policyCondition");
-        query.setRange(0, 1);
-        PolicyViolation result = singleResult(query.execute(pv.getType(), pv.getComponent(), pv.getPolicyCondition()));
-        if (result == null) {
-            result = persist(pv);
-        }
-        return result;
-    }
-
-    /**
      * Returns a List of all Policy objects.
      * This method if designed NOT to provide paginated results.
      * @return a List of all Policy objects

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -735,14 +735,6 @@ public class QueryManager extends AlpineQueryManager {
         return getPolicyQueryManager().updatePolicyCondition(policyCondition);
     }
 
-    public synchronized void reconcilePolicyViolations(final Component component, final List<PolicyViolation> policyViolations) {
-        getPolicyQueryManager().reconcilePolicyViolations(component, policyViolations);
-    }
-
-    public synchronized PolicyViolation addPolicyViolationIfNotExist(final PolicyViolation pv) {
-        return getPolicyQueryManager().addPolicyViolationIfNotExist(pv);
-    }
-
     public List<PolicyViolation> getAllPolicyViolations() {
         return getPolicyQueryManager().getAllPolicyViolations();
     }

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -214,9 +214,7 @@ public class PolicyResourceTest extends ResourceTest {
         violation.setPolicyCondition(condition);
         violation.setType(PolicyViolation.Type.OPERATIONAL);
         violation.setTimestamp(new Date());
-        violation = qm.addPolicyViolationIfNotExist(violation);
-
-        qm.reconcilePolicyViolations(component, singletonList(violation));
+        qm.persist(violation);
 
         final Response response = target(V1_POLICY + "/" + policy.getUuid())
                 .request()

--- a/src/test/java/org/dependencytrack/tasks/metrics/AbstractMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/AbstractMetricsUpdateTaskTest.java
@@ -59,7 +59,7 @@ abstract class AbstractMetricsUpdateTaskTest extends AbstractPostgresEnabledTest
         policyViolation.setPolicyCondition(policyCondition);
         policyViolation.setTimestamp(new Date());
         policyViolation.setType(type);
-        return qm.addPolicyViolationIfNotExist(policyViolation);
+        return qm.persist(policyViolation);
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes failure to delete `PolicyViolation`s when they have an audit trail.

The original bug was in the legacy policy engine, but the CEL-based one also had it :)

Ports https://github.com/DependencyTrack/dependency-track/pull/3228 from DT v4.10.0.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/983

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Some leftover code from the legacy policy engine was removed.

The new test uncovered a bug in `versatile` as well, which was fixed in `0.4.1`: https://github.com/nscuro/versatile/commit/2f71a3d87ab931f3ea9ad39200a1cf4e26f5453c

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
