### PR TITLE
Encode length constraints for vuln policy fields in JSON schema

### DIFF
--- a/src/main/java/org/dependencytrack/model/VulnerabilityPolicy.java
+++ b/src/main/java/org/dependencytrack/model/VulnerabilityPolicy.java
@@ -58,12 +58,13 @@ public class VulnerabilityPolicy implements Serializable {
 
     @Persistent
     @Column(name = "DESCRIPTION", allowsNull = "true")
-    @Size(max = 4096)
+    @Size(min = 1, max = 512)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The description may only contain printable characters")
     private String description;
 
     @Persistent
     @Column(name = "AUTHOR", allowsNull = "true", jdbcType = "VARCHAR")
+    @Size(min = 1, max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The author may only contain printable characters")
     private String author;
 

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -88,4 +88,8 @@
                                  onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="ID"
                                  referencedTableName="VULNERABILITY" validate="true"/>
     </changeSet>
+
+    <changeSet id="v5.5.0-6" author="nscuro">
+        <modifyDataType tableName="VULNERABILITY_POLICY" columnName="DESCRIPTION" newDataType="VARCHAR(512)"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/schema/vulnerability-policy-v1.schema.json
+++ b/src/main/resources/schema/vulnerability-policy-v1.schema.json
@@ -13,15 +13,21 @@
     },
     "name": {
       "description": "Name of the policy.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
     },
     "description": {
       "description": "Short description of the policy.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
     },
     "author": {
       "description": "Name of the policy author.",
-      "type": "string"
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 255
     },
     "validFrom": {
       "description": "When the policy should take effect (in RFC3339 format).",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Encodes length constraints for vuln policy fields in JSON schema.

The length of the `name`, `author`, and `description` fields are ultimately capped by the database schema. Until now, the JSON schema did not reflect those constraints, making it hard to detect invalid policies sooner.

This change extends the length of the `DESCRIPTION` column from `255` to `512`, and includes `minLength` / `maxLength` constraints for all string fields in the JSON schema.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
