### PR TITLE
Add option to exit after running database migrations

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -98,6 +98,7 @@ public enum ConfigKey implements Config.Key {
     DATABASE_MIGRATION_USERNAME("database.migration.username", null),
     DATABASE_MIGRATION_PASSWORD("database.migration.password", null),
     DATABASE_RUN_MIGRATIONS("database.run.migrations", true),
+    DATABASE_RUN_MIGRATIONS_ONLY("database.run.migrations.only", false),
 
     DEV_SERVICES_ENABLED("dev.services.enabled", false),
     DEV_SERVICES_IMAGE_FRONTEND("dev.services.image.frontend", "ghcr.io/dependencytrack/hyades-frontend:snapshot"),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -232,6 +232,14 @@ alpine.datanucleus.cache.level2.type=none
 # @type:     boolean
 database.run.migrations=true
 
+# Defines whether the application should exit upon successful execution of database migrations.
+# Enabling this option makes the application suitable for running as k8s init container.
+# Has no effect unless database.run.migrations is `true`.
+#
+# @category: Database
+# @type:     boolean
+# database.run.migrations.only=false
+
 # Defines the database JDBC URL to use when executing migrations.
 # If not set, the value of alpine.database.url will be used.
 # Should generally not be set, unless TLS authentication is used,


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds option to exit after running database migrations.

This makes it possible to run the API server as its own init container, as outlined here: https://www.liquibase.com/blog/using-liquibase-in-kubernetes

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
