### PR TITLE
Backport fix for update component external references

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -585,6 +585,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         component.setInternal(transientComponent.isInternal());
         component.setAuthor(transientComponent.getAuthor());
         component.setSupplier(transientComponent.getSupplier());
+        component.setExternalReferences(transientComponent.getExternalReferences());
         final Component result = persist(component);
         return result;
     }

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentResource.java
@@ -501,6 +501,7 @@ public class ComponentResource extends AlpineResource {
                 component.setSha3_256(StringUtils.trimToNull(jsonComponent.getSha3_256()));
                 component.setSha3_384(StringUtils.trimToNull(jsonComponent.getSha3_384()));
                 component.setSha3_512(StringUtils.trimToNull(jsonComponent.getSha3_512()));
+                component.setExternalReferences(jsonComponent.getExternalReferences());
 
                 final License resolvedLicense = qm.getLicense(jsonComponent.getLicense());
                 if (resolvedLicense != null) {


### PR DESCRIPTION
### Description

Backport small fix for updating external references of a component.

### Addressed Issue

upstream fix : https://github.com/DependencyTrack/dependency-track/pull/3805

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~~This PR implements an enhancement, and I have provided tests to verify that it works as intended~~
- [ ] ~~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~~
- [ ] ~~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~~
