### PR TITLE
Port mapping for attributed on while cloning project

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -583,7 +583,8 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                     // Add vulnerabilties and finding attribution from the source component to the cloned component
                     for (Vulnerability vuln : sourceComponent.getVulnerabilities()) {
                         final FindingAttribution sourceAttribution = this.getFindingAttribution(vuln, sourceComponent);
-                        this.addVulnerability(vuln, clonedComponent, sourceAttribution.getAnalyzerIdentity(), sourceAttribution.getAlternateIdentifier(), sourceAttribution.getReferenceUrl());
+                        this.addVulnerability(vuln, clonedComponent, sourceAttribution.getAnalyzerIdentity(), sourceAttribution.getAlternateIdentifier(),
+                                sourceAttribution.getReferenceUrl(), sourceAttribution.getAttributedOn());
                     }
                     clonedComponents.put(sourceComponent.getId(), clonedComponent);
                 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -881,6 +881,11 @@ public class QueryManager extends AlpineQueryManager {
         getVulnerabilityQueryManager().addVulnerability(vulnerability, component, analyzerIdentity, alternateIdentifier, referenceUrl);
     }
 
+    public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
+                                 String alternateIdentifier, String referenceUrl, Date attributedOn) {
+        getVulnerabilityQueryManager().addVulnerability(vulnerability, component, analyzerIdentity, alternateIdentifier, referenceUrl, attributedOn);
+    }
+
     public void removeVulnerability(Vulnerability vulnerability, Component component) {
         getVulnerabilityQueryManager().removeVulnerability(vulnerability, component);
     }

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -37,7 +37,6 @@ import org.dependencytrack.resources.v1.vo.AffectedProject;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -47,9 +46,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 final class VulnerabilityQueryManager extends QueryManager implements IQueryManager {
 
@@ -200,7 +199,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @param analyzerIdentity the identify of the analyzer
      */
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity) {
-        this.addVulnerability(vulnerability, component, analyzerIdentity, null, null);
+        this.addVulnerability(vulnerability, component, analyzerIdentity, null, null, null);
     }
 
     /**
@@ -213,10 +212,28 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      */
     public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
                                  String alternateIdentifier, String referenceUrl) {
+        this.addVulnerability(vulnerability, component, analyzerIdentity, alternateIdentifier, referenceUrl, null);
+    }
+
+    /**
+     * Adds a vulnerability to a component.
+     * @param vulnerability the vulnerability to add
+     * @param component the component affected by the vulnerability
+     * @param analyzerIdentity the identify of the analyzer
+     * @param alternateIdentifier the optional identifier if the analyzer refers to the vulnerability by an alternative identifier
+     * @param referenceUrl the optional URL that references the occurrence of the vulnerability if uniquely identified
+     * @param attributedOn the optional attribution date of the vulnerability. Used primarily when cloning projects, leave null when adding a new one.
+     */
+    public void addVulnerability(Vulnerability vulnerability, Component component, AnalyzerIdentity analyzerIdentity,
+                                 String alternateIdentifier, String referenceUrl, Date attributedOn) {
         if (!contains(vulnerability, component)) {
             component.addVulnerability(vulnerability);
             component = persist(component);
-            persist(new FindingAttribution(component, vulnerability, analyzerIdentity, alternateIdentifier, referenceUrl));
+            FindingAttribution findingAttribution = new FindingAttribution(component, vulnerability, analyzerIdentity, alternateIdentifier, referenceUrl);
+            if (attributedOn != null) {
+                findingAttribution.setAttributedOn(attributedOn);
+            }
+            persist(findingAttribution);
         }
     }
 


### PR DESCRIPTION
### Description

Attribution dates where not passed on when cloning a project. This lead to all cloned vulnerabilities having attribution dates equals to that of the action performed. The attribution date has been added to all necessary methods and can be nullified if not needed.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1190

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly
