### PR TITLE
Rename topic prefix config

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -59,12 +59,12 @@ there's no need to deploy it in an application server like Tomcat or WildFly.
 ## Running
 
 In case you want to provide a topic prefix to use in conjunction with hyades application then the environment variable
-to export is API_TOPIC_PREFIX<br/>
+to export is KAFKA_TOPIC_PREFIX<br/>
 If the host environment requires ssl configuration then below configurations need to be passed:
 
 | Environment Variable                    | Description                              | Default | Required |
 |:----------------------------------------|:-----------------------------------------|:--------|:--------:|
-| `API_TOPIC_PREFIX`                      | Prefix for topic names                   | -       |    ✅     |
+| `KAFKA_TOPIC_PREFIX`                      | Prefix for topic names                   | -       |    ✅     |
 | `KAFKA_TLS_ENABLED`                     | Whether tls is enabled                   | false   |    ❌     |
 | `KAFKA_SECURTY_PROTOCOL`                | Security protocol to be used             | -       |    ❌     |
 | `KAFKA_TRUSTSTORE_PATH`                 | Trust store path to be used              | -       |    ❌     |

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -23,7 +23,7 @@ public enum ConfigKey implements Config.Key {
 
     KEY_STORE_PASSWORD("kafka.keystore.password", ""),
     KAFKA_NUM_STREAM_THREADS("kafka.num.stream.threads", 1),
-    KAFKA_TOPIC_PREFIX("api.topic.prefix", ""),
+    KAFKA_TOPIC_PREFIX("kafka.topic.prefix", ""),
     KAFKA_PRODUCER_DRAIN_TIMEOUT_DURATION("kafka.producer.drain.timeout.duration", "PT30S"),
     KAFKA_STREAMS_DESERIALIZATION_EXCEPTION_THRESHOLD_COUNT("kafka.streams.deserialization.exception.threshold.count", "5"),
     KAFKA_STREAMS_DESERIALIZATION_EXCEPTION_THRESHOLD_INTERVAL("kafka.streams.deserialization.exception.threshold.interval", "PT30M"),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -420,7 +420,7 @@ kafka.keystore.path=
 kafka.keystore.password=
 
 # Optional
-api.topic.prefix=
+kafka.topic.prefix=
 
 # Required
 application.id=dtrack-apiserver

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaTopicsTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaTopicsTest.java
@@ -13,7 +13,7 @@ public class KafkaTopicsTest {
 
     @Test
     public void testTopicNameWithPrefix() {
-        environmentVariables.set("API_TOPIC_PREFIX", "foo-bar.baz.");
+        environmentVariables.set("KAFKA_TOPIC_PREFIX", "foo-bar.baz.");
         assertThat(KafkaTopics.VULN_ANALYSIS_RESULT.name()).isEqualTo("foo-bar.baz.dtrack.vuln-analysis.result");
     }
 


### PR DESCRIPTION
### Description

`api.topic.prefix` needs to be changed to `kafka.topic.prefix` to reduce ambiguity as it's unclear what api refers to.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1080 

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
