### PR TITLE
Fix partial `license` objects being returned by `/api/v1/component` for components with unresolved license

### DIFF
--- a/src/main/java/org/dependencytrack/model/sqlmapping/ComponentProjection.java
+++ b/src/main/java/org/dependencytrack/model/sqlmapping/ComponentProjection.java
@@ -217,23 +217,22 @@ public class ComponentProjection {
         project.setVersion(result.projectVersion);
         componentPersistent.setProject(project);
 
-        var license = new License();
-        license.setName(result.licenseName);
         if (result.licenseUuid != null) {
+            final var license = new License();
             license.setUuid(UUID.fromString(result.licenseUuid));
+            license.setLicenseId(result.licenseId);
+            license.setName(result.licenseName);
+            if (result.isCustomLicense != null) {
+                license.setCustomLicense(result.isCustomLicense);
+            }
+            if (result.isFsfLibre != null) {
+                license.setFsfLibre(result.isFsfLibre);
+            }
+            if (result.isOsiApproved != null) {
+                license.setOsiApproved(result.isOsiApproved);
+            }
+            componentPersistent.setResolvedLicense(license);
         }
-        if (result.isCustomLicense != null) {
-            license.setCustomLicense(result.isCustomLicense);
-        }
-        if (result.isFsfLibre != null) {
-            license.setFsfLibre(result.isFsfLibre);
-        }
-        license.setLicenseId(result.licenseId);
-        if (result.isOsiApproved != null) {
-            license.setOsiApproved(result.isOsiApproved);
-        }
-        license.setName(result.licenseName);
-        componentPersistent.setResolvedLicense(license);
 
         var componentMetaInformation = new ComponentMetaInformation(result.publishedAt,
                 result.integrityCheckStatus != null ? IntegrityMatchStatus.valueOf(result.integrityCheckStatus) : null,


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes partial `license` objects being returned by `/api/v1/component` for components with unresolved license.

This caused licenses to be displayed as `unresolved` in the UI, even though no resolved license exists at all.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Before:

![Screenshot 2024-02-15 at 00 32 20](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/0b0f7855-7384-487b-8a5b-e909b1f14ccd)

After:

![Screenshot 2024-02-15 at 00 30 56](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/8597ebd8-5ff3-4271-9938-99a1966f87e7)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
