### PR TITLE
Include CVSS and OWASP RR vectors in notifications

### DIFF
--- a/src/main/java/org/dependencytrack/parser/dependencytrack/NotificationModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/dependencytrack/NotificationModelConverter.java
@@ -336,9 +336,12 @@ public final class NotificationModelConverter {
         Optional.ofNullable(vulnerability.getRecommendation()).ifPresent(builder::setRecommendation);
         Optional.ofNullable(vulnerability.getCvssV2BaseScore()).map(BigDecimal::doubleValue).ifPresent(builder::setCvssV2);
         Optional.ofNullable(vulnerability.getCvssV3BaseScore()).map(BigDecimal::doubleValue).ifPresent(builder::setCvssV3);
+        Optional.ofNullable(vulnerability.getCvssV2Vector()).ifPresent(builder::setCvssV2Vector);
+        Optional.ofNullable(vulnerability.getCvssV3Vector()).ifPresent(builder::setCvssV3Vector);
         Optional.ofNullable(vulnerability.getOwaspRRLikelihoodScore()).map(BigDecimal::doubleValue).ifPresent(builder::setOwaspRrLikelihood);
         Optional.ofNullable(vulnerability.getOwaspRRTechnicalImpactScore()).map(BigDecimal::doubleValue).ifPresent(builder::setOwaspRrTechnicalImpact);
         Optional.ofNullable(vulnerability.getOwaspRRBusinessImpactScore()).map(BigDecimal::doubleValue).ifPresent(builder::setOwaspRrBusinessImpact);
+        Optional.ofNullable(vulnerability.getOwaspRRVector()).ifPresent(builder::setOwaspRrVector);
         Optional.ofNullable(vulnerability.getSeverity()).map(Enum::name).ifPresent(builder::setSeverity);
         Optional.ofNullable(vulnerability.getCwes())
                 .orElseGet(Collections::emptyList).stream()

--- a/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -104,6 +104,14 @@ public interface NotificationSubjectDao extends SqlObject {
                 WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3SCORE"
                 ELSE "V"."CVSSV3BASESCORE"
               END                              AS "vulnCvssV3BaseScore",
+              CASE
+                WHEN "A"."CVSSV2VECTOR" IS NOT NULL THEN "A"."CVSSV2VECTOR"
+                ELSE "V"."CVSSV2VECTOR"
+              END                              AS "vulnCvssV2Vector",
+              CASE
+                WHEN "A"."CVSSV3VECTOR" IS NOT NULL THEN "A"."CVSSV3VECTOR"
+                ELSE "V"."CVSSV3VECTOR"
+              END                              AS "vulnCvssV3Vector",            
               -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
               --  How to handle this?
               CASE

--- a/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -105,13 +105,13 @@ public interface NotificationSubjectDao extends SqlObject {
                 ELSE "V"."CVSSV3BASESCORE"
               END                              AS "vulnCvssV3BaseScore",
               CASE
-                WHEN "A"."CVSSV2VECTOR" IS NOT NULL THEN "A"."CVSSV2VECTOR"
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV2VECTOR"
                 ELSE "V"."CVSSV2VECTOR"
               END                              AS "vulnCvssV2Vector",
               CASE
-                WHEN "A"."CVSSV3VECTOR" IS NOT NULL THEN "A"."CVSSV3VECTOR"
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3VECTOR"
                 ELSE "V"."CVSSV3VECTOR"
-              END                              AS "vulnCvssV3Vector",            
+              END                              AS "vulnCvssV3Vector",              
               -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
               --  How to handle this?
               CASE
@@ -126,6 +126,10 @@ public interface NotificationSubjectDao extends SqlObject {
                 WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPSCORE"
                 ELSE "V"."OWASPRRTECHNICALIMPACTSCORE"
               END                              AS "vulnOwaspRrTechnicalImpactScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPVECTOR"
+                ELSE "V"."OWASPRRVECTOR"
+              END                              AS "vulnOwaspRrVector",
               "CALC_SEVERITY"(
                 "V"."SEVERITY",
                 "A"."SEVERITY",
@@ -219,6 +223,14 @@ public interface NotificationSubjectDao extends SqlObject {
                 WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3SCORE"
                 ELSE "V"."CVSSV3BASESCORE"
               END                              AS "vulnCvssV3BaseScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV2VECTOR"
+                ELSE "V"."CVSSV2VECTOR"
+              END                              AS "vulnCvssV2Vector",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3VECTOR"
+                ELSE "V"."CVSSV3VECTOR"
+              END                              AS "vulnCvssV3Vector", 
               -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
               --  How to handle this?
               CASE
@@ -233,6 +245,10 @@ public interface NotificationSubjectDao extends SqlObject {
                 WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPSCORE"
                 ELSE "V"."OWASPRRTECHNICALIMPACTSCORE"
               END                              AS "vulnOwaspRrTechnicalImpactScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPVECTOR"
+                ELSE "V"."OWASPRRVECTOR"
+              END                              AS "vulnOwaspRrVector",
               "CALC_SEVERITY"(
                 "V"."SEVERITY",
                 "A"."SEVERITY",
@@ -322,6 +338,14 @@ public interface NotificationSubjectDao extends SqlObject {
                 WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3SCORE"
                 ELSE "V"."CVSSV3BASESCORE"
               END                              AS "vulnCvssV3BaseScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV2VECTOR"
+                ELSE "V"."CVSSV2VECTOR"
+              END                              AS "vulnCvssV2Vector",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."CVSSV3VECTOR"
+                ELSE "V"."CVSSV3VECTOR"        
+              END                              AS "vulnCvssV3Vector",
               -- TODO: Analysis only has a single score, but OWASP RR defines multiple.
               --  How to handle this?
               CASE
@@ -336,6 +360,10 @@ public interface NotificationSubjectDao extends SqlObject {
                 WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPSCORE"
                 ELSE "V"."OWASPRRTECHNICALIMPACTSCORE"
               END                              AS "vulnOwaspRrTechnicalImpactScore",
+              CASE
+                WHEN "A"."SEVERITY" IS NOT NULL THEN "A"."OWASPVECTOR"
+                ELSE "V"."OWASPRRVECTOR"
+              END                              AS "vulnOwaspRrVector",
               "CALC_SEVERITY"(
                 "V"."SEVERITY",
                 "A"."SEVERITY",

--- a/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
@@ -57,6 +57,7 @@ public class NotificationVulnerabilityRowMapper implements RowMapper<Vulnerabili
         maybeSet(rs, "vulnOwaspRrBusinessImpactScore", RowMapperUtil::nullableDouble, builder::setOwaspRrBusinessImpact);
         maybeSet(rs, "vulnOwaspRrLikelihoodScore", RowMapperUtil::nullableDouble, builder::setOwaspRrLikelihood);
         maybeSet(rs, "vulnOwaspRrTechnicalImpactScore", RowMapperUtil::nullableDouble, builder::setOwaspRrTechnicalImpact);
+        maybeSet(rs, "vulnOwaspRrVector", ResultSet::getString, builder::setOwaspRrVector);
         maybeSet(rs, "vulnSeverity", ResultSet::getString, builder::setSeverity);
         maybeSet(rs, "vulnCwes", NotificationVulnerabilityRowMapper::maybeConvertCwes, builder::addAllCwes);
         maybeSet(rs, "vulnAliasesJson", (ignored, columnName) ->

--- a/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationVulnerabilityRowMapper.java
@@ -52,6 +52,8 @@ public class NotificationVulnerabilityRowMapper implements RowMapper<Vulnerabili
         maybeSet(rs, "vulnRecommendation", ResultSet::getString, builder::setRecommendation);
         maybeSet(rs, "vulnCvssV2BaseScore", RowMapperUtil::nullableDouble, builder::setCvssV2);
         maybeSet(rs, "vulnCvssV3BaseScore", RowMapperUtil::nullableDouble, builder::setCvssV3);
+        maybeSet(rs, "vulnCvssV2Vector", ResultSet::getString, builder::setCvssV2Vector);
+        maybeSet(rs, "vulnCvssV3Vector", ResultSet::getString, builder::setCvssV3Vector);
         maybeSet(rs, "vulnOwaspRrBusinessImpactScore", RowMapperUtil::nullableDouble, builder::setOwaspRrBusinessImpact);
         maybeSet(rs, "vulnOwaspRrLikelihoodScore", RowMapperUtil::nullableDouble, builder::setOwaspRrLikelihood);
         maybeSet(rs, "vulnOwaspRrTechnicalImpactScore", RowMapperUtil::nullableDouble, builder::setOwaspRrTechnicalImpact);

--- a/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -189,8 +189,9 @@ message Vulnerability {
   optional double owasp_rr_business_impact = 13 [json_name = "owaspRRBusinessImpact"];
   optional string severity = 14;
   repeated Cwe cwes = 15;
-  optional string cvss_v2_vector = 16;
-  optional string cvss_v3_vector = 17;
+  optional string cvss_v2_vector = 16 [json_name = "cvssV2Vector"];
+  optional string cvss_v3_vector = 17 [json_name = "cvssV3Vector"];
+  optional string owasp_rr_vector = 18 [json_name = "owaspRRVector"];
 
   message Alias {
     string id = 1 [json_name = "vulnId"];

--- a/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -189,6 +189,8 @@ message Vulnerability {
   optional double owasp_rr_business_impact = 13 [json_name = "owaspRRBusinessImpact"];
   optional string severity = 14;
   repeated Cwe cwes = 15;
+  optional string cvss_v2_vector = 16;
+  optional string cvss_v3_vector = 17;
 
   message Alias {
     string id = 1 [json_name = "vulnId"];

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -320,6 +320,14 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
                     assertThat(subject.getProject().getName()).isEqualTo("acme-app");
                     assertThat(subject.getProject().getVersion()).isEqualTo("1.0.0");
                     assertThat(subject.getVulnerabilitiesCount()).isEqualTo(2);
+                    assertThat(subject.getVulnerabilitiesList()).satisfiesExactlyInAnyOrder(
+                            vulnerability -> {
+                                assertThat(vulnerability.getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
+                            },
+                            vulnerability -> {
+                                assertThat(vulnerability.getCvssV2Vector()).isEqualTo("(AV:N/AC:M/Au:S/C:P/I:P/A:P)");
+                            }
+                    );
                 },
                 record -> {
                     assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_NEW_VULNERABILITY.name());

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -246,10 +246,13 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
         final var vulnA = new Vulnerability();
         vulnA.setVulnId("INT-001");
         vulnA.setSource(Vulnerability.Source.INTERNAL);
+        vulnA.setCvssV2Vector("(AV:N/AC:M/Au:S/C:P/I:P/A:P)");
         qm.persist(vulnA);
         final var vulnB = new Vulnerability();
         vulnB.setVulnId("SONATYPE-002");
         vulnB.setSource(Vulnerability.Source.OSSINDEX);
+        vulnB.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
+        qm.persist(vulnB);
         final var vulnC = new Vulnerability();
         vulnC.setVulnId("INT-002");
         vulnC.setSource(Vulnerability.Source.INTERNAL);
@@ -326,6 +329,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
                     assertThat(notification.getGroup()).isEqualTo(GROUP_NEW_VULNERABILITY);
                     assertThat(notification.getSubject().is(NewVulnerabilitySubject.class)).isTrue();
                     final var subject = notification.getSubject().unpack(NewVulnerabilitySubject.class);
+                    assertThat(subject.getVulnerability().getCvssV2Vector()).isEqualTo("(AV:N/AC:M/Au:S/C:P/I:P/A:P)");
                     assertThat(subject.getVulnerabilityAnalysisLevel()).isEqualTo("BOM_UPLOAD_ANALYSIS");
                 },
                 record -> {
@@ -336,6 +340,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
                     assertThat(notification.getGroup()).isEqualTo(GROUP_NEW_VULNERABILITY);
                     assertThat(notification.getSubject().is(NewVulnerabilitySubject.class)).isTrue();
                     final var subject = notification.getSubject().unpack(NewVulnerabilitySubject.class);
+                    assertThat(subject.getVulnerability().getCvssV3Vector()).isEqualTo("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
                     assertThat(subject.getVulnerabilityAnalysisLevel()).isEqualTo("BOM_UPLOAD_ANALYSIS");
                 }
                 // INT-002 is discarded because it is internal but doesn't exist in the database.

--- a/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -88,9 +88,12 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         vulnA.setSeverity(Severity.MEDIUM);
         vulnA.setCvssV2BaseScore(BigDecimal.valueOf(1.1));
         vulnA.setCvssV3BaseScore(BigDecimal.valueOf(2.2));
+        vulnA.setCvssV2Vector("(AV:N/AC:M/Au:S/C:P/I:P/A:P)");
+        vulnA.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
         vulnA.setOwaspRRBusinessImpactScore(BigDecimal.valueOf(3.3));
         vulnA.setOwaspRRLikelihoodScore(BigDecimal.valueOf(4.4));
         vulnA.setOwaspRRTechnicalImpactScore(BigDecimal.valueOf(5.5));
+        vulnA.setOwaspRRVector("(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)");
         vulnA.setCwes(List.of(666, 777));
         qm.persist(vulnA);
 
@@ -182,7 +185,10 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                     "subtitle": "vulnASubTitle",
                                     "title": "vulnATitle",
                                     "uuid": "${json-unit.matches:vulnUuid}",
-                                    "vulnId": "CVE-100"
+                                    "vulnId": "CVE-100",
+                                    "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
+                                    "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                    "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
                                   },
                                   "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
                                   "affectedProjectsReference": {
@@ -257,7 +263,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                             "vulnId": "CVE-100",
                             "source": "NVD",
                             "cvssv3": 10.0,
-                            "severity": "CRITICAL"
+                            "severity": "CRITICAL",
+                            "cvssV3Vector": "cvssV3VectorOverwrite"
                           },
                           "vulnerabilityAnalysisLevel": "BOM_UPLOAD_ANALYSIS",
                           "affectedProjects": [
@@ -309,9 +316,12 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         vulnA.setSeverity(Severity.MEDIUM);
         vulnA.setCvssV2BaseScore(BigDecimal.valueOf(1.1));
         vulnA.setCvssV3BaseScore(BigDecimal.valueOf(2.2));
+        vulnA.setCvssV2Vector("(AV:N/AC:M/Au:S/C:P/I:P/A:P)");
+        vulnA.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
         vulnA.setOwaspRRBusinessImpactScore(BigDecimal.valueOf(3.3));
         vulnA.setOwaspRRLikelihoodScore(BigDecimal.valueOf(4.4));
         vulnA.setOwaspRRTechnicalImpactScore(BigDecimal.valueOf(5.5));
+        vulnA.setOwaspRRVector("(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)");
         vulnA.setCwes(List.of(666, 777));
         qm.persist(vulnA);
 
@@ -388,6 +398,9 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                   "name": "Regular Expression without Anchors"
                                 }
                               ],
+                              "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
+                              "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                              "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)",
                               "aliases": [
                                 {"vulnId": "GHSA-100", "source": "GITHUB"}
                               ]
@@ -461,7 +474,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                               "vulnId": "CVE-100",
                               "source": "NVD",
                               "cvssv3": 10.0,
-                              "severity": "CRITICAL"
+                              "severity": "CRITICAL",
+                              "cvssV3Vector": "cvssV3VectorOverwrite"
                             }
                           ]
                         }
@@ -503,9 +517,12 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
         vulnA.setSeverity(Severity.MEDIUM);
         vulnA.setCvssV2BaseScore(BigDecimal.valueOf(1.1));
         vulnA.setCvssV3BaseScore(BigDecimal.valueOf(2.2));
+        vulnA.setCvssV2Vector("(AV:N/AC:M/Au:S/C:P/I:P/A:P)");
+        vulnA.setCvssV3Vector("CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H");
         vulnA.setOwaspRRBusinessImpactScore(BigDecimal.valueOf(3.3));
         vulnA.setOwaspRRLikelihoodScore(BigDecimal.valueOf(4.4));
         vulnA.setOwaspRRTechnicalImpactScore(BigDecimal.valueOf(5.5));
+        vulnA.setOwaspRRVector("(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)");
         vulnA.setCwes(List.of(666, 777));
         qm.persist(vulnA);
 
@@ -580,7 +597,10 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                                  "cweId": 777,
                                                  "name": "Regular Expression without Anchors"
                                              }
-                                         ]
+                                         ],
+                                         "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
+                                         "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                         "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
                                      },
                                      "analysis": {
                                          "component": {
@@ -634,7 +654,10 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                                      "cweId": 777,
                                                      "name": "Regular Expression without Anchors"
                                                  }
-                                             ]
+                                             ],
+                                         "cvssV2Vector": "(AV:N/AC:M/Au:S/C:P/I:P/A:P)",
+                                         "cvssV3Vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+                                         "owaspRRVector": "(SL:5/M:5/O:2/S:9/ED:4/EE:2/A:7/ID:2/LC:2/LI:2/LAV:7/LAC:9/FD:3/RD:5/NC:0/PV:7)"
                                          },
                                          "state": "NOT_AFFECTED",
                                          "suppressed": false


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly
