### PR TITLE
Ingest BOM generation timestamp

### DIFF
--- a/src/main/java/org/dependencytrack/model/Bom.java
+++ b/src/main/java/org/dependencytrack/model/Bom.java
@@ -102,6 +102,10 @@ public class Bom implements Serializable {
     @NotNull
     private UUID uuid;
 
+    @Persistent
+    @Column(name = "BOM_GENERATED")
+    private Date bomGenerated;
+
     public long getId() {
         return id;
     }
@@ -164,5 +168,13 @@ public class Bom implements Serializable {
 
     public void setUuid(UUID uuid) {
         this.uuid = uuid;
+    }
+
+    public Date getBomGenerated() {
+        return bomGenerated;
+    }
+
+    public void setBomGenerated(Date bomGenerated) {
+        this.bomGenerated = bomGenerated;
     }
 }

--- a/src/main/java/org/dependencytrack/model/Bom.java
+++ b/src/main/java/org/dependencytrack/model/Bom.java
@@ -103,8 +103,8 @@ public class Bom implements Serializable {
     private UUID uuid;
 
     @Persistent
-    @Column(name = "BOM_GENERATED")
-    private Date bomGenerated;
+    @Column(name = "GENERATED")
+    private Date generated;
 
     public long getId() {
         return id;
@@ -170,11 +170,11 @@ public class Bom implements Serializable {
         this.uuid = uuid;
     }
 
-    public Date getBomGenerated() {
-        return bomGenerated;
+    public Date getGenerated() {
+        return generated;
     }
 
-    public void setBomGenerated(Date bomGenerated) {
-        this.bomGenerated = bomGenerated;
+    public void setGenerated(Date generated) {
+        this.generated = generated;
     }
 }

--- a/src/main/java/org/dependencytrack/persistence/BomQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/BomQueryManager.java
@@ -61,7 +61,7 @@ final class BomQueryManager extends QueryManager implements IQueryManager {
         bom.setSpecVersion(specVersion);
         bom.setBomVersion(bomVersion);
         bom.setSerialNumber(serialNumber);
-        bom.setBomGenerated(bomGenerated);
+        bom.setGenerated(bomGenerated);
         return persist(bom);
     }
 

--- a/src/main/java/org/dependencytrack/persistence/BomQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/BomQueryManager.java
@@ -53,7 +53,7 @@ final class BomQueryManager extends QueryManager implements IQueryManager {
      * @param imported the Date when the bom was imported
      * @return a new Bom object
      */
-    public Bom createBom(Project project, Date imported, Bom.Format format, String specVersion, Integer bomVersion, String serialNumber, final UUID uploadToken) {
+    public Bom createBom(Project project, Date imported, Bom.Format format, String specVersion, Integer bomVersion, String serialNumber, final UUID uploadToken, Date bomGenerated) {
         final Bom bom = new Bom();
         bom.setImported(imported);
         bom.setProject(project);
@@ -61,6 +61,7 @@ final class BomQueryManager extends QueryManager implements IQueryManager {
         bom.setSpecVersion(specVersion);
         bom.setBomVersion(bomVersion);
         bom.setSerialNumber(serialNumber);
+        bom.setBomGenerated(bomGenerated);
         return persist(bom);
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -587,8 +587,8 @@ public class QueryManager extends AlpineQueryManager {
         return getProjectQueryManager().getProjectProperties(project);
     }
 
-    public Bom createBom(Project project, Date imported, Bom.Format format, String specVersion, Integer bomVersion, String serialNumber, final UUID uploadToken) {
-        return getBomQueryManager().createBom(project, imported, format, specVersion, bomVersion, serialNumber, uploadToken);
+    public Bom createBom(Project project, Date imported, Bom.Format format, String specVersion, Integer bomVersion, String serialNumber, final UUID uploadToken, Date bomGenerated) {
+        return getBomQueryManager().createBom(project, imported, format, specVersion, bomVersion, serialNumber, uploadToken, bomGenerated);
     }
 
     public List<Bom> getAllBoms(Project project) {

--- a/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -188,7 +188,7 @@ public interface CelPolicyDao {
                 sqlSelectColumns.add("\"PM\".\"TOOLS\" AS \"metadata_tools\"");
             }
             if (requirements.get(TYPE_PROJECT_METADATA).contains("bom_generated")) {
-                sqlSelectColumns.add("\"BM\".\"BOM_GENERATED\" AS \"bom_generated\"");
+                sqlSelectColumns.add("\"BM\".\"GENERATED\" AS \"bom_generated\"");
             }
         }
 

--- a/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -64,6 +64,10 @@ public interface CelPolicyDao {
               INNER JOIN
                 "PROJECT_METADATA" AS "PM" ON "PM"."PROJECT_ID" = "P"."ID"
             </#if>
+            <#if fetchColumns?filter(col -> col?contains("\\"bom_generated\\""))?size gt 0>
+              INNER JOIN
+                "BOM" AS "BM" ON "BM"."PROJECT_ID" = "P"."ID"
+            </#if>
             <#if fetchPropertyColumns?size gt 0>
               LEFT JOIN LATERAL (
                 SELECT
@@ -179,9 +183,13 @@ public interface CelPolicyDao {
                 .collect(Collectors.toList());
 
         if (fieldsToLoad.contains("metadata")
-            && requirements.containsKey(TYPE_PROJECT_METADATA)
-            && requirements.get(TYPE_PROJECT_METADATA).contains("tools")) {
-            sqlSelectColumns.add("\"PM\".\"TOOLS\" AS \"metadata_tools\"");
+            && requirements.containsKey(TYPE_PROJECT_METADATA)) {
+            if (requirements.get(TYPE_PROJECT_METADATA).contains("tools")) {
+                sqlSelectColumns.add("\"PM\".\"TOOLS\" AS \"metadata_tools\"");
+            }
+            if (requirements.get(TYPE_PROJECT_METADATA).contains("bom_generated")) {
+                sqlSelectColumns.add("\"BM\".\"BOM_GENERATED\" AS \"bom_generated\"");
+            }
         }
 
         final var sqlPropertySelectColumns = new ArrayList<String>();

--- a/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyProjectRowMapper.java
+++ b/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyProjectRowMapper.java
@@ -59,11 +59,12 @@ public class CelPolicyProjectRowMapper implements RowMapper<Project> {
         maybeSet(rs, "tags", RowMapperUtil::stringArray, builder::addAllTags);
         maybeSet(rs, "properties", CelPolicyProjectRowMapper::maybeConvertProperties, builder::addAllProperties);
 
+        final Project.Metadata.Builder metadataBuilder = Project.Metadata.newBuilder();
         if (hasColumn(rs, "metadata_tools")) {
-            builder.setMetadata(Project.Metadata.newBuilder()
-                    .setTools(convertMetadataTools(rs))
-                    .build());
+            metadataBuilder.setTools(convertMetadataTools(rs));
         }
+        maybeSet(rs, "bom_generated", RowMapperUtil::nullableTimestamp, metadataBuilder::setBomGenerated);
+        builder.setMetadata(metadataBuilder.build());
 
         return builder.build();
     }

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -814,7 +814,7 @@ public class BomUploadProcessingTask implements Subscriber {
         bom.setSerialNumber(ctx.bomSerialNumber);
         bom.setBomVersion(ctx.bomVersion);
         bom.setImported(bomImportDate);
-        bom.setBomGenerated(bomGeneratedTimestamp);
+        bom.setGenerated(bomGeneratedTimestamp);
         pm.makePersistent(bom);
 
         project.setLastBomImport(bomImportDate);

--- a/src/main/proto/org/dependencytrack/policy/v1/policy.proto
+++ b/src/main/proto/org/dependencytrack/policy/v1/policy.proto
@@ -101,6 +101,7 @@ message Project {
 
   message Metadata {
     optional Tools tools = 1;
+    optional google.protobuf.Timestamp bom_generated = 2;
   }
 
   message Property {

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -36,4 +36,10 @@
             <column name="PURL"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="v5.5.0-3" author="sahibamittal">
+        <addColumn tableName="BOM">
+            <column name="BOM_GENERATED" type="TIMESTAMP WITH TIME ZONE"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -39,7 +39,7 @@
 
     <changeSet id="v5.5.0-3" author="sahibamittal">
         <addColumn tableName="BOM">
-            <column name="BOM_GENERATED" type="TIMESTAMP WITH TIME ZONE"/>
+            <column name="GENERATED" type="TIMESTAMP WITH TIME ZONE"/>
         </addColumn>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/model/ProjectTest.java
+++ b/src/test/java/org/dependencytrack/model/ProjectTest.java
@@ -31,7 +31,7 @@ public class ProjectTest extends PersistenceCapableTest {
     public void testProjectPersistence() {
         Project p1 = qm.createProject("Example Project 1", "Description 1", "1.0", null, null, null, true, false);
         Project p2 = qm.createProject("Example Project 2", "Description 2", "1.1", null, null, null, true, false);
-        Bom bom = qm.createBom(p1, new Date(), Bom.Format.CYCLONEDX, "1.1", 1, UUID.randomUUID().toString(), UUID.randomUUID());
+        Bom bom = qm.createBom(p1, new Date(), Bom.Format.CYCLONEDX, "1.1", 1, UUID.randomUUID().toString(), UUID.randomUUID(), null);
 
         Assert.assertEquals("Example Project 1", p1.getName());
         Assert.assertEquals("Example Project 2", p2.getName());

--- a/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ProjectQueryManagerTest.java
@@ -148,7 +148,7 @@ public class ProjectQueryManagerTest extends PersistenceCapableTest {
         qm.persist(projectMetrics);
 
         // Create a BOM.
-        final Bom bom = qm.createBom(project, new Date(), Bom.Format.CYCLONEDX, "1.4", 1, "serialNumber", UUID.randomUUID());
+        final Bom bom = qm.createBom(project, new Date(), Bom.Format.CYCLONEDX, "1.4", 1, "serialNumber", UUID.randomUUID(), null);
 
         // Create a child project with an accompanying component.
         final var projectChild = new Project();

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -111,7 +111,7 @@ public class CelPolicyEngineTest extends PersistenceCapableTest {
 
         final var bom = new Bom();
         bom.setProject(project);
-        bom.setBomGenerated(new java.util.Date(999));
+        bom.setGenerated(new java.util.Date(999));
         bom.setImported(new Date());
         qm.persist(bom);
 

--- a/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -24,6 +24,7 @@ import com.github.packageurl.PackageURL;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.BomUploadEvent;
 import org.dependencytrack.model.AnalyzerIdentity;
+import org.dependencytrack.model.Bom;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
@@ -107,6 +108,12 @@ public class CelPolicyEngineTest extends PersistenceCapableTest {
         project.setSwidTagId("projectSwidTagId");
         project.setLastBomImport(new java.util.Date());
         qm.persist(project);
+
+        final var bom = new Bom();
+        bom.setProject(project);
+        bom.setBomGenerated(new java.util.Date(999));
+        bom.setImported(new Date());
+        qm.persist(bom);
 
         final var toolComponentLicense = new License();
         toolComponentLicense.setUuid(UUID.randomUUID());
@@ -288,6 +295,7 @@ public class CelPolicyEngineTest extends PersistenceCapableTest {
                   && project.purl == "projectPurl"
                   && project.swid_tag_id == "projectSwidTagId"
                   && has(project.last_bom_import)
+                  && project.metadata.bom_generated == timestamp("1970-01-01T00:00:00.999Z")
                   && project.metadata.tools.components.all(tool,
                        tool.group == "toolComponentGroup"
                          && tool.name == "toolComponentName"

--- a/src/test/java/org/dependencytrack/policy/cel/persistence/CelPolicyDaoTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/persistence/CelPolicyDaoTest.java
@@ -25,6 +25,7 @@ import com.google.protobuf.util.JsonFormat;
 import net.javacrumbs.jsonunit.core.Option;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Bom;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.FetchStatus;
@@ -47,6 +48,7 @@ import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMP
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_LICENSE;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_LICENSE_GROUP;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
+import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT_METADATA;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT_PROPERTY;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_VULNERABILITY;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_VULNERABILITY_ALIAS;
@@ -75,6 +77,12 @@ public class CelPolicyDaoTest extends PersistenceCapableTest {
                 qm.createTag("projectTagB")
         ));
 
+        var bom = new Bom();
+        bom.setProject(project);
+        bom.setBomGenerated(new Date());
+        bom.setImported(new Date());
+        qm.persist(bom);
+
         final var requirements = new HashSetValuedHashMap<Type, String>();
         requirements.putAll(TYPE_PROJECT, org.dependencytrack.proto.policy.v1.Project.getDescriptor().getFields().stream()
                 .map(Descriptors.FieldDescriptor::getName)
@@ -82,6 +90,7 @@ public class CelPolicyDaoTest extends PersistenceCapableTest {
         requirements.putAll(TYPE_PROJECT_PROPERTY, org.dependencytrack.proto.policy.v1.Project.Property.getDescriptor().getFields().stream()
                 .map(Descriptors.FieldDescriptor::getName)
                 .toList());
+        requirements.put(TYPE_PROJECT_METADATA, "bom_generated");
 
         final var protoProject = org.dependencytrack.proto.policy.v1.Project.newBuilder()
                 .setUuid(project.getUuid().toString())
@@ -107,7 +116,10 @@ public class CelPolicyDaoTest extends PersistenceCapableTest {
                           "cpe": "projectCpe",
                           "purl": "projectPurl",
                           "swidTagId": "projectSwidTagId",
-                          "lastBomImport": "${json-unit.any-string}"
+                          "lastBomImport": "${json-unit.any-string}",
+                          "metadata": {
+                            "bomGenerated": "${json-unit.any-string}"
+                          }
                         }
                         """);
     }

--- a/src/test/java/org/dependencytrack/policy/cel/persistence/CelPolicyDaoTest.java
+++ b/src/test/java/org/dependencytrack/policy/cel/persistence/CelPolicyDaoTest.java
@@ -79,7 +79,7 @@ public class CelPolicyDaoTest extends PersistenceCapableTest {
 
         var bom = new Bom();
         bom.setProject(project);
-        bom.setBomGenerated(new Date());
+        bom.setGenerated(new Date());
         bom.setImported(new Date());
         qm.persist(bom);
 

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -964,6 +964,18 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         });
     }
 
+    @Test
+    public void informWithBomContainingTimestampTest() throws Exception {
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()), createTempBomFile("bom-metadata-timestamp.json"));
+        qm.createWorkflowSteps(bomUploadEvent.getChainIdentifier());
+        new BomUploadProcessingTask().inform(bomUploadEvent);
+        assertBomProcessedNotification();
+
+        var boms = qm.getAllBoms(project);
+        assertThat(boms.get(0).getBomGenerated()).isNotNull();
+    }
+
     private void assertBomProcessedNotification() throws Exception {
         try {
             assertThat(kafkaMockProducer.history()).anySatisfy(record -> {

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -973,7 +973,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         assertBomProcessedNotification();
 
         var boms = qm.getAllBoms(project);
-        assertThat(boms.get(0).getBomGenerated()).isEqualTo("2021-02-09T20:40:32Z");
+        assertThat(boms.get(0).getGenerated()).isEqualTo("2021-02-09T20:40:32Z");
     }
 
     private void assertBomProcessedNotification() throws Exception {

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -973,7 +973,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
         assertBomProcessedNotification();
 
         var boms = qm.getAllBoms(project);
-        assertThat(boms.get(0).getBomGenerated()).isNotNull();
+        assertThat(boms.get(0).getBomGenerated()).isEqualTo("2021-02-09T20:40:32Z");
     }
 
     private void assertBomProcessedNotification() throws Exception {

--- a/src/test/resources/unit/bom-metadata-timestamp.json
+++ b/src/test/resources/unit/bom-metadata-timestamp.json
@@ -1,0 +1,10 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-08-14T18:28:05.217Z"
+  },
+  "components": []
+}

--- a/src/test/resources/unit/bom-metadata-timestamp.json
+++ b/src/test/resources/unit/bom-metadata-timestamp.json
@@ -4,7 +4,7 @@
   "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-08-14T18:28:05.217Z"
+    "timestamp": "2021-02-09T20:40:32Z"
   },
   "components": []
 }


### PR DESCRIPTION
### Description

Dependency-Track currently only tracks when a BOM was uploaded, but not when the BOM was generated.

Generators can include the generation timestamp in the [metadata.timestamp](https://cyclonedx.org/docs/1.5/json/#metadata_timestamp) node of the BOM. If it is available, DT should ingest it and make it available in CEL policies.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1059

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly
