### PR TITLE
Upgrade wiremock and kotlin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,8 @@
         <lib.liquibase.version>4.28.0</lib.liquibase.version>
         <lib.micrometer-jvm-extras.version>0.2.2</lib.micrometer-jvm-extras.version>
         <lib.minio.version>8.5.11</lib.minio.version>
+        <lib.kotlin-stdlib.version>2.0.0</lib.kotlin-stdlib.version>
+        <lib.wiremock.version>3.8.0</lib.wiremock.version>
         <lib.packageurl.version>1.5.0</lib.packageurl.version>
         <lib.parallel-consumer.version>0.5.3.0</lib.parallel-consumer.version>
         <lib.pebble.version>3.2.2</lib.pebble.version>
@@ -379,9 +381,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>3.0.1</version>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>${lib.wiremock.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -436,6 +438,17 @@
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
             <version>${lib.minio.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib-jdk8</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${lib.kotlin-stdlib.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,22 @@
                 <artifactId>oauth2-oidc-sdk</artifactId>
                 <version>${nimbusds-oauth2-oidc-sdk}</version>
             </dependency>
+            <dependency>
+                <groupId>io.minio</groupId>
+                <artifactId>minio</artifactId>
+                <version>${lib.minio.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-stdlib-jdk8</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-stdlib-jdk8</artifactId>
+                <version>${lib.kotlin-stdlib.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -434,21 +450,14 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
             <version>${lib.jackson.version}</version>
         </dependency>
+
         <dependency>
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
-            <version>${lib.minio.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jetbrains.kotlin</groupId>
-                    <artifactId>kotlin-stdlib-jdk8</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${lib.kotlin-stdlib.version}</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,8 @@
                 <artifactId>oauth2-oidc-sdk</artifactId>
                 <version>${nimbusds-oauth2-oidc-sdk}</version>
             </dependency>
+
+            <!-- Managed dependencies to exclude/override vulnerable version of kotlin-stdlib-jdk8 -->
             <dependency>
                 <groupId>io.minio</groupId>
                 <artifactId>minio</artifactId>


### PR DESCRIPTION
### Description

Upgrade kotlin and wire mock dependency versions.
Old versions are resulting into Snyk vulnerabilities.

### Addressed Issue

NA

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
