### PR TITLE
Add strict token permissions in GH workflows and update image to Java 21 JRE

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -17,6 +17,8 @@ on:
       registry-0-psw:
         required: true
 
+permissions: { }
+
 jobs:
   build-java:
     runs-on: ubuntu-latest
@@ -56,6 +58,8 @@ jobs:
 
   build-container:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required to upload trivy's SARIF output
     needs:
       - build-java
     steps:

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -16,12 +16,16 @@ on:
       - 'docs/**'
   workflow_dispatch:
 
+permissions: { }
+
 jobs:
   call-build:
     uses: ./.github/workflows/_meta-build.yaml
     with:
       app-version: "snapshot"
       publish-container: ${{ github.ref == 'refs/heads/main' }}
+    permissions:
+      security-events: write # Required to upload trivy's SARIF output
     secrets:
       registry-0-usr: ${{ github.repository_owner }}
       registry-0-psw: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -8,6 +8,8 @@ on:
       - released
   workflow_dispatch:
 
+permissions: { }
+
 jobs:
   read-version:
     runs-on: ubuntu-latest
@@ -36,6 +38,8 @@ jobs:
     with:
       app-version: ${{ needs.read-version.outputs.version }}
       publish-container: true
+    permissions:
+      security-events: write # Required to upload trivy's SARIF output
     secrets:
       registry-0-usr: ${{ github.repository_owner }}
       registry-0-psw: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -9,6 +9,8 @@ on:
         description: 'Use this to overwrite the version number to release, otherwise uses the current SNAPSHOT version (expected format x.y.z)'
         type: string
 
+permissions: { }
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -24,6 +24,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions: { }
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -2,8 +2,7 @@ name: Dependency Review
 on:
   pull_request:
 
-permissions:
-  contents: read
+permissions: { }
 
 jobs:
   dependency-review:

--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -4,13 +4,14 @@ on:
   schedule:
     - cron: '0 10 * * *'
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: { }
 
 jobs:
   action:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write # Required to lock issues
+      pull-requests: write # Required to lock PRs
     # don't run on forks
     if: ${{ contains(github.repository, 'DependencyTrack/') }}
     steps:

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.8.1_1-jre-focal@sha256:bed33979fe79ff4448686ca4074b43b87a8ea26f80cb3d6a9873634c4098ddfb AS jre-build
+FROM eclipse-temurin:21_35-jre-jammy@sha256:82685ae01f788128caf3e0085e4fde21b9d1815dbbd3263082804d1de26f309c AS jre-build
 
 FROM debian:stable-slim@sha256:4255c9f8a4d6e66488adc0c2084c99df44bda22849b21b3afc0e9746e9a0be18
 


### PR DESCRIPTION
### Description

1. Add strict token permissions in Github action workflows. https://github.com/DependencyTrack/dependency-track/pull/3104
2. Add Java 21 JRE in container images. https://github.com/DependencyTrack/dependency-track/pull/3089

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/983

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
