### PR TITLE
Remove dependency on `kafka-junit`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,6 @@
         <lib.jdbi.version>3.45.1</lib.jdbi.version>
         <lib.json-unit.version>3.2.7</lib.json-unit.version>
         <lib.kafka.version>3.7.0</lib.kafka.version>
-        <lib.kafka-junit.version>3.6.0</lib.kafka-junit.version>
         <lib.liquibase.version>4.28.0</lib.liquibase.version>
         <lib.micrometer-jvm-extras.version>0.2.2</lib.micrometer-jvm-extras.version>
         <lib.minio.version>8.5.10</lib.minio.version>
@@ -486,34 +485,6 @@
             <artifactId>json-unit-assertj</artifactId>
             <version>${lib.json-unit.version}</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.mguenther.kafka</groupId>
-            <artifactId>kafka-junit</artifactId>
-            <version>${lib.kafka-junit.version}</version>
-            <scope>test</scope>
-            <!--
-                kafka-junit pulls in the entire Kafka application as dependency.
-                Some transitive dependencies of Kafka do not play well with Jersey / Grizzly.
-            -->
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.module</groupId>
-                    <artifactId>jackson-module-scala_2.13</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-csv</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.datatype</groupId>
-                    <artifactId>jackson-datatype-jdk8</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-reload4j</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>

--- a/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
@@ -19,15 +19,17 @@
 package org.dependencytrack.event.kafka.processor.api;
 
 import alpine.Config;
-import net.mguenther.kafka.junit.ExternalKafkaCluster;
-import net.mguenther.kafka.junit.KeyValue;
-import net.mguenther.kafka.junit.SendKeyValues;
-import net.mguenther.kafka.junit.TopicConfig;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.kafka.KafkaTopics.Topic;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,6 +46,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,22 +63,38 @@ public class ProcessorManagerTest {
     public RedpandaContainer kafkaContainer = new RedpandaContainer(DockerImageName
             .parse("docker.redpanda.com/vectorized/redpanda:v24.1.7"));
 
-    private ExternalKafkaCluster kafka;
+    private AdminClient adminClient;
+    private Producer<String, String> producer;
     private Config configMock;
 
     @Before
     public void setUp() {
-        kafka = ExternalKafkaCluster.at(kafkaContainer.getBootstrapServers());
+        adminClient = AdminClient.create(Map.of(BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers()));
+        producer = new KafkaProducer<>(Map.ofEntries(
+                Map.entry(BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers()),
+                Map.entry(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class),
+                Map.entry(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class)
+        ));
 
         configMock = mock(Config.class);
         when(configMock.getProperty(eq(ConfigKey.KAFKA_BOOTSTRAP_SERVERS)))
                 .thenReturn(kafkaContainer.getBootstrapServers());
     }
 
+    @After
+    public void tearDown() {
+        if (adminClient != null) {
+            adminClient.close();
+        }
+        if (producer != null) {
+            producer.close();
+        }
+    }
+
     @Test
     public void testSingleRecordProcessor() throws Exception {
         final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
-        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+        adminClient.createTopics(List.of(new NewTopic(inputTopic.name(), 3, (short) 1))).all().get();
 
         final var recordsProcessed = new AtomicInteger(0);
 
@@ -93,9 +112,7 @@ public class ProcessorManagerTest {
             processorManager.registerProcessor("foo", inputTopic, processor);
 
             for (int i = 0; i < 100; i++) {
-                kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo" + i, "bar" + i)))
-                        .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-                        .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i));
             }
 
             processorManager.startAll();
@@ -109,7 +126,7 @@ public class ProcessorManagerTest {
     @Test
     public void testSingleRecordProcessorRetry() throws Exception {
         final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
-        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+        adminClient.createTopics(List.of(new NewTopic(inputTopic.name(), 3, (short) 1))).all().get();
 
         final var attemptsCounter = new AtomicInteger(0);
 
@@ -139,9 +156,7 @@ public class ProcessorManagerTest {
         try (final var processorManager = new ProcessorManager(UUID.randomUUID(), configMock)) {
             processorManager.registerProcessor("foo", inputTopic, processor);
 
-            kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo", "bar")))
-                    .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-                    .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+            producer.send(new ProducerRecord<>("input", "foo", "bar"));
 
             processorManager.startAll();
 
@@ -154,7 +169,7 @@ public class ProcessorManagerTest {
     @Test
     public void testBatchProcessor() throws Exception {
         final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
-        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+        adminClient.createTopics(List.of(new NewTopic(inputTopic.name(), 3, (short) 1))).all().get();
 
         final var recordsProcessed = new AtomicInteger(0);
         final var actualBatchSizes = new ConcurrentLinkedQueue<>();
@@ -178,9 +193,7 @@ public class ProcessorManagerTest {
             processorManager.registerBatchProcessor("foo", inputTopic, recordProcessor);
 
             for (int i = 0; i < 1_000; i++) {
-                kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo" + i, "bar" + i)))
-                        .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-                        .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i));
             }
 
             processorManager.startAll();
@@ -196,8 +209,7 @@ public class ProcessorManagerTest {
     @Test
     public void testWithMaxConcurrencyMatchingPartitionCount() throws Exception {
         final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
-
-        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(12));
+        adminClient.createTopics(List.of(new NewTopic(inputTopic.name(), 12, (short) 1))).all().get();
 
         when(configMock.getPassThroughProperties(eq("kafka.processor.foo")))
                 .thenReturn(Map.of(
@@ -218,9 +230,7 @@ public class ProcessorManagerTest {
             processorManager.registerProcessor("foo", inputTopic, processor);
 
             for (int i = 0; i < 100; i++) {
-                kafka.send(SendKeyValues.to("input", List.of(new KeyValue<>("foo" + i, "bar" + i)))
-                        .with(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName())
-                        .with(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName()));
+                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i));
             }
 
             processorManager.startAll();
@@ -234,11 +244,10 @@ public class ProcessorManagerTest {
     }
 
     @Test
-    public void testStartAllWithMissingTopics() {
+    public void testStartAllWithMissingTopics() throws Exception {
         final var inputTopicA = new Topic<>("input-a", Serdes.String(), Serdes.String());
         final var inputTopicB = new Topic<>("input-b", Serdes.String(), Serdes.String());
-
-        kafka.createTopic(TopicConfig.withName(inputTopicA.name()).withNumberOfPartitions(3));
+        adminClient.createTopics(List.of(new NewTopic(inputTopicA.name(), 3, (short) 1))).all().get();
 
         final Processor<String, String> processor = record -> {
         };
@@ -257,9 +266,9 @@ public class ProcessorManagerTest {
     }
 
     @Test
-    public void testProbeHealth() {
+    public void testProbeHealth() throws Exception {
         final var inputTopic = new Topic<>("input", Serdes.String(), Serdes.String());
-        kafka.createTopic(TopicConfig.withName(inputTopic.name()).withNumberOfPartitions(3));
+        adminClient.createTopics(List.of(new NewTopic(inputTopic.name(), 3, (short) 1))).all().get();
 
         final Processor<String, String> processor = record -> {
         };


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes dependency on `kafka-junit`.

The minimal value we get out of it doesn't justify pulling in Kafka in its entirety as a dependency, even if it's just in `test` scope.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly~
