### PR TITLE
Bump Redpanda to v23.3.11

### DIFF
--- a/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
@@ -58,7 +58,7 @@ public class ProcessorManagerTest {
 
     @Rule
     public RedpandaContainer kafkaContainer = new RedpandaContainer(DockerImageName
-            .parse("docker.redpanda.com/vectorized/redpanda:v23.3.6"));
+            .parse("docker.redpanda.com/vectorized/redpanda:v23.3.11"));
 
     private ExternalKafkaCluster kafka;
     private Config configMock;

--- a/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/streams/KafkaStreamsTest.java
@@ -45,7 +45,7 @@ abstract class KafkaStreamsTest extends PersistenceCapableTest {
 
     @Rule
     public RedpandaContainer container = new RedpandaContainer(DockerImageName
-            .parse("docker.redpanda.com/vectorized/redpanda:v23.3.6"));
+            .parse("docker.redpanda.com/vectorized/redpanda:v23.3.11"));
 
     KafkaStreams kafkaStreams;
     ExternalKafkaCluster kafka;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Bumps the Redpanda image used in tests to v23.3.11.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
