### PR TITLE
Port: Apply consistent formatting to SQL query

### DIFF
--- a/src/main/java/org/dependencytrack/integrations/kenna/KennaDataTransformer.java
+++ b/src/main/java/org/dependencytrack/integrations/kenna/KennaDataTransformer.java
@@ -73,7 +73,7 @@ public class KennaDataTransformer {
         final JSONArray vulns = new JSONArray();
         final List<Finding> findings = qm.getFindings(project);
         for (final Finding finding: findings) {
-            final Map analysis = finding.getAnalysis();
+            final Map<String, Object> analysis = finding.getAnalysis();
             final Object suppressed = finding.getAnalysis().get("isSuppressed");
             if (suppressed instanceof Boolean) {
                 final boolean isSuppressed = (Boolean)analysis.get("isSuppressed");

--- a/src/main/java/org/dependencytrack/model/Finding.java
+++ b/src/main/java/org/dependencytrack/model/Finding.java
@@ -88,7 +88,7 @@ public class Finding implements Serializable {
                 ON "COMPONENT"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
              INNER JOIN "VULNERABILITY"
                 ON "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
-             INNER JOIN "EPSS"
+             LEFT JOIN "EPSS"
                 ON "VULNERABILITY"."VULNID" = "EPSS"."CVE"
              INNER JOIN "FINDINGATTRIBUTION"
                 ON "COMPONENT"."ID" = "FINDINGATTRIBUTION"."COMPONENT_ID"

--- a/src/main/java/org/dependencytrack/model/Finding.java
+++ b/src/main/java/org/dependencytrack/model/Finding.java
@@ -53,48 +53,58 @@ public class Finding implements Serializable {
      * in double quotes to satisfy PostgreSQL case-sensitive requirements. This also places a requirement
      * on ANSI_QUOTES mode being enabled in MySQL. SQL Server works regardless and is just happy to be invited :-)
      */
-    public static final String QUERY = "SELECT " +
-            "\"COMPONENT\".\"UUID\"," +
-            "\"COMPONENT\".\"NAME\"," +
-            "\"COMPONENT\".\"GROUP\"," +
-            "\"COMPONENT\".\"VERSION\"," +
-            "\"COMPONENT\".\"PURL\"," +
-            "\"COMPONENT\".\"CPE\"," +
-            "\"VULNERABILITY\".\"UUID\"," +
-            "\"VULNERABILITY\".\"SOURCE\"," +
-            "\"VULNERABILITY\".\"VULNID\"," +
-            "\"VULNERABILITY\".\"TITLE\"," +
-            "\"VULNERABILITY\".\"SUBTITLE\"," +
-            "\"VULNERABILITY\".\"DESCRIPTION\"," +
-            "\"VULNERABILITY\".\"RECOMMENDATION\"," +
-            "\"VULNERABILITY\".\"SEVERITY\"," +
-            "\"VULNERABILITY\".\"CVSSV2BASESCORE\"," +
-            "\"VULNERABILITY\".\"CVSSV3BASESCORE\"," +
-            "\"VULNERABILITY\".\"OWASPRRLIKELIHOODSCORE\"," +
-            "\"VULNERABILITY\".\"OWASPRRTECHNICALIMPACTSCORE\"," +
-            "\"VULNERABILITY\".\"OWASPRRBUSINESSIMPACTSCORE\"," +
-            "\"EPSS\".\"SCORE\"," +
-            "\"EPSS\".\"PERCENTILE\"," +
-            "\"VULNERABILITY\".\"CWES\"," +
-            "\"FINDINGATTRIBUTION\".\"ANALYZERIDENTITY\"," +
-            "\"FINDINGATTRIBUTION\".\"ATTRIBUTED_ON\"," +
-            "\"FINDINGATTRIBUTION\".\"ALT_ID\"," +
-            "\"FINDINGATTRIBUTION\".\"REFERENCE_URL\"," +
-            "\"ANALYSIS\".\"STATE\"," +
-            "\"ANALYSIS\".\"SUPPRESSED\" " +
-            "FROM \"COMPONENT\" " +
-            "INNER JOIN \"COMPONENTS_VULNERABILITIES\" ON (\"COMPONENT\".\"ID\" = \"COMPONENTS_VULNERABILITIES\".\"COMPONENT_ID\") " +
-            "INNER JOIN \"VULNERABILITY\" ON (\"COMPONENTS_VULNERABILITIES\".\"VULNERABILITY_ID\" = \"VULNERABILITY\".\"ID\") " +
-            "LEFT JOIN \"EPSS\" ON (\"VULNERABILITY\".\"VULNID\" = \"EPSS\".\"CVE\") " +
-            "INNER JOIN \"FINDINGATTRIBUTION\" ON (\"COMPONENT\".\"ID\" = \"FINDINGATTRIBUTION\".\"COMPONENT_ID\") AND (\"VULNERABILITY\".\"ID\" = \"FINDINGATTRIBUTION\".\"VULNERABILITY_ID\")" +
-            "LEFT JOIN \"ANALYSIS\" ON (\"COMPONENT\".\"ID\" = \"ANALYSIS\".\"COMPONENT_ID\") AND (\"VULNERABILITY\".\"ID\" = \"ANALYSIS\".\"VULNERABILITY_ID\") AND (\"COMPONENT\".\"PROJECT_ID\" = \"ANALYSIS\".\"PROJECT_ID\") " +
-            "WHERE \"COMPONENT\".\"PROJECT_ID\" = ?";
+    // language=SQL
+    public static final String QUERY = """
+            SELECT "COMPONENT"."UUID"
+                 , "COMPONENT"."NAME"
+                 , "COMPONENT"."GROUP"
+                 , "COMPONENT"."VERSION"
+                 , "COMPONENT"."PURL"
+                 , "COMPONENT"."CPE"
+                 , "VULNERABILITY"."UUID"
+                 , "VULNERABILITY"."SOURCE"
+                 , "VULNERABILITY"."VULNID"
+                 , "VULNERABILITY"."TITLE"
+                 , "VULNERABILITY"."SUBTITLE"
+                 , "VULNERABILITY"."DESCRIPTION"
+                 , "VULNERABILITY"."RECOMMENDATION"
+                 , "VULNERABILITY"."SEVERITY"
+                 , "VULNERABILITY"."CVSSV2BASESCORE"
+                 , "VULNERABILITY"."CVSSV3BASESCORE"
+                 , "VULNERABILITY"."OWASPRRLIKELIHOODSCORE"
+                 , "VULNERABILITY"."OWASPRRTECHNICALIMPACTSCORE"
+                 , "VULNERABILITY"."OWASPRRBUSINESSIMPACTSCORE"
+                 , "EPSS"."SCORE"
+                 , "EPSS"."PERCENTILE"
+                 , "VULNERABILITY"."CWES"
+                 , "FINDINGATTRIBUTION"."ANALYZERIDENTITY"
+                 , "FINDINGATTRIBUTION"."ATTRIBUTED_ON"
+                 , "FINDINGATTRIBUTION"."ALT_ID"
+                 , "FINDINGATTRIBUTION"."REFERENCE_URL"
+                 , "ANALYSIS"."STATE"
+                 , "ANALYSIS"."SUPPRESSED"
+              FROM "COMPONENT"
+             INNER JOIN "COMPONENTS_VULNERABILITIES"
+                ON "COMPONENT"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
+             INNER JOIN "VULNERABILITY"
+                ON "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+             INNER JOIN "EPSS"
+                ON "VULNERABILITY"."VULNID" = "EPSS"."CVE"
+             INNER JOIN "FINDINGATTRIBUTION"
+                ON "COMPONENT"."ID" = "FINDINGATTRIBUTION"."COMPONENT_ID"
+               AND "VULNERABILITY"."ID" = "FINDINGATTRIBUTION"."VULNERABILITY_ID"
+              LEFT JOIN "ANALYSIS"
+                ON "COMPONENT"."ID" = "ANALYSIS"."COMPONENT_ID"
+               AND "VULNERABILITY"."ID" = "ANALYSIS"."VULNERABILITY_ID"
+               AND "COMPONENT"."PROJECT_ID" = "ANALYSIS"."PROJECT_ID"
+             WHERE "COMPONENT"."PROJECT_ID" = ?
+            """;
 
-    private UUID project;
-    private Map<String, Object> component = new LinkedHashMap<>();
-    private Map<String, Object> vulnerability = new LinkedHashMap<>();
-    private Map<String, Object> analysis = new LinkedHashMap<>();
-    private Map<String, Object> attribution = new LinkedHashMap<>();
+    private final UUID project;
+    private final Map<String, Object> component = new LinkedHashMap<>();
+    private final Map<String, Object> vulnerability = new LinkedHashMap<>();
+    private final Map<String, Object> analysis = new LinkedHashMap<>();
+    private final Map<String, Object> attribution = new LinkedHashMap<>();
 
     /**
      * Constructs a new Finding object. The generic Object array passed as an argument is the
@@ -146,19 +156,19 @@ public class Finding implements Serializable {
         optValue(analysis, "isSuppressed", o[27], false);
     }
 
-    public Map getComponent() {
+    public Map<String, Object> getComponent() {
         return component;
     }
 
-    public Map getVulnerability() {
+    public Map<String, Object> getVulnerability() {
         return vulnerability;
     }
 
-    public Map getAnalysis() {
+    public Map<String, Object> getAnalysis() {
         return analysis;
     }
 
-    public Map getAttribution() {
+    public Map<String, Object> getAttribution() {
         return attribution;
     }
 

--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -20,7 +20,6 @@ package org.dependencytrack.persistence;
 
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.PackageURL;
-import org.datanucleus.api.jdo.JDOQuery;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalysisComment;
 import org.dependencytrack.model.AnalysisJustification;
@@ -338,7 +337,7 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
      */
     @SuppressWarnings("unchecked")
     public List<Finding> getFindings(Project project, boolean includeSuppressed) {
-        final Query<Object[]> query = pm.newQuery(JDOQuery.SQL_QUERY_LANGUAGE, Finding.QUERY);
+        final Query<Object[]> query = pm.newQuery(Query.SQL, Finding.QUERY);
         query.setParameters(project.getId());
         final List<Object[]> list = query.executeList();
         final List<Finding> findings = new ArrayList<>();

--- a/src/test/java/org/dependencytrack/model/FindingTest.java
+++ b/src/test/java/org/dependencytrack/model/FindingTest.java
@@ -31,16 +31,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class FindingTest extends PersistenceCapableTest {
 
-    private UUID projectUuid = UUID.randomUUID();
-    private Date attributedOn = new Date();
-    private Finding finding = new Finding(projectUuid, "component-uuid", "component-name", "component-group",
+    private final UUID projectUuid = UUID.randomUUID();
+    private final Date attributedOn = new Date();
+    private final Finding finding = new Finding(projectUuid, "component-uuid", "component-name", "component-group",
             "component-version", "component-purl", "component-cpe", "vuln-uuid", "vuln-source", "vuln-vulnId", "vuln-title",
             "vuln-subtitle", "vuln-description", "vuln-recommendation", Severity.HIGH, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
             BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9), null, AnalyzerIdentity.INTERNAL_ANALYZER, attributedOn, null, null, AnalysisState.NOT_AFFECTED, true);
 
     @Test
     public void testComponent() {
-        Map map = finding.getComponent();
+        Map<String, Object> map = finding.getComponent();
         Assert.assertEquals("component-uuid", map.get("uuid"));
         Assert.assertEquals("component-name", map.get("name"));
         Assert.assertEquals("component-group", map.get("group"));
@@ -50,7 +50,7 @@ public class FindingTest extends PersistenceCapableTest {
 
     @Test
     public void testVulnerability() {
-        Map map = finding.getVulnerability();
+        Map<String, Object> map = finding.getVulnerability();
         Assert.assertEquals("vuln-uuid", map.get("uuid"));
         Assert.assertEquals("vuln-source", map.get("source"));
         Assert.assertEquals("vuln-vulnId", map.get("vulnId"));
@@ -71,7 +71,7 @@ public class FindingTest extends PersistenceCapableTest {
 
     @Test
     public void testAnalysis() {
-        Map map = finding.getAnalysis();
+        Map<String, Object> map = finding.getAnalysis();
         Assert.assertEquals(AnalysisState.NOT_AFFECTED, map.get("state"));
         Assert.assertEquals(true, map.get("isSuppressed"));
     }


### PR DESCRIPTION
### Description

Applies consistent formatting to SQL queries, and utilizes Java text blocks instead of string concatenation for multi-line queries.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1190

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly
