### PR TITLE
Prevent concurrent processing of multiple BOMs for the same project

### DIFF
--- a/src/main/java/org/dependencytrack/util/WaitingLockConfiguration.java
+++ b/src/main/java/org/dependencytrack/util/WaitingLockConfiguration.java
@@ -1,0 +1,50 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import net.javacrumbs.shedlock.core.LockConfiguration;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * @since 5.5.0
+ */
+public class WaitingLockConfiguration extends LockConfiguration {
+
+    private final Duration pollInterval;
+    private final Duration waitTimeout;
+
+    public WaitingLockConfiguration(final Instant createdAt, final String name,
+                                    final Duration lockAtMostFor, final Duration lockAtLeastFor,
+                                    final Duration pollInterval, final Duration waitTimeout) {
+        super(createdAt, name, lockAtMostFor, lockAtLeastFor);
+        this.pollInterval = pollInterval;
+        this.waitTimeout = waitTimeout;
+    }
+
+    public Duration getPollInterval() {
+        return pollInterval;
+    }
+
+    public Duration getWaitTimeout() {
+        return waitTimeout;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/util/WaitingLockProvider.java
+++ b/src/main/java/org/dependencytrack/util/WaitingLockProvider.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import alpine.common.logging.Logger;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.core.SimpleLock;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+/**
+ * @since 5.5.0
+ */
+class WaitingLockProvider implements LockProvider {
+
+    private static final Logger LOGGER = Logger.getLogger(WaitingLockProvider.class);
+
+    private final LockProvider delegateLockProvider;
+    private final Duration pollInterval;
+    private final Duration waitTimeout;
+
+    WaitingLockProvider(final LockProvider delegateLockProvider, final Duration pollInterval, final Duration waitTimeout) {
+        this.delegateLockProvider = delegateLockProvider;
+        this.pollInterval = pollInterval;
+        this.waitTimeout = waitTimeout;
+    }
+
+    @NotNull
+    @Override
+    public Optional<SimpleLock> lock(@NotNull final LockConfiguration lockConfiguration) {
+        final Instant waitStart = Instant.now();
+
+        Optional<SimpleLock> lock;
+        while (Instant.now().isBefore(waitStart.plus(waitTimeout))) {
+            lock = delegateLockProvider.lock(lockConfiguration);
+
+            if (lock.isPresent()) {
+                LOGGER.debug("Lock acquired: %s".formatted(lockConfiguration.getName()));
+                return lock;
+            }
+
+            try {
+                LOGGER.debug("Failed to acquire lock %s; Retrying in %s".formatted(lockConfiguration.getName(), pollInterval));
+
+                //noinspection BusyWait
+                Thread.sleep(pollInterval.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Thread was interrupted while waiting for lock %s".formatted(lockConfiguration.getName()), e);
+            }
+        }
+
+        LOGGER.warn("Failed to obtain lock %s after waiting for %s".formatted(lockConfiguration.getName(), waitTimeout));
+        return Optional.empty();
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prevents concurrent processing of multiple BOMs for the same project.

Uses database-backed Shedlock locks to serialize BOM processing by project UUID.

In contrast to vanilla Shedlock behavior, this implementation waits for a given period of time until a lock can be acquired. Per default, Shedlock simply skips execution when lock acquisition fails.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1267

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
