### PR TITLE
Improve efficiency of `InternalComponentIdentificationTask`

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -79,18 +79,6 @@ import java.util.UUID;
         @FetchGroup(name = "IDENTITY", members = {
                 @Persistent(name = "id"),
                 @Persistent(name = "uuid")
-        }),
-        @FetchGroup(name = "INTERNAL_IDENTIFICATION", members = {
-                @Persistent(name = "id"),
-                @Persistent(name = "group"),
-                @Persistent(name = "name"),
-                @Persistent(name = "internal"),
-                @Persistent(name = "uuid")
-        }),
-        @FetchGroup(name = "METRICS_UPDATE", members = {
-                @Persistent(name = "id"),
-                @Persistent(name = "lastInheritedRiskScore"),
-                @Persistent(name = "uuid")
         })
 })
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -103,9 +91,7 @@ public class Component implements Serializable {
      */
     public enum FetchGroup {
         ALL,
-        IDENTITY,
-        INTERNAL_IDENTIFICATION,
-        METRICS_UPDATE
+        IDENTITY
     }
 
     @PrimaryKey

--- a/src/main/java/org/dependencytrack/tasks/InternalComponentIdentificationTask.java
+++ b/src/main/java/org/dependencytrack/tasks/InternalComponentIdentificationTask.java
@@ -31,14 +31,16 @@ import org.dependencytrack.model.Component;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.InternalComponentIdentifier;
 import org.dependencytrack.util.LockProvider;
+import org.jdbi.v3.core.statement.PreparedBatch;
+import org.jdbi.v3.core.statement.SqlStatements;
 
-import javax.jdo.PersistenceManager;
-import javax.jdo.Query;
-import javax.jdo.Transaction;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.jdbi;
 import static org.dependencytrack.tasks.LockName.INTERNAL_COMPONENT_IDENTIFICATION_TASK_LOCK;
 import static org.dependencytrack.util.LockProvider.isLockToBeExtended;
 
@@ -63,15 +65,22 @@ public class InternalComponentIdentificationTask implements Subscriber {
         }
     }
 
-    private void analyze() throws Exception {
+    private void analyze() {
         final Instant startTime = Instant.now();
         LOGGER.info("Starting internal component identification");
         LockConfiguration lockConfiguration = LockProvider.getLockConfigurationByLockName(INTERNAL_COMPONENT_IDENTIFICATION_TASK_LOCK);
-        try (final var qm = new QueryManager()) {
-            final PersistenceManager pm = qm.getPersistenceManager();
+        final var internalComponentIdentifier = new InternalComponentIdentifier();
 
-            final var internalComponentIdentifier = new InternalComponentIdentifier();
-            List<Component> components = fetchNextComponentsPage(pm, null);
+        try (final var qm = new QueryManager()) {
+            if (!internalComponentIdentifier.hasPatterns() && !internalComponentsExist(qm)) {
+                LOGGER.debug("""
+                        No internal patterns configured, and no components currently
+                        marked as internal exist; Nothing to do""");
+                return;
+            }
+
+            final var changedInternalStatusByComponentId = new HashMap<Long, Boolean>(250);
+            List<Component> components = fetchNextComponentsPage(qm, null);
             while (!components.isEmpty()) {
                 //Extend the lock by 5 min everytime we have a page.
                 //We will get max 1000 components in a page
@@ -79,17 +88,18 @@ public class InternalComponentIdentificationTask implements Subscriber {
                 //It might finish execution before lock could be extended resulting in error
                 LOGGER.debug("extending lock of internal component identification by 5 min");
                 long cumulativeProcessingDuration = System.currentTimeMillis() - startTime.toEpochMilli();
-                if(isLockToBeExtended(cumulativeProcessingDuration, INTERNAL_COMPONENT_IDENTIFICATION_TASK_LOCK)) {
+                if (isLockToBeExtended(cumulativeProcessingDuration, INTERNAL_COMPONENT_IDENTIFICATION_TASK_LOCK)) {
                     LockExtender.extendActiveLock(Duration.ofMinutes(5).plus(lockConfiguration.getLockAtLeastFor()), lockConfiguration.getLockAtLeastFor());
                 }
+
                 for (final Component component : components) {
                     String coordinates = component.getName();
                     if (StringUtils.isNotBlank(component.getGroup())) {
                         coordinates = component.getGroup() + ":" + coordinates;
                     }
 
-                    final boolean internal = internalComponentIdentifier.isInternal(component);;
-                    if (internal) {
+                    final boolean internal = internalComponentIdentifier.isInternal(component);
+                    if (internal && LOGGER.isDebugEnabled()) {
                         LOGGER.debug("Component " + coordinates + " (" + component.getUuid() + ") was identified to be internal");
                     }
 
@@ -101,50 +111,73 @@ public class InternalComponentIdentificationTask implements Subscriber {
                             LOGGER.info("Component " + coordinates + " (" + component.getUuid()
                                     + ") was previously identified as internal. It is no longer identified as internal.");
                         }
-                    }
 
-                    if (component.isInternal() != internal) {
-                        final Transaction trx = pm.currentTransaction();
-                        try {
-                            trx.begin();
-                            component.setInternal(internal);
-                            trx.commit();
-                        } finally {
-                            if (trx.isActive()) {
-                                trx.rollback();
-                            }
-                        }
+                        changedInternalStatusByComponentId.put(component.getId(), internal);
                     }
                 }
 
+                updateInternalStatuses(qm, changedInternalStatusByComponentId);
+                changedInternalStatusByComponentId.clear();
+
                 final long lastId = components.getLast().getId();
-                components = fetchNextComponentsPage(pm, lastId);
+                components = fetchNextComponentsPage(qm, lastId);
             }
         }
         LOGGER.info("Internal component identification completed in "
                 + DateFormatUtils.format(Duration.between(startTime, Instant.now()).toMillis(), "mm:ss:SS"));
     }
 
-    /**
-     * Efficiently page through all components using keyset pagination.
-     *
-     * @param pm     The {@link PersistenceManager} to use
-     * @param lastId ID of the last {@link Component} in the previous result set, or {@code null} if this is the first invocation
-     * @return A {@link List} representing a page of up to {@code 500} {@link Component}s
-     * @throws Exception When closing the query failed
-     * @see <a href="https://use-the-index-luke.com/no-offset">Keyset pagination</a>
-     */
-    private List<Component> fetchNextComponentsPage(final PersistenceManager pm, final Long lastId) throws Exception {
-        try (final Query<Component> query = pm.newQuery(Component.class)) {
-            if (lastId != null) {
-                query.setFilter("id < :lastId");
-                query.setParameters(lastId);
-            }
-            query.setOrdering("id DESC");
-            query.setRange(0, 1000);
-            query.getFetchPlan().setGroup(Component.FetchGroup.INTERNAL_IDENTIFICATION.name());
-            return List.copyOf(query.executeList());
+    private boolean internalComponentsExist(final QueryManager qm) {
+        return jdbi(qm).withHandle(handle -> handle.createQuery("""
+                        SELECT EXISTS(SELECT 1 FROM "COMPONENT" WHERE "INTERNAL")
+                        """)
+                .mapTo(Boolean.class)
+                .one());
+    }
+
+    private List<Component> fetchNextComponentsPage(final QueryManager qm, final Long lastId) {
+        return jdbi(qm).withHandle(handle -> handle.createQuery(/* language=InjectedFreeMarker */ """
+                        <#-- @ftlvariable name="lastId" type="boolean" -->
+                        SELECT "ID"
+                             , "GROUP"
+                             , "NAME"
+                             , "INTERNAL"
+                             , "UUID"
+                          FROM "COMPONENT"
+                        <#if lastId>
+                         WHERE "ID" < :lastId
+                        </#if>
+                         ORDER BY "ID" DESC
+                         FETCH NEXT 1000 ROWS ONLY
+                        """)
+                // lastId parameter is not bound for first iteration.
+                .configure(SqlStatements.class, cfg -> cfg.setUnusedBindingAllowed(true))
+                .bind("lastId", lastId)
+                .defineNamedBindings()
+                .mapToBean(Component.class)
+                .list());
+    }
+
+    private void updateInternalStatuses(final QueryManager qm, final Map<Long, Boolean> internalStatusByComponentId) {
+        if (internalStatusByComponentId.isEmpty()) {
+            return;
         }
+
+        jdbi(qm).useTransaction(handle -> {
+            final PreparedBatch batch = handle.prepareBatch("""
+                    UPDATE "COMPONENT"
+                       SET "INTERNAL" = :internal
+                     WHERE "ID" = :id
+                    """);
+
+            internalStatusByComponentId.forEach((componentId, internalStatus) -> {
+                batch.bind("id", componentId);
+                batch.bind("internal", internalStatus);
+                batch.add();
+            });
+
+            batch.execute();
+        });
     }
 
 }

--- a/src/main/java/org/dependencytrack/util/InternalComponentIdentifier.java
+++ b/src/main/java/org/dependencytrack/util/InternalComponentIdentifier.java
@@ -75,6 +75,10 @@ public class InternalComponentIdentifier {
         return matchesGroup || matchesName;
     }
 
+    public boolean hasPatterns() {
+        return patternsSupplier.get().hasPattern();
+    }
+
     private static Patterns loadPatterns() {
         try (final var qm = new QueryManager()) {
             final ConfigProperty groupsRegexProperty = qm.getConfigProperty(


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improve efficiency of the `InternalComponentIdentificationTask`.

For large portfolios, the task tends to:

* Run for too long
* Consume too much memory

Which is caused by:

* DataNucleus fetching too many fields, even when specifying a `FetchGroup` with only a small selection of fields. For some reason it keeps using the default `FetchGroup`, which for `Component` contains way too much data (e.g. `directDependencies`).
* DataNucleus not supporting batch updates, requiring a new transaction for every single component.
* The task needlessly iterating through all components in the portfolio, even though no patterns are configured.

This is addressed by:

* Using JDBI to query data
* Using JDBI to perform updates in batches
* Returning early when no patterns are configured, and no component is currently marked as internal

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
