### PR TITLE
Remove unnecessary length constraints from VARCHAR(N) columns

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -118,7 +118,6 @@ public class Component implements Serializable {
 
     @Persistent
     @Column(name = "PUBLISHER", jdbcType = "VARCHAR")
-    @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The publisher may only contain printable characters")
     private String publisher;
 
@@ -130,7 +129,6 @@ public class Component implements Serializable {
     @Persistent
     @Column(name = "GROUP", jdbcType = "VARCHAR")
     @Index(name = "COMPONENT_GROUP_IDX")
-    @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The group may only contain printable characters")
     private String group;
 
@@ -138,7 +136,6 @@ public class Component implements Serializable {
     @Column(name = "NAME", jdbcType = "VARCHAR", allowsNull = "false")
     @Index(name = "COMPONENT_NAME_IDX")
     @NotBlank
-    @Size(min = 1, max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The name may only contain printable characters")
     private String name;
@@ -158,7 +155,6 @@ public class Component implements Serializable {
 
     @Persistent
     @Column(name = "FILENAME", jdbcType = "VARCHAR")
-    @Size(max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.FS_DIRECTORY_NAME, message = "The specified filename is not valid and cannot be used as a filename")
     private String filename;
@@ -253,7 +249,6 @@ public class Component implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Index(name = "COMPONENT_PURL_IDX")
     @Column(name = "PURL", jdbcType = "VARCHAR", length = 1024)
-    @Size(max = 1024)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String purl;
@@ -278,22 +273,19 @@ public class Component implements Serializable {
     private Boolean internal;
 
     @Persistent
-    @Column(name = "DESCRIPTION", jdbcType = "VARCHAR", length = 1024)
-    @Size(max = 1024)
+    @Column(name = "DESCRIPTION", jdbcType = "VARCHAR")
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The description may only contain printable characters")
     private String description;
 
     @Persistent
-    @Column(name = "COPYRIGHT", jdbcType = "VARCHAR", length = 1024)
-    @Size(max = 1024)
+    @Column(name = "COPYRIGHT", jdbcType = "VARCHAR")
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The copyright may only contain printable characters")
     private String copyright;
 
     @Persistent
     @Column(name = "LICENSE", jdbcType = "VARCHAR")
-    @Size(max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The license may only contain printable characters")
     private String license;
@@ -306,7 +298,6 @@ public class Component implements Serializable {
 
     @Persistent
     @Column(name = "LICENSE_URL", jdbcType = "VARCHAR")
-    @Size(max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.URL, message = "The license URL must be a valid URL")
     private String licenseUrl;

--- a/src/main/java/org/dependencytrack/model/Cwe.java
+++ b/src/main/java/org/dependencytrack/model/Cwe.java
@@ -59,7 +59,6 @@ public class Cwe implements Serializable {
 
     @Persistent
     @Column(name = "NAME", jdbcType = "VARCHAR", allowsNull = "false")
-    @Size(max = 255)
     @NotNull
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The name may only contain printable characters")

--- a/src/main/resources/migration/changelog-v5.3.0.xml
+++ b/src/main/resources/migration/changelog-v5.3.0.xml
@@ -2494,4 +2494,17 @@
             <column name="MANUFACTURER" type="TEXT"/>
         </addColumn>
     </changeSet>
+
+    <changeSet id="v5.3.0-16" author="sahibamittal">
+        <modifyDataType  columnName="PUBLISHER" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="NAME" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="GROUP" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="FILENAME" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="PURL" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="DESCRIPTION" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="COPYRIGHT" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="LICENSE" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="LICENSE_URL" newDataType="TEXT" tableName="COMPONENT"/>
+        <modifyDataType  columnName="NAME" newDataType="TEXT" tableName="CWE"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

Create a database migration that converts VARCHAR(N) columns to TEXT to lift the artificial length constraints.
Keep the constraints for columns where the maximum value length is known, e.g. SHA256.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/1077 

### Checklist

- [ ] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
