### PR TITLE
Fix incorrect coverage variation reported by Codacy for PRs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -636,6 +636,16 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>org/cyclonedx/proto/**/*</exclude>
+                        <exclude>org/dependencytrack/proto/**/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes incorrect coverage variation reported by Codacy for PRs.

The build on `main` does not include coverage for generated Proto classes, but PR builds do.

![image](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/b8d6d4c4-8a51-4abc-819f-ad3d77ac3796)

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Codacy ignoring Proto files for builds on `main` ([source](https://github.com/DependencyTrack/hyades-apiserver/actions/runs/8329428329/job/22791833434#step:5:103)):

```
2024-03-18 16:32:10.684Z  warn [GitFileNameUpdaterAndFilter] File: Ignoring org/cyclonedx/proto/v1_4/VulnerabilityAnalysisOrBuilder.java for coverage calculation. No matching file found in the repository.  - (GitFileNameUpdaterAndFilter.scala:22)
```

Because the source code of a PR is not present when submitting coverage reports, Codacy can't match against local files and thus uploads the entire report without prior filtering ([source](https://github.com/DependencyTrack/hyades-apiserver/actions/runs/8345883176/job/22841827240#step:3:37)):

```
2024-03-19 15:35:38.119Z  warn [ReportRules] Report files will not be matched against git files, reason: Could not retrieve files from local Git directory, error message: java.lang.InstantiationException: org.eclipse.jgit.internal.JGitText  - (ReportRules.scala:332)
```

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
