### PR TITLE
Fix missing argument list for `DROP FUNCTION` migrations

### DIFF
--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -145,9 +145,10 @@
     <changeSet id="v5.5.0-11" author="nscuro">
         <customChange class="org.dependencytrack.persistence.migration.change.v550.ComputeSeveritiesChange"/>
         <sql splitStatements="true">
-            DROP FUNCTION IF EXISTS "CVSSV2_TO_SEVERITY";
-            DROP FUNCTION IF EXISTS "CVSSV3_TO_SEVERITY";
-            DROP FUNCTION IF EXISTS "CALC_SEVERITY";
+            DROP FUNCTION IF EXISTS "CVSSV2_TO_SEVERITY"(NUMERIC);
+            DROP FUNCTION IF EXISTS "CVSSV3_TO_SEVERITY"(NUMERIC);
+            DROP FUNCTION IF EXISTS "CALC_SEVERITY"(VARCHAR, NUMERIC, NUMERIC);
+            DROP FUNCTION IF EXISTS "CALC_SEVERITY"(VARCHAR, VARCHAR, NUMERIC, NUMERIC);
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes missing argument list for `DROP FUNCTION` migrations.

`CALC_SEVERITY` can exist with both 3, and 4 arguments, depending on when the system was first deployed. `CALC_SEVERITY` was updated to take an additional `"severity_override" VARCHAR` argument in https://github.com/DependencyTrack/hyades-apiserver/commit/6845ea1b7c11f163d9d712fdeaac9593fc903469#diff-8a05bac09ccef76206adca46106e47020121bc13254146fc287fd1279ddfad8a, but the previous version of the function was not dropped back then.

This adds argument lists to all functions being dropped, to avoid ambiguity.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
