### PR TITLE
Add endpoint for updating API key comment

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -49,6 +49,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.List;
 
+import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
+
 /**
  * JAX-RS resources for processing teams.
  *
@@ -240,6 +242,35 @@ public class TeamResource extends AlpineResource {
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The API key could not be found.").build();
             }
+        }
+    }
+
+    @POST
+    @Path("/key/{apikey}/comment")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(value = "Updates an API key's comment", response = ApiKey.class)
+    @ApiResponses(value = {
+            @ApiResponse(code = 401, message = "Unauthorized"),
+            @ApiResponse(code = 404, message = "The API key could not be found")
+    })
+    @PermissionRequired(Permissions.Constants.ACCESS_MANAGEMENT)
+    public Response updateApiKeyComment(@PathParam("apikey") final String apikey,
+                                        final String comment) {
+        try (final var qm = new QueryManager()) {
+            qm.getPersistenceManager().setProperty(PROPERTY_RETAIN_VALUES, "true");
+
+            return qm.runInTransaction(() -> {
+                final ApiKey apiKey = qm.getApiKey(apikey);
+                if (apiKey == null) {
+                    return Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The API key could not be found.")
+                            .build();
+                }
+                apiKey.setComment(comment);
+                return Response.ok(apiKey).build();
+            });
         }
     }
 

--- a/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.common.util.UuidUtil;
+import alpine.model.ApiKey;
 import alpine.model.ConfigProperty;
 import alpine.model.ManagedUser;
 import alpine.model.Team;
@@ -42,6 +43,10 @@ import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 public class TeamResourceTest extends ResourceTest {
 
@@ -269,5 +274,43 @@ public class TeamResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assert.assertEquals("The API key could not be found.", body);
+    }
+
+    @Test
+    public void updateApiKeyCommentTest() {
+        final Team team = qm.createTeam("foo", true);
+        final ApiKey apiKey = team.getApiKeys().get(0);
+
+        assertThat(apiKey.getCreated()).isNotNull();
+        assertThat(apiKey.getLastUsed()).isNull();
+        assertThat(apiKey.getComment()).isNull();
+
+        final Response response = jersey.target("%s/key/%s/comment".formatted(V1_TEAM, apiKey.getKey())).request()
+                .header(X_API_KEY, this.apiKey)
+                .post(Entity.entity("Some comment 123", MediaType.TEXT_PLAIN));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .withMatcher("key", equalTo(apiKey.getKey()))
+                .withMatcher("maskedKey", equalTo(apiKey.getMaskedKey()))
+                .isEqualTo("""
+                        {
+                          "key": "${json-unit.matches:key}",
+                          "maskedKey": "${json-unit.matches:maskedKey}",
+                          "created": "${json-unit.any-number}",
+                          "lastUsed": null,
+                          "comment": "Some comment 123"
+                        }
+                        """);
+    }
+
+    @Test
+    public void updateApiKeyCommentNotFoundTest() {
+        final Response response = jersey.target("%s/key/does-not-exist/comment".formatted(V1_TEAM)).request()
+                .header(X_API_KEY, this.apiKey)
+                .post(Entity.entity("Some comment 123", MediaType.TEXT_PLAIN));
+
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(getPlainTextBody(response)).isEqualTo("The API key could not be found.");
     }
 }


### PR DESCRIPTION
### Description

Adds REST endpoint for updating API key comment.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1190

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly
