### PR TITLE
Publish histograms for event processing durations

### DIFF
--- a/src/main/java/org/dependencytrack/common/MdcKeys.java
+++ b/src/main/java/org/dependencytrack/common/MdcKeys.java
@@ -28,6 +28,7 @@ public final class MdcKeys {
     public static final String MDC_KAFKA_RECORD_PARTITION = "kafkaRecordPartition";
     public static final String MDC_KAFKA_RECORD_OFFSET = "kafkaRecordOffset";
     public static final String MDC_KAFKA_RECORD_KEY = "kafkaRecordKey";
+    public static final String MDC_PROJECT_UUID = "projectUuid";
     public static final String MDC_SCAN_TOKEN = "scanToken";
 
     private MdcKeys() {

--- a/src/main/java/org/dependencytrack/observability/MeterRegistryCustomizer.java
+++ b/src/main/java/org/dependencytrack/observability/MeterRegistryCustomizer.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.observability;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.distribution.DistributionStatisticConfig;
+import org.jetbrains.annotations.NotNull;
+
+public class MeterRegistryCustomizer implements alpine.common.metrics.MeterRegistryCustomizer {
+
+    @Override
+    public void accept(final MeterRegistry meterRegistry) {
+        meterRegistry.config().meterFilter(new PercentilesHistogramMeterFilter());
+    }
+
+    private static final class PercentilesHistogramMeterFilter implements MeterFilter {
+
+        @Override
+        public DistributionStatisticConfig configure(@NotNull final Meter.Id id,
+                                                     @NotNull final DistributionStatisticConfig config) {
+            if ("alpine_event_processing".equals(id.getName())
+                    || "pc.user.function.processing.time".equals(id.getName())) {
+                return DistributionStatisticConfig.builder()
+                        .percentiles() // Disable client-side calculation of percentiles.
+                        .percentilesHistogram(true) // Publish histogram instead.
+                        .build()
+                        .merge(config);
+            }
+
+            return config;
+        }
+
+    }
+
+}

--- a/src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTask.java
@@ -22,7 +22,6 @@ import alpine.common.logging.Logger;
 import alpine.common.util.SystemUtil;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
-import io.micrometer.core.instrument.Timer;
 import net.javacrumbs.shedlock.core.LockConfiguration;
 import net.javacrumbs.shedlock.core.LockExtender;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
@@ -71,7 +70,7 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
 
     private void updateMetrics(final boolean forceRefresh) throws Exception {
         LOGGER.info("Executing portfolio metrics update");
-        final Timer.Sample timerSample = Timer.start();
+        final long startTimeNs = System.nanoTime();
 
         try {
             if (forceRefresh) {
@@ -81,11 +80,7 @@ public class PortfolioMetricsUpdateTask implements Subscriber {
 
             Metrics.updatePortfolioMetrics();
         } finally {
-            final long durationNanos = timerSample.stop(Timer
-                    .builder("metrics_update")
-                    .tag("target", "portfolio")
-                    .register(alpine.common.metrics.Metrics.getRegistry()));
-            LOGGER.info("Completed portfolio metrics update in " + Duration.ofNanos(durationNanos));
+            LOGGER.info("Completed portfolio metrics update in " + Duration.ofNanos(System.nanoTime() - startTimeNs));
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/ProjectMetricsUpdateTask.java
@@ -21,16 +21,18 @@ package org.dependencytrack.tasks.metrics;
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
-import io.micrometer.core.instrument.Timer;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.metrics.Metrics;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.WorkflowState;
 import org.dependencytrack.model.WorkflowStep;
 import org.dependencytrack.persistence.QueryManager;
+import org.slf4j.MDC;
 
 import java.time.Duration;
 import java.util.UUID;
+
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
 
 /**
  * A {@link Subscriber} task that updates {@link Project} metrics.
@@ -44,32 +46,27 @@ public class ProjectMetricsUpdateTask implements Subscriber {
     @Override
     public void inform(final Event e) {
         if (e instanceof final ProjectMetricsUpdateEvent event) {
-            WorkflowState metricsUpdateState;
-            try (final var qm = new QueryManager()) {
-                metricsUpdateState = qm.updateStartTimeIfWorkflowStateExists(event.getChainIdentifier(), WorkflowStep.METRICS_UPDATE);
+            try (final var qm = new QueryManager();
+                 var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, event.getUuid().toString())) {
+                final WorkflowState metricsUpdateState = qm.updateStartTimeIfWorkflowStateExists(event.getChainIdentifier(), WorkflowStep.METRICS_UPDATE);
                 try {
                     updateMetrics(event.getUuid());
                     qm.updateWorkflowStateToComplete(metricsUpdateState);
-                } catch (Exception ex) {
+                } catch (RuntimeException ex) {
                     qm.updateWorkflowStateToFailed(metricsUpdateState, ex.getMessage());
-                    LOGGER.error("An unexpected error occurred while updating metrics for project " + event.getUuid(), ex);
+                    LOGGER.error("An unexpected error occurred while updating metrics", ex);
                 }
             }
         }
     }
 
     private static void updateMetrics(final UUID uuid) {
-        LOGGER.debug("Executing metrics update for project " + uuid);
-        final Timer.Sample timerSample = Timer.start();
-
+        LOGGER.debug("Executing metrics update");
+        final long startTimeNs = System.nanoTime();
         try {
             Metrics.updateProjectMetrics(uuid);
         } finally {
-            final long durationNanos = timerSample.stop(Timer
-                    .builder("metrics_update")
-                    .tag("target", "project")
-                    .register(alpine.common.metrics.Metrics.getRegistry()));
-            LOGGER.debug("Completed metrics update for project " + uuid + " in " + Duration.ofNanos(durationNanos));
+            LOGGER.debug("Completed metrics update in %s".formatted(Duration.ofNanos(System.nanoTime() - startTimeNs)));
         }
     }
 

--- a/src/main/java/org/dependencytrack/tasks/metrics/VulnerabilityMetricsUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/VulnerabilityMetricsUpdateTask.java
@@ -19,12 +19,9 @@
 package org.dependencytrack.tasks.metrics;
 
 import alpine.common.logging.Logger;
-import alpine.common.metrics.Metrics;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
-import io.micrometer.core.instrument.Timer;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
-import org.apache.commons.lang3.time.DurationFormatUtils;
 import org.dependencytrack.event.VulnerabilityMetricsUpdateEvent;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.persistence.QueryManager;
@@ -32,6 +29,7 @@ import org.dependencytrack.util.LockProvider;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -65,7 +63,7 @@ public class VulnerabilityMetricsUpdateTask implements Subscriber {
 
     private void updateMetrics() throws Exception {
         LOGGER.info("Executing metrics update on vulnerability database");
-        final Timer.Sample timerSample = Timer.start();
+        final long startTimeNs = System.nanoTime();
         final var measuredAt = new Date();
 
         try (final var qm = new QueryManager()) {
@@ -108,13 +106,8 @@ public class VulnerabilityMetricsUpdateTask implements Subscriber {
 
             qm.synchronizeVulnerabilityMetrics(Stream.concat(monthlyStream, yearlyStream).toList());
 
-            LOGGER.info("Completed metrics update on vulnerability database in " +
-                    DurationFormatUtils.formatDuration(new Date().getTime() - measuredAt.getTime(), "mm:ss:SS"));
-        } finally {
-            timerSample.stop(Timer
-                    .builder("metrics_update")
-                    .tag("target", "vulnerabilities")
-                    .register(Metrics.getRegistry()));
+            LOGGER.info("Completed metrics update on vulnerability database in %s"
+                    .formatted(Duration.ofNanos(System.nanoTime() - startTimeNs)));
         }
     }
 

--- a/src/main/resources/META-INF/services/alpine.common.metrics.MeterRegistryCustomizer
+++ b/src/main/resources/META-INF/services/alpine.common.metrics.MeterRegistryCustomizer
@@ -1,0 +1,1 @@
+org.dependencytrack.observability.MeterRegistryCustomizer


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enables publishing of histograms for the `alpine_event_processing` and `pc.user.function.processing.time` timers. This allows us to calculate percentiles (p99, p95, etc.) in Prometheus. Percentiles give a much clearer picture than a simple average, which we have been using so far.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

The way of configuring this via `MeterFilter` is in accordance with Micrometer's documentation, see https://docs.micrometer.io/micrometer/reference/concepts/histogram-quantiles.html.

An easy-to-digest overview of the different meter types, including histograms, can be found on Timescale's blog: https://www.timescale.com/blog/four-types-prometheus-metrics-to-collect/

Example for how this looks on a Grafana dashboard:

![Screenshot 2024-04-13 at 21 40 47](https://github.com/DependencyTrack/hyades-apiserver/assets/5693141/d6f15330-162a-4044-8562-a788850ba102)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have added corresponding [update logic](https://github.com/DependencyTrack/dependency-track/tree/master/src/main/java/org/dependencytrack/upgrade)~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/dependency-track/tree/master/docs/_docs) accordingly~
