### PR TITLE
Port: Disable Maven transfer progress in CI

### DIFF
--- a/.github/workflows/_meta-build.yaml
+++ b/.github/workflows/_meta-build.yaml
@@ -62,13 +62,11 @@ jobs:
           chmod +x "$HOME/.local/bin/cyclonedx"
 
       - name: Build with Maven
-        env:
-          MAVEN_ARGS: "-B --no-transfer-progress"
         run: |-
-          mvn clean
-          mvn package -Dmaven.test.skip=true -P enhance -P embedded-jetty -Dservices.bom.merge.skip=false -Dlogback.configuration.file=src/main/docker/logback.xml
-          mvn clean -P clean-exclude-wars
-          mvn cyclonedx:makeBom -Dservices.bom.merge.skip=false org.codehaus.mojo:exec-maven-plugin:exec@merge-services-bom
+          mvn -B --no-transfer-progress clean
+          mvn -B --no-transfer-progress package -Dmaven.test.skip=true -P enhance -P embedded-jetty -Dservices.bom.merge.skip=false -Dlogback.configuration.file=src/main/docker/logback.xml
+          mvn -B --no-transfer-progress clean -P clean-exclude-wars
+          mvn -B --no-transfer-progress cyclonedx:makeBom -Dservices.bom.merge.skip=false org.codehaus.mojo:exec-maven-plugin:exec@merge-services-bom
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4.3.1

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -77,7 +77,7 @@ jobs:
           cache: 'maven'
 
       - name: Set Version
-        run: mvn versions:set -DnewVersion=${VERSION}
+        run: mvn -B --no-transfer-progress versions:set -DnewVersion=${VERSION}
 
       - name: Commit Version
         env:
@@ -138,7 +138,7 @@ jobs:
           ref: ${{ needs.prepare-release.outputs.release-branch }}
 
       - name: Set SNAPSHOT Version after Release
-        run: mvn versions:set -DnewVersion=${NEXT_VERSION}
+        run: mvn -B --no-transfer-progress versions:set -DnewVersion=${NEXT_VERSION}
 
       - name: Commit SNAPSHOT Version
         env:

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -60,11 +60,10 @@ jobs:
 
       - name: Execute unit tests
         env:
-          MAVEN_ARGS: "-B --no-transfer-progress"
           TESTCONTAINERS_REUSE_ENABLE: "true"
         run: |-
-          mvn clean
-          mvn test -P enhance
+          mvn -B --no-transfer-progress clean
+          mvn -B --no-transfer-progress test -P enhance
 
       # Publishing coverage to Codacy is only possible for builds of push events.
       # PRs from forks do not get access to repository secrets.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/3677 from Dependency-Track v4.11.0.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/1190

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
