### PR TITLE
Disable logging to file

### DIFF
--- a/src/main/docker/logback-json.xml
+++ b/src/main/docker/logback-json.xml
@@ -29,10 +29,6 @@
         <appender-ref ref="JSON_STDOUT" />
     </logger>
 
-    <logger name="org.apache.kafka" level="WARN" additivity="false">
-        <appender-ref ref="JSON_STDOUT" />
-    </logger>
-
     <root level="WARN">
         <appender-ref ref="JSON_STDOUT" />
     </root>

--- a/src/main/docker/logback.xml
+++ b/src/main/docker/logback.xml
@@ -1,83 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.dependency-track/dependency-track.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${user.home}/.dependency-track/dependency-track.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>9</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder>
-            <pattern>%date [%marker] %level [%logger] %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date %level [%logger{0}] %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="SECURITY_CONSOLE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.dependency-track/dependency-track-audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${user.home}/.dependency-track/dependency-track-audit.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>9</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-        <filter class="org.owasp.security.logging.filter.SecurityMarkerFilter"/>
-        <encoder>
-            <pattern>%date [%marker] %level - %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="EMBEDDED_SERVER" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.dependency-track/server.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${user.home}/.dependency-track/server.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>9</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder>
-            <pattern>%date [%marker] %level [%logger] %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
-        </encoder>
-    </appender>
-
     <logger name="alpine" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SECURITY_CONSOLE" />
     </logger>
 
     <logger name="org.dependencytrack" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SECURITY_CONSOLE" />
     </logger>
 
     <logger name="org.eclipse.jetty" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
-        <appender-ref ref="EMBEDDED_SERVER" />
-    </logger>
-
-    <logger name="org.apache.kafka" level="WARN" additivity="false">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
     </logger>
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SECURITY_CONSOLE" />
     </root>
-
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,80 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true">
-
-    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.dependency-track/dependency-track.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${user.home}/.dependency-track/dependency-track.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>9</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder>
-            <pattern>%date [%marker] %level [%logger] %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%date %level [%logger{0}] %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="SECURITY_CONSOLE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.dependency-track/dependency-track-audit.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${user.home}/.dependency-track/dependency-track-audit.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>9</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-        <filter class="org.owasp.security.logging.filter.SecurityMarkerFilter"/>
-        <encoder>
-            <pattern>%date [%marker] %level - %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
-        </encoder>
-    </appender>
-
-    <appender name="EMBEDDED_SERVER" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>${user.home}/.dependency-track/server.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${user.home}/.dependency-track/server.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>9</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>10MB</maxFileSize>
-        </triggeringPolicy>
-        <encoder>
-            <pattern>%date [%marker] %level [%logger] %msg%replace( [%mdc{}]){' \[\]', ''}%n</pattern>
-        </encoder>
-    </appender>
-
     <logger name="alpine" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SECURITY_CONSOLE" />
+        <appender-ref ref="STDOUT" />
     </logger>
 
     <logger name="org.dependencytrack" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SECURITY_CONSOLE" />
+        <appender-ref ref="STDOUT" />
     </logger>
 
     <logger name="org.eclipse.jetty" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
-        <appender-ref ref="EMBEDDED_SERVER" />
-    </logger>
-
-    <logger name="org.apache.kafka" level="WARN" additivity="false">
         <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
     </logger>
 
     <root level="WARN">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="SECURITY_CONSOLE" />
+        <appender-ref ref="STDOUT" />
     </root>
-
 </configuration>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Disables logging to file.

For containerized workloads, logs are expected to be grabbed from STDOUT, writing them to disk unnecessarily adds storage requirements.

In the original config, three rolling file appenders, each with up to 10 files of up to 10MB each were configured. This led to up to 300MB of hidden storage requirement for long-running instances.


### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
