### PR TITLE
Make `PROJECT.ACTIVE` non-nullable

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -283,7 +283,7 @@ public class Project implements Serializable {
     @Persistent
     @Column(name = "ACTIVE")
     @JsonSerialize(nullsUsing = BooleanDefaultTrueSerializer.class)
-    private Boolean active; // Added in v3.6. Existing records need to be nullable on upgrade.
+    private boolean active = true;
 
     @Persistent(table = "PROJECT_ACCESS_TEAMS", defaultFetchGroup = "true")
     @Join(column = "PROJECT_ID")
@@ -506,11 +506,11 @@ public class Project implements Serializable {
         this.externalReferences = externalReferences;
     }
 
-    public Boolean isActive() {
+    public boolean isActive() {
         return active;
     }
 
-    public void setActive(Boolean active) {
+    public void setActive(boolean active) {
         this.active = active;
     }
 

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -441,9 +441,6 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         if (project.getParent() != null && !Boolean.TRUE.equals(project.getParent().isActive())) {
             throw new IllegalArgumentException("An inactive Parent cannot be selected as parent");
         }
-        if (project.isActive() == null) {
-            project.setActive(Boolean.TRUE);
-        }
         final Project result = persist(project);
         final List<Tag> resolvedTags = resolveTags(tags);
         bind(project, resolvedTags);

--- a/src/main/java/org/dependencytrack/tasks/RepositoryMetaAnalyzerTask.java
+++ b/src/main/java/org/dependencytrack/tasks/RepositoryMetaAnalyzerTask.java
@@ -142,7 +142,7 @@ public class RepositoryMetaAnalyzerTask implements Subscriber {
 
     private List<ComponentProjection> fetchNextComponentsPage(final PersistenceManager pm, final Project project, final long offset) throws Exception {
         try (final Query<Component> query = pm.newQuery(Component.class)) {
-            var filter = "(project.active == :projectActive || project.active == null) && purlCoordinates != null";
+            var filter = "project.active == :projectActive && purlCoordinates != null";
             var params = new HashMap<String, Object>();
             params.put("projectActive", true);
             if (project != null) {

--- a/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -150,7 +150,7 @@ public class VulnerabilityAnalysisTask implements Subscriber {
 
     private List<ComponentProjection> fetchNextComponentsPage(final PersistenceManager pm, final Project project, final Long lastId) throws Exception {
         try (final Query<Component> query = pm.newQuery(Component.class)) {
-            var filter = "(project.active == :projectActive || project.active == null)";
+            var filter = "project.active == :projectActive";
             var params = new HashMap<String, Object>();
             params.put("projectActive", true);
             if (project != null) {

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -158,4 +158,10 @@
         <modifyDataType tableName="COMPONENT_PROPERTY" columnName="PROPERTYVALUE" newDataType="VARCHAR(1024)"/>
         <modifyDataType tableName="COMPONENT_PROPERTY" columnName="DESCRIPTION" newDataType="VARCHAR(255)"/>
     </changeSet>
+
+    <changeSet id="v5.5.0-13" author="nscuro">
+        <sql>UPDATE "PROJECT" SET "ACTIVE" = TRUE WHERE "ACTIVE" IS NULL</sql>
+        <addDefaultValue tableName="PROJECT" columnName="ACTIVE" defaultValueBoolean="true"/>
+        <addNotNullConstraint tableName="PROJECT" columnName="ACTIVE"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/model/ProjectTest.java
+++ b/src/test/java/org/dependencytrack/model/ProjectTest.java
@@ -55,11 +55,9 @@ public class ProjectTest extends PersistenceCapableTest {
         project.setName("Example Project 1");
         project.setDescription("Description 1");
         project.setVersion("1.0");
-        project.setActive(null);
 
         Project persistedProject = qm.createProject(project, null, false);
 
-        Assert.assertNotNull(persistedProject.isActive());
         Assert.assertTrue(persistedProject.isActive());
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -458,24 +458,6 @@ public class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
-    public void updateProjectTestIsActiveEqualsNull() {
-        Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
-        project.setDescription("Test project");
-        project.setActive(null);
-        Assert.assertNull(project.isActive());
-        Response response = jersey.target(V1_PROJECT)
-                .request()
-                .header(X_API_KEY, apiKey)
-                .post(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ABC", json.getString("name"));
-        Assert.assertEquals("1.0", json.getString("version"));
-        Assert.assertEquals("Test project", json.getString("description"));
-    }
-
-    @Test
     public void updateProjectTagsTest() {
         final var tags = Stream.of("tag1", "tag2").map(qm::createTag).collect(Collectors.toUnmodifiableList());
         final var p1 = qm.createProject("ABC", "Test project", "1.0", tags, null, null, true, false);

--- a/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
@@ -66,34 +66,12 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
         componentProjectC.setVersion("3.0.1");
         qm.persist(componentProjectC);
 
-        // Create an active project where the active flag is `null`.
-        // We only consider projects to be inactive when the active flag is set to `false` explicitly.
-        final var projectD = qm.createProject("acme-app-d", null, "4.0.0", null, null, null, true, false);
-        projectD.setActive(null);
-        qm.persist(projectD);
-        final var componentProjectD = new Component();
-        componentProjectD.setProject(projectD);
-        componentProjectD.setGroup("acme");
-        componentProjectD.setName("acme-lib-d");
-        componentProjectD.setVersion("4.0.1");
-        qm.persist(componentProjectD);
-
         new VulnerabilityAnalysisTask().inform(new PortfolioVulnerabilityAnalysisEvent());
 
         assertThat(kafkaMockProducer.history()).satisfiesExactlyInAnyOrder(
                 record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
                 record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
                 record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
-                record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
-                record -> {
-                    assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name());
-                    final var command = deserializeValue(KafkaTopics.VULN_ANALYSIS_COMMAND, record);
-                    assertThat(command.getComponent().getUuid()).isEqualTo(componentProjectD.getUuid().toString());
-                    assertThat(command.getComponent().hasCpe()).isFalse();
-                    assertThat(command.getComponent().hasPurl()).isFalse();
-                    assertThat(command.getComponent().hasSwidTagId()).isFalse();
-                    assertThat(command.getComponent().getInternal()).isFalse();
-                },
                 record -> {
                     assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name());
                     final var command = deserializeValue(KafkaTopics.VULN_ANALYSIS_COMMAND, record);
@@ -217,33 +195,6 @@ public class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
         assertThat(kafkaMockProducer.history()).satisfiesExactly(
                 record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name())
                 // Component of inactive project must not have been submitted for analysis
-        );
-    }
-
-    @Test
-    public void testProjectVulnerabilityAnalysisWithProjectAndActiveFlagNull() {
-        final var project = qm.createProject("acme-app-a", null, "1.0.0", null, null, null, false, false);
-        project.setActive(null);
-        qm.persist(project);
-        final var componentA = new Component();
-        componentA.setProject(project);
-        componentA.setName("acme-lib-a");
-        componentA.setVersion("1.0.1");
-        qm.persist(componentA);
-
-        new VulnerabilityAnalysisTask().inform(new ProjectVulnerabilityAnalysisEvent(project.getUuid()));
-
-        assertThat(kafkaMockProducer.history()).satisfiesExactly(
-                record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_CREATED.name()),
-                record -> {
-                    assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_COMMAND.name());
-                    final var command = deserializeValue(KafkaTopics.VULN_ANALYSIS_COMMAND, record);
-                    assertThat(command.getComponent().getUuid()).isEqualTo(componentA.getUuid().toString());
-                    assertThat(command.getComponent().hasCpe()).isFalse();
-                    assertThat(command.getComponent().hasPurl()).isFalse();
-                    assertThat(command.getComponent().hasSwidTagId()).isFalse();
-                    assertThat(command.getComponent().getInternal()).isFalse();
-                }
         );
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

For historical reasons, the `ACTIVE` column of the `PROJECT` table has been nullable. The differentiation between `true`, `false`, and `null`, where `null` is treated like `true`, causes many unnecessary problems.

This change cleans fixes this by making the column non-nullable. It further makes `true` the default value to ensure that new projects default to being active.

Existing projects with `ACTIVE` set to `NULL` will be updated to `true` upon upgrade.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
