### PR TITLE
Start Jersey `TestContainer` once per class vs. once per test method

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -121,7 +121,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
     /**
      * Loads the default permissions
      */
-    private void loadDefaultPermissions() {
+    public void loadDefaultPermissions() {
         try (QueryManager qm = new QueryManager()) {
             LOGGER.info("Synchronizing permissions to datastore");
             for (final Permissions permission : Permissions.values()) {
@@ -198,7 +198,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
     /**
      * Loads the default repositories
      */
-    private void loadDefaultRepositories() {
+    public void loadDefaultRepositories() {
         try (QueryManager qm = new QueryManager()) {
             LOGGER.info("Synchronizing default repositories to datastore");
             qm.createRepository(RepositoryType.CPAN, "cpan-public-registry", "https://fastapi.metacpan.org/v1/", true, false, false, null, null);
@@ -237,7 +237,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
     /**
      * Loads the default notification publishers
      */
-    private void loadDefaultNotificationPublishers() {
+    public void loadDefaultNotificationPublishers() {
         try (QueryManager qm = new QueryManager()) {
             LOGGER.info("Synchronizing notification publishers to datastore");
             try {

--- a/src/test/java/org/dependencytrack/JerseyTestRule.java
+++ b/src/test/java/org/dependencytrack/JerseyTestRule.java
@@ -1,0 +1,87 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack;
+
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.glassfish.jersey.servlet.ServletContainer;
+import org.glassfish.jersey.test.DeploymentContext;
+import org.glassfish.jersey.test.JerseyTest;
+import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.glassfish.jersey.test.spi.TestContainerException;
+import org.glassfish.jersey.test.spi.TestContainerFactory;
+import org.junit.rules.ExternalResource;
+
+import javax.ws.rs.client.WebTarget;
+
+/**
+ * @since 4.11.0
+ */
+public class JerseyTestRule extends ExternalResource {
+
+    private final JerseyTest jerseyTest;
+
+    public JerseyTestRule(final ResourceConfig resourceConfig) {
+        this.jerseyTest = new JerseyTest() {
+
+            @Override
+            protected TestContainerFactory getTestContainerFactory() throws TestContainerException {
+                return new DTGrizzlyWebTestContainerFactory();
+            }
+
+            @Override
+            protected void configureClient(final ClientConfig config) {
+                // Prevent InaccessibleObjectException with JDK >= 16 when performing PATCH requests
+                // using the default HttpUrlConnection connector provider.
+                // See https://github.com/eclipse-ee4j/jersey/issues/4825
+                config.connectorProvider(new GrizzlyConnectorProvider());
+            }
+
+            @Override
+            protected DeploymentContext configureDeployment() {
+                return ServletDeploymentContext.forServlet(new ServletContainer(resourceConfig)).build();
+            }
+
+        };
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        jerseyTest.setUp();
+    }
+
+    @Override
+    protected void after() {
+        try {
+            jerseyTest.tearDown();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public WebTarget target() {
+        return jerseyTest.target();
+    }
+
+    public final WebTarget target(final String path) {
+        return jerseyTest.target(path);
+    }
+
+}

--- a/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
@@ -42,6 +42,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -49,6 +50,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_BOM_PROCESSED;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_VULN_ANALYSIS_COMPLETE;
@@ -67,6 +69,7 @@ import static org.dependencytrack.util.KafkaTestUtil.deserializeValue;
 public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProcessorTest {
 
     @Before
+    @Override
     public void before() throws Exception {
         super.before();
 
@@ -77,6 +80,7 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
     }
 
     @After
+    @Override
     public void after() {
         EventService.getInstance().unsubscribe(EventSubscriber.class);
         EVENTS.clear();
@@ -238,20 +242,24 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
             assertThat(subject.getFindingsCount()).isZero();
         });
 
-        assertThat(EVENTS).satisfiesExactly(
-                event -> {
-                    assertThat(event).isInstanceOf(ProjectPolicyEvaluationEvent.class);
-                    final var policyEvalEvent = (ProjectPolicyEvaluationEvent) event;
-                    assertThat(policyEvalEvent.getUuid()).isEqualTo(project.getUuid());
-                    assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                },
-                event -> {
-                    assertThat(event).isInstanceOf(ProjectMetricsUpdateEvent.class);
-                    final var metricsUpdateEvent = (ProjectMetricsUpdateEvent) event;
-                    assertThat(metricsUpdateEvent.getUuid()).isEqualTo(project.getUuid());
-                    assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                }
-        );
+        await("Internal event publish")
+                .atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    assertThat(EVENTS).satisfiesExactly(
+                            event -> {
+                                assertThat(event).isInstanceOf(ProjectPolicyEvaluationEvent.class);
+                                final var policyEvalEvent = (ProjectPolicyEvaluationEvent) event;
+                                assertThat(policyEvalEvent.getUuid()).isEqualTo(project.getUuid());
+                                assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                            },
+                            event -> {
+                                assertThat(event).isInstanceOf(ProjectMetricsUpdateEvent.class);
+                                final var metricsUpdateEvent = (ProjectMetricsUpdateEvent) event;
+                                assertThat(metricsUpdateEvent.getUuid()).isEqualTo(project.getUuid());
+                                assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                            }
+                    );
+                });
     }
 
     @Test
@@ -447,20 +455,24 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
 
         assertThat(kafkaMockProducer.history()).isEmpty();
 
-        assertThat(EVENTS).satisfiesExactly(
-                event -> {
-                    assertThat(event).isInstanceOf(ComponentPolicyEvaluationEvent.class);
-                    final var policyEvalEvent = (ComponentPolicyEvaluationEvent) event;
-                    assertThat(policyEvalEvent.getUuid()).isEqualTo(component.getUuid());
-                    assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                },
-                event -> {
-                    assertThat(event).isInstanceOf(ComponentMetricsUpdateEvent.class);
-                    final var metricsUpdateEvent = (ComponentMetricsUpdateEvent) event;
-                    assertThat(metricsUpdateEvent.getUuid()).isEqualTo(component.getUuid());
-                    assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                }
-        );
+        await("Internal event publish")
+                .atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> {
+                    assertThat(EVENTS).satisfiesExactly(
+                            event -> {
+                                assertThat(event).isInstanceOf(ComponentPolicyEvaluationEvent.class);
+                                final var policyEvalEvent = (ComponentPolicyEvaluationEvent) event;
+                                assertThat(policyEvalEvent.getUuid()).isEqualTo(component.getUuid());
+                                assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                            },
+                            event -> {
+                                assertThat(event).isInstanceOf(ComponentMetricsUpdateEvent.class);
+                                final var metricsUpdateEvent = (ComponentMetricsUpdateEvent) event;
+                                assertThat(metricsUpdateEvent.getUuid()).isEqualTo(component.getUuid());
+                                assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                            }
+                    );
+                });
     }
 
     private static final ConcurrentLinkedQueue<Event> EVENTS = new ConcurrentLinkedQueue<>();

--- a/src/test/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/RepositoryMetaResultProcessorTest.java
@@ -48,6 +48,7 @@ public class RepositoryMetaResultProcessorTest extends AbstractProcessorTest {
     public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Before
+    @Override
     public void before() throws Exception {
         super.before();
 

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityMirrorProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityMirrorProcessorTest.java
@@ -33,6 +33,7 @@ import static org.dependencytrack.util.KafkaTestUtil.generateBomFromJson;
 public class VulnerabilityMirrorProcessorTest extends AbstractProcessorTest {
 
     @Before
+    @Override
     public void before() throws Exception {
         super.before();
 

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -106,6 +106,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
     private VulnerabilityScanResultProcessor processor;
 
     @Before
+    @Override
     public void before() throws Exception {
         super.before();
 

--- a/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -23,6 +23,7 @@ import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
 import net.jcip.annotations.NotThreadSafe;
 import org.apache.http.HttpStatus;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.kafka.KafkaTopics;
@@ -39,9 +40,7 @@ import org.dependencytrack.proto.notification.v1.Notification;
 import org.dependencytrack.resources.v1.vo.AnalysisRequest;
 import org.dependencytrack.util.NotificationUtil;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.Json;
@@ -64,15 +63,12 @@ import static org.dependencytrack.util.KafkaTestUtil.deserializeValue;
 @NotThreadSafe
 public class AnalysisResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(AnalysisResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)
-                                .register(AuthorizationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(AnalysisResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(AuthorizationFilter.class));
 
     @Test
     public void retrieveAnalysisTest() {
@@ -97,7 +93,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 AnalysisJustification.CODE_NOT_REACHABLE, AnalysisResponse.WILL_NOT_FIX, "Analysis details here", true);
         qm.makeAnalysisComment(analysis, "Analysis comment here", "Jane Doe");
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", vulnerability.getUuid())
@@ -139,7 +135,7 @@ public class AnalysisResourceTest extends ResourceTest {
         vulnerability.setComponents(List.of(component));
         vulnerability = qm.createVulnerability(vulnerability, false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", vulnerability.getUuid())
@@ -169,7 +165,7 @@ public class AnalysisResourceTest extends ResourceTest {
         vulnerability.setComponents(List.of(component));
         vulnerability = qm.createVulnerability(vulnerability, false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", vulnerability.getUuid())
                 .request()
@@ -198,7 +194,7 @@ public class AnalysisResourceTest extends ResourceTest {
         vulnerability.setComponents(List.of(component));
         vulnerability = qm.createVulnerability(vulnerability, false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", UUID.randomUUID())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", vulnerability.getUuid())
@@ -229,7 +225,7 @@ public class AnalysisResourceTest extends ResourceTest {
         vulnerability.setComponents(List.of(component));
         vulnerability = qm.createVulnerability(vulnerability, false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", UUID.randomUUID())
                 .queryParam("vulnerability", vulnerability.getUuid())
@@ -260,7 +256,7 @@ public class AnalysisResourceTest extends ResourceTest {
         vulnerability.setComponents(List.of(component));
         qm.createVulnerability(vulnerability, false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
                 .queryParam("component", component.getUuid())
                 .queryParam("vulnerability", UUID.randomUUID())
@@ -274,7 +270,7 @@ public class AnalysisResourceTest extends ResourceTest {
 
     @Test
     public void retrieveAnalysisUnauthorizedTest() {
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", UUID.randomUUID())
                 .queryParam("component", UUID.randomUUID())
                 .queryParam("vulnerability", UUID.randomUUID())
@@ -308,7 +304,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
                 AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -364,7 +360,7 @@ public class AnalysisResourceTest extends ResourceTest {
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
                 vulnerability.getUuid().toString(), null, null, null, null, null, null);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -419,7 +415,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 vulnerability.getUuid().toString(), AnalysisState.EXPLOITABLE, AnalysisJustification.NOT_SET,
                 AnalysisResponse.UPDATE, "New analysis details here", "New analysis comment here", false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -497,7 +493,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
                 AnalysisResponse.WILL_NOT_FIX, "Analysis details here", null, true);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -546,7 +542,7 @@ public class AnalysisResourceTest extends ResourceTest {
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
                 vulnerability.getUuid().toString(), null, null, null, null, null, null);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -610,7 +606,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
                 AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -642,7 +638,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
                 AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -674,7 +670,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 UUID.randomUUID().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
                 AnalysisResponse.WILL_NOT_FIX, "Analysis details here", "Analysis comment here", true);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -712,7 +708,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL,
                 AnalysisResponse.UPDATE, "New analysis details here", "New analysis comment here", false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));
@@ -763,7 +759,7 @@ public class AnalysisResourceTest extends ResourceTest {
                 UUID.randomUUID().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.PROTECTED_BY_MITIGATING_CONTROL,
                 AnalysisResponse.UPDATE, "Analysis details here", "Analysis comment here", false);
 
-        final Response response = target(V1_ANALYSIS)
+        final Response response = jersey.target(V1_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(analysisRequest, MediaType.APPLICATION_JSON));

--- a/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
@@ -20,13 +20,12 @@ package org.dependencytrack.resources.v1;
 
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Project;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -41,13 +40,10 @@ import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BADGE_EN
 
 public class BadgeResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(BadgeResource.class)
-                                .register(ApiFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(BadgeResource.class)
+                    .register(ApiFilter.class));
 
     @Override
     public void before() throws Exception {
@@ -58,7 +54,7 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByUuidTest() {
         Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = target(V1_BADGE + "/vulns/project/" + project.getUuid()).request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + project.getUuid()).request()
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
@@ -68,14 +64,14 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByUuidProjectDisabledTest() {
         disableBadge();
-        Response response = target(V1_BADGE + "/vulns/project/" + UUID.randomUUID()).request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + UUID.randomUUID()).request()
                 .get(Response.class);
         Assert.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
     public void projectVulnerabilitiesByUuidProjectNotFoundTest() {
-        Response response = target(V1_BADGE + "/vulns/project/" + UUID.randomUUID()).request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/" + UUID.randomUUID()).request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -83,7 +79,7 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByNameAndVersionTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0").request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.0.0").request()
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
@@ -93,14 +89,14 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByNameAndVersionDisabledTest() {
         disableBadge();
-        Response response = target(V1_BADGE + "/vulns/project/ProjectNameDoesNotExist/1.0.0").request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/ProjectNameDoesNotExist/1.0.0").request()
                 .get(Response.class);
         Assert.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
     public void projectVulnerabilitiesByNameAndVersionProjectNotFoundTest() {
-        Response response = target(V1_BADGE + "/vulns/project/ProjectNameDoesNotExist/1.0.0").request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/ProjectNameDoesNotExist/1.0.0").request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -108,7 +104,7 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectVulnerabilitiesByNameAndVersionVersionNotFoundTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = target(V1_BADGE + "/vulns/project/Acme%20Example/1.2.0").request()
+        Response response = jersey.target(V1_BADGE + "/vulns/project/Acme%20Example/1.2.0").request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -116,7 +112,7 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByUuidTest() {
         Project project = qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = target(V1_BADGE + "/violations/project/" + project.getUuid()).request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + project.getUuid()).request()
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
@@ -126,14 +122,14 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByUuidProjectDisabledTest() {
         disableBadge();
-        Response response = target(V1_BADGE + "/violations/project/" + UUID.randomUUID()).request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + UUID.randomUUID()).request()
                 .get(Response.class);
         Assert.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
     public void projectPolicyViolationsByUuidProjectNotFoundTest() {
-        Response response = target(V1_BADGE + "/violations/project/" + UUID.randomUUID()).request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/" + UUID.randomUUID()).request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -141,7 +137,7 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByNameAndVersionTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0").request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.0.0").request()
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals("image/svg+xml", response.getHeaderString("Content-Type"));
@@ -151,14 +147,14 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByNameAndVersionDisabledTest() {
         disableBadge();
-        Response response = target(V1_BADGE + "/violations/project/ProjectNameDoesNotExist/1.0.0").request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/ProjectNameDoesNotExist/1.0.0").request()
                 .get(Response.class);
         Assert.assertEquals(204, response.getStatus(), 0);
     }
 
     @Test
     public void projectPolicyViolationsByNameAndVersionProjectNotFoundTest() {
-        Response response = target(V1_BADGE + "/violations/project/ProjectNameDoesNotExist/1.0.0").request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/ProjectNameDoesNotExist/1.0.0").request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }
@@ -166,7 +162,7 @@ public class BadgeResourceTest extends ResourceTest {
     @Test
     public void projectPolicyViolationsByNameAndVersionVersionNotFoundTest() {
         qm.createProject("Acme Example", null, "1.0.0", null, null, null, true, false);
-        Response response = target(V1_BADGE + "/violations/project/Acme%20Example/1.2.0").request()
+        Response response = jersey.target(V1_BADGE + "/violations/project/Acme%20Example/1.2.0").request()
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
     }

--- a/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CalculatorResourceTest.java
@@ -20,12 +20,11 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 import us.springett.owasp.riskrating.Level;
 
@@ -34,18 +33,15 @@ import javax.ws.rs.core.Response;
 
 public class CalculatorResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(CalculatorResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(CalculatorResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getCvssScoresV3Test() {
-        Response response = target(V1_CALCULATOR + "/cvss")
+        Response response = jersey.target(V1_CALCULATOR + "/cvss")
                 .queryParam("vector", "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -61,7 +57,7 @@ public class CalculatorResourceTest extends ResourceTest {
 
     @Test
     public void getCvssScoresV2Test() {
-        Response response = target(V1_CALCULATOR + "/cvss")
+        Response response = jersey.target(V1_CALCULATOR + "/cvss")
                 .queryParam("vector", "(AV:N/AC:L/Au:N/C:P/I:P/A:P)")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -77,7 +73,7 @@ public class CalculatorResourceTest extends ResourceTest {
 
     @Test
     public void getCvssScoresInvalidTest() {
-        Response response = target(V1_CALCULATOR + "/cvss")
+        Response response = jersey.target(V1_CALCULATOR + "/cvss")
                 .queryParam("vector", "foobar")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -90,7 +86,7 @@ public class CalculatorResourceTest extends ResourceTest {
 
     @Test
     public void getOwaspRRScoresTest() {
-        Response response = target(V1_CALCULATOR + "/owasp")
+        Response response = jersey.target(V1_CALCULATOR + "/owasp")
                 .queryParam("vector", "SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -109,7 +105,7 @@ public class CalculatorResourceTest extends ResourceTest {
 
     @Test
     public void getOwaspScoresInvalidTest() {
-        Response response = target(V1_CALCULATOR + "/owasp")
+        Response response = jersey.target(V1_CALCULATOR + "/owasp")
                 .queryParam("vector", "foobar")
                 .request()
                 .header(X_API_KEY, apiKey)

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourcePostgresTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourcePostgresTest.java
@@ -19,18 +19,18 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import org.apache.http.HttpStatus;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.Json;
@@ -46,19 +46,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ComponentResourcePostgresTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(ComponentResource.class)
-                                .register(ApiFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(ComponentResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getAllComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
-        final Response response = target(V1_COMPONENT + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -73,7 +71,7 @@ public class ComponentResourcePostgresTest extends ResourceTest {
     public void getOutdatedComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
-        final Response response = target(V1_COMPONENT + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
                 .queryParam("onlyOutdated", true)
                 .queryParam("onlyDirect", false)
                 .request()
@@ -90,7 +88,7 @@ public class ComponentResourcePostgresTest extends ResourceTest {
     public void getOutdatedDirectComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
-        final Response response = target(V1_COMPONENT + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
                 .queryParam("onlyOutdated", true)
                 .queryParam("onlyDirect", true)
                 .request()
@@ -107,7 +105,7 @@ public class ComponentResourcePostgresTest extends ResourceTest {
     public void getAllDirectComponentsTest() throws MalformedPackageURLException {
         final Project project = prepareProject();
 
-        final Response response = target(V1_COMPONENT + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
                 .queryParam("onlyDirect", true)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -140,7 +138,7 @@ public class ComponentResourcePostgresTest extends ResourceTest {
         componentC.setName("somethingCompletelyDifferent");
         qm.persist(componentC);
 
-        final Response response = target(V1_COMPONENT + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
                 .queryParam("searchText", "ACME")
                 .request()
                 .header(X_API_KEY, apiKey)

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -18,17 +18,16 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.server.filters.ApiFilter;
-import alpine.server.filters.AuthenticationFilter;
 import alpine.model.ConfigProperty;
 import alpine.model.IConfigProperty;
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -42,21 +41,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfigPropertyResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(ConfigPropertyResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(ConfigPropertyResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getConfigPropertiesTest() {
         qm.createConfigProperty("my.group", "my.string", "ABC", IConfigProperty.PropertyType.STRING, "A string");
         qm.createConfigProperty("my.group", "my.integer", "1", IConfigProperty.PropertyType.INTEGER, "A integer");
         qm.createConfigProperty("my.group", "my.password", "password", IConfigProperty.PropertyType.ENCRYPTEDSTRING, "A password");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -85,7 +81,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.string", "ABC", IConfigProperty.PropertyType.STRING, "A string");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("DEF");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -103,7 +99,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.boolean", "false", IConfigProperty.PropertyType.BOOLEAN, "A boolean");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("true");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -121,7 +117,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.number", "7.75", IConfigProperty.PropertyType.NUMBER, "A number");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("5.50");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -139,7 +135,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.TASK_SCHEDULER_LDAP_SYNC_CADENCE.getGroupName(), "my.cadence", "24", IConfigProperty.PropertyType.INTEGER, "A cadence");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("-2");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(400, response.getStatus(), 0);
@@ -152,7 +148,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty(ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getGroupName(), ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getPropertyName(), "24", IConfigProperty.PropertyType.INTEGER, ConfigPropertyConstants.SEARCH_INDEXES_CONSISTENCY_CHECK_DELTA_THRESHOLD.getDescription());
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("-1");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(400, response.getStatus(), 0);
@@ -165,7 +161,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.url", "http://localhost", IConfigProperty.PropertyType.URL, "A url");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("http://localhost/path");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -183,7 +179,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.uuid", "a496cabc-749d-4751-b9e5-3b49b656d018", IConfigProperty.PropertyType.UUID, "A uuid");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -201,7 +197,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         ConfigProperty property = qm.createConfigProperty("my.group", "my.encryptedString", "aaaaa", IConfigProperty.PropertyType.ENCRYPTEDSTRING, "A encrypted string");
         ConfigProperty request = qm.detach(ConfigProperty.class, property.getId());
         request.setPropertyValue("bbbbb");
-        Response response = target(V1_CONFIG_PROPERTY).request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -224,7 +220,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
                 ConfigPropertyConstants.INTERNAL_CLUSTER_ID.getDescription()
         );
 
-        final Response response = target(V1_CONFIG_PROPERTY).request()
+        final Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity("""
                         {
@@ -250,7 +246,7 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         prop4 = qm.detach(ConfigProperty.class, prop4.getId());
         prop3.setPropertyValue("XYZ");
         prop4.setPropertyValue("-2");
-        Response response = target(V1_CONFIG_PROPERTY+"/aggregate").request()
+        Response response = jersey.target(V1_CONFIG_PROPERTY+"/aggregate").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(Arrays.asList(prop1, prop2, prop3, prop4), MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
@@ -20,14 +20,13 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.persistence.CweImporter;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -36,14 +35,11 @@ import javax.ws.rs.core.Response;
 
 public class CweResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(CweResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(CweResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Before
     public void before() throws Exception {
@@ -54,7 +50,7 @@ public class CweResourceTest extends ResourceTest {
 
     @Test
     public void getCwesTest() {
-        Response response = target(V1_CWE).request()
+        Response response = jersey.target(V1_CWE).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -68,7 +64,7 @@ public class CweResourceTest extends ResourceTest {
 
     @Test
     public void getCweTest() {
-        Response response = target(V1_CWE + "/79").request()
+        Response response = jersey.target(V1_CWE + "/79").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/DependencyGraphResourceTest.java
@@ -41,6 +41,7 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import net.javacrumbs.jsonunit.core.Option;
 import org.apache.http.HttpStatus;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
@@ -49,10 +50,8 @@ import org.dependencytrack.model.RepositoryMetaComponent;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.model.ServiceComponent;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.json.JSONArray;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -68,15 +67,11 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class DependencyGraphResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(DependencyGraphResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
-    }
-
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(DependencyGraphResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getComponentsAndServicesByComponentUuidTests() {
@@ -120,7 +115,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
 
         final UUID rootUuid = qm.createComponent(rootComponent, false).getUuid();
 
-        final Response response = target(V1_DEPENDENCY_GRAPH + "/component/" + rootUuid.toString() + "/directDependencies")
+        final Response response = jersey.target(V1_DEPENDENCY_GRAPH + "/component/" + rootUuid.toString() + "/directDependencies")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -202,7 +197,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
 
         final UUID rootUuid = qm.createComponent(rootComponent, false).getUuid();
 
-        final Response response = target(V1_DEPENDENCY_GRAPH + "/component/" + rootUuid.toString() + "/directDependencies")
+        final Response response = jersey.target(V1_DEPENDENCY_GRAPH + "/component/" + rootUuid.toString() + "/directDependencies")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -250,7 +245,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
         project.setDirectDependencies(jsonArray.toString());
         qm.updateProject(project, false);
 
-        final Response response = target(V1_DEPENDENCY_GRAPH + "/project/" + project.getUuid().toString() + "/directDependencies")
+        final Response response = jersey.target(V1_DEPENDENCY_GRAPH + "/project/" + project.getUuid().toString() + "/directDependencies")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -326,7 +321,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
         project.setDirectDependencies(jsonArray.toString());
         qm.updateProject(project, false);
 
-        final Response response = target(V1_DEPENDENCY_GRAPH + "/project/" + project.getUuid().toString() + "/directDependencies")
+        final Response response = jersey.target(V1_DEPENDENCY_GRAPH + "/project/" + project.getUuid().toString() + "/directDependencies")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -374,7 +369,7 @@ public class DependencyGraphResourceTest extends ResourceTest {
                 """.formatted(componentWithPurl.getUuid(), componentWithoutPurl.getUuid()));
         qm.persist(project);
 
-        final Response response = target("%s/project/%s/directDependencies".formatted(V1_DEPENDENCY_GRAPH, project.getUuid()))
+        final Response response = jersey.target("%s/project/%s/directDependencies".formatted(V1_DEPENDENCY_GRAPH, project.getUuid()))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.Config;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
@@ -32,11 +33,9 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.WorkflowStep;
 import org.dependencytrack.persistence.CweImporter;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -54,18 +53,16 @@ import static org.junit.Assert.assertEquals;
 
 public class FindingResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(FindingResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(FindingResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Before
-    public void setUp() throws Exception {
-        super.setUp();
+    @Override
+    public void before() throws Exception {
+        super.before();
         new CweImporter().processCweDefinitions();
     }
 
@@ -87,7 +84,7 @@ public class FindingResourceTest extends ResourceTest {
         qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
-        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
+        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertEquals(200, response.getStatus(), 0);
@@ -139,7 +136,7 @@ public class FindingResourceTest extends ResourceTest {
 
     @Test
     public void getFindingsByProjectInvalidTest() {
-        Response response = target(V1_FINDING + "/project/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_FINDING + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertEquals(404, response.getStatus(), 0);
@@ -166,7 +163,7 @@ public class FindingResourceTest extends ResourceTest {
         qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
-        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString() + "/export").request()
+        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString() + "/export").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertEquals(200, response.getStatus(), 0);
@@ -226,7 +223,7 @@ public class FindingResourceTest extends ResourceTest {
 
     @Test
     public void exportFindingsByProjectInvalidTest() {
-        Response response = target(V1_FINDING + "/project/" + UUID.randomUUID().toString() + "/export").request()
+        Response response = jersey.target(V1_FINDING + "/project/" + UUID.randomUUID().toString() + "/export").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertEquals(404, response.getStatus(), 0);
@@ -284,7 +281,7 @@ public class FindingResourceTest extends ResourceTest {
         qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
         qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
         qm.addVulnerability(v4, c5, AnalyzerIdentity.NONE);
-        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
+        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertEquals(200, response.getStatus(), 0);
@@ -345,7 +342,7 @@ public class FindingResourceTest extends ResourceTest {
 
         Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
         qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
-        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
+        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertEquals(200, response.getStatus(), 0);
@@ -370,7 +367,7 @@ public class FindingResourceTest extends ResourceTest {
     public void testWorkflowStepsShouldBeCreatedOnReanalyze() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
 
-        Response response = target(V1_FINDING + "/project/" + p1.getUuid().toString() +  "/analyze").request()
+        Response response = jersey.target(V1_FINDING + "/project/" + p1.getUuid().toString() +  "/analyze").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json("{}"));
         Map<String, String> responseMap = response.readEntity(Map.class);

--- a/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LdapResourceTest.java
@@ -18,16 +18,15 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.model.MappedLdapGroup;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import alpine.model.MappedLdapGroup;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.resources.v1.vo.MappedLdapGroupRequest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -39,18 +38,15 @@ import java.util.UUID;
 
 public class LdapResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(LdapResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(LdapResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void retrieveLdapGroupsNotEnabledTest() {
-        Response response = target(V1_LDAP + "/groups").request()
+        Response response = jersey.target(V1_LDAP + "/groups").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -65,7 +61,7 @@ public class LdapResourceTest extends ResourceTest {
     public void retrieveLdapGroupsTest() {
         qm.createMappedLdapGroup(team, "CN=Developers,OU=R&D,O=Acme");
         qm.createMappedLdapGroup(team, "CN=QA,OU=R&D,O=Acme");
-        Response response = target(V1_LDAP + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_LDAP + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -80,7 +76,7 @@ public class LdapResourceTest extends ResourceTest {
     @Test
     public void addMappingTest() {
         MappedLdapGroupRequest request = new MappedLdapGroupRequest(team.getUuid().toString(), "CN=Administrators,OU=R&D,O=Acme");
-        Response response = target(V1_LDAP + "/mapping").request()
+        Response response = jersey.target(V1_LDAP + "/mapping").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -93,7 +89,7 @@ public class LdapResourceTest extends ResourceTest {
     @Test
     public void addMappingInvalidTest() {
         MappedLdapGroupRequest request = new MappedLdapGroupRequest(UUID.randomUUID().toString(), "CN=Administrators,OU=R&D,O=Acme");
-        Response response = target(V1_LDAP + "/mapping").request()
+        Response response = jersey.target(V1_LDAP + "/mapping").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -105,7 +101,7 @@ public class LdapResourceTest extends ResourceTest {
     @Test
     public void deleteMappingTest() {
         MappedLdapGroup mapping = qm.createMappedLdapGroup(team, "CN=Finance,OU=R&D,O=Acme");
-        Response response = target(V1_LDAP + "/mapping/" + mapping.getUuid().toString()).request()
+        Response response = jersey.target(V1_LDAP + "/mapping/" + mapping.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete(Response.class);
         Assert.assertEquals(204, response.getStatus(), 0);
@@ -114,7 +110,7 @@ public class LdapResourceTest extends ResourceTest {
 
     @Test
     public void deleteMappingInvalidTest() {
-        Response response = target(V1_LDAP + "/mapping/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_LDAP + "/mapping/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/LicenseResourceTest.java
@@ -21,15 +21,13 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.License;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
-import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -40,24 +38,22 @@ import javax.ws.rs.core.Response;
 
 public class LicenseResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(LicenseResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(LicenseResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
-    @Before
-    public void loadDefaultLicenses() {
-        DefaultObjectGenerator dog = new DefaultObjectGenerator();
-        dog.contextInitialized(null);
+    @Override
+    public void before() throws Exception {
+        super.before();
+        final var generator = new DefaultObjectGenerator();
+        generator.loadDefaultLicenses();
     }
 
     @Test
     public void getLicensesTest() {
-        Response response = target(V1_LICENSE).request()
+        Response response = jersey.target(V1_LICENSE).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -73,7 +69,7 @@ public class LicenseResourceTest extends ResourceTest {
 
     @Test
     public void getLicensesConciseTest() {
-        Response response = target(V1_LICENSE + "/concise").request()
+        Response response = jersey.target(V1_LICENSE + "/concise").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -89,7 +85,7 @@ public class LicenseResourceTest extends ResourceTest {
 
     @Test
     public void getLicense() {
-        Response response = target(V1_LICENSE + "/Apache-2.0").request()
+        Response response = jersey.target(V1_LICENSE + "/Apache-2.0").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -104,7 +100,7 @@ public class LicenseResourceTest extends ResourceTest {
 
     @Test
     public void getLicenseInvalid() {
-        Response response = target(V1_LICENSE + "/blah").request()
+        Response response = jersey.target(V1_LICENSE + "/blah").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -118,7 +114,7 @@ public class LicenseResourceTest extends ResourceTest {
         License license = new License();
         license.setName("Acme Example");
         license.setLicenseId("Acme-Example-License");
-        Response response = target(V1_LICENSE)
+        Response response = jersey.target(V1_LICENSE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(license, MediaType.APPLICATION_JSON));
@@ -139,7 +135,7 @@ public class LicenseResourceTest extends ResourceTest {
         License license = new License();
         license.setName("Apache License 2.0");
         license.setLicenseId("Apache-2.0");
-        Response response = target(V1_LICENSE)
+        Response response = jersey.target(V1_LICENSE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(license, MediaType.APPLICATION_JSON));
@@ -153,7 +149,7 @@ public class LicenseResourceTest extends ResourceTest {
     public void createCustomLicenseWithoutLicenseId() {
         License license = new License();
         license.setName("Acme Example");
-        Response response = target(V1_LICENSE)
+        Response response = jersey.target(V1_LICENSE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(license, MediaType.APPLICATION_JSON));
@@ -169,7 +165,7 @@ public class LicenseResourceTest extends ResourceTest {
         license.setCustomLicense(true);
         qm.createCustomLicense(license, false);
 
-        Response response = target(V1_LICENSE + "/" + license.getLicenseId())
+        Response response = jersey.target(V1_LICENSE + "/" + license.getLicenseId())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -184,7 +180,7 @@ public class LicenseResourceTest extends ResourceTest {
         license1.setName("Acme Example");
         License license2 = qm.createCustomLicense(license1, false);
         license1.setCustomLicense(false);
-        Response response = target(V1_LICENSE + "/" + license1.getLicenseId())
+        Response response = jersey.target(V1_LICENSE + "/" + license1.getLicenseId())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -23,6 +23,7 @@ import alpine.model.Team;
 import alpine.notification.NotificationLevel;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.NotificationPublisher;
 import org.dependencytrack.model.NotificationRule;
@@ -33,11 +34,9 @@ import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -57,20 +56,17 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class NotificationRuleResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(NotificationRuleResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(NotificationRuleResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Before
     public void before() throws Exception {
         super.before();
-        DefaultObjectGenerator generator = new DefaultObjectGenerator();
-        generator.contextInitialized(null);
+        final var generator = new DefaultObjectGenerator();
+        generator.loadDefaultNotificationPublishers();
     }
 
     @Test
@@ -79,7 +75,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         NotificationRule r1 = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         NotificationRule r2 = qm.createNotificationRule("Rule 2", NotificationScope.PORTFOLIO, NotificationLevel.WARNING, publisher);
         NotificationRule r3 = qm.createNotificationRule("Rule 3", NotificationScope.SYSTEM, NotificationLevel.ERROR, publisher);
-        Response response = target(V1_NOTIFICATION_RULE).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -107,7 +103,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         rule.setNotificationLevel(NotificationLevel.WARNING);
         rule.setScope(NotificationScope.SYSTEM);
         rule.setPublisher(publisher);
-        Response response = target(V1_NOTIFICATION_RULE).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(rule, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
@@ -134,7 +130,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         rule.setNotificationLevel(NotificationLevel.WARNING);
         rule.setScope(NotificationScope.SYSTEM);
         rule.setPublisher(publisher);
-        Response response = target(V1_NOTIFICATION_RULE).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(rule, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -149,7 +145,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule.setName("Example Rule");
         rule.setNotifyOn(Collections.singleton(NotificationGroup.NEW_VULNERABILITY));
-        Response response = target(V1_NOTIFICATION_RULE).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(rule, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -170,7 +166,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule = qm.detach(NotificationRule.class, rule.getId());
         rule.setUuid(UUID.randomUUID());
-        Response response = target(V1_NOTIFICATION_RULE).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(rule, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -184,7 +180,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Rule 1", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
         rule.setName("Example Rule");
-        Response response = target(V1_NOTIFICATION_RULE).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE).request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(rule, MediaType.APPLICATION_JSON)); // HACK
@@ -197,7 +193,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -213,7 +209,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void addProjectToRuleInvalidRuleTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
-        Response response = target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -227,7 +223,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.SYSTEM, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(406, response.getStatus(), 0);
@@ -240,7 +236,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void addProjectToRuleInvalidProjectTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -258,7 +254,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         projects.add(project);
         rule.setProjects(projects);
         qm.persist(rule);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -274,7 +270,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         projects.add(project);
         rule.setProjects(projects);
         qm.persist(rule);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -285,7 +281,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void removeProjectFromRuleInvalidRuleTest() {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
-        Response response = target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -299,7 +295,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.SYSTEM, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(406, response.getStatus(), 0);
@@ -312,7 +308,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void removeProjectFromRuleInvalidProjectTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -326,7 +322,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Project project = qm.createProject("Acme Example", null, null, null, null, null, true, false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/project/" + project.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -338,7 +334,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -354,7 +350,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void addTeamToRuleInvalidRuleTest(){
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
-        Response response = target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -367,7 +363,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void addTeamToRuleInvalidTeamTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -386,7 +382,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         teams.add(team);
         rule.setTeams(teams);
         qm.persist(rule);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -398,7 +394,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         Assert.assertEquals(406, response.getStatus(), 0);
@@ -412,7 +408,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         final Team team = qm.createTeam("Team Example", false);
         final NotificationPublisher publisher = qm.createNotificationPublisher("foo", "description", SendMailPublisher.name(), "template", "templateMimeType", false);
         final NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        final Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid() + "/team/" + team.getUuid()).request()
+        final Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid() + "/team/" + team.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(""));
         assertThat(response.getStatus()).isEqualTo(200);
@@ -459,7 +455,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         teams.add(team);
         rule.setTeams(teams);
         qm.persist(rule);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -470,7 +466,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void removeTeamFromRuleInvalidRuleTest() {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
-        Response response = target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + UUID.randomUUID().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -483,7 +479,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
     public void removeTeamFromRuleInvalidTeamTest() {
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -497,7 +493,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -509,7 +505,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.SLACK.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        Response response = target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
+        Response response = jersey.target(V1_NOTIFICATION_RULE + "/" + rule.getUuid().toString() + "/team/" + team.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(406, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/OidcResourceUnauthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OidcResourceUnauthenticatedTest.java
@@ -19,11 +19,10 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -32,17 +31,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OidcResourceUnauthenticatedTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(OidcResource.class)
-                        .register(ApiFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(OidcResource.class)
+                    .register(ApiFilter.class));
 
     @Test
     public void isAvailableShouldReturnFalseWhenOidcIsNotAvailable() {
-        final Response response = target(V1_OIDC + "/available")
+        final Response response = jersey.target(V1_OIDC + "/available")
                 .request().get();
 
         assertThat(getPlainTextBody(response)).isEqualTo("false");

--- a/src/test/java/org/dependencytrack/resources/v1/OsvEcosystemResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/OsvEcosystemResourceTest.java
@@ -21,13 +21,12 @@ package org.dependencytrack.resources.v1;
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -38,14 +37,11 @@ import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SO
 
 public class OsvEcosystemResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(OsvEcosytemResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(OsvEcosytemResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Before
     public void before() throws Exception {
@@ -64,7 +60,7 @@ public class OsvEcosystemResourceTest extends ResourceTest {
 
     @Test
     public void getEcosystemsTest() {
-        Response response = target(V1_OSV_ECOSYSTEM).request()
+        Response response = jersey.target(V1_OSV_ECOSYSTEM).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -74,7 +70,7 @@ public class OsvEcosystemResourceTest extends ResourceTest {
         Assert.assertFalse(json.isEmpty());
         var total = json.size();
 
-        response = target(V1_OSV_ECOSYSTEM + "/inactive").request()
+        response = jersey.target(V1_OSV_ECOSYSTEM + "/inactive").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -18,21 +18,19 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.server.filters.ApiFilter;
-import alpine.server.filters.AuthenticationFilter;
 import alpine.model.ManagedUser;
 import alpine.model.Permission;
 import alpine.model.Team;
-import alpine.server.auth.PasswordService;
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.persistence.DefaultObjectGenerator;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -44,25 +42,22 @@ import java.util.UUID;
 
 public class PermissionResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(PermissionResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(PermissionResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Before
     public void before() throws Exception {
         super.before();
-        DefaultObjectGenerator generator = new DefaultObjectGenerator();
-        generator.contextInitialized(null);
+        final var generator = new DefaultObjectGenerator();
+        generator.loadDefaultPermissions();
     }
 
     @Test
     public void getAllPermissionsTest() {
-        Response response = target(V1_PERMISSION).request()
+        Response response = jersey.target(V1_PERMISSION).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -76,10 +71,10 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void addPermissionToUserTest() {
-        ManagedUser user = qm.createManagedUser("user1", new String(PasswordService.createHash("password".toCharArray())));
+        ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         qm.close();
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -92,7 +87,7 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void addPermissionToUserInvalidUserTest() {
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/blah").request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/blah").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -103,10 +98,10 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void addPermissionToUserInvalidPermissionTest() {
-        ManagedUser user = qm.createManagedUser("user1", new String(PasswordService.createHash("password".toCharArray())));
+        ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         qm.close();
-        Response response = target(V1_PERMISSION + "/BLAH/user/" + username).request()
+        Response response = jersey.target(V1_PERMISSION + "/BLAH/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -117,13 +112,13 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void addPermissionToUserDuplicateTest() {
-        ManagedUser user = qm.createManagedUser("user1", new String(PasswordService.createHash("password".toCharArray())));
+        ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         Permission permission = qm.getPermission(Permissions.PORTFOLIO_MANAGEMENT.name());
         user.getPermissions().add(permission);
         qm.persist(user);
         qm.close();
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -132,13 +127,13 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void removePermissionFromUserTest() {
-        ManagedUser user = qm.createManagedUser("user1", new String(PasswordService.createHash("password".toCharArray())));
+        ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         Permission permission = qm.getPermission(Permissions.PORTFOLIO_MANAGEMENT.name());
         user.getPermissions().add(permission);
         qm.persist(user);
         qm.close();
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -150,7 +145,7 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void removePermissionFromUserInvalidUserTest() {
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/blah").request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/user/blah").request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -161,10 +156,10 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void removePermissionFromUserInvalidPermissionTest() {
-        ManagedUser user = qm.createManagedUser("user1", new String(PasswordService.createHash("password".toCharArray())));
+        ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
         qm.close();
-        Response response = target(V1_PERMISSION + "/BLAH/user/" + username).request()
+        Response response = jersey.target(V1_PERMISSION + "/BLAH/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -175,9 +170,9 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void removePermissionFromUserNoChangesTest() {
-        ManagedUser user = qm.createManagedUser("user1", new String(PasswordService.createHash("password".toCharArray())));
+        ManagedUser user = qm.createManagedUser("user1", TEST_USER_PASSWORD_HASH);
         String username = user.getUsername();
-        Response response = target(V1_PERMISSION + "/BOM_UPLOAD/user/" + username).request()
+        Response response = jersey.target(V1_PERMISSION + "/BOM_UPLOAD/user/" + username).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -189,7 +184,7 @@ public class PermissionResourceTest extends ResourceTest {
         Team team = qm.createTeam("team1", false);
         String teamUuid = team.getUuid().toString();
         qm.close();
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -202,7 +197,7 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void addPermissionToTeamInvalidTeamTest() {
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -216,7 +211,7 @@ public class PermissionResourceTest extends ResourceTest {
         Team team = qm.createTeam("team1", false);
         String teamUuid = team.getUuid().toString();
         qm.close();
-        Response response = target(V1_PERMISSION + "/BLAH/team/" + teamUuid).request()
+        Response response = jersey.target(V1_PERMISSION + "/BLAH/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -233,7 +228,7 @@ public class PermissionResourceTest extends ResourceTest {
         team.getPermissions().add(permission);
         qm.persist(team);
         qm.close();
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(304, response.getStatus(), 0);
@@ -248,7 +243,7 @@ public class PermissionResourceTest extends ResourceTest {
         team.getPermissions().add(permission);
         qm.persist(team);
         qm.close();
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -260,7 +255,7 @@ public class PermissionResourceTest extends ResourceTest {
 
     @Test
     public void removePermissionFromTeamInvalidTeamTest() {
-        Response response = target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_PERMISSION + "/PORTFOLIO_MANAGEMENT/team/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -274,7 +269,7 @@ public class PermissionResourceTest extends ResourceTest {
         Team team = qm.createTeam("team1", false);
         String teamUuid = team.getUuid().toString();
         qm.close();
-        Response response = target(V1_PERMISSION + "/BLAH/team/" + teamUuid).request()
+        Response response = jersey.target(V1_PERMISSION + "/BLAH/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -287,7 +282,7 @@ public class PermissionResourceTest extends ResourceTest {
     public void removePermissionFromTeamNoChangesTest() {
         Team team = qm.createTeam("team1", false);
         String teamUuid = team.getUuid().toString();
-        Response response = target(V1_PERMISSION + "/BOM_UPLOAD/team/" + teamUuid).request()
+        Response response = jersey.target(V1_PERMISSION + "/BOM_UPLOAD/team/" + teamUuid).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(304, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyConditionResourceTest.java
@@ -20,13 +20,12 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.PolicyCondition;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.client.Entity;
@@ -38,20 +37,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PolicyConditionResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(PolicyConditionResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(PolicyConditionResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void testCreateExpressionCondition() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
 
-        final Response response = target("%s/%s/condition".formatted(V1_POLICY, policy.getUuid()))
+        final Response response = jersey.target("%s/%s/condition".formatted(V1_POLICY, policy.getUuid()))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity("""
@@ -79,7 +75,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
     public void testCreateExpressionConditionWithError() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.FAIL);
 
-        final Response response = target("%s/%s/condition".formatted(V1_POLICY, policy.getUuid()))
+        final Response response = jersey.target("%s/%s/condition".formatted(V1_POLICY, policy.getUuid()))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity("""
@@ -111,7 +107,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
         final PolicyCondition condition = qm.createPolicyCondition(policy,
                 PolicyCondition.Subject.VULNERABILITY_ID, PolicyCondition.Operator.IS, "foobar");
 
-        final Response response = target("%s/condition".formatted(V1_POLICY))
+        final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity("""
@@ -142,7 +138,7 @@ public class PolicyConditionResourceTest extends ResourceTest {
         final PolicyCondition condition = qm.createPolicyCondition(policy,
                 PolicyCondition.Subject.VULNERABILITY_ID, PolicyCondition.Operator.IS, "foobar");
 
-        final Response response = target("%s/condition".formatted(V1_POLICY))
+        final Response response = jersey.target("%s/condition".formatted(V1_POLICY))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity("""

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Policy;
@@ -29,9 +30,7 @@ import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -46,14 +45,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PolicyResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(PolicyResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(PolicyResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getPoliciesTest() {
@@ -61,7 +57,7 @@ public class PolicyResourceTest extends ResourceTest {
             qm.createPolicy("policy" + i, Policy.Operator.ANY, Policy.ViolationState.INFO);
         }
 
-        final Response response = target(V1_POLICY)
+        final Response response = jersey.target(V1_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -79,7 +75,7 @@ public class PolicyResourceTest extends ResourceTest {
     public void getPolicyByUuidTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -99,7 +95,7 @@ public class PolicyResourceTest extends ResourceTest {
         policy.setOperator(Policy.Operator.ANY);
         policy.setViolationState(Policy.ViolationState.INFO);
 
-        final Response response = target(V1_POLICY)
+        final Response response = jersey.target(V1_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
@@ -122,7 +118,7 @@ public class PolicyResourceTest extends ResourceTest {
         policy.setOperator(Policy.Operator.ALL);
         policy.setViolationState(Policy.ViolationState.FAIL);
 
-        final Response response = target(V1_POLICY)
+        final Response response = jersey.target(V1_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
@@ -143,7 +139,7 @@ public class PolicyResourceTest extends ResourceTest {
         final Policy policy = new Policy();
         policy.setName("policy");
 
-        final Response response = target(V1_POLICY)
+        final Response response = jersey.target(V1_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(policy, MediaType.APPLICATION_JSON));
@@ -165,7 +161,7 @@ public class PolicyResourceTest extends ResourceTest {
 
         policy.setViolationState(Policy.ViolationState.FAIL);
         policy.setIncludeChildren(true);
-        final Response response = target(V1_POLICY)
+        final Response response = jersey.target(V1_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(policy, MediaType.APPLICATION_JSON));
@@ -184,7 +180,7 @@ public class PolicyResourceTest extends ResourceTest {
     public void deletePolicyTest() {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -215,7 +211,7 @@ public class PolicyResourceTest extends ResourceTest {
         violation.setTimestamp(new Date());
         qm.persist(violation);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -230,7 +226,7 @@ public class PolicyResourceTest extends ResourceTest {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -250,7 +246,7 @@ public class PolicyResourceTest extends ResourceTest {
         policy.setProjects(singletonList(project));
         qm.persist(policy);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -266,7 +262,7 @@ public class PolicyResourceTest extends ResourceTest {
         policy.setProjects(singletonList(project));
         qm.persist(policy);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -279,7 +275,7 @@ public class PolicyResourceTest extends ResourceTest {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/project/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -293,7 +289,7 @@ public class PolicyResourceTest extends ResourceTest {
         final Tag tag = qm.createTag("Policy Tag");
         System.out.println("Tag being created is "+qm.getTagByName("Policy Tag"));
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -313,7 +309,7 @@ public class PolicyResourceTest extends ResourceTest {
         policy.setTags(singletonList(tag));
         qm.persist(policy);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -329,7 +325,7 @@ public class PolicyResourceTest extends ResourceTest {
         policy.setTags(singletonList(tag));
         qm.persist(policy);
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -342,7 +338,7 @@ public class PolicyResourceTest extends ResourceTest {
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         final Tag tag = qm.createTag("Policy Tag");
 
-        final Response response = target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid() + "/tag/" + tag.getName())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();

--- a/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/PolicyViolationResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
@@ -29,9 +30,7 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -45,15 +44,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class PolicyViolationResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(PolicyViolationResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)
-                                .register(AuthorizationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(PolicyViolationResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(AuthorizationFilter.class));
 
     @Test
     public void getViolationsTest() {
@@ -77,7 +73,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
         violation.setTimestamp(new Date());
         violation = qm.persist(violation);
 
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -99,7 +95,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
 
     @Test
     public void getViolationsUnauthorizedTest() {
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -148,7 +144,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
             }
         }
 
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .queryParam("searchText", "0")
                 .path("/project/" + project.getUuid())
                 .request()
@@ -207,7 +203,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
         qm.persist(violation);
 
         // Requesting violations for projectB must not yield violations for projectA.
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/project/" + projectB.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -221,7 +217,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
 
     @Test
     public void getViolationsByProjectUnauthorizedTest() {
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/project/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -234,7 +230,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     public void getViolationsByProjectNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/project/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -266,7 +262,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
         violation.setTimestamp(new Date());
         violation = qm.persist(violation);
 
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/component/" + component.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -288,7 +284,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
 
     @Test
     public void getViolationsByComponentUnauthorizedTest() {
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/component/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -301,7 +297,7 @@ public class PolicyViolationResourceTest extends ResourceTest {
     public void getViolationsByComponentNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
-        final Response response = target(V1_POLICY_VIOLATION)
+        final Response response = jersey.target(V1_POLICY_VIOLATION)
                 .path("/component/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectPropertyResourceTest.java
@@ -18,18 +18,17 @@
  */
 package org.dependencytrack.resources.v1;
 
+import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import alpine.model.IConfigProperty;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectProperty;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -41,21 +40,18 @@ import java.util.UUID;
 
 public class ProjectPropertyResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(ProjectPropertyResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(ProjectPropertyResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getPropertiesTest() {
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
         qm.createProjectProperty(project, "mygroup", "prop1", "value1", IConfigProperty.PropertyType.STRING, "Test Property 1");
         qm.createProjectProperty(project, "mygroup", "prop2", "value2", IConfigProperty.PropertyType.ENCRYPTEDSTRING, "Test Property 2");
-        Response response = target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -77,7 +73,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
 
     @Test
     public void getPropertiesInvalidTest() {
-       Response response = target(V1_PROJECT + "/" + UUID.randomUUID().toString() + "/property").request()
+       Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -96,7 +92,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         property.setPropertyValue("value1");
         property.setPropertyType(IConfigProperty.PropertyType.STRING);
         property.setDescription("Test Property 1");
-        Response response = target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
@@ -119,7 +115,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         property.setPropertyValue("value1");
         property.setPropertyType(IConfigProperty.PropertyType.ENCRYPTEDSTRING);
         property.setDescription("Test Property 1");
-        Response response = target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
@@ -145,7 +141,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         property.setPropertyValue("value1");
         property.setPropertyType(IConfigProperty.PropertyType.STRING);
         property.setDescription("Test Property 1");
-        Response response = target(V1_PROJECT + "/" + uuid + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + uuid + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
         Assert.assertEquals(409, response.getStatus(), 0);
@@ -164,7 +160,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         property.setPropertyValue("value1");
         property.setPropertyType(IConfigProperty.PropertyType.STRING);
         property.setDescription("Test Property 1");
-        Response response = target(V1_PROJECT + "/" + UUID.randomUUID() + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(property, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -181,7 +177,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         qm.getPersistenceManager().detachCopy(property);
         qm.close();
         property.setPropertyValue("updatedValue");
-        Response response = target(V1_PROJECT + "/" + uuid + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + uuid + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(property, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -203,7 +199,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         property.setPropertyValue("value1");
         property.setPropertyType(IConfigProperty.PropertyType.STRING);
         property.setDescription("Test Property 1");
-        Response response = target(V1_PROJECT + "/" + UUID.randomUUID().toString() + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID().toString() + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(property, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -219,7 +215,7 @@ public class ProjectPropertyResourceTest extends ResourceTest {
         String uuid = project.getUuid().toString();
         qm.getPersistenceManager().detachCopy(property);
         qm.close();
-        Response response = target(V1_PROJECT + "/" + uuid + "/property").request()
+        Response response = jersey.target(V1_PROJECT + "/" + uuid + "/property").request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true) // HACK
                 .method("DELETE", Entity.entity(property, MediaType.APPLICATION_JSON)); // HACK

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -23,6 +23,7 @@ import alpine.event.framework.EventService;
 import alpine.model.IConfigProperty.PropertyType;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.event.CloneProjectEvent;
 import org.dependencytrack.event.kafka.KafkaTopics;
@@ -46,12 +47,10 @@ import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.tasks.CloneProjectTask;
 import org.glassfish.jersey.client.HttpUrlConnectorProvider;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.Json;
@@ -85,19 +84,17 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ProjectResourceTest extends ResourceTest {
 
-    @After
-    public void tearDown() throws Exception {
-        EventService.getInstance().unsubscribe(CloneProjectTask.class);
-        super.tearDown();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(ProjectResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
+    @After
     @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(ProjectResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
+    public void after() {
+        EventService.getInstance().unsubscribe(CloneProjectTask.class);
+        super.after();
     }
 
     @Test
@@ -105,7 +102,7 @@ public class ProjectResourceTest extends ResourceTest {
         for (int i = 0; i < 1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -137,7 +134,7 @@ public class ProjectResourceTest extends ResourceTest {
         // Create a second project that the current principal has no access to.
         qm.createProject("acme-app-b", null, "2.0.0", null, null, null, true, false);
 
-        final Response response = target(V1_PROJECT)
+        final Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -155,7 +152,7 @@ public class ProjectResourceTest extends ResourceTest {
         for (int i = 0; i < 1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .queryParam("name", "Acme Example")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -174,7 +171,7 @@ public class ProjectResourceTest extends ResourceTest {
         for (int i = 0; i < 1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, true, false);
         }
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .queryParam("name", "blah")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -194,7 +191,7 @@ public class ProjectResourceTest extends ResourceTest {
         for (int i = 500; i < 1000; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, false, false);
         }
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .queryParam("name", "Acme Example")
                 .queryParam("excludeInactive", "true")
                 .request()
@@ -212,7 +209,7 @@ public class ProjectResourceTest extends ResourceTest {
         for (int i = 0; i < 500; i++) {
             qm.createProject("Acme Example", null, String.valueOf(i), null, null, null, false, false);
         }
-        Response response = target(V1_PROJECT + "/lookup")
+        Response response = jersey.target(V1_PROJECT + "/lookup")
                 .queryParam("name", "Acme Example")
                 .queryParam("version", "10")
                 .request()
@@ -234,7 +231,7 @@ public class ProjectResourceTest extends ResourceTest {
     public void getProjectsAscOrderedRequestTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .queryParam(ORDER_BY, "name")
                 .queryParam(SORT, SORT_ASC)
                 .request()
@@ -251,7 +248,7 @@ public class ProjectResourceTest extends ResourceTest {
     public void getProjectsDescOrderedRequestTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .queryParam(ORDER_BY, "name")
                 .queryParam(SORT, SORT_DESC)
                 .request()
@@ -267,7 +264,7 @@ public class ProjectResourceTest extends ResourceTest {
     @Test
     public void getProjectByUuidTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/" + project.getUuid())
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -284,7 +281,7 @@ public class ProjectResourceTest extends ResourceTest {
     @Test
     public void getProjectByInvalidUuidTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/" + UUID.randomUUID())
+        Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -301,7 +298,7 @@ public class ProjectResourceTest extends ResourceTest {
         tags.add(tag);
         qm.createProject("ABC", null, "1.0", tags, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/tag/" + "production")
+        Response response = jersey.target(V1_PROJECT + "/tag/" + "production")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -319,7 +316,7 @@ public class ProjectResourceTest extends ResourceTest {
         tags.add(tag);
         qm.createProject("ABC", null, "1.0", tags, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/tag/" + "production")
+        Response response = jersey.target(V1_PROJECT + "/tag/" + "production")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -337,7 +334,7 @@ public class ProjectResourceTest extends ResourceTest {
         tags.add(tag);
         qm.createProject("ABC", null, "1.0", tags, null, null, true, false);
         qm.createProject("DEF", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/tag/" + "stable")
+        Response response = jersey.target(V1_PROJECT + "/tag/" + "stable")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -354,7 +351,7 @@ public class ProjectResourceTest extends ResourceTest {
         project.setName("Acme Example");
         project.setVersion("1.0");
         project.setDescription("Test project");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -381,12 +378,12 @@ public class ProjectResourceTest extends ResourceTest {
         Project project = new Project();
         project.setName("Acme Example");
         project.setVersion("1.0");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
-        response = target(V1_PROJECT)
+        response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -409,7 +406,7 @@ public class ProjectResourceTest extends ResourceTest {
                     throw new RuntimeException(e);
                 }
 
-                final Response response = target(V1_PROJECT)
+                final Response response = jersey.target(V1_PROJECT)
                         .request()
                         .header(X_API_KEY, apiKey)
                         .put(Entity.entity("""
@@ -435,7 +432,7 @@ public class ProjectResourceTest extends ResourceTest {
     public void createProjectEmptyTest() {
         Project project = new Project();
         project.setName(" ");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -446,7 +443,7 @@ public class ProjectResourceTest extends ResourceTest {
     public void updateProjectTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         project.setDescription("Test project");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -464,7 +461,7 @@ public class ProjectResourceTest extends ResourceTest {
         project.setDescription("Test project");
         project.setActive(null);
         Assert.assertNull(project.isActive());
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -492,7 +489,7 @@ public class ProjectResourceTest extends ResourceTest {
         }).collect(Collectors.toList()));
 
         // update the 1st time and add another tag
-        var response = target(V1_PROJECT)
+        var response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
@@ -509,7 +506,7 @@ public class ProjectResourceTest extends ResourceTest {
         Assert.assertEquals("tag3", jsonTags.get(2).asJsonObject().getString("name"));
 
         // and update again with the same tags ... issue #1165
-        response = target(V1_PROJECT)
+        response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
@@ -522,7 +519,7 @@ public class ProjectResourceTest extends ResourceTest {
 
         // and finally delete one of the tags
         jsonProject.getTags().remove(0);
-        response = target(V1_PROJECT)
+        response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(jsonProject, MediaType.APPLICATION_JSON));
@@ -537,7 +534,7 @@ public class ProjectResourceTest extends ResourceTest {
     public void updateProjectEmptyNameTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         project.setName(" ");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -550,7 +547,7 @@ public class ProjectResourceTest extends ResourceTest {
         Project project = qm.createProject("DEF", null, "1.0", null, null, null, true, false);
         project = qm.detach(Project.class, project.getId());
         project.setName("ABC");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -562,7 +559,7 @@ public class ProjectResourceTest extends ResourceTest {
     @Test
     public void deleteProjectTest() {
         Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/" + project.getUuid().toString())
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid().toString())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -572,7 +569,7 @@ public class ProjectResourceTest extends ResourceTest {
     @Test
     public void deleteProjectInvalidUuidTest() {
         qm.createProject("ABC", null, "1.0", null, null, null, true, false);
-        Response response = target(V1_PROJECT + "/" + UUID.randomUUID().toString())
+        Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID().toString())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -586,7 +583,7 @@ public class ProjectResourceTest extends ResourceTest {
 
         final var jsonProject = new Project();
         jsonProject.setDescription(p1.getDescription());
-        final var response = target(V1_PROJECT + "/" + p1.getUuid())
+        final var response = jersey.target(V1_PROJECT + "/" + p1.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -602,7 +599,7 @@ public class ProjectResourceTest extends ResourceTest {
         qm.createProject("ABC", "Test project", "0.9", null, null, null, false, false);
         final var jsonProject = new Project();
         jsonProject.setVersion("0.9");
-        final var response = target(V1_PROJECT + "/" + p1.getUuid())
+        final var response = jersey.target(V1_PROJECT + "/" + p1.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -613,7 +610,7 @@ public class ProjectResourceTest extends ResourceTest {
 
     @Test
     public void patchProjectNotFoundTest() {
-        final var response = target(V1_PROJECT + "/" + UUID.randomUUID())
+        final var response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -632,7 +629,7 @@ public class ProjectResourceTest extends ResourceTest {
                         .add("uuid", newParent.getUuid().toString()))
                 .build();
 
-        final Response response = target(V1_PROJECT + "/" + project.getUuid())
+        final Response response = jersey.target(V1_PROJECT + "/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -679,7 +676,7 @@ public class ProjectResourceTest extends ResourceTest {
         final var jsonProject = new Project();
         jsonProject.setExternalReferences(externalReferences);
 
-        final var response = target(V1_PROJECT + "/" + project.getUuid())
+        final var response = jersey.target(V1_PROJECT + "/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -708,7 +705,7 @@ public class ProjectResourceTest extends ResourceTest {
                         .add("uuid", UUID.randomUUID().toString()))
                 .build();
 
-        final Response response = target(V1_PROJECT + "/" + project.getUuid())
+        final Response response = jersey.target(V1_PROJECT + "/" + project.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -765,7 +762,7 @@ public class ProjectResourceTest extends ResourceTest {
         jsonProjectSupplier.setUrls(new String[]{"https://supplier.example.com"});
         jsonProjectSupplier.setContacts(List.of(jsonProjectSupplierContact));
         jsonProject.setSupplier(jsonProjectSupplier);
-        final var response = target(V1_PROJECT + "/" + p1.getUuid())
+        final var response = jersey.target(V1_PROJECT + "/" + p1.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(HttpUrlConnectorProvider.SET_METHOD_WORKAROUND, true)
@@ -818,7 +815,7 @@ public class ProjectResourceTest extends ResourceTest {
         Project parent = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
         Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
         qm.createProject("GHI", null, "1.0", null, child, null, true, false);
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .queryParam("onlyRoot", true)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -837,7 +834,7 @@ public class ProjectResourceTest extends ResourceTest {
         Project child = qm.createProject("DEF", null, "1.0", null, parent, null, true, false);
         qm.createProject("GHI", null, "1.0", null, parent, null, true, false);
         qm.createProject("JKL", null, "1.0", null, child, null, true, false);
-        Response response = target(V1_PROJECT + "/" + parent.getUuid().toString() + "/children")
+        Response response = jersey.target(V1_PROJECT + "/" + parent.getUuid().toString() + "/children")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -883,12 +880,12 @@ public class ProjectResourceTest extends ResourceTest {
     public void createProjectWithoutVersionDuplicateTest() {
         Project project = new Project();
         project.setName("Acme Example");
-        Response response = target(V1_PROJECT)
+        Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
-        response = target(V1_PROJECT)
+        response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(project, MediaType.APPLICATION_JSON));
@@ -918,7 +915,7 @@ public class ProjectResourceTest extends ResourceTest {
         Project child = qm.createProject("GHI", null, "1.0", null, parent, null, true, false);
         qm.createProject("JKL", null, "1.0", null, child, null, true, false);
 
-        Response response = target(V1_PROJECT + "/withoutDescendantsOf/" + parent.getUuid())
+        Response response = jersey.target(V1_PROJECT + "/withoutDescendantsOf/" + parent.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -990,7 +987,7 @@ public class ProjectResourceTest extends ResourceTest {
                 AnalysisJustification.REQUIRES_ENVIRONMENT, AnalysisResponse.WILL_NOT_FIX, "details", false);
         qm.makeAnalysisComment(analysis, "comment", "commenter");
 
-        final Response response = target("%s/clone".formatted(V1_PROJECT)).request()
+        final Response response = jersey.target("%s/clone".formatted(V1_PROJECT)).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json("""
                         {
@@ -1075,7 +1072,7 @@ public class ProjectResourceTest extends ResourceTest {
         project.setVersion("1.0.0");
         qm.persist(project);
 
-        final Response response = target("%s/clone".formatted(V1_PROJECT)).request()
+        final Response response = jersey.target("%s/clone".formatted(V1_PROJECT)).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json("""
                         {
@@ -1109,7 +1106,7 @@ public class ProjectResourceTest extends ResourceTest {
         noAccessProject.setVersion("2.0.0");
         qm.persist(noAccessProject);
 
-        Response response = target("%s/clone".formatted(V1_PROJECT)).request()
+        Response response = jersey.target("%s/clone".formatted(V1_PROJECT)).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json("""
                         {
@@ -1120,7 +1117,7 @@ public class ProjectResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(403);
         assertThat(getPlainTextBody(response)).isEqualTo("Access to the specified project is forbidden");
 
-        response = target("%s/clone".formatted(V1_PROJECT)).request()
+        response = jersey.target("%s/clone".formatted(V1_PROJECT)).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json("""
                         {

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -20,13 +20,12 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.Policy;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.JsonArray;
@@ -35,14 +34,11 @@ import java.util.List;
 
 public class TagResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(TagResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(TagResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getAllTagsWithOrderingTest() {
@@ -53,7 +49,7 @@ public class TagResourceTest extends ResourceTest {
         qm.createProject("Project B", null, "1", List.of(qm.getTagByName("Tag 2"), qm.getTagByName("Tag 3"), qm.getTagByName("Tag 4")), null, null, true, false);
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
 
-        Response response = target(V1_TAG + "/" + policy.getUuid())
+        Response response = jersey.target(V1_TAG + "/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -78,7 +74,7 @@ public class TagResourceTest extends ResourceTest {
         Policy policy = qm.createPolicy("Test Policy", Policy.Operator.ANY, Policy.ViolationState.INFO);
         policy.setProjects(List.of(qm.getProject("Project A", "1"), qm.getProject("Project C", "1")));
 
-        Response response = target(V1_TAG + "/" + policy.getUuid())
+        Response response = jersey.target(V1_TAG + "/" + policy.getUuid())
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();

--- a/src/test/java/org/dependencytrack/resources/v1/UserResourceUnauthenticatedTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/UserResourceUnauthenticatedTest.java
@@ -18,15 +18,15 @@
  */
 package org.dependencytrack.resources.v1;
 
-import alpine.server.filters.ApiFilter;
 import alpine.model.ManagedUser;
 import alpine.server.auth.PasswordService;
+import alpine.server.filters.ApiFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.client.Entity;
@@ -36,12 +36,19 @@ import javax.ws.rs.core.Response;
 
 public class UserResourceUnauthenticatedTest extends ResourceTest {
 
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(UserResource.class)
+                    .register(ApiFilter.class));
+
+    private ManagedUser testUser;
+
+    @Before
     @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(UserResource.class)
-                        .register(ApiFilter.class)))
-                .build();
+    public void before() throws Exception {
+        super.before();
+        testUser = qm.createManagedUser("testuser", TEST_USER_PASSWORD_HASH);
+        qm.addUserToTeam(testUser, team);
     }
 
     @Test
@@ -49,7 +56,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
-        Response response = target(V1_USER + "/login").request()
+        Response response = jersey.target(V1_USER + "/login").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -66,7 +73,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "testuser");
-        Response response = target(V1_USER + "/login").request()
+        Response response = jersey.target(V1_USER + "/login").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(403, response.getStatus(), 0);
@@ -77,7 +84,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         Form form = new Form();
         form.param("username", "testuser");
         form.param("password", "wrong");
-        Response response = target(V1_USER + "/login").request()
+        Response response = jersey.target(V1_USER + "/login").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(401, response.getStatus(), 0);
@@ -88,7 +95,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         final Form form = new Form();
         form.param("accessToken", "accessToken");
 
-        final Response response = target(V1_USER + "/oidc/login").request()
+        final Response response = jersey.target(V1_USER + "/oidc/login").request()
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
 
         // OIDC is disabled by default
@@ -103,7 +110,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "Password1!");
         Assert.assertTrue(PasswordService.matches("testuser".toCharArray(), testUser));
-        Response response = target(V1_USER + "/forceChangePassword").request()
+        Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -123,7 +130,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "Password1!");
         Assert.assertTrue(PasswordService.matches("testuser".toCharArray(), testUser));
-        Response response = target(V1_USER + "/forceChangePassword").request()
+        Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -139,7 +146,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         form.param("password", "testuser");
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "blah");
-        Response response = target(V1_USER + "/forceChangePassword").request()
+        Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(406, response.getStatus(), 0);
@@ -155,7 +162,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         form.param("password", "testuser");
         form.param("newPassword", "testuser");
         form.param("confirmPassword", "testuser");
-        Response response = target(V1_USER + "/forceChangePassword").request()
+        Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(406, response.getStatus(), 0);
@@ -173,7 +180,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         form.param("password", "testuser");
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "Password1!");
-        Response response = target(V1_USER + "/forceChangePassword").request()
+        Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(403, response.getStatus(), 0);
@@ -189,7 +196,7 @@ public class UserResourceUnauthenticatedTest extends ResourceTest {
         form.param("password", "blah");
         form.param("newPassword", "Password1!");
         form.param("confirmPassword", "Password1!");
-        Response response = target(V1_USER + "/forceChangePassword").request()
+        Response response = jersey.target(V1_USER + "/forceChangePassword").request()
                 .accept(MediaType.TEXT_PLAIN)
                 .post(Entity.entity(form, MediaType.APPLICATION_FORM_URLENCODED_TYPE));
         Assert.assertEquals(401, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import net.javacrumbs.jsonunit.core.Option;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
@@ -32,9 +33,7 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -45,15 +44,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class VexResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(VexResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)
-                                .register(MultiPartFeature.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(VexResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(MultiPartFeature.class));
 
     @Test
     public void exportProjectAsCycloneDxTest() {
@@ -120,7 +116,7 @@ public class VexResourceTest extends ResourceTest {
                 ));
         qm.persist(project);
 
-        final Response response = target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
+        final Response response = jersey.target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);

--- a/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ViolationAnalysisResourceTest.java
@@ -22,6 +22,7 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
 import net.jcip.annotations.NotThreadSafe;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.kafka.KafkaTopics;
@@ -40,9 +41,7 @@ import org.dependencytrack.proto.notification.v1.Notification;
 import org.dependencytrack.resources.v1.vo.ViolationAnalysisRequest;
 import org.dependencytrack.util.NotificationUtil;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.Json;
@@ -65,15 +64,12 @@ import static org.dependencytrack.util.KafkaTestUtil.deserializeValue;
 @NotThreadSafe
 public class ViolationAnalysisResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(ViolationAnalysisResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)
-                                .register(AuthorizationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(ViolationAnalysisResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(AuthorizationFilter.class));
 
     @Test
     public void retrieveAnalysisTest() {
@@ -104,7 +100,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         violationAnalysis = qm.persist(violationAnalysis);
         qm.makeViolationAnalysisComment(violationAnalysis, "Analysis comment here", "Jane Doe");
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .queryParam("component", component.getUuid())
                 .queryParam("policyViolation", violation.getUuid())
                 .request()
@@ -125,7 +121,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
 
     @Test
     public void retrieveAnalysisUnauthorizedTest() {
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .queryParam("component", UUID.randomUUID())
                 .queryParam("policyViolation", UUID.randomUUID())
                 .request()
@@ -139,7 +135,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
     public void retrieveAnalysisComponentNotFoundTest() {
         initializeWithPermissions(Permissions.VIEW_POLICY_VIOLATION);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .queryParam("component", UUID.randomUUID())
                 .queryParam("policyViolation", UUID.randomUUID())
                 .request()
@@ -162,7 +158,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         component.setVersion("1.0");
         component = qm.createComponent(component, false);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .queryParam("component", component.getUuid())
                 .queryParam("policyViolation", UUID.randomUUID())
                 .request()
@@ -198,7 +194,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(component.getUuid().toString(),
                 violation.getUuid().toString(), ViolationAnalysisState.APPROVED, "Some comment", false);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -255,7 +251,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(component.getUuid().toString(),
                 violation.getUuid().toString(), null, null, null);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -312,7 +308,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(component.getUuid().toString(),
                 violation.getUuid().toString(), ViolationAnalysisState.REJECTED, "Some comment", false);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -380,7 +376,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(component.getUuid().toString(),
                 violation.getUuid().toString(), ViolationAnalysisState.APPROVED, null, true);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -428,7 +424,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(component.getUuid().toString(),
                 violation.getUuid().toString(), null, null, null);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -461,7 +457,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(), ViolationAnalysisState.REJECTED, "Some comment", false);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -476,7 +472,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(), ViolationAnalysisState.REJECTED, "Some comment", false);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
@@ -500,7 +496,7 @@ public class ViolationAnalysisResourceTest extends ResourceTest {
         final var request = new ViolationAnalysisRequest(component.getUuid().toString(),
                 UUID.randomUUID().toString(), ViolationAnalysisState.REJECTED, "Some comment", false);
 
-        final Response response = target(V1_VIOLATION_ANALYSIS)
+        final Response response = jersey.target(V1_VIOLATION_ANALYSIS)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityPolicyBundleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityPolicyBundleResourceTest.java
@@ -21,13 +21,12 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.VulnerabilityPolicyBundle;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -38,15 +37,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class VulnerabilityPolicyBundleResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(VulnerabilityPolicyBundleResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)
-                                .register(AuthorizationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(VulnerabilityPolicyBundleResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(AuthorizationFilter.class));
 
     @Test
     public void getVulnerabilityPolicyResourceBundle() {
@@ -58,7 +54,7 @@ public class VulnerabilityPolicyBundleResourceTest extends ResourceTest {
 
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
-        final Response response = target(V1_VULNERABILITY_POLICY_BUNDLE)
+        final Response response = jersey.target(V1_VULNERABILITY_POLICY_BUNDLE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -78,7 +74,7 @@ public class VulnerabilityPolicyBundleResourceTest extends ResourceTest {
 
         initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
 
-        final Response response = target(V1_VULNERABILITY_POLICY_BUNDLE)
+        final Response response = jersey.target(V1_VULNERABILITY_POLICY_BUNDLE)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityPolicyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityPolicyResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import org.apache.http.HttpStatus;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.event.VulnerabilityPolicyFetchEvent;
 import org.dependencytrack.model.WorkflowState;
@@ -31,9 +32,7 @@ import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyAnalysis;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyRating;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
@@ -58,20 +57,17 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
     @Rule
     public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(VulnerabilityPolicyResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(VulnerabilityPolicyResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void testVulnerablePolicies() {
         var vulnPolicy = getVulnerabilityPolicyInstance(0);
         jdbi(qm).withExtension(VulnerabilityPolicyDao.class, dao -> dao.create(vulnPolicy));
-        final Response response = target(V1_VULNERABILITY_POLICY)
+        final Response response = jersey.target(V1_VULNERABILITY_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -120,7 +116,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
             jdbi(qm).withExtension(VulnerabilityPolicyDao.class, dao -> dao.create(vulnPolicy));
         }
 
-        final Response response = target(V1_VULNERABILITY_POLICY)
+        final Response response = jersey.target(V1_VULNERABILITY_POLICY)
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -139,7 +135,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
         environmentVariables.set(VULNERABILITY_POLICY_ANALYSIS_ENABLED.name(), "true");
 
         // Trigger the workflow for the first time.
-        Response response = target(V1_VULNERABILITY_POLICY + "/bundle/sync")
+        Response response = jersey.target(V1_VULNERABILITY_POLICY + "/bundle/sync")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -151,7 +147,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
                 """);
 
         // Workflow is still in progress, trying to trigger it again will not work.
-        response = target(V1_VULNERABILITY_POLICY + "/bundle/sync")
+        response = jersey.target(V1_VULNERABILITY_POLICY + "/bundle/sync")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -169,7 +165,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
         ));
 
         // Triggering the workflow should be allowed again.
-        response = target(V1_VULNERABILITY_POLICY + "/bundle/sync")
+        response = jersey.target(V1_VULNERABILITY_POLICY + "/bundle/sync")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -197,7 +193,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
                     throw new RuntimeException(e);
                 }
 
-                final Response response = target(V1_VULNERABILITY_POLICY + "/bundle/sync")
+                final Response response = jersey.target(V1_VULNERABILITY_POLICY + "/bundle/sync")
                         .request()
                         .header(X_API_KEY, apiKey)
                         .post(null);
@@ -239,7 +235,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
                     throw new RuntimeException(e);
                 }
 
-                final Response response = target(V1_VULNERABILITY_POLICY + "/bundle/sync")
+                final Response response = jersey.target(V1_VULNERABILITY_POLICY + "/bundle/sync")
                         .request()
                         .header(X_API_KEY, apiKey)
                         .post(null);
@@ -258,7 +254,7 @@ public class VulnerabilityPolicyResourceTest extends ResourceTest {
 
     @Test
     public void triggerVulnerabilityPolicyBundleSyncWithFeatureDisabledTest() {
-        final Response response = target(V1_VULNERABILITY_POLICY + "/bundle/sync")
+        final Response response = jersey.target(V1_VULNERABILITY_POLICY + "/bundle/sync")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.AnalysisJustification;
@@ -36,10 +37,8 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.CweImporter;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
 import org.junit.Assert;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.json.Json;
@@ -53,19 +52,16 @@ import java.util.UUID;
 
 public class VulnerabilityResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                new ResourceConfig(VulnerabilityResource.class)
-                        .register(ApiFilter.class)
-                        .register(AuthenticationFilter.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(VulnerabilityResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class));
 
     @Test
     public void getVulnerabilitiesByComponentUuidTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -92,7 +88,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilitiesByComponentInvalidTest() throws Exception  {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/component/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -104,7 +100,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilitiesByComponentUuidIncludeSuppressedTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid().toString())
+        Response response = jersey.target(V1_VULNERABILITY + "/component/" + sampleData.c1.getUuid().toString())
                 .queryParam("suppressed", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -134,7 +130,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilitiesByProjectTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/project/" + sampleData.p1.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/project/" + sampleData.p1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -167,7 +163,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilitiesByProjectIncludeProjectSuppressedTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/project/" + sampleData.p2.getUuid().toString())
+        Response response = jersey.target(V1_VULNERABILITY + "/project/" + sampleData.p2.getUuid().toString())
                 .queryParam("suppressed", "true")
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -184,7 +180,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilitiesByProjectInvalidTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/project/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/project/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -196,7 +192,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilityByUuidTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/" + sampleData.v1.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + sampleData.v1.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -209,7 +205,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilityByUuidInvalidTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -221,7 +217,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilityByVulnIdTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId()).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -239,7 +235,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getVulnerabilityByVulnIdInvalidTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah").request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -251,7 +247,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getAffectedProjectTest() throws Exception {
         SampleData sampleData = new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId() + "/projects").request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId() + "/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -265,7 +261,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getAffectedProjectInvalidTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/projects").request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -288,7 +284,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         sampleData.p2.setAccessTeams(List.of(team));
         qm.persist(sampleData.p2);
 
-        final Response response = target(V1_VULNERABILITY + "/source/" + sampleData.v4.getSource() + "/vuln/" + sampleData.v4.getVulnId() + "/projects").request()
+        final Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v4.getSource() + "/vuln/" + sampleData.v4.getVulnId() + "/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -302,7 +298,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
     @Test
     public void getAllVulnerabilitiesTest() throws Exception {
         new SampleData();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -341,7 +337,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         sampleData.p2.setAccessTeams(List.of(team));
         qm.persist(sampleData.p2);
 
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -383,7 +379,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                 .add("versionType", "RANGE")
                                 .add("versionEndIncluding", "1.2.3")))
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
         Assert.assertEquals(201, response.getStatus(), 0);
@@ -438,7 +434,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                 .add("versionType", "RANGE")
                                 .add("versionEndIncluding", "1.2.3")))
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
         Assert.assertEquals(400, response.getStatus(), 0);
@@ -458,7 +454,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .add("vulnId", "ACME-1")
                 .add("cwe", Json.createObjectBuilder().add("cweId", 80))
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
         Assert.assertEquals(201, response.getStatus(), 0);
@@ -489,7 +485,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .add("cvssV3Vector", "CVSS:3.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L")
                 .add("owaspRRVector", "SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3")
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .put(Entity.json(payload.toString()));
         Assert.assertEquals(409, response.getStatus(), 0);
@@ -516,7 +512,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .add("tags", Json.createArrayBuilder().add(Json.createObjectBuilder().add("name", "vuln-tag")))
                 .add("uuid", vuln.getUuid().toString())
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(payload.toString()));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -557,7 +553,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .add("owaspRRVector", "SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3")
                 .add("uuid", UUID.randomUUID().toString())
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(payload.toString()));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -581,7 +577,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .add("owaspRRVector", "SL:1/M:1/O:0/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3")
                 .add("uuid", vuln.getUuid().toString())
                 .build();
-        Response response = target(V1_VULNERABILITY).request()
+        Response response = jersey.target(V1_VULNERABILITY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(payload.toString()));
         Assert.assertEquals(406, response.getStatus(), 0);
@@ -600,7 +596,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln = qm.createVulnerability(vuln, false);
         final AffectedVersionAttribution attribution = qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, vuln, vs));
 
-        final Response response = target(V1_VULNERABILITY + "/" + vuln.getUuid()).request()
+        final Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(204, response.getStatus());
@@ -622,7 +618,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -636,7 +632,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/BLAH/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/BLAH/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -651,7 +647,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         qm.createVulnerability(vuln, false);
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -671,7 +667,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -685,7 +681,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString() + "/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -700,7 +696,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln = qm.createVulnerability(vuln, false);
-        Response response = target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -720,7 +716,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -734,7 +730,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/BLAH/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/BLAH/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -749,7 +745,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         qm.createVulnerability(vuln, false);
-        Response response = target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -769,7 +765,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(200, response.getStatus(), 0);
@@ -783,7 +779,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         comp.setProject(project);
         comp.setName("Test Component");
         comp = qm.createComponent(comp, false);
-        Response response = target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString() + "/component/" + comp.getUuid().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + UUID.randomUUID().toString() + "/component/" + comp.getUuid().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -798,7 +794,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln = qm.createVulnerability(vuln, false);
-        Response response = target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
         Assert.assertEquals(404, response.getStatus(), 0);
@@ -913,7 +909,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setTags(List.of(existingTag));
         vuln = qm.createVulnerability(vuln, false);
 
-        Response response = target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/tags")
+        Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/tags")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.json(List.of("new-tag-1", "new-tag-2")));
@@ -941,7 +937,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         qm.bind(vuln1, List.of(tag));
         qm.bind(vuln2, List.of(tag));
 
-        Response response = target(V1_VULNERABILITY + "/tag/" + tag.getName()).request()
+        Response response = jersey.target(V1_VULNERABILITY + "/tag/" + tag.getName()).request()
                 .header(X_API_KEY, apiKey)
                 .get();
         Assert.assertEquals(200, response.getStatus(), 0);

--- a/src/test/java/org/dependencytrack/resources/v1/WorkflowResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/WorkflowResourceTest.java
@@ -22,13 +22,12 @@ import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import net.javacrumbs.jsonunit.core.Option;
 import org.apache.http.HttpStatus;
+import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.WorkflowState;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.server.ResourceConfig;
-import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.test.DeploymentContext;
-import org.glassfish.jersey.test.ServletDeploymentContext;
+import org.junit.ClassRule;
 import org.junit.Test;
 
 import javax.ws.rs.core.Response;
@@ -47,15 +46,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class WorkflowResourceTest extends ResourceTest {
 
-    @Override
-    protected DeploymentContext configureDeployment() {
-        return ServletDeploymentContext.forServlet(new ServletContainer(
-                        new ResourceConfig(WorkflowResource.class)
-                                .register(ApiFilter.class)
-                                .register(AuthenticationFilter.class)
-                                .register(MultiPartFeature.class)))
-                .build();
-    }
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(WorkflowResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(MultiPartFeature.class));
 
     @Test
     public void getWorkflowStatusOk() {
@@ -79,7 +75,7 @@ public class WorkflowResourceTest extends ResourceTest {
         workflowState2.setUpdatedAt(Date.from(Instant.now()));
         qm.persist(workflowState2);
 
-        Response response = target(V1_WORKFLOW + "/token/" + uuid + "/status").request()
+        Response response = jersey.target(V1_WORKFLOW + "/token/" + uuid + "/status").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
@@ -120,7 +116,7 @@ public class WorkflowResourceTest extends ResourceTest {
         qm.persist(workflowState1);
 
         UUID randomUuid = UUID.randomUUID();
-        Response response = target(V1_WORKFLOW + "/token/" + randomUuid + "/status").request()
+        Response response = jersey.target(V1_WORKFLOW + "/token/" + randomUuid + "/status").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Starts the Jersey `TestContainer` once per class vs. once per test method.

Reduces the time it takes to execute the entire test suite, since the Jersey context is not torn down and rebuilt from scratch as often.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/3668

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
