### PR TITLE
Rename Kafka topic prefix config

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -59,12 +59,12 @@ there's no need to deploy it in an application server like Tomcat or WildFly.
 ## Running
 
 In case you want to provide a topic prefix to use in conjunction with hyades application then the environment variable
-to export is KAFKA_TOPIC_PREFIX<br/>
+to export is DT_KAFKA_TOPIC_PREFIX<br/>
 If the host environment requires ssl configuration then below configurations need to be passed:
 
 | Environment Variable                    | Description                              | Default | Required |
 |:----------------------------------------|:-----------------------------------------|:--------|:--------:|
-| `KAFKA_TOPIC_PREFIX`                      | Prefix for topic names                   | -       |    ✅     |
+| `DT_KAFKA_TOPIC_PREFIX`                 | Prefix for topic names                   | -       |    ✅     |
 | `KAFKA_TLS_ENABLED`                     | Whether tls is enabled                   | false   |    ❌     |
 | `KAFKA_SECURTY_PROTOCOL`                | Security protocol to be used             | -       |    ❌     |
 | `KAFKA_TRUSTSTORE_PATH`                 | Trust store path to be used              | -       |    ❌     |

--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -34,7 +34,7 @@ public enum ConfigKey implements Config.Key {
     KAFKA_PRODUCER_DRAIN_TIMEOUT_DURATION("kafka.producer.drain.timeout.duration", "PT30S"),
     KAFKA_TLS_ENABLED("kafka.tls.enabled", false),
     KAFKA_TLS_PROTOCOL("kafka.security.protocol", ""),
-    KAFKA_TOPIC_PREFIX("kafka.topic.prefix", ""),
+    DT_KAFKA_TOPIC_PREFIX("dt.kafka.topic.prefix", ""),
     KAFKA_TRUST_STORE_PASSWORD("kafka.truststore.password", ""),
     KAFKA_TRUST_STORE_PATH("kafka.truststore.path", ""),
 

--- a/src/main/java/org/dependencytrack/event/kafka/KafkaTopics.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaTopics.java
@@ -90,7 +90,7 @@ public final class KafkaTopics {
 
         @Override
         public String name() {
-            return Config.getInstance().getProperty(ConfigKey.KAFKA_TOPIC_PREFIX) + name;
+            return Config.getInstance().getProperty(ConfigKey.DT_KAFKA_TOPIC_PREFIX) + name;
         }
 
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -662,7 +662,7 @@ kafka.keystore.password=
 
 # @category: Kafka
 # @type:     string
-kafka.topic.prefix=
+dt.kafka.topic.prefix=
 
 # Defines the order in which records are being processed.
 # Valid options are:

--- a/src/test/java/org/dependencytrack/event/kafka/KafkaTopicsTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/KafkaTopicsTest.java
@@ -31,7 +31,7 @@ public class KafkaTopicsTest {
 
     @Test
     public void testTopicNameWithPrefix() {
-        environmentVariables.set("KAFKA_TOPIC_PREFIX", "foo-bar.baz.");
+        environmentVariables.set("DT_KAFKA_TOPIC_PREFIX", "foo-bar.baz.");
         assertThat(KafkaTopics.VULN_ANALYSIS_RESULT.name()).isEqualTo("foo-bar.baz.dtrack.vuln-analysis.result");
     }
 


### PR DESCRIPTION
### Description

Creation of Kafka Streams repartition topics currently fails with Unknown topic config name: prefix, when using Apache Kafka instead of Redpanda.

Rename the prefix config to avoid the error.

### Addressed Issue

https://github.com/DependencyTrack/hyades/pull/1411
https://github.com/DependencyTrack/hyades/issues/1392

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
