### PR TITLE
Improve Liquibase logging integration

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/migration/LiquibaseLogger.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/LiquibaseLogger.java
@@ -38,15 +38,15 @@ class LiquibaseLogger extends AbstractLogger {
 
     @Override
     public void log(final Level level, final String message, final Throwable e) {
-        if (level == Level.SEVERE) {
+        if (Level.SEVERE.equals(level)) {
             logger.error(message, e);
-        } else if (level == Level.WARNING) {
+        } else if (Level.WARNING.equals(level)) {
             logger.warn(message, e);
-        } else if (level == Level.INFO) {
+        } else if (Level.INFO.equals(level)) {
             logger.info(message, e);
-        } else if (level == Level.CONFIG || level == Level.FINE) {
+        } else if (Level.CONFIG.equals(level) || Level.FINE.equals(level)) {
             logger.debug(message, e);
-        } else if (level == Level.FINER || level == Level.FINEST) {
+        } else if (Level.FINER.equals(level) || Level.FINEST.equals(level)) {
             logger.trace(message, e);
         }
     }

--- a/src/main/java/org/dependencytrack/persistence/migration/LiquibaseLogger.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/LiquibaseLogger.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.migration;
+
+import alpine.common.logging.Logger;
+import liquibase.logging.core.AbstractLogService;
+import liquibase.logging.core.AbstractLogger;
+import liquibase.plugin.Plugin;
+
+import java.util.logging.Level;
+
+/**
+ * @since 5.5.0
+ */
+class LiquibaseLogger extends AbstractLogger {
+
+    private final Logger logger;
+
+    LiquibaseLogger(final Class<?> clazz) {
+        this.logger = Logger.getLogger(clazz);
+    }
+
+    @Override
+    public void log(final Level level, final String message, final Throwable e) {
+        if (level == Level.SEVERE) {
+            logger.error(message, e);
+        } else if (level == Level.WARNING) {
+            logger.warn(message, e);
+        } else if (level == Level.INFO) {
+            logger.info(message, e);
+        } else if (level == Level.CONFIG || level == Level.FINE) {
+            logger.debug(message, e);
+        } else if (level == Level.FINER || level == Level.FINEST) {
+            logger.trace(message, e);
+        }
+    }
+
+    static class LogService extends AbstractLogService {
+
+        @Override
+        public int getPriority() {
+            return Plugin.PRIORITY_SPECIALIZED;
+        }
+
+        @Override
+        public liquibase.logging.Logger getLog(final Class clazz) {
+            return new LiquibaseLogger(clazz);
+        }
+
+    }
+
+}

--- a/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
@@ -24,14 +24,16 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import liquibase.Liquibase;
 import liquibase.Scope;
+import liquibase.UpdateSummaryOutputEnum;
 import liquibase.command.CommandScope;
 import liquibase.command.core.UpdateCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
+import liquibase.command.core.helpers.DbUrlConnectionArgumentsCommandStep;
+import liquibase.command.core.helpers.ShowSummaryArgument;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.logging.core.NoOpLogService;
 import liquibase.resource.ClassLoaderResourceAccessor;
+import liquibase.ui.LoggerUIService;
 import org.dependencytrack.common.ConfigKey;
 
 import javax.servlet.ServletContextEvent;
@@ -64,25 +66,25 @@ public class MigrationInitializer implements ServletContextListener {
 
         LOGGER.info("Running migrations");
         try (final HikariDataSource dataSource = createDataSource()) {
-            runMigration(dataSource, false);
+            runMigration(dataSource);
         } catch (Exception e) {
             throw new RuntimeException("Failed to execute migrations", e);
         }
     }
 
-    public static void runMigration(final DataSource dataSource, final boolean silent) throws Exception {
+    public static void runMigration(final DataSource dataSource) throws Exception {
         final var scopeAttributes = new HashMap<String, Object>();
-        if (silent) {
-            scopeAttributes.put(Scope.Attr.logService.name(), new NoOpLogService());
-        }
+        scopeAttributes.put(Scope.Attr.logService.name(), new LiquibaseLogger.LogService());
+        scopeAttributes.put(Scope.Attr.ui.name(), new LoggerUIService());
 
         Scope.child(scopeAttributes, () -> {
             final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()));
             final var liquibase = new Liquibase("migration/changelog-main.xml", new ClassLoaderResourceAccessor(), database);
 
             final var updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
-            updateCommand.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, liquibase.getDatabase());
+            updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, liquibase.getDatabase());
             updateCommand.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, liquibase.getChangeLogFile());
+            updateCommand.addArgumentValue(ShowSummaryArgument.SHOW_SUMMARY_OUTPUT, UpdateSummaryOutputEnum.LOG);
             updateCommand.execute();
         });
     }

--- a/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
@@ -73,13 +73,17 @@ public class MigrationInitializer implements ServletContextListener {
     }
 
     public static void runMigration(final DataSource dataSource) throws Exception {
+        runMigration(dataSource, "migration/changelog-main.xml");
+    }
+
+    public static void runMigration(final DataSource dataSource, final String changelogResourcePath) throws Exception {
         final var scopeAttributes = new HashMap<String, Object>();
         scopeAttributes.put(Scope.Attr.logService.name(), new LiquibaseLogger.LogService());
         scopeAttributes.put(Scope.Attr.ui.name(), new LoggerUIService());
 
         Scope.child(scopeAttributes, () -> {
             final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()));
-            final var liquibase = new Liquibase("migration/changelog-main.xml", new ClassLoaderResourceAccessor(), database);
+            final var liquibase = new Liquibase(changelogResourcePath, new ClassLoaderResourceAccessor(), database);
 
             final var updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
             updateCommand.addArgumentValue(DbUrlConnectionArgumentsCommandStep.DATABASE_ARG, liquibase.getDatabase());

--- a/src/test/java/org/dependencytrack/PostgresTestContainer.java
+++ b/src/test/java/org/dependencytrack/PostgresTestContainer.java
@@ -37,7 +37,7 @@ public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestConta
 
         // NB: Container reuse won't be active unless either:
         //  - The environment variable TESTCONTAINERS_REUSE_ENABLE=true is set
-        //  - testcontainers.reuse.enable=false is set in ~/.testcontainers.properties
+        //  - testcontainers.reuse.enable=true is set in ~/.testcontainers.properties
         withReuse(true);
     }
 
@@ -58,7 +58,7 @@ public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestConta
         try {
             MigrationInitializer.runMigration(dataSource);
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new RuntimeException("Failed to execute migrations", e);
         }
     }
 

--- a/src/test/java/org/dependencytrack/PostgresTestContainer.java
+++ b/src/test/java/org/dependencytrack/PostgresTestContainer.java
@@ -56,7 +56,7 @@ public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestConta
         dataSource.setPassword(getPassword());
 
         try {
-            MigrationInitializer.runMigration(dataSource, /* silent */ true);
+            MigrationInitializer.runMigration(dataSource);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/test/java/org/dependencytrack/persistence/migration/change/v530/RenameForeignKeysChangeTest.java
+++ b/src/test/java/org/dependencytrack/persistence/migration/change/v530/RenameForeignKeysChangeTest.java
@@ -18,15 +18,7 @@
  */
 package org.dependencytrack.persistence.migration.change.v530;
 
-import liquibase.Liquibase;
-import liquibase.Scope;
-import liquibase.command.CommandScope;
-import liquibase.command.core.UpdateCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
-import liquibase.database.Database;
-import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.resource.ClassLoaderResourceAccessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,9 +26,8 @@ import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.migration.MigrationInitializer.runMigration;
 import static org.dependencytrack.persistence.migration.change.v530.RenameForeignKeysChange.getForeignNameMappings;
 
 public class RenameForeignKeysChangeTest {
@@ -65,15 +56,7 @@ public class RenameForeignKeysChangeTest {
         dataSource.setUser(postgresContainer.getUsername());
         dataSource.setPassword(postgresContainer.getPassword());
 
-        Scope.child(Collections.emptyMap(), () -> {
-            final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()));
-            final var liquibase = new Liquibase("migration/custom/RenameForeignKeysChangeTest-changelog.xml", new ClassLoaderResourceAccessor(), database);
-
-            final var updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
-            updateCommand.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, liquibase.getDatabase());
-            updateCommand.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, liquibase.getChangeLogFile());
-            updateCommand.execute();
-        });
+        runMigration(dataSource, "migration/custom/RenameForeignKeysChangeTest-changelog.xml");
 
         assertThat(getForeignNameMappings(new JdbcConnection(dataSource.getConnection()))).isEmpty();
     }

--- a/src/test/java/org/dependencytrack/persistence/migration/change/v530/RenameNumberedIndexesChangeTest.java
+++ b/src/test/java/org/dependencytrack/persistence/migration/change/v530/RenameNumberedIndexesChangeTest.java
@@ -18,15 +18,7 @@
  */
 package org.dependencytrack.persistence.migration.change.v530;
 
-import liquibase.Liquibase;
-import liquibase.Scope;
-import liquibase.command.CommandScope;
-import liquibase.command.core.UpdateCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
-import liquibase.database.Database;
-import liquibase.database.DatabaseFactory;
 import liquibase.database.jvm.JdbcConnection;
-import liquibase.resource.ClassLoaderResourceAccessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,9 +26,8 @@ import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Collections;
-
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.migration.MigrationInitializer.runMigration;
 import static org.dependencytrack.persistence.migration.change.v530.RenameNumberedIndexesChange.getIndexNameMappingsFromPostgres;
 
 public class RenameNumberedIndexesChangeTest {
@@ -65,15 +56,7 @@ public class RenameNumberedIndexesChangeTest {
         dataSource.setUser(postgresContainer.getUsername());
         dataSource.setPassword(postgresContainer.getPassword());
 
-        Scope.child(Collections.emptyMap(), () -> {
-            final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()));
-            final var liquibase = new Liquibase("migration/custom/RenameNumberedIndexesChangeTest-changelog.xml", new ClassLoaderResourceAccessor(), database);
-
-            final var updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
-            updateCommand.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, liquibase.getDatabase());
-            updateCommand.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, liquibase.getChangeLogFile());
-            updateCommand.execute();
-        });
+        runMigration(dataSource, "migration/custom/RenameNumberedIndexesChangeTest-changelog.xml");
 
         assertThat(getIndexNameMappingsFromPostgres(new JdbcConnection(dataSource.getConnection()))).isEmpty();
     }

--- a/src/test/java/org/dependencytrack/persistence/migration/change/v550/ComputeSeveritiesChangeTest.java
+++ b/src/test/java/org/dependencytrack/persistence/migration/change/v550/ComputeSeveritiesChangeTest.java
@@ -18,15 +18,6 @@
  */
 package org.dependencytrack.persistence.migration.change.v550;
 
-import liquibase.Liquibase;
-import liquibase.Scope;
-import liquibase.command.CommandScope;
-import liquibase.command.core.UpdateCommandStep;
-import liquibase.command.core.helpers.DbUrlConnectionCommandStep;
-import liquibase.database.Database;
-import liquibase.database.DatabaseFactory;
-import liquibase.database.jvm.JdbcConnection;
-import liquibase.resource.ClassLoaderResourceAccessor;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -36,10 +27,10 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.util.Collections;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.migration.MigrationInitializer.runMigration;
 
 public class ComputeSeveritiesChangeTest {
 
@@ -86,15 +77,7 @@ public class ComputeSeveritiesChangeTest {
 
         assertThat(hasVulnsWithoutSeverity(dataSource.getConnection())).isTrue();
 
-        Scope.child(Collections.emptyMap(), () -> {
-            final Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(dataSource.getConnection()));
-            final var liquibase = new Liquibase("migration/custom/ComputeSeveritiesChangeTest-changelog.xml", new ClassLoaderResourceAccessor(), database);
-
-            final var updateCommand = new CommandScope(UpdateCommandStep.COMMAND_NAME);
-            updateCommand.addArgumentValue(DbUrlConnectionCommandStep.DATABASE_ARG, liquibase.getDatabase());
-            updateCommand.addArgumentValue(UpdateCommandStep.CHANGELOG_FILE_ARG, liquibase.getChangeLogFile());
-            updateCommand.execute();
-        });
+        runMigration(dataSource, "migration/custom/ComputeSeveritiesChangeTest-changelog.xml");
 
         assertThat(hasVulnsWithoutSeverity(dataSource.getConnection())).isFalse();
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves Liquibase logging integration.

Liquibase has its own logging system, and as such has previously bypassed the log setup of Dependency-Track. This caused a very verbose output whenever migrations were executed.

This change now integrates Liquibase with DT's slf4j-based logging system. Per default, we only log messages from Liquibase with level `WARNING` or higher. This can of course be tweaked in `logback.xml`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
