### PR TITLE
Port : add project tags parameter for bom endpoints

### DIFF
--- a/src/main/java/org/dependencytrack/model/Tag.java
+++ b/src/main/java/org/dependencytrack/model/Tag.java
@@ -50,6 +50,13 @@ public class Tag implements Serializable {
 
     private static final long serialVersionUID = -7798359808664731988L;
 
+    public Tag() {
+    }
+
+    public Tag(final String name) {
+        this.name = name;
+    }
+
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
     @JsonIgnore

--- a/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/BomSubmitRequest.java
@@ -28,6 +28,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import org.dependencytrack.model.Tag;
+
+import java.util.List;
 
 /**
  * Defines a custom request object used when uploading bill-of-material (bom) documents.
@@ -51,6 +54,8 @@ public final class BomSubmitRequest {
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The project version may only contain printable characters")
     private final String projectVersion;
 
+    private final List<Tag> projectTags;
+
     @Pattern(regexp = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", message = "The parent UUID must be a valid 36 character UUID")
     private final String parentUUID;
 
@@ -71,15 +76,17 @@ public final class BomSubmitRequest {
     public BomSubmitRequest(String project,
                             String projectName,
                             String projectVersion,
+                            List<Tag> projectTags,
                             boolean autoCreate,
                             String bom) {
-        this(project, projectName, projectVersion, autoCreate, null, null, null, bom);
+        this(project, projectName, projectVersion, projectTags, autoCreate, null, null, null, bom);
     }
 
     @JsonCreator
     public BomSubmitRequest(@JsonProperty(value = "project") String project,
                             @JsonProperty(value = "projectName") String projectName,
                             @JsonProperty(value = "projectVersion") String projectVersion,
+                            @JsonProperty(value = "projectTags") List<Tag> projectTags,
                             @JsonProperty(value = "autoCreate") boolean autoCreate,
                             @JsonProperty(value = "parentUUID") String parentUUID,
                             @JsonProperty(value = "parentName") String parentName,
@@ -88,6 +95,7 @@ public final class BomSubmitRequest {
         this.project = project;
         this.projectName = projectName;
         this.projectVersion = projectVersion;
+        this.projectTags = projectTags;
         this.autoCreate = autoCreate;
         this.parentUUID = parentUUID;
         this.parentName = parentName;
@@ -108,6 +116,11 @@ public final class BomSubmitRequest {
     @Schema(example = "1.0.0")
     public String getProjectVersion() {
         return projectVersion;
+    }
+
+    @Schema(example = "tag1, tag2")
+    public List<Tag> getProjectTags() {
+        return projectTags;
     }
 
     @Schema(example = "5341f53c-611b-4388-9d9c-731026dc5eec")


### PR DESCRIPTION
### Description

Add project tags in parameters to be able to upload a bom and auto-create the project with specific tags.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
