### PR TITLE
Fix `ProcessedVulnerabilityScanResultProcessorTest` flakiness

### DIFF
--- a/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
@@ -21,7 +21,6 @@ package org.dependencytrack.event.kafka.processor;
 import alpine.event.framework.Event;
 import alpine.event.framework.EventService;
 import alpine.event.framework.Subscriber;
-
 import org.dependencytrack.event.ComponentMetricsUpdateEvent;
 import org.dependencytrack.event.ComponentPolicyEvaluationEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
@@ -245,22 +244,20 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
 
         await("Internal event publish")
                 .atMost(Duration.ofSeconds(1))
-                .untilAsserted(() -> {
-                    assertThat(EVENTS).satisfiesExactly(
-                            event -> {
-                                assertThat(event).isInstanceOf(ProjectPolicyEvaluationEvent.class);
-                                final var policyEvalEvent = (ProjectPolicyEvaluationEvent) event;
-                                assertThat(policyEvalEvent.getUuid()).isEqualTo(project.getUuid());
-                                assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                            },
-                            event -> {
-                                assertThat(event).isInstanceOf(ProjectMetricsUpdateEvent.class);
-                                final var metricsUpdateEvent = (ProjectMetricsUpdateEvent) event;
-                                assertThat(metricsUpdateEvent.getUuid()).isEqualTo(project.getUuid());
-                                assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                            }
-                    );
-                });
+                .untilAsserted(() -> assertThat(EVENTS).satisfiesExactly(
+                        event -> {
+                            assertThat(event).isInstanceOf(ProjectPolicyEvaluationEvent.class);
+                            final var policyEvalEvent = (ProjectPolicyEvaluationEvent) event;
+                            assertThat(policyEvalEvent.getUuid()).isEqualTo(project.getUuid());
+                            assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                        },
+                        event -> {
+                            assertThat(event).isInstanceOf(ProjectMetricsUpdateEvent.class);
+                            final var metricsUpdateEvent = (ProjectMetricsUpdateEvent) event;
+                            assertThat(metricsUpdateEvent.getUuid()).isEqualTo(project.getUuid());
+                            assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                        }
+                ));
     }
 
     @Test
@@ -316,6 +313,13 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
                     assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
                 }
         );
+
+        await("Internal event publish")
+                .atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(EVENTS).satisfiesExactly(
+                        event -> assertThat(event).isInstanceOf(ProjectPolicyEvaluationEvent.class),
+                        event -> assertThat(event).isInstanceOf(ProjectMetricsUpdateEvent.class)
+                ));
     }
 
     @Test
@@ -372,6 +376,8 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
                     assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
                 }
         );
+
+        assertThat(EVENTS).isEmpty();
     }
 
     @Test
@@ -407,6 +413,13 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
 
         assertThat(kafkaMockProducer.history()).satisfiesExactly(record ->
                 assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name()));
+
+        await("Internal event publish")
+                .atMost(Duration.ofSeconds(1))
+                .untilAsserted(() -> assertThat(EVENTS).satisfiesExactly(
+                        event -> assertThat(event).isInstanceOf(ProjectPolicyEvaluationEvent.class),
+                        event -> assertThat(event).isInstanceOf(ProjectMetricsUpdateEvent.class)
+                ));
     }
 
     @Test
@@ -458,22 +471,20 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
 
         await("Internal event publish")
                 .atMost(Duration.ofSeconds(1))
-                .untilAsserted(() -> {
-                    assertThat(EVENTS).satisfiesExactly(
-                            event -> {
-                                assertThat(event).isInstanceOf(ComponentPolicyEvaluationEvent.class);
-                                final var policyEvalEvent = (ComponentPolicyEvaluationEvent) event;
-                                assertThat(policyEvalEvent.getUuid()).isEqualTo(component.getUuid());
-                                assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                            },
-                            event -> {
-                                assertThat(event).isInstanceOf(ComponentMetricsUpdateEvent.class);
-                                final var metricsUpdateEvent = (ComponentMetricsUpdateEvent) event;
-                                assertThat(metricsUpdateEvent.getUuid()).isEqualTo(component.getUuid());
-                                assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
-                            }
-                    );
-                });
+                .untilAsserted(() -> assertThat(EVENTS).satisfiesExactly(
+                        event -> {
+                            assertThat(event).isInstanceOf(ComponentPolicyEvaluationEvent.class);
+                            final var policyEvalEvent = (ComponentPolicyEvaluationEvent) event;
+                            assertThat(policyEvalEvent.getUuid()).isEqualTo(component.getUuid());
+                            assertThat(policyEvalEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                        },
+                        event -> {
+                            assertThat(event).isInstanceOf(ComponentMetricsUpdateEvent.class);
+                            final var metricsUpdateEvent = (ComponentMetricsUpdateEvent) event;
+                            assertThat(metricsUpdateEvent.getUuid()).isEqualTo(component.getUuid());
+                            assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
+                        }
+                ));
     }
 
     private static final ConcurrentLinkedQueue<Event> EVENTS = new ConcurrentLinkedQueue<>();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `ProcessedVulnerabilityScanResultProcessorTest` flakiness.

The test occasionally fails because internal events from a previous test make it to the next.

To reduce the likelihood of this happening, every test now explicitly waits for all expected events.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Example test failure: https://github.com/DependencyTrack/hyades-apiserver/actions/runs/9528216172/job/26265663122

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
