### PR TITLE
Re-calculate historical risk score

### DIFF
--- a/src/main/java/org/dependencytrack/event/HistoricalRiskScoreUpdateEvent.java
+++ b/src/main/java/org/dependencytrack/event/HistoricalRiskScoreUpdateEvent.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.event;
+
+import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+/**
+ * Defines an {@link Event} used to trigger historical risk score metrics updates.
+ *
+ * @since 5.0.0
+ */
+public class HistoricalRiskScoreUpdateEvent extends SingletonCapableEvent {
+
+    private final boolean weightHistoryEnabled;
+
+    public HistoricalRiskScoreUpdateEvent() {
+        this(true);
+    }
+
+    public HistoricalRiskScoreUpdateEvent(final boolean weightHistoryEnabled) {
+        this.setSingleton(true);
+        this.weightHistoryEnabled = weightHistoryEnabled;
+    }
+
+    public boolean isWeightHistoryEnabled() {
+        return weightHistoryEnabled;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/metrics/Metrics.java
+++ b/src/main/java/org/dependencytrack/metrics/Metrics.java
@@ -63,6 +63,17 @@ public final class Metrics {
         StoredProcedures.execute(Procedure.UPDATE_PORTFOLIO_METRICS);
     }
 
+
+    /**
+     * Update historical risk scores for the entire portfolio.
+     * <p>
+     *
+     * @since 5.0.0
+     */
+    public static void updateHistoricalRiskScores() {
+        StoredProcedures.execute(Procedure.UPDATE_HISTORICAL_RISK_SCORES);
+    }
+
     /**
      * Update metrics for a given {@link Project}.
      * <p>

--- a/src/main/java/org/dependencytrack/persistence/StoredProcedures.java
+++ b/src/main/java/org/dependencytrack/persistence/StoredProcedures.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 public final class StoredProcedures {
 
     public enum Procedure {
+        UPDATE_HISTORICAL_RISK_SCORES,
         UPDATE_COMPONENT_METRICS,
         UPDATE_PROJECT_METRICS,
         UPDATE_PORTFOLIO_METRICS;

--- a/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.time.DateUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.ComponentMetricsUpdateEvent;
 import org.dependencytrack.event.PortfolioMetricsUpdateEvent;
+import org.dependencytrack.event.HistoricalRiskScoreUpdateEvent;
 import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.DependencyMetrics;
@@ -81,6 +82,23 @@ public class MetricsResource extends AlpineResource {
         }
     }
 
+    @GET 
+    @Path("/riskscore/refresh")
+    @Produces(MediaType.APPLICATION_JSON)
+    @ApiOperation(
+        value = "Requests a refresh of the historical risk score metrics",
+        response = PortfolioMetrics.class,
+        notes = "<p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong></p>"
+    )
+    @ApiResponses(value = {
+        @ApiResponse(code = 401, message = "Unauthorized")
+    })
+    @PermissionRequired(Permissions.Constants.PORTFOLIO_MANAGEMENT)
+    public Response RefreshHistoricalRiskScoreMetrics() {
+        Event.dispatch(new HistoricalRiskScoreUpdateEvent());
+        return Response.ok().build();
+    }
+    
     @GET
     @Path("/portfolio/current")
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/java/org/dependencytrack/tasks/metrics/HistoricalRiskScoreUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/HistoricalRiskScoreUpdateTask.java
@@ -1,0 +1,88 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.tasks.metrics;
+
+import alpine.common.logging.Logger;
+import alpine.common.util.SystemUtil;
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
+import net.javacrumbs.shedlock.core.LockConfiguration;
+import net.javacrumbs.shedlock.core.LockExtender;
+import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.apache.commons.collections4.ListUtils;
+import org.dependencytrack.event.CallbackEvent;
+import org.dependencytrack.event.HistoricalRiskScoreUpdateEvent;
+import org.dependencytrack.event.ProjectMetricsUpdateEvent;
+import org.dependencytrack.metrics.Metrics;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.util.LockProvider;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.Query;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.dependencytrack.tasks.LockName.PORTFOLIO_METRICS_TASK_LOCK;
+import static org.dependencytrack.util.LockProvider.isLockToBeExtended;
+
+
+/**
+ * A {@link Subscriber} task that updates portfolio metrics.
+ *
+ * @since 4.6.0
+ */
+public class HistoricalRiskScoreUpdateTask implements Subscriber {
+
+    private static final Logger LOGGER = Logger.getLogger(PortfolioMetricsUpdateTask.class);
+
+    @Override
+    public void inform(final Event e) {
+        if (e instanceof final HistoricalRiskScoreUpdateEvent event) {
+            try {
+                LockProvider.executeWithLock(PORTFOLIO_METRICS_TASK_LOCK, (LockingTaskExecutor.Task)() -> updateMetrics(event.isForceRefresh()));
+            } catch (Throwable ex) {
+                LOGGER.error("Error in acquiring lock and executing portfolio metrics task", ex);
+            }
+        }
+    }
+
+    private void updateMetrics(final boolean weightHistoryEnabled) throws Exception {
+        LOGGER.info("Executing historical risk score metrics update");
+        final long startTimeNs = System.nanoTime();
+
+        try {
+            if (weightHistoryEnabled) {
+                LOGGER.info("Refreshing historical risk score metrics");
+                Metrics.updateHistoricalRiskScores();
+            }
+
+            Metrics.updatePortfolioMetrics();
+        } finally {
+            LOGGER.info("Completed historical risk score metrics update in " + Duration.ofNanos(System.nanoTime() - startTimeNs));
+        }
+    }
+
+    public record ProjectProjection(long id, UUID uuid) {
+    }
+
+}

--- a/src/main/java/org/dependencytrack/tasks/metrics/HistoricalRiskScoreUpdateTask.java
+++ b/src/main/java/org/dependencytrack/tasks/metrics/HistoricalRiskScoreUpdateTask.java
@@ -19,31 +19,17 @@
 package org.dependencytrack.tasks.metrics;
 
 import alpine.common.logging.Logger;
-import alpine.common.util.SystemUtil;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
-import net.javacrumbs.shedlock.core.LockConfiguration;
-import net.javacrumbs.shedlock.core.LockExtender;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
-import org.apache.commons.collections4.ListUtils;
-import org.dependencytrack.event.CallbackEvent;
 import org.dependencytrack.event.HistoricalRiskScoreUpdateEvent;
-import org.dependencytrack.event.ProjectMetricsUpdateEvent;
 import org.dependencytrack.metrics.Metrics;
-import org.dependencytrack.model.Project;
-import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.LockProvider;
 
-import javax.jdo.PersistenceManager;
-import javax.jdo.Query;
 import java.time.Duration;
-import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import static org.dependencytrack.tasks.LockName.PORTFOLIO_METRICS_TASK_LOCK;
-import static org.dependencytrack.util.LockProvider.isLockToBeExtended;
 
 
 /**
@@ -59,7 +45,7 @@ public class HistoricalRiskScoreUpdateTask implements Subscriber {
     public void inform(final Event e) {
         if (e instanceof final HistoricalRiskScoreUpdateEvent event) {
             try {
-                LockProvider.executeWithLock(PORTFOLIO_METRICS_TASK_LOCK, (LockingTaskExecutor.Task)() -> updateMetrics(event.isForceRefresh()));
+                LockProvider.executeWithLock(PORTFOLIO_METRICS_TASK_LOCK, (LockingTaskExecutor.Task)() -> updateMetrics(event.isWeightHistoryEnabled()));
             } catch (Throwable ex) {
                 LOGGER.error("Error in acquiring lock and executing portfolio metrics task", ex);
             }

--- a/src/main/resources/migration/procedures/procedure_update_historical_risk_scores.sql
+++ b/src/main/resources/migration/procedures/procedure_update_historical_risk_scores.sql
@@ -11,4 +11,5 @@ DECLARE
   "v_risk_score"                              NUMERIC; -- Inherited risk score
 BEGIN 
     UPDATE "DEPENDENCYMETRICS" SET "v_risk_score" = "CALC_RISK_SCORE"("v_critical", "v_high", "v_medium", "v_low", "v_unassigned");
+END;
 $$;

--- a/src/main/resources/migration/procedures/procedure_update_historical_risk_scores.sql
+++ b/src/main/resources/migration/procedures/procedure_update_historical_risk_scores.sql
@@ -1,0 +1,14 @@
+CREATE OR REPLACE PROCEDURE "UPDATE_HISTORICAL_RISK_SCORES"()
+   LANGUAGE "plpgsql"
+AS
+$$
+DECLARE 
+  "v_critical"                                INT; -- Number of vulnerabilities with critical severity
+  "v_high"                                    INT; -- Number of vulnerabilities with high severity
+  "v_medium"                                  INT; -- Number of vulnerabilities with medium severity
+  "v_low"                                     INT; -- Number of vulnerabilities with low severity
+  "v_unassigned"                              INT; -- Number of vulnerabilities with unassigned severity
+  "v_risk_score"                              NUMERIC; -- Inherited risk score
+BEGIN 
+    UPDATE "DEPENDENCYMETRICS" SET "v_risk_score" = "CALC_RISK_SCORE"("v_critical", "v_high", "v_medium", "v_low", "v_unassigned");
+$$;


### PR DESCRIPTION
### Description

Related to https://github.com/DependencyTrack/dependency-track/issues/2824 , this issue is to allow the custom weights of risk scores to be re-calculated. 

### Addressed Issue

Related to https://github.com/DependencyTrack/dependency-track/issues/2824 

Front end issue to go along with this is https://github.com/DependencyTrack/hyades-frontend/pull/94 

### Additional Details
Adds a new endpoint to tell the database to recalculate with `/riskscore/refresh`. If there's a better approach for this, I'm all ears! 

This PR is draft, I have a few questions / open ended items: 
- I'm not super experienced with SQL so I'm confused about how to define the columns to make sure the risk scores are recalculated throughout the `DEPENDENCYMETRICS` table. 
- I need to only run this recalculation if `weight.history.enabled` is True, don't run this when false. Where would this logic be done?
- Tests haven't been added yet

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
