### PR TITLE
Port : Truncate component property value

### DIFF
--- a/src/main/java/org/dependencytrack/model/ComponentProperty.java
+++ b/src/main/java/org/dependencytrack/model/ComponentProperty.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects;
+import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.model.validation.EnumValue;
 
 import javax.jdo.annotations.Column;
@@ -145,7 +146,7 @@ public class ComponentProperty implements IConfigProperty, Serializable {
     }
 
     public void setPropertyValue(final String propertyValue) {
-        this.propertyValue = propertyValue;
+        this.propertyValue = StringUtils.abbreviate(propertyValue, 255);
     }
 
     public PropertyType getPropertyType() {

--- a/src/main/java/org/dependencytrack/model/ComponentProperty.java
+++ b/src/main/java/org/dependencytrack/model/ComponentProperty.java
@@ -69,6 +69,7 @@ public class ComponentProperty implements IConfigProperty, Serializable {
 
     @Persistent
     @Column(name = "GROUPNAME")
+    @Size(min = 1, max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = "\\P{Cc}+", message = "The groupName must not contain control characters")
     private String groupName;
@@ -76,6 +77,7 @@ public class ComponentProperty implements IConfigProperty, Serializable {
     @Persistent
     @Column(name = "PROPERTYNAME", allowsNull = "false")
     @NotBlank
+    @Size(min = 1, max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = "\\P{Cc}+", message = "The propertyName must not contain control characters")
     private String propertyName;
@@ -101,6 +103,7 @@ public class ComponentProperty implements IConfigProperty, Serializable {
 
     @Persistent
     @Column(name = "DESCRIPTION")
+    @Size(max = 255)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = "\\P{Cc}+", message = "The description must not contain control characters")
     private String description;

--- a/src/main/java/org/dependencytrack/model/ComponentProperty.java
+++ b/src/main/java/org/dependencytrack/model/ComponentProperty.java
@@ -36,6 +36,7 @@ import javax.jdo.annotations.Unique;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -80,7 +81,8 @@ public class ComponentProperty implements IConfigProperty, Serializable {
     private String propertyName;
 
     @Persistent
-    @Column(name = "PROPERTYVALUE")
+    @Column(name = "PROPERTYVALUE", length = 1024)
+    @Size(max = 1024)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = "\\P{Cc}+", message = "The propertyValue must not contain control characters")
     private String propertyValue;
@@ -146,7 +148,7 @@ public class ComponentProperty implements IConfigProperty, Serializable {
     }
 
     public void setPropertyValue(final String propertyValue) {
-        this.propertyValue = StringUtils.abbreviate(propertyValue, 255);
+        this.propertyValue = StringUtils.abbreviate(propertyValue, 1024);
     }
 
     public PropertyType getPropertyType() {

--- a/src/main/java/org/dependencytrack/model/ProjectProperty.java
+++ b/src/main/java/org/dependencytrack/model/ProjectProperty.java
@@ -76,7 +76,7 @@ public class ProjectProperty implements IConfigProperty, Serializable {
 
     @Persistent
     @Column(name = "PROPERTYVALUE", length = 1024)
-    @Size(min = 0, max = 1024)
+    @Size(max = 1024)
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     @Pattern(regexp = "[\\P{Cc}]+", message = "The propertyValue must not contain control characters")
     private String propertyValue;

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -150,4 +150,11 @@
             DROP FUNCTION IF EXISTS "CALC_SEVERITY";
         </sql>
     </changeSet>
+
+    <changeSet id="v5.5.0-12" author="sahibamittal">
+        <modifyDataType tableName="COMPONENT_PROPERTY" columnName="GROUPNAME" newDataType="VARCHAR(255)"/>
+        <modifyDataType tableName="COMPONENT_PROPERTY" columnName="PROPERTYNAME" newDataType="VARCHAR(255)"/>
+        <modifyDataType tableName="COMPONENT_PROPERTY" columnName="PROPERTYVALUE" newDataType="VARCHAR(1024)"/>
+        <modifyDataType tableName="COMPONENT_PROPERTY" columnName="DESCRIPTION" newDataType="VARCHAR(255)"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -36,6 +36,8 @@ import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.WorkflowStep;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -688,174 +690,135 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals(MEDIA_TYPE_SARIF_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
         final String jsonResponse = getPlainTextBody(response);
+        JSONArray resultArray = new JSONObject(jsonResponse).getJSONArray("runs").getJSONObject(0).getJSONArray("results");
 
         assertThatJson(jsonResponse)
                 .withMatcher("version", equalTo(new About().getVersion()))
-                .withMatcher("fullName", equalTo("OWASP Dependency-Track - " + new About().getVersion()))
-                .isEqualTo(json("""
-                {
-                        "version": "2.1.0",
-                        "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
-                        "runs": [
-                          {
-                            "tool": {
-                              "driver": {
-                                "name": "OWASP Dependency-Track",
-                                "fullName": "${json-unit.matches:fullName}",
-                                "version": "${json-unit.matches:version}",
-                                "informationUri": "https://dependencytrack.org/",
-                                "rules": [
-                                  {
-                                    "id": "Vuln-1",
-                                    "name": "ImproperNeutralizationOfScript-relatedHtmlTagsInAWebPage(basicXss)",
-                                    "shortDescription": {
-                                      "text": "Vuln-1"
-                                    },
-                                    "fullDescription": {
-                                      "text": "This is a description"
-                                    }
-                                  },
-                                  {
-                                    "id": "Vuln-2",
-                                    "name": "PathEquivalence:'filename'(trailingSpace)",
-                                    "shortDescription": {
-                                      "text": "Vuln-2"
-                                    },
-                                    "fullDescription": {
-                                      "text": "Yet another description but with surrounding whitespaces"
-                                    }
-                                  },
-                                  {
-                                    "id": "Vuln-3",
-                                    "name": "RelativePathTraversal",
-                                    "shortDescription": {
-                                      "text": "Vuln-3"
-                                    },
-                                    "fullDescription": {
-                                      "text": "A description-with-hyphens-(and parentheses)"
-                                    }
-                                  }
-                                ]
-                              }
-                            },
-                            "results": [
+                .withMatcher("fullName", equalTo("OWASP Dependency-Track - " + new About().getVersion()));
+
+        assertThat(resultArray).hasSize(4);
+        assertThat(resultArray).satisfiesExactlyInAnyOrder(
+                vuln1 -> assertThatJson(vuln1).isEqualTo("""
+                        {
+                          "ruleId": "Vuln-1",
+                          "message": {
+                            "text": "This is a description"
+                          },
+                          "locations": [
+                            {
+                              "logicalLocations": [
                                 {
-                                  "ruleId": "Vuln-1",
-                                  "message": {
-                                    "text": "This is a description"
-                                  },
-                                  "locations": [
-                                    {
-                                      "logicalLocations": [
-                                        {
-                                          "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "level": "error",
-                                  "properties": {
-                                    "name": "Component 1",
-                                    "group": "org.acme",
-                                    "version": "1.1.4",
-                                    "source": "INTERNAL",
-                                    "cweId": "80",
-                                    "cvssV3BaseScore": "",
-                                    "epssScore": "",
-                                    "epssPercentile": "",
-                                    "severityRank": "0",
-                                    "recommendation": ""
-                                  }
-                                },
-                                {
-                                  "ruleId": "Vuln-3",
-                                  "message": {
-                                    "text": "A description-with-hyphens-(and parentheses)"
-                                  },
-                                  "locations": [
-                                    {
-                                      "logicalLocations": [
-                                        {
-                                          "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "level": "note",
-                                  "properties": {
-                                    "name": "Component 1",
-                                    "group": "org.acme",
-                                    "version": "1.1.4",
-                                    "source": "INTERNAL",
-                                    "cweId": "23",
-                                    "cvssV3BaseScore": "",
-                                    "epssScore": "",
-                                    "epssPercentile": "",
-                                    "severityRank": "3",
-                                    "recommendation": "Recommendation with whitespaces"
-                                  }
-                                },
-                                {
-                                  "ruleId": "Vuln-2",
-                                  "message": {
-                                    "text": "Yet another description but with surrounding whitespaces"
-                                  },
-                                  "locations": [
-                                    {
-                                      "logicalLocations": [
-                                        {
-                                          "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "level": "error",
-                                  "properties": {
-                                    "name": "Component 1",
-                                    "group": "org.acme",
-                                    "version": "1.1.4",
-                                    "source": "INTERNAL",
-                                    "cweId": "46",
-                                    "cvssV3BaseScore": "",
-                                    "epssScore": "",
-                                    "epssPercentile": "",
-                                    "severityRank": "1",
-                                    "recommendation": ""
-                                  }
-                                },
-                                {
-                                  "ruleId": "Vuln-3",
-                                  "message": {
-                                    "text": "A description-with-hyphens-(and parentheses)"
-                                  },
-                                  "locations": [
-                                    {
-                                      "logicalLocations": [
-                                        {
-                                          "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
-                                        }
-                                      ]
-                                    }
-                                  ],
-                                  "level": "note",
-                                  "properties": {
-                                    "name": "Component 2",
-                                    "group": "com.xyz",
-                                    "version": "2.78.123",
-                                    "source": "INTERNAL",
-                                    "cweId": "23",
-                                    "cvssV3BaseScore": "",
-                                    "epssScore": "",
-                                    "epssPercentile": "",
-                                    "severityRank": "3",
-                                    "recommendation": "Recommendation with whitespaces"
-                                  }
+                                  "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
                                 }
-                            ]
+                              ]
+                            }
+                          ],
+                          "level": "error",
+                          "properties": {
+                            "name": "Component 1",
+                            "group": "org.acme",
+                            "version": "1.1.4",
+                            "source": "INTERNAL",
+                            "cweId": "80",
+                            "cvssV3BaseScore": "",
+                            "epssScore": "",
+                            "epssPercentile": "",
+                            "severityRank": "0",
+                            "recommendation": ""
                           }
-                        ]
-                      }
-            """));
+                        }
+                """),
+                vuln2 -> assertThatJson(vuln2).isEqualTo("""
+                        {
+                           "ruleId": "Vuln-2",
+                           "message": {
+                             "text": "Yet another description but with surrounding whitespaces"
+                           },
+                           "locations": [
+                             {
+                               "logicalLocations": [
+                                 {
+                                   "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                 }
+                               ]
+                             }
+                           ],
+                           "level": "error",
+                           "properties": {
+                             "name": "Component 1",
+                             "group": "org.acme",
+                             "version": "1.1.4",
+                             "source": "INTERNAL",
+                             "cweId": "46",
+                             "cvssV3BaseScore": "",
+                             "epssScore": "",
+                             "epssPercentile": "",
+                             "severityRank": "1",
+                             "recommendation": ""
+                           }
+                        }
+                """),
+                vuln3 -> assertThatJson(vuln3).isEqualTo("""
+                        {
+                           "ruleId": "Vuln-3",
+                           "message": {
+                             "text": "A description-with-hyphens-(and parentheses)"
+                           },
+                           "locations": [
+                             {
+                               "logicalLocations": [
+                                 {
+                                   "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
+                                 }
+                               ]
+                             }
+                           ],
+                           "level": "note",
+                           "properties": {
+                             "name": "Component 1",
+                             "group": "org.acme",
+                             "version": "1.1.4",
+                             "source": "INTERNAL",
+                             "cweId": "23",
+                             "cvssV3BaseScore": "",
+                             "epssScore": "",
+                             "epssPercentile": "",
+                             "severityRank": "3",
+                             "recommendation": "Recommendation with whitespaces"
+                           }
+                        }
+                """),
+                vuln3 -> assertThatJson(vuln3).isEqualTo("""
+                        {
+                           "ruleId": "Vuln-3",
+                           "message": {
+                             "text": "A description-with-hyphens-(and parentheses)"
+                           },
+                           "locations": [
+                             {
+                               "logicalLocations": [
+                                 {
+                                   "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
+                                 }
+                               ]
+                             }
+                           ],
+                           "level": "note",
+                           "properties": {
+                             "name": "Component 2",
+                             "group": "com.xyz",
+                             "version": "2.78.123",
+                             "source": "INTERNAL",
+                             "cweId": "23",
+                             "cvssV3BaseScore": "",
+                             "epssScore": "",
+                             "epssPercentile": "",
+                             "severityRank": "3",
+                             "recommendation": "Recommendation with whitespaces"
+                           }
+                        }
+                """)
+        );
     }
 
     private Component createComponent(Project project, String name, String version) {

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -196,6 +196,13 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                     assertThat(property.getPropertyValue()).isEqualTo("qux");
                     assertThat(property.getPropertyType()).isEqualTo(PropertyType.STRING);
                     assertThat(property.getDescription()).isNull();
+                },
+                property -> {
+                    assertThat(property.getGroupName()).isNull();
+                    assertThat(property.getPropertyName()).isEqualTo("long");
+                    assertThat(property.getPropertyValue()).isEqualTo("a".repeat(252) + "...");
+                    assertThat(property.getPropertyType()).isEqualTo(PropertyType.STRING);
+                    assertThat(property.getDescription()).isNull();
                 }
         );
 

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -200,7 +200,7 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 property -> {
                     assertThat(property.getGroupName()).isNull();
                     assertThat(property.getPropertyName()).isEqualTo("long");
-                    assertThat(property.getPropertyValue()).isEqualTo("a".repeat(252) + "...");
+                    assertThat(property.getPropertyValue()).isEqualTo("a".repeat(1021) + "...");
                     assertThat(property.getPropertyType()).isEqualTo(PropertyType.STRING);
                     assertThat(property.getDescription()).isNull();
                 }

--- a/src/test/resources/unit/bom-1.xml
+++ b/src/test/resources/unit/bom-1.xml
@@ -92,6 +92,7 @@
                 <property name="foo:bar">baz</property>
                 <property name="foo:bar">qux</property>
                 <property name="foo:bar">qux</property>
+                <property name="long">aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</property>
             </properties>
         </component>
     </components>


### PR DESCRIPTION
### Description

Truncates ComponentProperty values.

This is both to prevent the database's length constraint from being violated, and to avoid storing unnecessary long values. Some tools may misuse properties, and in those cases having the complete value is usually not of interest to users.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1190

### Checklist

- [x] I have read and understand the [contributing guidelines](../CONTRIBUTING.md#pull-requests)
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog](https://github.com/DependencyTrack/hyades-apiserver/tree/main/src/main/resources/migration) accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://github.com/DependencyTrack/hyades/tree/main/docs) accordingly
