### PR TITLE
Add active Field To Project Versions

### DIFF
--- a/src/main/java/org/dependencytrack/model/ProjectVersion.java
+++ b/src/main/java/org/dependencytrack/model/ProjectVersion.java
@@ -27,38 +27,5 @@ import java.util.UUID;
  * Value object holding UUID and version for a project
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ProjectVersion implements Serializable {
-
-    private static final long serialVersionUID = 1L;
-
-    private UUID uuid;
-
-    private String version;
-
-    public ProjectVersion() {
-        this.uuid = null;
-        this.version = null;
-    }
-
-    public ProjectVersion(UUID uuid, String version) {
-        this.uuid = uuid;
-        this.version = version;
-
-    }
-
-    public void setUuid(UUID uuid) {
-        this.uuid = uuid;
-    }
-
-    public UUID getUuid() {
-        return uuid;
-    }
-
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    public String getVersion() {
-        return version;
-    }
+public record ProjectVersion(UUID uuid, String version, Boolean active) implements Serializable {
 }

--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -1201,7 +1201,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final Query<Project> query = pm.newQuery(Project.class);
         query.setFilter("name == :name");
         query.setParameters(project.getName());
-        query.setResult("uuid, version");
+        query.setResult("uuid, version, active");
         query.setOrdering("id asc"); // Ensure consistent ordering
         return query.executeResultList(ProjectVersion.class);
     }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -2036,4 +2036,34 @@ public class ProjectResourceTest extends ResourceTest {
         Assert.assertNotNull(json.getString("token"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("token")));
     }
+
+    @Test
+    public void validateProjectVersionsActiveInactiveTest() {
+        Project project = qm.createProject("ABC", null, "1.0", null, null, null, true, false);
+        qm.createProject("ABC", null, "2.0", null, null, null, false, false);
+        qm.createProject("ABC", null, "3.0", null, null, null, true, false);
+
+        Response response = jersey.target(V1_PROJECT + "/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+
+        Assert.assertEquals(200, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals("ABC", json.getString("name"));
+        Assert.assertEquals(3, json.getJsonArray("versions").size());
+
+        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(0).getJsonString("uuid").getString());
+        Assert.assertEquals("1.0", json.getJsonArray("versions").getJsonObject(0).getJsonString("version").getString());
+        Assert.assertTrue(json.getJsonArray("versions").getJsonObject(0).getBoolean("active"));
+
+        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(1).getJsonString("uuid").getString());
+        Assert.assertEquals("2.0", json.getJsonArray("versions").getJsonObject(1).getJsonString("version").getString());
+        Assert.assertFalse(json.getJsonArray("versions").getJsonObject(1).getBoolean("active"));
+
+        Assert.assertNotNull(json.getJsonArray("versions").getJsonObject(2).getJsonString("uuid").getString());
+        Assert.assertEquals("3.0", json.getJsonArray("versions").getJsonObject(2).getJsonString("version").getString());
+        Assert.assertTrue(json.getJsonArray("versions").getJsonObject(2).getBoolean("active"));
+    }
 }


### PR DESCRIPTION
### Description

In order for the frontend to distinguish between active or inactive project versions, we need to include the active boolean field to ProjectVersion model.

### Addressed Issue

Backport change : https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
