### PR TITLE
Fix breaking change in vulnerability policy schema

### DIFF
--- a/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicy.java
+++ b/src/main/java/org/dependencytrack/policy/vulnerability/VulnerabilityPolicy.java
@@ -47,7 +47,14 @@ public class VulnerabilityPolicy implements Serializable {
 
     private List<VulnerabilityPolicyRating> ratings;
 
-    private VulnerabilityPolicyOperation operationMode;
+    /**
+     * Operation mode of the policy.
+     * <p>
+     * Defaults to {@link VulnerabilityPolicyOperation#APPLY} to remain backward-compatible.
+     *
+     * @since 5.5.0
+     */
+    private VulnerabilityPolicyOperation operationMode = VulnerabilityPolicyOperation.APPLY;
 
     public void setName(final String name) {
         this.name = name;

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -164,4 +164,10 @@
         <addDefaultValue tableName="PROJECT" columnName="ACTIVE" defaultValueBoolean="true"/>
         <addNotNullConstraint tableName="PROJECT" columnName="ACTIVE"/>
     </changeSet>
+
+    <changeSet id="v5.5.0-14" author="nscuro">
+        <sql>UPDATE "VULNERABILITY_POLICY" SET "OPERATION_MODE" = 'APPLY' WHERE "OPERATION_MODE" IS NULL</sql>
+        <addDefaultValue tableName="VULNERABILITY_POLICY" columnName="OPERATION_MODE" defaultValue="APPLY"/>
+        <addNotNullConstraint tableName="VULNERABILITY_POLICY" columnName="OPERATION_MODE"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/schema/vulnerability-policy-v1.schema.json
+++ b/src/main/resources/schema/vulnerability-policy-v1.schema.json
@@ -48,7 +48,7 @@
       "minItems": 1
     },
     "analysis": {
-      "description": "The analysis to apply when all expressions match.",
+      "description": "The analysis to apply when all conditions match.",
       "type": "object",
       "properties": {
         "state": {
@@ -75,14 +75,14 @@
       "required": ["state"]
     },
     "ratings": {
-      "description": "0..3 ratings to apply to the finding when all expressions match.",
+      "description": "0..3 ratings to apply to the finding when all conditions match.",
       "type": "array",
       "items": { "$ref": "#/$defs/rating" },
       "minItems": 0,
       "maxItems": 3
     },
     "operationMode": {
-      "description": "Mode of operation for the vulnerability policy.",
+      "description": "Mode of operation for the policy. Defaults to APPLY.",
       "enum": ["DISABLED", "APPLY", "LOG"]
     }
   },
@@ -111,6 +111,6 @@
       "required": ["method", "severity"]
     }
   },
-  "required": ["apiVersion", "type", "name", "conditions", "analysis", "operationMode"],
+  "required": ["apiVersion", "type", "name", "conditions", "analysis"],
   "additionalProperties": false
 }

--- a/src/test/java/org/dependencytrack/policy/validation/PolicySchemaValidationTest.java
+++ b/src/test/java/org/dependencytrack/policy/validation/PolicySchemaValidationTest.java
@@ -62,8 +62,7 @@ public class PolicySchemaValidationTest {
                 error -> assertThat(error.getMessage()).isEqualTo("$.analysis.justification: does not have a value in the enumeration [CODE_NOT_PRESENT, CODE_NOT_REACHABLE, REQUIRES_CONFIGURATION, REQUIRES_DEPENDENCY, REQUIRES_ENVIRONMENT, PROTECTED_BY_COMPILER, PROTECTED_AT_RUNTIME, PROTECTED_AT_PERIMETER, PROTECTED_BY_MITIGATING_CONTROL]"),
                 error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].severity: does not have a value in the enumeration [CRITICAL, HIGH, MEDIUM, LOW, INFO, UNASSIGNED]"),
                 error -> assertThat(error.getMessage()).contains("$.ratings[0].vector: does not match the regex pattern"),
-                error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].score: string found, number expected"),
-                error -> assertThat(error.getMessage()).isEqualTo("$: required property 'operationMode' not found")
+                error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].score: string found, number expected")
         );
     }
 }

--- a/src/test/java/org/dependencytrack/util/VulnerabilityPolicyUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/VulnerabilityPolicyUtilTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.junit.Assert.assertEquals;
 
@@ -189,7 +190,6 @@ public class VulnerabilityPolicyUtilTest extends PersistenceCapableTest {
                     vector: CVSS:2.0/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L
                     severity: HIGH
                     score: 8.3
-                operationMode: APPLY
                 """;
         List<VulnerabilityPolicy> createVulnerabilityPolicyList = new ArrayList<>();
         List<VulnerabilityPolicy> updateVulnerabilityPolicyList = new ArrayList<>();
@@ -197,7 +197,13 @@ public class VulnerabilityPolicyUtilTest extends PersistenceCapableTest {
         VulnerabilityPolicyUtil.parseVulnerabilityPolicy(out, createVulnerabilityPolicyList,
                 updateVulnerabilityPolicyList, policyNames);
         VulnerabilityPolicyUtil.saveParsedVulnerabilities(createVulnerabilityPolicyList, updateVulnerabilityPolicyList, policyNames);
-        Assertions.assertEquals(1, withJdbiHandle(handle -> handle.attach(VulnerabilityPolicyDao.class).getAll()).size());
+
+        List<VulnerabilityPolicy> savedPolicies = withJdbiHandle(handle -> handle.attach(VulnerabilityPolicyDao.class).getAll());
+        Assertions.assertEquals(1, savedPolicies.size());
+
+        // Since 5.5.0: Default to operation mode APPLY if the policy does not explicit set one.
+        assertThat(savedPolicies).satisfiesExactly(policy ->
+                assertThat(policy.getOperationMode()).isEqualTo(VulnerabilityPolicyOperation.APPLY));
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes breaking change in vulnerability policy schema.

`operationMode` was added as a new mandatory field, breaking backward-compatibility. Make it optional instead, and default to the previous behavior (`APPLY`) if it is not set.

During upgrade, the respective database column will be populated with the default value, and a `NOT NULL` constraint is added.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
