### PR TITLE
Ingest `metadata.tools` and make it available in CEL policies

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -23,6 +23,7 @@ import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.github.packageurl.MalformedPackageURLException;
@@ -114,17 +115,20 @@ public class Component implements Serializable {
     @Persistent
     @Column(name = "AUTHOR", jdbcType = "CLOB")
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The author may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String author;
 
     @Persistent
     @Column(name = "PUBLISHER", jdbcType = "VARCHAR")
     @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The publisher may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String publisher;
 
     @Persistent(defaultFetchGroup = "true")
     @Convert(OrganizationalEntityJsonConverter.class)
     @Column(name = "SUPPLIER", jdbcType = "CLOB", allowsNull = "true")
+    @JsonView(JsonViews.MetadataTools.class)
     private OrganizationalEntity supplier;
 
     @Persistent
@@ -132,6 +136,7 @@ public class Component implements Serializable {
     @Index(name = "COMPONENT_GROUP_IDX")
     @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The group may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String group;
 
     @Persistent
@@ -141,6 +146,7 @@ public class Component implements Serializable {
     @Size(min = 1, max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The name may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String name;
 
     @Persistent
@@ -148,12 +154,14 @@ public class Component implements Serializable {
     @Size(max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The version may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String version;
 
     @Persistent
     @Column(name = "CLASSIFIER", jdbcType = "VARCHAR")
     @Index(name = "COMPONENT_CLASSIFIER_IDX")
     @Extension(vendorName = "datanucleus", key = "enum-check-constraint", value = "true")
+    @JsonView(JsonViews.MetadataTools.class)
     private Classifier classifier;
 
     @Persistent
@@ -174,72 +182,84 @@ public class Component implements Serializable {
     @Index(name = "COMPONENT_MD5_IDX")
     @Column(name = "MD5", jdbcType = "VARCHAR", length = 32)
     @Pattern(regexp = "^[0-9a-fA-F]{32}$", message = "The MD5 hash must be a valid 32 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String md5;
 
     @Persistent
     @Index(name = "COMPONENT_SHA1_IDX")
     @Column(name = "SHA1", jdbcType = "VARCHAR", length = 40)
     @Pattern(regexp = "^[0-9a-fA-F]{40}$", message = "The SHA1 hash must be a valid 40 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha1;
 
     @Persistent
     @Index(name = "COMPONENT_SHA256_IDX")
     @Column(name = "SHA_256", jdbcType = "VARCHAR", length = 64)
     @Pattern(regexp = "^[0-9a-fA-F]{64}$", message = "The SHA-256 hash must be a valid 64 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha256;
 
     @Persistent
     @Index(name = "COMPONENT_SHA384_IDX")
     @Column(name = "SHA_384", jdbcType = "VARCHAR", length = 96)
     @Pattern(regexp = "^[0-9a-fA-F]{96}$", message = "The SHA-384 hash must be a valid 96 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha384;
 
     @Persistent
     @Index(name = "COMPONENT_SHA512_IDX")
     @Column(name = "SHA_512", jdbcType = "VARCHAR", length = 128)
     @Pattern(regexp = "^[0-9a-fA-F]{128}$", message = "The SHA-512 hash must be a valid 128 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha512;
 
     @Persistent
     @Index(name = "COMPONENT_SHA3_256_IDX")
     @Column(name = "SHA3_256", jdbcType = "VARCHAR", length = 64)
     @Pattern(regexp = "^[0-9a-fA-F]{64}$", message = "The SHA3-256 hash must be a valid 64 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha3_256;
 
     @Persistent
     @Index(name = "COMPONENT_SHA3_384_IDX")
     @Column(name = "SHA3_384", jdbcType = "VARCHAR", length = 96)
     @Pattern(regexp = "^[0-9a-fA-F]{96}$", message = "The SHA3-384 hash must be a valid 96 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha3_384;
 
     @Persistent
     @Index(name = "COMPONENT_SHA3_512_IDX")
     @Column(name = "SHA3_512", jdbcType = "VARCHAR", length = 128)
     @Pattern(regexp = "^[0-9a-fA-F]{128}$", message = "The SHA3-512 hash must be a valid 128 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String sha3_512;
 
     @Persistent
     @Index(name = "COMPONENT_BLAKE2B_256_IDX")
     @Column(name = "BLAKE2B_256", jdbcType = "VARCHAR", length = 64)
     @Pattern(regexp = RegexSequence.Definition.HASH_SHA256, message = "The BLAKE2b hash must be a valid 64 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String blake2b_256;
 
     @Persistent
     @Index(name = "COMPONENT_BLAKE2B_384_IDX")
     @Column(name = "BLAKE2B_384", jdbcType = "VARCHAR", length = 96)
     @Pattern(regexp = RegexSequence.Definition.HASH_SHA384, message = "The BLAKE2b hash must be a valid 96 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String blake2b_384;
 
     @Persistent
     @Index(name = "COMPONENT_BLAKE2B_512_IDX")
     @Column(name = "BLAKE2B_512", jdbcType = "VARCHAR", length = 128)
     @Pattern(regexp = RegexSequence.Definition.HASH_SHA512, message = "The BLAKE2b hash must be a valid 128 character HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String blake2b_512;
 
     @Persistent
     @Index(name = "COMPONENT_BLAKE3_IDX")
     @Column(name = "BLAKE3", jdbcType = "VARCHAR", length = 255)
     @Pattern(regexp = RegexSequence.Definition.HEXADECIMAL, message = "The BLAKE3 hash must be a valid HEX number")
+    @JsonView(JsonViews.MetadataTools.class)
     private String blake3;
 
     @Persistent
@@ -248,6 +268,7 @@ public class Component implements Serializable {
     @Size(max = 255)
     //Patterns obtained from https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd
     @Pattern(regexp = "(cpe:2\\.3:[aho\\*\\-](:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#$$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|}~]))+(\\?*|\\*?))|[\\*\\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\\*\\-]))(:(((\\?*|\\*?)([a-zA-Z0-9\\-\\._]|(\\\\[\\\\\\*\\?!\"#$$%&'\\(\\)\\+,/:;<=>@\\[\\]\\^`\\{\\|}~]))+(\\?*|\\*?))|[\\*\\-])){4})|([c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\\._\\-~%]*){0,6})", message = "The CPE must conform to the CPE v2.2 or v2.3 specification defined by NIST")
+    @JsonView(JsonViews.MetadataTools.class)
     private String cpe;
 
     @Persistent(defaultFetchGroup = "true")
@@ -256,6 +277,7 @@ public class Component implements Serializable {
     @Size(max = 1024)
     @com.github.packageurl.validator.PackageURL
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String purl;
 
     @Persistent(defaultFetchGroup = "true")
@@ -270,6 +292,7 @@ public class Component implements Serializable {
     @Index(name = "COMPONENT_SWID_TAGID_IDX")
     @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The SWID tagId may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String swidTagId;
 
     @Persistent
@@ -323,6 +346,7 @@ public class Component implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "EXTERNAL_REFERENCES")
     @Serialized
+    @JsonView(JsonViews.MetadataTools.class)
     private List<ExternalReference> externalReferences;
 
     @Persistent

--- a/src/main/java/org/dependencytrack/model/DataClassification.java
+++ b/src/main/java/org/dependencytrack/model/DataClassification.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 
 import java.io.Serializable;
 
@@ -50,7 +51,10 @@ public class DataClassification implements Serializable {
         }
     }
 
+    @JsonView(JsonViews.MetadataTools.class)
     private Direction direction;
+
+    @JsonView(JsonViews.MetadataTools.class)
     private String name;
 
     public Direction getDirection() {

--- a/src/main/java/org/dependencytrack/model/ExternalReference.java
+++ b/src/main/java/org/dependencytrack/model/ExternalReference.java
@@ -21,6 +21,7 @@ package org.dependencytrack.model;
 import alpine.common.validation.RegexSequence;
 import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import javax.validation.constraints.NotBlank;
@@ -38,14 +39,17 @@ public class ExternalReference implements Serializable {
 
     private static final long serialVersionUID = -5885851731192037664L;
 
+    @JsonView(JsonViews.MetadataTools.class)
     private org.cyclonedx.model.ExternalReference.Type type;
 
     @NotBlank
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String url;
 
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The comment may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String comment;
 
     public org.cyclonedx.model.ExternalReference.Type getType() {

--- a/src/main/java/org/dependencytrack/model/JsonViews.java
+++ b/src/main/java/org/dependencytrack/model/JsonViews.java
@@ -1,0 +1,16 @@
+package org.dependencytrack.model;
+
+import com.fasterxml.jackson.annotation.JsonView;
+
+/**
+ * Marker interfaces to be used in conjunction with Jackson's {@link JsonView} annotation.
+ */
+public class JsonViews {
+
+    /**
+     * Marks fields to be included when (de-)serializing {@link Tools}.
+     */
+    public interface MetadataTools {
+    }
+
+}

--- a/src/main/java/org/dependencytrack/model/OrganizationalContact.java
+++ b/src/main/java/org/dependencytrack/model/OrganizationalContact.java
@@ -20,6 +20,7 @@ package org.dependencytrack.model;
 
 import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.io.Serializable;
@@ -37,12 +38,15 @@ public class OrganizationalContact implements Serializable {
     private static final long serialVersionUID = -1026863376484187244L;
 
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String name;
 
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String email;
 
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String phone;
 
     public String getName() {

--- a/src/main/java/org/dependencytrack/model/OrganizationalEntity.java
+++ b/src/main/java/org/dependencytrack/model/OrganizationalEntity.java
@@ -21,6 +21,7 @@ package org.dependencytrack.model;
 import alpine.server.json.TrimmedStringArrayDeserializer;
 import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import java.io.Serializable;
@@ -41,11 +42,14 @@ public class OrganizationalEntity implements Serializable {
     private static final long serialVersionUID = 5333594855427723634L;
 
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String name;
 
     @JsonDeserialize(using = TrimmedStringArrayDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String[] urls;
 
+    @JsonView(JsonViews.MetadataTools.class)
     private List<OrganizationalContact> contacts;
 
     public String getName() {

--- a/src/main/java/org/dependencytrack/model/ProjectMetadata.java
+++ b/src/main/java/org/dependencytrack/model/ProjectMetadata.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.dependencytrack.persistence.converter.OrganizationalContactsJsonConverter;
 import org.dependencytrack.persistence.converter.OrganizationalEntityJsonConverter;
+import org.dependencytrack.persistence.converter.ToolsJsonConverter;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
@@ -66,6 +67,11 @@ public class ProjectMetadata {
     @Column(name = "AUTHORS", jdbcType = "CLOB", allowsNull = "true")
     private List<OrganizationalContact> authors;
 
+    @Persistent(defaultFetchGroup = "true")
+    @Convert(ToolsJsonConverter.class)
+    @Column(name = "TOOLS", jdbcType = "CLOB", allowsNull = "true")
+    private Tools tools;
+
     public long getId() {
         return id;
     }
@@ -96,6 +102,14 @@ public class ProjectMetadata {
 
     public void setAuthors(final List<OrganizationalContact> authors) {
         this.authors = authors;
+    }
+
+    public Tools getTools() {
+        return tools;
+    }
+
+    public void setTools(final Tools tools) {
+        this.tools = tools;
     }
 
 }

--- a/src/main/java/org/dependencytrack/model/ServiceComponent.java
+++ b/src/main/java/org/dependencytrack/model/ServiceComponent.java
@@ -23,6 +23,7 @@ import alpine.server.json.TrimmedStringArrayDeserializer;
 import alpine.server.json.TrimmedStringDeserializer;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 import javax.jdo.annotations.Column;
@@ -86,12 +87,14 @@ public class ServiceComponent implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "PROVIDER_ID")
     @Serialized
+    @JsonView(JsonViews.MetadataTools.class)
     private OrganizationalEntity provider;
 
     @Persistent
     @Column(name = "GROUP", jdbcType = "VARCHAR")
     @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The group may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String group;
 
     @Persistent
@@ -100,6 +103,7 @@ public class ServiceComponent implements Serializable {
     @Size(min = 1, max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The name may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String name;
 
     @Persistent
@@ -107,6 +111,7 @@ public class ServiceComponent implements Serializable {
     @Size(max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The version may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String version;
 
     @Persistent
@@ -114,25 +119,30 @@ public class ServiceComponent implements Serializable {
     @Size(max = 1024)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The description may only contain printable characters")
+    @JsonView(JsonViews.MetadataTools.class)
     private String description;
 
     @Persistent(defaultFetchGroup = "true")
     @Serialized
     @Column(name = "ENDPOINTS", jdbcType = "LONGVARBINARY")
     @JsonDeserialize(using = TrimmedStringArrayDeserializer.class)
+    @JsonView(JsonViews.MetadataTools.class)
     private String[] endpoints;
 
     @Persistent
     @Column(name = "AUTHENTICATED")
+    @JsonView(JsonViews.MetadataTools.class)
     private Boolean authenticated;
 
     @Persistent
     @Column(name = "X_TRUST_BOUNDARY")
+    @JsonView(JsonViews.MetadataTools.class)
     private Boolean crossesTrustBoundary;
 
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "DATA")
     @Serialized
+    @JsonView(JsonViews.MetadataTools.class)
     private List<DataClassification> data;
 
     //TODO add license support once Component license support is refactored
@@ -140,6 +150,7 @@ public class ServiceComponent implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "EXTERNAL_REFERENCES")
     @Serialized
+    @JsonView(JsonViews.MetadataTools.class)
     private List<ExternalReference> externalReferences;
 
     @Persistent

--- a/src/main/java/org/dependencytrack/model/Tools.java
+++ b/src/main/java/org/dependencytrack/model/Tools.java
@@ -1,0 +1,12 @@
+package org.dependencytrack.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonView;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public record Tools(
+        @JsonView(JsonViews.MetadataTools.class) List<Component> components,
+        @JsonView(JsonViews.MetadataTools.class) List<ServiceComponent> services) {
+}

--- a/src/main/java/org/dependencytrack/model/mapping/PolicyProtoMapper.java
+++ b/src/main/java/org/dependencytrack/model/mapping/PolicyProtoMapper.java
@@ -2,6 +2,9 @@ package org.dependencytrack.model.mapping;
 
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.License;
+import org.dependencytrack.model.LicenseGroup;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
 
@@ -19,6 +22,43 @@ import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
  * Utility class to map objects from Dependency-Track's internal data model to Policy protocol buffers.
  */
 public class PolicyProtoMapper {
+
+    public static org.dependencytrack.proto.policy.v1.Component mapToProto(final Component component) {
+        if (component == null) {
+            return org.dependencytrack.proto.policy.v1.Component.getDefaultInstance();
+        }
+
+        // An object attached to a persistence context could do lazy loading of fields when accessing them.
+        // Ensure this can't happen, as it could cause massive performance degradation.
+        assertNonPersistent(component, "component must not be persistent");
+
+        final org.dependencytrack.proto.policy.v1.Component.Builder protoBuilder =
+                org.dependencytrack.proto.policy.v1.Component.newBuilder();
+        maybeSet(asString(component.getUuid()), protoBuilder::setUuid);
+        maybeSet(component::getGroup, protoBuilder::setGroup);
+        maybeSet(component::getName, protoBuilder::setName);
+        maybeSet(component::getVersion, protoBuilder::setVersion);
+        maybeSet(asString(component.getClassifier()), protoBuilder::setClassifier);
+        maybeSet(component::getCpe, protoBuilder::setCpe);
+        maybeSet(component::getPurl, purl -> protoBuilder.setPurl(purl.canonicalize()));
+        maybeSet(component::getSwidTagId, protoBuilder::setSwidTagId);
+        maybeSet(component::isInternal, protoBuilder::setIsInternal);
+        maybeSet(component::getMd5, protoBuilder::setMd5);
+        maybeSet(component::getSha1, protoBuilder::setSha1);
+        maybeSet(component::getSha256, protoBuilder::setSha256);
+        maybeSet(component::getSha384, protoBuilder::setSha384);
+        maybeSet(component::getSha512, protoBuilder::setSha512);
+        maybeSet(component::getSha3_256, protoBuilder::setSha3256);
+        maybeSet(component::getSha3_384, protoBuilder::setSha3384);
+        maybeSet(component::getSha3_512, protoBuilder::setSha3512);
+        maybeSet(component::getBlake2b_256, protoBuilder::setBlake2B256);
+        maybeSet(component::getBlake2b_384, protoBuilder::setBlake2B384);
+        maybeSet(component::getBlake2b_512, protoBuilder::setBlake2B512);
+        maybeSet(component::getBlake3, protoBuilder::setBlake3);
+        maybeSet(component::getResolvedLicense, license -> protoBuilder.setResolvedLicense(mapToProto(license)));
+
+        return protoBuilder.build();
+    }
 
     public static org.dependencytrack.proto.policy.v1.Vulnerability mapToProto(final Vulnerability vuln) {
         if (vuln == null) {
@@ -58,6 +98,46 @@ public class PolicyProtoMapper {
         maybeSet(asDouble(vuln.getEpssScore()), protoBuilder::setEpssScore);
         maybeSet(asDouble(vuln.getEpssPercentile()), protoBuilder::setEpssPercentile);
 
+        return protoBuilder.build();
+    }
+
+    private static org.dependencytrack.proto.policy.v1.License mapToProto(final License license) {
+        if (license == null) {
+            return org.dependencytrack.proto.policy.v1.License.getDefaultInstance();
+        }
+
+        // An object attached to a persistence context could do lazy loading of fields when accessing them.
+        // Ensure this can't happen, as it could cause massive performance degradation.
+        assertNonPersistent(license, "license must not be persistent");
+
+        final org.dependencytrack.proto.policy.v1.License.Builder protoBuilder =
+                org.dependencytrack.proto.policy.v1.License.newBuilder();
+        maybeSet(asString(license.getUuid()), protoBuilder::setUuid);
+        maybeSet(license::getLicenseId, protoBuilder::setId);
+        maybeSet(license::getName, protoBuilder::setName);
+        maybeSet(license::isOsiApproved, protoBuilder::setIsOsiApproved);
+        maybeSet(license::isFsfLibre, protoBuilder::setIsFsfLibre);
+        maybeSet(license::isDeprecatedLicenseId, protoBuilder::setIsDeprecatedId);
+        maybeSet(license::isCustomLicense, protoBuilder::setIsCustom);
+        maybeSet(license::getLicenseGroups, licenseGroups -> licenseGroups.stream()
+                .map(PolicyProtoMapper::mapToProto).forEach(protoBuilder::addGroups));
+
+        return protoBuilder.build();
+    }
+
+    private static org.dependencytrack.proto.policy.v1.License.Group mapToProto(final LicenseGroup licenseGroup) {
+        if (licenseGroup == null) {
+            return org.dependencytrack.proto.policy.v1.License.Group.getDefaultInstance();
+        }
+
+        // An object attached to a persistence context could do lazy loading of fields when accessing them.
+        // Ensure this can't happen, as it could cause massive performance degradation.
+        assertNonPersistent(licenseGroup, "licenseGroup must not be persistent");
+
+        final org.dependencytrack.proto.policy.v1.License.Group.Builder protoBuilder =
+                org.dependencytrack.proto.policy.v1.License.Group.newBuilder();
+        maybeSet(asString(licenseGroup.getUuid()), protoBuilder::setUuid);
+        maybeSet(licenseGroup::getName, protoBuilder::setName);
         return protoBuilder.build();
     }
 

--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -27,6 +27,7 @@ import org.cyclonedx.model.Hash;
 import org.cyclonedx.model.LicenseChoice;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.Swid;
+import org.cyclonedx.model.Tool;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
@@ -43,6 +44,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectMetadata;
 import org.dependencytrack.model.ServiceComponent;
 import org.dependencytrack.model.Severity;
+import org.dependencytrack.model.Tools;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.parser.cyclonedx.CycloneDXExporter;
@@ -83,14 +85,49 @@ public class ModelConverter {
     }
 
     public static ProjectMetadata convertToProjectMetadata(final Metadata cdxMetadata) {
+        if (cdxMetadata == null) {
+            return null;
+        }
+
         final var projectMetadata = new ProjectMetadata();
         projectMetadata.setSupplier(ModelConverter.convert(cdxMetadata.getSupplier()));
         projectMetadata.setAuthors(ModelConverter.convertCdxContacts(cdxMetadata.getAuthors()));
+
+        final var toolComponents = new ArrayList<Component>();
+        final var toolServices = new ArrayList<ServiceComponent>();
+        if (cdxMetadata.getTools() != null) {
+            cdxMetadata.getTools().stream().map(ModelConverter::convert).forEach(toolComponents::add);
+        }
+        if (cdxMetadata.getToolChoice() != null) {
+            if (cdxMetadata.getToolChoice().getComponents() != null) {
+                cdxMetadata.getToolChoice().getComponents().stream().map(ModelConverter::convertComponent).forEach(toolComponents::add);
+            }
+            if (cdxMetadata.getToolChoice().getServices() != null) {
+                cdxMetadata.getToolChoice().getServices().stream().map(ModelConverter::convertService).forEach(toolServices::add);
+            }
+        }
+        if (!toolComponents.isEmpty() || !toolServices.isEmpty()) {
+            projectMetadata.setTools(new Tools(
+                    toolComponents.isEmpty() ? null : toolComponents,
+                    toolServices.isEmpty() ? null : toolServices
+            ));
+        }
+
         return projectMetadata;
     }
 
-    public static Project convertToProject(final Metadata cdxMetadata, final ProjectMetadata projectMetadata) {
-        final var cdxComponent = cdxMetadata.getComponent();
+    public static Project convertToProject(final org.cyclonedx.model.Metadata cdxMetadata) {
+        if (cdxMetadata == null || cdxMetadata.getComponent() == null) {
+            return null;
+        }
+
+        final Project project = convertToProject(cdxMetadata.getComponent());
+        project.setManufacturer(convert(cdxMetadata.getManufacture()));
+
+        return project;
+    }
+
+    public static Project convertToProject(final org.cyclonedx.model.Component cdxComponent) {
         final var project = new Project();
         project.setAuthor(trimToNull(cdxComponent.getAuthor()));
         project.setPublisher(trimToNull(cdxComponent.getPublisher()));
@@ -100,9 +137,7 @@ public class ModelConverter {
         project.setVersion(trimToNull(cdxComponent.getVersion()));
         project.setDescription(trimToNull(cdxComponent.getDescription()));
         project.setExternalReferences(convertExternalReferences(cdxComponent.getExternalReferences()));
-        project.setManufacturer(ModelConverter.convert(cdxMetadata.getManufacture()));
         project.setSupplier(ModelConverter.convert(cdxComponent.getSupplier()));
-        project.setMetadata(projectMetadata);
 
         if (cdxComponent.getPurl() != null) {
             try {
@@ -224,6 +259,47 @@ public class ModelConverter {
             }
 
             component.setChildren(children);
+        }
+
+        return component;
+    }
+
+    private static Component convert(@SuppressWarnings("deprecation") final Tool tool) {
+        if (tool == null) {
+            return null;
+        }
+
+        final var component = new Component();
+        if (tool.getVendor() != null && !tool.getVendor().isBlank()) {
+            final var supplier = new OrganizationalEntity();
+            supplier.setName(trimToNull(tool.getVendor()));
+            component.setSupplier(supplier);
+        }
+        component.setName(trimToNull(tool.getName()));
+        component.setVersion(trimToNull(tool.getVersion()));
+        component.setExternalReferences(convertExternalReferences(tool.getExternalReferences()));
+
+        if (tool.getHashes() != null && !tool.getHashes().isEmpty()) {
+            for (final org.cyclonedx.model.Hash cdxHash : tool.getHashes()) {
+                final Consumer<String> hashSetter = switch (cdxHash.getAlgorithm().toLowerCase()) {
+                    case "md5" -> component::setMd5;
+                    case "sha-1" -> component::setSha1;
+                    case "sha-256" -> component::setSha256;
+                    case "sha-384" -> component::setSha384;
+                    case "sha-512" -> component::setSha512;
+                    case "sha3-256" -> component::setSha3_256;
+                    case "sha3-384" -> component::setSha3_384;
+                    case "sha3-512" -> component::setSha3_512;
+                    case "blake2b-256" -> component::setBlake2b_256;
+                    case "blake2b-384" -> component::setBlake2b_384;
+                    case "blake2b-512" -> component::setBlake2b_512;
+                    case "blake3" -> component::setBlake3;
+                    default -> null;
+                };
+                if (hashSetter != null) {
+                    hashSetter.accept(cdxHash.getValue());
+                }
+            }
         }
 
         return component;

--- a/src/main/java/org/dependencytrack/persistence/converter/ToolsJsonConverter.java
+++ b/src/main/java/org/dependencytrack/persistence/converter/ToolsJsonConverter.java
@@ -1,0 +1,25 @@
+package org.dependencytrack.persistence.converter;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.dependencytrack.model.JsonViews;
+import org.dependencytrack.model.Tools;
+
+public class ToolsJsonConverter extends AbstractJsonConverter<Tools> {
+
+    public ToolsJsonConverter() {
+        super(new TypeReference<>() {}, JsonViews.MetadataTools.class);
+    }
+
+    @Override
+    public String convertToDatastore(final Tools attributeValue) {
+        // Overriding is required for DataNucleus to correctly detect the return type.
+        return super.convertToDatastore(attributeValue);
+    }
+
+    @Override
+    public Tools convertToAttribute(final String datastoreValue) {
+        // Overriding is required for DataNucleus to correctly detect the return type.
+        return super.convertToAttribute(datastoreValue);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -10,6 +10,7 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.proto.policy.v1.Component;
 import org.dependencytrack.proto.policy.v1.License;
 import org.dependencytrack.proto.policy.v1.Project;
+import org.dependencytrack.proto.policy.v1.Tools;
 import org.dependencytrack.proto.policy.v1.VersionDistance;
 import org.dependencytrack.proto.policy.v1.Vulnerability;
 import org.jdbi.v3.core.Handle;
@@ -128,7 +129,9 @@ public class CelCommonPolicyLibrary implements Library {
                         License.getDefaultInstance(),
                         License.Group.getDefaultInstance(),
                         Project.getDefaultInstance(),
+                        Project.Metadata.getDefaultInstance(),
                         Project.Property.getDefaultInstance(),
+                        Tools.getDefaultInstance(),
                         Vulnerability.getDefaultInstance(),
                         Vulnerability.Alias.getDefaultInstance(),
                         VersionDistance.getDefaultInstance()

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyEngine.java
@@ -42,8 +42,6 @@ import org.dependencytrack.policy.cel.compat.VersionDistanceCelScriptBuilder;
 import org.dependencytrack.policy.cel.compat.VulnerabilityIdCelPolicyScriptSourceBuilder;
 import org.dependencytrack.policy.cel.mapping.ComponentProjection;
 import org.dependencytrack.policy.cel.mapping.LicenseProjection;
-import org.dependencytrack.policy.cel.mapping.ProjectProjection;
-import org.dependencytrack.policy.cel.mapping.ProjectPropertyProjection;
 import org.dependencytrack.policy.cel.mapping.VulnerabilityProjection;
 import org.dependencytrack.policy.cel.persistence.CelPolicyDao;
 import org.dependencytrack.proto.policy.v1.Vulnerability;
@@ -381,52 +379,6 @@ public class CelPolicyEngine {
                 })
                 .filter(Objects::nonNull)
                 .toList();
-    }
-
-    private static org.dependencytrack.proto.policy.v1.Project mapToProto(final ProjectProjection projection) {
-        final org.dependencytrack.proto.policy.v1.Project.Builder builder = org.dependencytrack.proto.policy.v1.Project.newBuilder()
-                .setUuid(trimToEmpty(projection.uuid))
-                .setGroup(trimToEmpty(projection.group))
-                .setName(trimToEmpty(projection.name))
-                .setVersion(trimToEmpty(projection.version))
-                .setClassifier(trimToEmpty(projection.classifier))
-                .setCpe(trimToEmpty(projection.cpe))
-                .setPurl(trimToEmpty(projection.purl))
-                .setSwidTagId(trimToEmpty(projection.swidTagId));
-        Optional.ofNullable(projection.isActive).ifPresent(builder::setIsActive);
-        Optional.ofNullable(projection.lastBomImport).map(Timestamps::fromDate).ifPresent(builder::setLastBomImport);
-
-        if (projection.propertiesJson != null) {
-            try {
-                final List<ProjectPropertyProjection> properties =
-                        OBJECT_MAPPER.readValue(projection.propertiesJson, new TypeReference<>() {
-                        });
-                for (final ProjectPropertyProjection property : properties) {
-                    builder.addProperties(org.dependencytrack.proto.policy.v1.Project.Property.newBuilder()
-                            .setGroup(trimToEmpty(property.group))
-                            .setName(trimToEmpty(property.name))
-                            .setValue(trimToEmpty(property.value))
-                            .setType(trimToEmpty(property.type))
-                            .build());
-                }
-            } catch (JacksonException e) {
-                LOGGER.warn("Failed to parse properties from %s for project %s"
-                        .formatted(projection.propertiesJson, projection.id), e);
-            }
-        }
-
-        if (projection.tagsJson != null) {
-            try {
-                final List<String> tags = OBJECT_MAPPER.readValue(projection.tagsJson, new TypeReference<>() {
-                });
-                builder.addAllTags(tags);
-            } catch (JacksonException e) {
-                LOGGER.warn("Failed to parse tags from %s for project %s"
-                        .formatted(projection.tagsJson, projection.id), e);
-            }
-        }
-
-        return builder.build();
     }
 
     private static org.dependencytrack.proto.policy.v1.Component mapToProto(final ComponentProjection projection,

--- a/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
@@ -41,6 +41,7 @@ import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMP
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_LICENSE;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_LICENSE_GROUP;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
+import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT_METADATA;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT_PROPERTY;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_VULNERABILITY;
 
@@ -280,6 +281,11 @@ public class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolicyEvalu
         if (cacheKeyParts.contains("properties") && requirements.containsKey(TYPE_PROJECT_PROPERTY)) {
             for (final String propertyFieldName : requirements.get(TYPE_PROJECT_PROPERTY)) {
                 cacheKeyParts.add("property.%s".formatted(propertyFieldName));
+            }
+        }
+        if (cacheKeyParts.contains("metadata") && requirements.containsKey(TYPE_PROJECT_METADATA)) {
+            for (final String metadataFieldName : requirements.get(TYPE_PROJECT_METADATA)) {
+                cacheKeyParts.add("metadata.%s".formatted(metadataFieldName));
             }
         }
 

--- a/src/main/java/org/dependencytrack/policy/cel/definition/CelPolicyTypes.java
+++ b/src/main/java/org/dependencytrack/policy/cel/definition/CelPolicyTypes.java
@@ -4,6 +4,7 @@ import com.google.api.expr.v1alpha1.Type;
 import org.dependencytrack.proto.policy.v1.Component;
 import org.dependencytrack.proto.policy.v1.License;
 import org.dependencytrack.proto.policy.v1.Project;
+import org.dependencytrack.proto.policy.v1.Tools;
 import org.dependencytrack.proto.policy.v1.Vulnerability;
 import org.dependencytrack.proto.policy.v1.VersionDistance;
 import org.projectnessie.cel.checker.Decls;
@@ -14,7 +15,9 @@ public class CelPolicyTypes {
     public static final Type TYPE_LICENSE = Decls.newObjectType(License.getDescriptor().getFullName());
     public static final Type TYPE_LICENSE_GROUP = Decls.newObjectType(License.Group.getDescriptor().getFullName());
     public static final Type TYPE_PROJECT = Decls.newObjectType(Project.getDescriptor().getFullName());
+    public static final Type TYPE_PROJECT_METADATA = Decls.newObjectType(Project.Metadata.getDescriptor().getFullName());
     public static final Type TYPE_PROJECT_PROPERTY = Decls.newObjectType(Project.Property.getDescriptor().getFullName());
+    public static final Type TYPE_TOOLS = Decls.newObjectType(Tools.getDescriptor().getFullName());
     public static final Type TYPE_VULNERABILITY = Decls.newObjectType(Vulnerability.getDescriptor().getFullName());
     public static final Type TYPE_VULNERABILITIES = Decls.newListType(TYPE_VULNERABILITY);
     public static final Type TYPE_VULNERABILITY_ALIAS = Decls.newObjectType(Vulnerability.Alias.getDescriptor().getFullName());

--- a/src/main/java/org/dependencytrack/policy/cel/mapping/ProjectProjection.java
+++ b/src/main/java/org/dependencytrack/policy/cel/mapping/ProjectProjection.java
@@ -38,7 +38,4 @@ public class ProjectProjection {
     @MappedField(protoFieldName = "last_bom_import", sqlColumnName = "LAST_BOM_IMPORTED")
     public Date lastBomImport;
 
-    public String propertiesJson;
-    public String tagsJson;
-
 }

--- a/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -97,6 +97,11 @@ message Project {
   optional string purl = 10;
   optional string swid_tag_id = 11;
   optional google.protobuf.Timestamp last_bom_import = 12;
+  optional Metadata metadata = 13;
+
+  message Metadata {
+    optional Tools tools = 1;
+  }
 
   message Property {
     string group = 1;
@@ -104,6 +109,13 @@ message Project {
     optional string value = 3;
     string type = 4;
   }
+}
+
+message Tools {
+  // Components used as tools.
+  repeated Component components = 1;
+
+  // TODO: Add services.
 }
 
 message Vulnerability {

--- a/src/main/resources/migration/changelog-v5.4.0.xml
+++ b/src/main/resources/migration/changelog-v5.4.0.xml
@@ -8,8 +8,9 @@
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
             http://www.liquibase.org/xml/ns/dbchangelog
             http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
-    <!-- Use separate changelogs per release. -->
-    <include file="migration/changelog-v5.3.0.xml"/>
-    <include file="migration/changelog-v5.4.0.xml"/>
-    <include file="migration/changelog-procedures.xml"/>
+    <changeSet id="v5.4.0-1" author="nscuro@protonmail.com">
+        <addColumn tableName="PROJECT_METADATA">
+            <column name="TOOLS" type="TEXT"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/model/mapping/PolicyProtoMapperTest.java
+++ b/src/test/java/org/dependencytrack/model/mapping/PolicyProtoMapperTest.java
@@ -112,7 +112,7 @@ public class PolicyProtoMapperTest extends PersistenceCapableTest {
 
     @Test
     public void testMapVulnerabilityToProtoWhenNull() {
-        assertThat(PolicyProtoMapper.mapToProto(null))
+        assertThat(PolicyProtoMapper.mapToProto((Vulnerability) null))
                 .isEqualTo(org.dependencytrack.proto.policy.v1.Vulnerability.getDefaultInstance());
     }
 

--- a/src/test/java/org/dependencytrack/persistence/converter/ToolsJsonConverterTest.java
+++ b/src/test/java/org/dependencytrack/persistence/converter/ToolsJsonConverterTest.java
@@ -1,0 +1,305 @@
+package org.dependencytrack.persistence.converter;
+
+import org.dependencytrack.model.Classifier;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.DataClassification;
+import org.dependencytrack.model.ExternalReference;
+import org.dependencytrack.model.OrganizationalEntity;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ServiceComponent;
+import org.dependencytrack.model.Tools;
+import org.dependencytrack.model.Vulnerability;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ToolsJsonConverterTest {
+
+    @Test
+    public void testConvertToDatastore() {
+        final var project = new Project();
+        project.setName("acme-app");
+
+        final var componentSupplier = new OrganizationalEntity();
+        componentSupplier.setName("componentSupplierName");
+
+        final var externalReference = new ExternalReference();
+        externalReference.setType(org.cyclonedx.model.ExternalReference.Type.DOCUMENTATION);
+        externalReference.setUrl("https://example.com");
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setId(123);
+        component.setUuid(UUID.randomUUID());
+        component.setAuthor("componentAuthor");
+        component.setPublisher("componentPublisher");
+        component.setSupplier(componentSupplier);
+        component.setGroup("componentGroup");
+        component.setName("componentName");
+        component.setVersion("componentVersion");
+        component.setClassifier(Classifier.LIBRARY);
+        component.setFilename("componentFilename");
+        component.setExtension("componentExtension");
+        component.setMd5("componentMd5");
+        component.setSha1("componentSha1");
+        component.setSha256("componentSha256");
+        component.setSha384("componentSha384");
+        component.setSha512("componentSha512");
+        component.setSha3_256("componentSha3_256");
+        component.setSha3_384("componentSha3_384");
+        component.setSha3_512("componentSha3_512");
+        component.setBlake2b_256("componentBlake2b_256");
+        component.setBlake2b_384("componentBlake2b_384");
+        component.setBlake2b_512("componentBlake2b_512");
+        component.setBlake3("componentBlake3");
+        component.setCpe("componentCpe");
+        component.setPurl("pkg:maven/componentGroup/componentName@componentVersion?foo=bar");
+        component.setPurlCoordinates("pkg:maven/componentGroup/componentName@componentVersion");
+        component.setSwidTagId("componentSwidTagId");
+        component.setInternal(true);
+        component.setDescription("componentDescription");
+        component.setCopyright("componentCopyright");
+        component.setLicense("componentLicense");
+        component.setLicenseExpression("componentLicenseExpression");
+        component.setLicenseUrl("componentLicenseUrl");
+        component.setDirectDependencies("componentDirectDependencies");
+        component.setExternalReferences(List.of(externalReference));
+        component.setParent(component);
+        component.setChildren(List.of(component));
+        component.setVulnerabilities(List.of(vuln));
+        component.setLastInheritedRiskScore(10.0);
+        component.setNotes("componentNotes");
+
+        final var serviceProvider = new OrganizationalEntity();
+        serviceProvider.setName("serviceProviderName");
+
+        final var serviceDataClassification = new DataClassification();
+        serviceDataClassification.setDirection(DataClassification.Direction.OUTBOUND);
+        serviceDataClassification.setName("serviceDataClassificationName");
+
+        final var service = new ServiceComponent();
+        service.setProject(project);
+        service.setId(123);
+        service.setUuid(UUID.randomUUID());
+        service.setProvider(serviceProvider);
+        service.setGroup("serviceGroup");
+        service.setName("serviceName");
+        service.setVersion("serviceVersion");
+        service.setDescription("serviceDescription");
+        service.setEndpoints(new String[]{"https://example.com"});
+        service.setAuthenticated(true);
+        service.setCrossesTrustBoundary(true);
+        service.setData(List.of(serviceDataClassification));
+        service.setExternalReferences(List.of(externalReference));
+        service.setParent(service);
+        service.setChildren(List.of(service));
+        service.setVulnerabilities(List.of(vuln));
+        service.setLastInheritedRiskScore(11.0);
+        service.setNotes("serviceNotes");
+
+        assertThatJson(new ToolsJsonConverter().convertToDatastore(new Tools(List.of(component), List.of(service))))
+                .isEqualTo("""
+                        {
+                          "components": [
+                            {
+                               "author": "componentAuthor",
+                               "blake2b_256": "componentBlake2b_256",
+                               "blake2b_384": "componentBlake2b_384",
+                               "blake2b_512": "componentBlake2b_512",
+                               "blake3": "componentBlake3",
+                               "classifier": "LIBRARY",
+                               "cpe": "componentCpe",
+                               "externalReferences": [
+                                 {
+                                   "type": "documentation",
+                                   "url": "https://example.com"
+                                 }
+                               ],
+                               "group": "componentGroup",
+                               "md5": "componentmd5",
+                               "name": "componentName",
+                               "publisher": "componentPublisher",
+                               "purl": "pkg:maven/componentGroup/componentName@componentVersion?foo=bar",
+                               "sha1": "componentsha1",
+                               "sha256": "componentsha256",
+                               "sha384": "componentsha384",
+                               "sha3_256": "componentsha3_256",
+                               "sha3_384": "componentsha3_384",
+                               "sha3_512": "componentsha3_512",
+                               "sha512": "componentsha512",
+                               "supplier": {
+                                 "name": "componentSupplierName"
+                               },
+                               "swidTagId": "componentSwidTagId",
+                               "version": "componentVersion"
+                             }
+                          ],
+                          "services": [
+                            {
+                              "provider": {
+                                "name": "serviceProviderName"
+                              },
+                              "group": "serviceGroup",
+                              "name": "serviceName",
+                              "version": "serviceVersion",
+                              "description": "serviceDescription",
+                              "endpoints": [
+                                "https://example.com"
+                              ],
+                              "authenticated": true,
+                              "crossesTrustBoundary": true,
+                              "data": [
+                                {
+                                  "direction": "OUTBOUND",
+                                  "name": "serviceDataClassificationName"
+                                }
+                              ],
+                              "externalReferences": [
+                                {
+                                  "type": "documentation",
+                                  "url": "https://example.com"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """);
+    }
+
+    @Test
+    public void testConvertToAttribute() {
+        final Tools tools = new ToolsJsonConverter().convertToAttribute("""
+                {
+                  "components": [
+                    {
+                       "author": "componentAuthor",
+                       "blake2b_256": "componentBlake2b_256",
+                       "blake2b_384": "componentBlake2b_384",
+                       "blake2b_512": "componentBlake2b_512",
+                       "blake3": "componentBlake3",
+                       "classifier": "LIBRARY",
+                       "cpe": "componentCpe",
+                       "externalReferences": [
+                         {
+                           "type": "documentation",
+                           "url": "https://example.com"
+                         }
+                       ],
+                       "group": "componentGroup",
+                       "md5": "componentmd5",
+                       "name": "componentName",
+                       "publisher": "componentPublisher",
+                       "purl": "pkg:maven/componentGroup/componentName@componentVersion?foo=bar",
+                       "sha1": "componentsha1",
+                       "sha256": "componentsha256",
+                       "sha384": "componentsha384",
+                       "sha3_256": "componentsha3_256",
+                       "sha3_384": "componentsha3_384",
+                       "sha3_512": "componentsha3_512",
+                       "sha512": "componentsha512",
+                       "supplier": {
+                         "name": "componentSupplierName"
+                       },
+                       "swidTagId": "componentSwidTagId",
+                       "version": "componentVersion"
+                     }
+                  ],
+                  "services": [
+                    {
+                      "provider": {
+                        "name": "serviceProviderName"
+                      },
+                      "group": "serviceGroup",
+                      "name": "serviceName",
+                      "version": "serviceVersion",
+                      "description": "serviceDescription",
+                      "endpoints": [
+                        "https://example.com"
+                      ],
+                      "authenticated": true,
+                      "crossesTrustBoundary": true,
+                      "data": [
+                        {
+                          "direction": "OUTBOUND",
+                          "name": "serviceDataClassificationName"
+                        }
+                      ],
+                      "externalReferences": [
+                        {
+                          "type": "documentation",
+                          "url": "https://example.com"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        assertThat(tools).isNotNull();
+        assertThat(tools.components()).satisfiesExactly(component -> {
+             assertThat(component.getAuthor()).isEqualTo("componentAuthor");
+             assertThat(component.getBlake2b_256()).isEqualTo("componentBlake2b_256");
+             assertThat(component.getBlake2b_384()).isEqualTo("componentBlake2b_384");
+             assertThat(component.getBlake2b_512()).isEqualTo("componentBlake2b_512");
+             assertThat(component.getBlake3()).isEqualTo("componentBlake3");
+             assertThat(component.getClassifier()).isEqualTo(Classifier.LIBRARY);
+             assertThat(component.getCpe()).isEqualTo("componentCpe");
+             assertThat(component.getExternalReferences()).satisfiesExactly(externalReference -> {
+                 assertThat(externalReference.getType()).isEqualTo(org.cyclonedx.model.ExternalReference.Type.DOCUMENTATION);
+                 assertThat(externalReference.getUrl()).isEqualTo("https://example.com");
+             });
+             assertThat(component.getGroup()).isEqualTo("componentGroup");
+             assertThat(component.getMd5()).isEqualTo("componentmd5");
+             assertThat(component.getName()).isEqualTo("componentName");
+             assertThat(component.getPublisher()).isEqualTo("componentPublisher");
+             assertThat(component.getPurl()).asString().isEqualTo("pkg:maven/componentGroup/componentName@componentVersion?foo=bar");
+             assertThat(component.getSha1()).isEqualTo("componentsha1");
+             assertThat(component.getSha256()).isEqualTo("componentsha256");
+             assertThat(component.getSha384()).isEqualTo("componentsha384");
+             assertThat(component.getSha512()).isEqualTo("componentsha512");
+             assertThat(component.getSha3_256()).isEqualTo("componentsha3_256");
+             assertThat(component.getSha3_384()).isEqualTo("componentsha3_384");
+             assertThat(component.getSha3_512()).isEqualTo("componentsha3_512");
+             assertThat(component.getSupplier()).satisfies(supplier -> assertThat(supplier.getName()).isEqualTo("componentSupplierName"));
+             assertThat(component.getSwidTagId()).isEqualTo("componentSwidTagId");
+             assertThat(component.getVersion()).isEqualTo("componentVersion");
+        });
+        assertThat(tools.services()).satisfiesExactly(service -> {
+            assertThat(service.getProvider()).satisfies(provider -> assertThat(provider.getName()).isEqualTo("serviceProviderName"));
+            assertThat(service.getGroup()).isEqualTo("serviceGroup");
+            assertThat(service.getName()).isEqualTo("serviceName");
+            assertThat(service.getVersion()).isEqualTo("serviceVersion");
+            assertThat(service.getDescription()).isEqualTo("serviceDescription");
+            assertThat(service.getEndpoints()).containsOnly("https://example.com");
+            assertThat(service.getAuthenticated()).isTrue();
+            assertThat(service.getCrossesTrustBoundary()).isTrue();
+            assertThat(service.getData()).satisfiesExactly(classification -> {
+                assertThat(classification.getDirection()).isEqualTo(DataClassification.Direction.OUTBOUND);
+                assertThat(classification.getName()).isEqualTo("serviceDataClassificationName");
+            });
+            assertThat(service.getExternalReferences()).satisfiesExactly(externalReference -> {
+                assertThat(externalReference.getType()).isEqualTo(org.cyclonedx.model.ExternalReference.Type.DOCUMENTATION);
+                assertThat(externalReference.getUrl()).isEqualTo("https://example.com");
+            });
+        });
+    }
+
+    @Test
+    public void testConvertToDatastoreNull() {
+        assertThat(new ToolsJsonConverter().convertToDatastore(null)).isNull();
+    }
+
+    @Test
+    public void testConvertToAttributeNull() {
+        assertThat(new ToolsJsonConverter().convertToAttribute(null)).isNull();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -907,6 +907,63 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         assertThat(qm.getAllServiceComponents(project)).isNotEmpty();
     }
 
+    @Test
+    public void informWithBomContainingMetadataToolsDeprecatedTest() throws Exception {
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()), createTempBomFile("bom-metadata-tool-deprecated.json"));
+        qm.createWorkflowSteps(bomUploadEvent.getChainIdentifier());
+        new BomUploadProcessingTask().inform(bomUploadEvent);
+        assertBomProcessedNotification();
+
+        qm.getPersistenceManager().refresh(project);
+        assertThat(project.getMetadata()).isNotNull();
+        assertThat(project.getMetadata().getTools()).isNotNull();
+        assertThat(project.getMetadata().getTools().components()).satisfiesExactly(component -> {
+            assertThat(component.getSupplier()).isNotNull();
+            assertThat(component.getSupplier().getName()).isEqualTo("Awesome Vendor");
+            assertThat(component.getName()).isEqualTo("Awesome Tool");
+            assertThat(component.getVersion()).isEqualTo("9.1.2");
+            assertThat(component.getSha1()).isEqualTo("25ed8e31b995bb927966616df2a42b979a2717f0");
+            assertThat(component.getSha256()).isEqualTo("a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df");
+        });
+        assertThat(project.getMetadata().getTools().services()).isNull();
+    }
+
+    @Test
+    public void informWithBomContainingMetadataToolsTest() throws Exception {
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+
+        final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()), createTempBomFile("bom-metadata-tool.json"));
+        qm.createWorkflowSteps(bomUploadEvent.getChainIdentifier());
+        new BomUploadProcessingTask().inform(bomUploadEvent);
+        assertBomProcessedNotification();
+
+        qm.getPersistenceManager().refresh(project);
+        assertThat(project.getMetadata()).isNotNull();
+        assertThat(project.getMetadata().getTools()).isNotNull();
+        assertThat(project.getMetadata().getTools().components()).satisfiesExactly(component -> {
+            assertThat(component.getGroup()).isEqualTo("Awesome Vendor");
+            assertThat(component.getName()).isEqualTo("Awesome Tool");
+            assertThat(component.getVersion()).isEqualTo("9.1.2");
+            assertThat(component.getSha1()).isEqualTo("25ed8e31b995bb927966616df2a42b979a2717f0");
+            assertThat(component.getSha256()).isEqualTo("a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df");
+        });
+        assertThat(project.getMetadata().getTools().services()).satisfiesExactly(service -> {
+            assertThat(service.getProvider()).isNotNull();
+            assertThat(service.getProvider().getName()).isEqualTo("Acme Org");
+            assertThat(service.getProvider().getUrls()).containsOnly("https://example.com");
+            assertThat(service.getGroup()).isEqualTo("com.example");
+            assertThat(service.getName()).isEqualTo("Acme Signing Server");
+            assertThat(service.getDescription()).isEqualTo("Signs artifacts");
+            assertThat(service.getEndpoints()).containsExactlyInAnyOrder(
+                    "https://example.com/sign",
+                    "https://example.com/verify",
+                    "https://example.com/tsa"
+            );
+        });
+    }
+
     private void assertBomProcessedNotification() throws Exception {
         try {
             assertThat(kafkaMockProducer.history()).anySatisfy(record -> {

--- a/src/test/resources/unit/bom-metadata-tool-deprecated.json
+++ b/src/test/resources/unit/bom-metadata-tool-deprecated.json
@@ -1,0 +1,26 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "Awesome Vendor",
+        "name": "Awesome Tool",
+        "version": "9.1.2",
+        "hashes": [
+          {
+            "alg": "SHA-1",
+            "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+          },
+          {
+            "alg": "SHA-256",
+            "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
+          }
+        ]
+      }
+    ]
+  },
+  "components": []
+}

--- a/src/test/resources/unit/bom-metadata-tool.json
+++ b/src/test/resources/unit/bom-metadata-tool.json
@@ -1,0 +1,47 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "group": "Awesome Vendor",
+          "name": "Awesome Tool",
+          "version": "9.1.2",
+          "hashes": [
+            {
+              "alg": "SHA-1",
+              "content": "25ed8e31b995bb927966616df2a42b979a2717f0"
+            },
+            {
+              "alg": "SHA-256",
+              "content": "a74f733635a19aefb1f73e5947cef59cd7440c6952ef0f03d09d974274cbd6df"
+            }
+          ]
+        }
+      ],
+      "services": [
+        {
+          "provider": {
+            "name": "Acme Org",
+            "url": [
+              "https://example.com"
+            ]
+          },
+          "group": "com.example",
+          "name": "Acme Signing Server",
+          "description": "Signs artifacts",
+          "endpoints": [
+            "https://example.com/sign",
+            "https://example.com/verify",
+            "https://example.com/tsa"
+          ]
+        }
+      ]
+    }
+  },
+  "components": []
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ingests `metadata.tools` from uploaded BOMs and makes it available in CEL policies.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1058

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

The internal model is aligned with CycloneDX v1.5, in that it differentiates between tools that are components, and tools that are services: https://cyclonedx.org/docs/1.5/json/#tab-pane_metadata_tools_oneOf_i0

When ingesting BOMs following v1.4 or older of the CycloneDX specification, `metadata.tools` array items will be converted to `metadata.tools.components`.

For the time being, tools are persisted as JSON column in the `PROJECT_METADATA` table. As such, tools will not be analyzed for vulnerabilities or other kinds of risk.

Tool components and services are treated as subsets of the internal `Component` and `ServiceComponent` models. This subset property is enforced via Jackson's `@JsonView`s, such that only specific fields are considered when serializing and deserializing to and from JSON.

Tools are made available in CEL policy expressions under `project.metadata.tools.components`. Tool components use the existing `v1.Component` type, which means that functions like `matches_version` can be used on them.

Example:

```js
project.metadata.tools.components.exists(tool,
    tool.name == "toolName" && tool.matches_range("vers:generic/>=1.2.3|<3"))
```

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
