### PR TITLE
Port : Generate SARIF File Of Project Vulnerability Findings

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -20,9 +20,12 @@ package org.dependencytrack.resources.v1;
 
 import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
+import alpine.model.About;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
+import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -30,6 +33,7 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.ResponseHeader;
+import org.apache.commons.text.WordUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.PortfolioRepositoryMetaAnalysisEvent;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
@@ -44,6 +48,7 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.BomUploadResponse;
 
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -51,6 +56,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -69,12 +77,13 @@ import java.util.stream.Collectors;
 public class FindingResource extends AlpineResource {
 
     private static final Logger LOGGER = Logger.getLogger(FindingResource.class);
+    public static final String MEDIA_TYPE_SARIF_JSON = "application/sarif+json";
 
     @GET
     @Path("/project/{uuid}")
-    @Produces(MediaType.APPLICATION_JSON)
+    @Produces({MediaType.APPLICATION_JSON, MEDIA_TYPE_SARIF_JSON})
     @ApiOperation(
-            value = "Returns a list of all findings for a specific project",
+            value = "Returns a list of all findings for a specific project or generates SARIF file if Accept: application/sarif+json header is provided",
             response = Finding.class,
             responseContainer = "List",
             responseHeaders = @ResponseHeader(name = TOTAL_COUNT_HEADER, response = Long.class, description = "The total number of findings"),
@@ -91,12 +100,23 @@ public class FindingResource extends AlpineResource {
                                          @ApiParam(value = "Optionally includes suppressed findings")
                                          @QueryParam("suppressed") boolean suppressed,
                                          @ApiParam(value = "Optionally limit findings to specific sources of vulnerability intelligence")
-                                         @QueryParam("source") Vulnerability.Source source) {
+                                         @QueryParam("source") Vulnerability.Source source,
+                                         @HeaderParam("accept") String acceptHeader) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
                 if (qm.hasAccess(super.getPrincipal(), project)) {
                     final List<Finding> findings = qm.getFindings(project, suppressed);
+                    if (acceptHeader != null && acceptHeader.contains(MEDIA_TYPE_SARIF_JSON)) {
+                        try {
+                            return Response.ok(generateSARIF(findings), MEDIA_TYPE_SARIF_JSON)
+                                    .header("content-disposition","attachment; filename=\"findings-" + uuid + ".sarif\"")
+                                    .build();
+                        } catch (IOException ioException) {
+                            LOGGER.error(ioException.getMessage(), ioException);
+                            return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("An error occurred while generating SARIF file").build();
+                        }
+                    }
                     if (source != null) {
                         final List<Finding> filteredList = findings.stream().filter(finding -> source.name().equals(finding.getVulnerability().get("source"))).collect(Collectors.toList());
                         return Response.ok(filteredList).header(TOTAL_COUNT_HEADER, filteredList.size()).build();
@@ -323,5 +343,46 @@ public class FindingResource extends AlpineResource {
             final PaginatedResult result = qm.getAllFindingsGroupedByVulnerability(filters, showInactive);
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
+    }
+
+    private String generateSARIF(List<Finding> findings) throws IOException {
+        final PebbleEngine engine = new PebbleEngine.Builder()
+                .newLineTrimming(false)
+                .defaultEscapingStrategy("json")
+                .build();
+        final PebbleTemplate sarifTemplate = engine.getTemplate("templates/findings/sarif.peb");
+
+        final Map<String, Object> context = new HashMap<>();
+        final About about = new About();
+
+        // Using "vulnId" as key, forming a list of unique vulnerabilities across all findings
+        // Also converts cweName to PascalCase, since it will be used as rule.name in the SARIF file
+        List<Map<String, Object>> uniqueVulnerabilities = findings.stream()
+                .collect(Collectors.toMap(
+                        finding -> finding.getVulnerability().get("vulnId"),
+                        FindingResource::convertCweNameToPascalCase,
+                        (existingVuln, replacementVuln) -> existingVuln))
+                .values()
+                .stream()
+                .toList();
+
+        context.put("findings", findings);
+        context.put("dependencyTrackVersion", about.getVersion());
+        context.put("uniqueVulnerabilities", uniqueVulnerabilities);
+
+        try (final Writer writer = new StringWriter()) {
+            sarifTemplate.evaluate(writer, context);
+            return writer.toString();
+        }
+    }
+
+    private static Map<String, Object> convertCweNameToPascalCase(Finding finding) {
+        final Object cweName = finding.getVulnerability()
+                .get("cweName");
+        if (cweName != null) {
+            final String pascalCasedCweName = WordUtils.capitalizeFully(cweName.toString()).replaceAll("\\s", "");
+            finding.getVulnerability().put("cweName", pascalCasedCweName);
+        }
+        return finding.getVulnerability();
     }
 }

--- a/src/main/resources/templates/findings/sarif.peb
+++ b/src/main/resources/templates/findings/sarif.peb
@@ -1,0 +1,58 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "OWASP Dependency-Track",
+          "fullName": "OWASP Dependency-Track - {{ dependencyTrackVersion }}",
+          "version": "{{ dependencyTrackVersion }}",
+          "informationUri": "https://dependencytrack.org/",
+          "rules": [{% for vuln in uniqueVulnerabilities %}
+            {
+              "id": "{{ vuln.vulnId }}",
+              "name": "{{ vuln.cweName }}",
+              "shortDescription": {
+                "text": "{{ vuln.vulnId }}"
+              },
+              "fullDescription": {
+                "text": "{{ vuln.description | trim }}"
+              }
+            }{% if not loop.last %},{% endif %}{% endfor %}
+          ]
+        }
+      },
+      "results": [{% for finding in findings %}
+        {
+          "ruleId": "{{ finding.vulnerability.vulnId }}",
+          "message": {
+            "text": "{{ finding.vulnerability.description | trim }}"
+          },
+          "locations": [
+            {
+              "logicalLocations": [
+                {
+                  "fullyQualifiedName": "{{ finding.component.purl }}"
+                }
+              ]
+            }
+          ],
+          "level": {% if ['LOW', 'INFO'] contains finding.vulnerability.severity %}"note",{% elseif finding.vulnerability.severity == 'MEDIUM' %}"warning",{% elseif ['HIGH', 'CRITICAL'] contains finding.vulnerability.severity %}"error",{% else %}"none",{% endif %}
+          "properties": {
+            "name": "{{ finding.component.name }}",
+            "group": "{{ finding.component.group }}",
+            "version": "{{ finding.component.version }}",
+            "source": "{{ finding.vulnerability.source }}",
+            "cweId": "{{ finding.vulnerability.cweId }}",
+            "cvssV3BaseScore": "{{ finding.vulnerability.cvssV3BaseScore }}",
+            "epssScore": "{{ finding.vulnerability.epssScore }}",
+            "epssPercentile": "{{ finding.vulnerability.epssPercentile }}",
+            "severityRank": "{{ finding.vulnerability.severityRank }}",
+            "recommendation": "{{ finding.vulnerability.recommendation | trim }}"
+          }
+        }{% if not loop.last %},{% endif %}{% endfor %}
+      ]
+    }
+  ]
+}

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.Config;
+import alpine.model.About;
 import alpine.model.ConfigProperty;
 import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
@@ -42,14 +43,19 @@ import org.junit.Test;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.WorkflowStatus.PENDING;
+import static org.dependencytrack.resources.v1.FindingResource.MEDIA_TYPE_SARIF_JSON;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
 
 public class FindingResourceTest extends ResourceTest {
@@ -654,6 +660,204 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals(1, json.getJsonObject(2).getJsonObject("vulnerability").getInt("affectedProjectCount"));
     }
 
+    @Test
+    public void getSARIFFindingsByProjectTest() {
+        Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, true, false);
+        Component c1 = createComponent(project, "Component 1", "1.1.4");
+        Component c2 = createComponent(project, "Component 2", "2.78.123");
+        c1.setGroup("org.acme");
+        c2.setGroup("com.xyz");
+        c1.setPurl("pkg:maven/org.acme/component1@1.1.4?type=jar");
+        c2.setPurl("pkg:maven/com.xyz/component2@2.78.123?type=jar");
+
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL, "Vuln Title 1", "This is a description", null, 80);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH, "Vuln Title 2", "   Yet another description but with surrounding whitespaces   ", "", 46);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.LOW, "Vuln Title 3", "A description-with-hyphens-(and parentheses)", "  Recommendation with whitespaces  ", 23);
+
+        // Note: Same vulnerability added to multiple components to test whether "rules" field doesn't contain duplicates
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c2, AnalyzerIdentity.NONE);
+
+        Response response = jersey.target(V1_FINDING + "/project/" + project.getUuid().toString()).request()
+                .header(HttpHeaders.ACCEPT, MEDIA_TYPE_SARIF_JSON)
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals(MEDIA_TYPE_SARIF_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
+        final String jsonResponse = getPlainTextBody(response);
+
+        assertThatJson(jsonResponse)
+                .withMatcher("version", equalTo(new About().getVersion()))
+                .withMatcher("fullName", equalTo("OWASP Dependency-Track - " + new About().getVersion()))
+                .isEqualTo(json("""
+                {
+                        "version": "2.1.0",
+                        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+                        "runs": [
+                          {
+                            "tool": {
+                              "driver": {
+                                "name": "OWASP Dependency-Track",
+                                "fullName": "${json-unit.matches:fullName}",
+                                "version": "${json-unit.matches:version}",
+                                "informationUri": "https://dependencytrack.org/",
+                                "rules": [
+                                  {
+                                    "id": "Vuln-1",
+                                    "name": "ImproperNeutralizationOfScript-relatedHtmlTagsInAWebPage(basicXss)",
+                                    "shortDescription": {
+                                      "text": "Vuln-1"
+                                    },
+                                    "fullDescription": {
+                                      "text": "This is a description"
+                                    }
+                                  },
+                                  {
+                                    "id": "Vuln-2",
+                                    "name": "PathEquivalence:'filename'(trailingSpace)",
+                                    "shortDescription": {
+                                      "text": "Vuln-2"
+                                    },
+                                    "fullDescription": {
+                                      "text": "Yet another description but with surrounding whitespaces"
+                                    }
+                                  },
+                                  {
+                                    "id": "Vuln-3",
+                                    "name": "RelativePathTraversal",
+                                    "shortDescription": {
+                                      "text": "Vuln-3"
+                                    },
+                                    "fullDescription": {
+                                      "text": "A description-with-hyphens-(and parentheses)"
+                                    }
+                                  }
+                                ]
+                              }
+                            },
+                            "results": [
+                              {
+                                "ruleId": "Vuln-1",
+                                "message": {
+                                  "text": "This is a description"
+                                },
+                                "locations": [
+                                  {
+                                    "logicalLocations": [
+                                      {
+                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "level": "error",
+                                "properties": {
+                                  "name": "Component 1",
+                                  "group": "org.acme",
+                                  "version": "1.1.4",
+                                  "source": "INTERNAL",
+                                  "cweId": "80",
+                                  "cvssV3BaseScore": "",
+                                  "epssScore": "",
+                                  "epssPercentile": "",
+                                  "severityRank": "0",
+                                  "recommendation": ""
+                                }
+                              },
+                              {
+                                "ruleId": "Vuln-2",
+                                "message": {
+                                  "text": "Yet another description but with surrounding whitespaces"
+                                },
+                                "locations": [
+                                  {
+                                    "logicalLocations": [
+                                      {
+                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "level": "error",
+                                "properties": {
+                                  "name": "Component 1",
+                                  "group": "org.acme",
+                                  "version": "1.1.4",
+                                  "source": "INTERNAL",
+                                  "cweId": "46",
+                                  "cvssV3BaseScore": "",
+                                  "epssScore": "",
+                                  "epssPercentile": "",
+                                  "severityRank": "1",
+                                  "recommendation": ""
+                                }
+                              },
+                              {
+                                "ruleId": "Vuln-3",
+                                "message": {
+                                  "text": "A description-with-hyphens-(and parentheses)"
+                                },
+                                "locations": [
+                                  {
+                                    "logicalLocations": [
+                                      {
+                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "level": "note",
+                                "properties": {
+                                  "name": "Component 1",
+                                  "group": "org.acme",
+                                  "version": "1.1.4",
+                                  "source": "INTERNAL",
+                                  "cweId": "23",
+                                  "cvssV3BaseScore": "",
+                                  "epssScore": "",
+                                  "epssPercentile": "",
+                                  "severityRank": "3",
+                                  "recommendation": "Recommendation with whitespaces"
+                                }
+                              },
+                              {
+                                "ruleId": "Vuln-3",
+                                "message": {
+                                  "text": "A description-with-hyphens-(and parentheses)"
+                                },
+                                "locations": [
+                                  {
+                                    "logicalLocations": [
+                                      {
+                                        "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "level": "note",
+                                "properties": {
+                                  "name": "Component 2",
+                                  "group": "com.xyz",
+                                  "version": "2.78.123",
+                                  "source": "INTERNAL",
+                                  "cweId": "23",
+                                  "cvssV3BaseScore": "",
+                                  "epssScore": "",
+                                  "epssPercentile": "",
+                                  "severityRank": "3",
+                                  "recommendation": "Recommendation with whitespaces"
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+            """));
+    }
+
     private Component createComponent(Project project, String name, String version) {
         Component component = new Component();
         component.setProject(project);
@@ -669,5 +873,30 @@ public class FindingResourceTest extends ResourceTest {
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
         return qm.createVulnerability(vulnerability, false);
+    }
+
+    private Vulnerability createVulnerability(String vulnId, Severity severity, String title, String description, String recommendation, Integer cweId) {
+        Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setVulnId(vulnId);
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(severity);
+        vulnerability.setTitle(title);
+        vulnerability.setDescription(description);
+        vulnerability.setRecommendation(recommendation);
+        vulnerability.setCwes(List.of(cweId));
+        return qm.createVulnerability(vulnerability, false);
+    }
+
+    private static String getSARIFLevelFromSeverity(Severity severity) {
+        if (Severity.LOW == severity || Severity.INFO == severity) {
+            return "note";
+        }
+        if (Severity.MEDIUM == severity) {
+            return "warning";
+        }
+        if (Severity.HIGH == severity || Severity.CRITICAL == severity) {
+            return "error";
+        }
+        return "none";
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -739,118 +739,118 @@ public class FindingResourceTest extends ResourceTest {
                               }
                             },
                             "results": [
-                              {
-                                "ruleId": "Vuln-1",
-                                "message": {
-                                  "text": "This is a description"
-                                },
-                                "locations": [
-                                  {
-                                    "logicalLocations": [
-                                      {
-                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                      }
-                                    ]
+                                {
+                                  "ruleId": "Vuln-1",
+                                  "message": {
+                                    "text": "This is a description"
+                                  },
+                                  "locations": [
+                                    {
+                                      "logicalLocations": [
+                                        {
+                                          "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "level": "error",
+                                  "properties": {
+                                    "name": "Component 1",
+                                    "group": "org.acme",
+                                    "version": "1.1.4",
+                                    "source": "INTERNAL",
+                                    "cweId": "80",
+                                    "cvssV3BaseScore": "",
+                                    "epssScore": "",
+                                    "epssPercentile": "",
+                                    "severityRank": "0",
+                                    "recommendation": ""
                                   }
-                                ],
-                                "level": "error",
-                                "properties": {
-                                  "name": "Component 1",
-                                  "group": "org.acme",
-                                  "version": "1.1.4",
-                                  "source": "INTERNAL",
-                                  "cweId": "80",
-                                  "cvssV3BaseScore": "",
-                                  "epssScore": "",
-                                  "epssPercentile": "",
-                                  "severityRank": "0",
-                                  "recommendation": ""
-                                }
-                              },
-                              {
-                                "ruleId": "Vuln-2",
-                                "message": {
-                                  "text": "Yet another description but with surrounding whitespaces"
                                 },
-                                "locations": [
-                                  {
-                                    "logicalLocations": [
-                                      {
-                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                      }
-                                    ]
+                                {
+                                  "ruleId": "Vuln-3",
+                                  "message": {
+                                    "text": "A description-with-hyphens-(and parentheses)"
+                                  },
+                                  "locations": [
+                                    {
+                                      "logicalLocations": [
+                                        {
+                                          "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "level": "note",
+                                  "properties": {
+                                    "name": "Component 1",
+                                    "group": "org.acme",
+                                    "version": "1.1.4",
+                                    "source": "INTERNAL",
+                                    "cweId": "23",
+                                    "cvssV3BaseScore": "",
+                                    "epssScore": "",
+                                    "epssPercentile": "",
+                                    "severityRank": "3",
+                                    "recommendation": "Recommendation with whitespaces"
                                   }
-                                ],
-                                "level": "error",
-                                "properties": {
-                                  "name": "Component 1",
-                                  "group": "org.acme",
-                                  "version": "1.1.4",
-                                  "source": "INTERNAL",
-                                  "cweId": "46",
-                                  "cvssV3BaseScore": "",
-                                  "epssScore": "",
-                                  "epssPercentile": "",
-                                  "severityRank": "1",
-                                  "recommendation": ""
-                                }
-                              },
-                              {
-                                "ruleId": "Vuln-3",
-                                "message": {
-                                  "text": "A description-with-hyphens-(and parentheses)"
                                 },
-                                "locations": [
-                                  {
-                                    "logicalLocations": [
-                                      {
-                                        "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                      }
-                                    ]
+                                {
+                                  "ruleId": "Vuln-2",
+                                  "message": {
+                                    "text": "Yet another description but with surrounding whitespaces"
+                                  },
+                                  "locations": [
+                                    {
+                                      "logicalLocations": [
+                                        {
+                                          "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "level": "error",
+                                  "properties": {
+                                    "name": "Component 1",
+                                    "group": "org.acme",
+                                    "version": "1.1.4",
+                                    "source": "INTERNAL",
+                                    "cweId": "46",
+                                    "cvssV3BaseScore": "",
+                                    "epssScore": "",
+                                    "epssPercentile": "",
+                                    "severityRank": "1",
+                                    "recommendation": ""
                                   }
-                                ],
-                                "level": "note",
-                                "properties": {
-                                  "name": "Component 1",
-                                  "group": "org.acme",
-                                  "version": "1.1.4",
-                                  "source": "INTERNAL",
-                                  "cweId": "23",
-                                  "cvssV3BaseScore": "",
-                                  "epssScore": "",
-                                  "epssPercentile": "",
-                                  "severityRank": "3",
-                                  "recommendation": "Recommendation with whitespaces"
-                                }
-                              },
-                              {
-                                "ruleId": "Vuln-3",
-                                "message": {
-                                  "text": "A description-with-hyphens-(and parentheses)"
                                 },
-                                "locations": [
-                                  {
-                                    "logicalLocations": [
-                                      {
-                                        "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
-                                      }
-                                    ]
+                                {
+                                  "ruleId": "Vuln-3",
+                                  "message": {
+                                    "text": "A description-with-hyphens-(and parentheses)"
+                                  },
+                                  "locations": [
+                                    {
+                                      "logicalLocations": [
+                                        {
+                                          "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "level": "note",
+                                  "properties": {
+                                    "name": "Component 2",
+                                    "group": "com.xyz",
+                                    "version": "2.78.123",
+                                    "source": "INTERNAL",
+                                    "cweId": "23",
+                                    "cvssV3BaseScore": "",
+                                    "epssScore": "",
+                                    "epssPercentile": "",
+                                    "severityRank": "3",
+                                    "recommendation": "Recommendation with whitespaces"
                                   }
-                                ],
-                                "level": "note",
-                                "properties": {
-                                  "name": "Component 2",
-                                  "group": "com.xyz",
-                                  "version": "2.78.123",
-                                  "source": "INTERNAL",
-                                  "cweId": "23",
-                                  "cvssV3BaseScore": "",
-                                  "epssScore": "",
-                                  "epssPercentile": "",
-                                  "severityRank": "3",
-                                  "recommendation": "Recommendation with whitespaces"
                                 }
-                              }
                             ]
                           }
                         ]


### PR DESCRIPTION
### Description

If request header Accept: application/sarif+json is provided to the GET Finding By Project UUID API, it will now return a SARIF file with the vulnerability findings in that project.

SARIF file is generated based on a pebble template.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1190

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly
