### PR TITLE
Add REST endpoints to tag and untag policies in bulk

### DIFF
--- a/src/main/java/org/dependencytrack/model/validation/ValidUuid.java
+++ b/src/main/java/org/dependencytrack/model/validation/ValidUuid.java
@@ -31,7 +31,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * @since 4.11.0
  */
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.TYPE_USE, ElementType.FIELD, ElementType.PARAMETER})
 @Constraint(validatedBy = {})
 @Retention(RUNTIME)
 @ReportAsSingleViolation

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1352,6 +1352,10 @@ public class QueryManager extends AlpineQueryManager {
         getProjectQueryManager().bind(project, tags);
     }
 
+    public void bind(Policy policy, List<Tag> tags) {
+        getProjectQueryManager().bind(policy, tags);
+    }
+
     public boolean hasAccessManagementPermission(final Object principal) {
         if (principal instanceof final UserPrincipal userPrincipal) {
             return hasAccessManagementPermission(userPrincipal);
@@ -1944,5 +1948,13 @@ public class QueryManager extends AlpineQueryManager {
 
     public void synchronizeComponentProperties(final Component component, final List<ComponentProperty> properties) {
         getComponentQueryManager().synchronizeComponentProperties(component, properties);
+    }
+
+    public void tagPolicies(final String tagName, final Collection<String> policyUuids) {
+        getTagQueryManager().tagPolicies(tagName, policyUuids);
+    }
+
+    public void untagPolicies(final String tagName, final Collection<String> policyUuids) {
+        getTagQueryManager().untagPolicies(tagName, policyUuids);
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -301,7 +301,10 @@ public class PolicyResource extends AlpineResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Adds a tag to a policy",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>"
+            description = """
+                    <p><strong>Deprecated</strong>. Use <code>POST /api/v1/tag/{name}/policy</code> instead.</p>
+                    <p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", content = @Content(schema = @Schema(implementation = Policy.class))),
@@ -310,6 +313,7 @@ public class PolicyResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The policy or tag could not be found")
     })
     @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    @Deprecated(forRemoval = true)
     public Response addTagToPolicy(
             @Parameter(description = "The UUID of the policy to add a project to", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("policyUuid") @ValidUuid String policyUuid,
@@ -341,7 +345,10 @@ public class PolicyResource extends AlpineResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Removes a tag from a policy",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>"
+            description = """
+                    <p><strong>Deprecated</strong>. Use <code>DELETE /api/v1/tag/{name}/policy</code> instead.</p>
+                    <p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", content = @Content(schema = @Schema(implementation = Policy.class))),
@@ -350,6 +357,7 @@ public class PolicyResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The policy or tag could not be found")
     })
     @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    @Deprecated(forRemoval = true)
     public Response removeTagFromPolicy(
             @Parameter(description = "The UUID of the policy to remove the tag from", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("policyUuid") @ValidUuid String policyUuid,

--- a/src/main/java/org/dependencytrack/resources/v1/TagResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TagResource.java
@@ -31,7 +31,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import jakarta.validation.constraints.Size;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
@@ -41,6 +45,10 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+
+import java.util.NoSuchElementException;
+import java.util.Set;
 
 @Path("/v1/tag")
 @io.swagger.v3.oas.annotations.tags.Tag(name = "tag")
@@ -72,5 +80,97 @@ public class TagResource extends AlpineResource {
             final PaginatedResult result = qm.getTags(policyUuid);
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
+    }
+
+    @POST
+    @Path("/{name}/policy")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Tags one or more policies.",
+            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Policies tagged successfully."
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "A tag with the provided name does not exist.",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)
+            )
+    })
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response tagPolicies(
+            @Parameter(description = "Name of the tag to assign", required = true)
+            @PathParam("name") final String tagName,
+            @Parameter(
+                    description = "UUIDs of policies to tag",
+                    required = true,
+                    array = @ArraySchema(schema = @Schema(type = "string", format = "uuid"))
+            )
+            @Size(min = 1, max = 100) final Set<@ValidUuid String> policyUuids
+    ) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            qm.tagPolicies(tagName, policyUuids);
+        } catch (RuntimeException e) {
+            // TODO: Move this to an ExceptionMapper once https://github.com/stevespringett/Alpine/pull/588 is available.
+            if (e.getCause() instanceof final NoSuchElementException nseException) {
+                return Response
+                        .status(404)
+                        .header("Content-Type", ProblemDetails.MEDIA_TYPE_JSON)
+                        .entity(new ProblemDetails(404, "Resource does not exist", nseException.getMessage()))
+                        .build();
+            }
+            throw e;
+        }
+        return Response.noContent().build();
+    }
+
+    @DELETE
+    @Path("/{name}/policy")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Untags one or more policies.",
+            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "204",
+                    description = "Policies untagged successfully."
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "A tag with the provided name does not exist.",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)
+            )
+    })
+    @PermissionRequired(Permissions.Constants.POLICY_MANAGEMENT)
+    public Response untagPolicies(
+            @Parameter(description = "Name of the tag", required = true)
+            @PathParam("name") final String tagName,
+            @Parameter(
+                    description = "UUIDs of policies to untag",
+                    required = true,
+                    array = @ArraySchema(schema = @Schema(type = "string", format = "uuid"))
+            )
+            @Size(min = 1, max = 100) final Set<@ValidUuid String> policyUuids
+    ) {
+        try (final var qm = new QueryManager(getAlpineRequest())) {
+            qm.untagPolicies(tagName, policyUuids);
+        } catch (RuntimeException e) {
+            // TODO: Move this to an ExceptionMapper once https://github.com/stevespringett/Alpine/pull/588 is available.
+            if (e.getCause() instanceof final NoSuchElementException nseException) {
+                return Response
+                        .status(404)
+                        .header("Content-Type", ProblemDetails.MEDIA_TYPE_JSON)
+                        .entity(new ProblemDetails(404, "Resource does not exist", nseException.getMessage()))
+                        .build();
+            }
+            throw e;
+        }
+        return Response.noContent().build();
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/problems/ProblemDetails.java
+++ b/src/main/java/org/dependencytrack/resources/v1/problems/ProblemDetails.java
@@ -20,6 +20,8 @@ package org.dependencytrack.resources.v1.problems;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.Response;
 
 import java.net.URI;
 
@@ -68,6 +70,27 @@ public class ProblemDetails {
             example = "https://api.example.org/foo/bar/example-instance"
     )
     private URI instance;
+
+    public ProblemDetails() {
+    }
+
+    public ProblemDetails(final int status, final String title, final String detail) {
+        this.status = status;
+        this.title = title;
+        this.detail = detail;
+    }
+
+    /**
+     * @since 4.12.0
+     */
+    public Response toResponse() {
+        return Response
+                .status(status)
+                .header(HttpHeaders.CONTENT_TYPE, MEDIA_TYPE_JSON)
+                .entity(this)
+                .build();
+    }
+
 
     public URI getType() {
         return type;

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -20,17 +20,28 @@ package org.dependencytrack.resources.v1;
 
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.Tag;
+import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import jakarta.json.JsonArray;
-import jakarta.ws.rs.core.Response;
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class TagResourceTest extends ResourceTest {
 
@@ -85,5 +96,216 @@ public class TagResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals(3, json.size());
         Assert.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
+    }
+
+    @Test
+    public void tagPoliciesTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policyA = new Policy();
+        policyA.setName("policy-a");
+        policyA.setOperator(Policy.Operator.ALL);
+        policyA.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyA);
+
+        final var policyB = new Policy();
+        policyB.setName("policy-b");
+        policyB.setOperator(Policy.Operator.ALL);
+        policyB.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyB);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(List.of(policyA.getUuid(), policyB.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(policyA.getTags()).satisfiesExactly(policyTag -> assertThat(policyTag.getName()).isEqualTo("foo"));
+        assertThat(policyB.getTags()).satisfiesExactly(policyTag -> assertThat(policyTag.getName()).isEqualTo("foo"));
+    }
+
+    @Test
+    public void tagPoliciesWithTagNotExistsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(List.of(policy.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                {
+                  "status": 404,
+                  "title": "Resource does not exist",
+                  "detail": "A tag with name foo does not exist"
+                }
+                """);
+    }
+
+    @Test
+    public void tagPoliciesWithNoPolicyUuidsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(Collections.emptyList()));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [
+                  {
+                    "message": "size must be between 1 and 100",
+                    "messageTemplate": "{jakarta.validation.constraints.Size.message}",
+                    "path": "tagPolicies.arg1",
+                    "invalidValue": "[]"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void untagPoliciesTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policyA = new Policy();
+        policyA.setName("policy-a");
+        policyA.setOperator(Policy.Operator.ALL);
+        policyA.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyA);
+
+        final var policyB = new Policy();
+        policyB.setName("policy-b");
+        policyB.setOperator(Policy.Operator.ALL);
+        policyB.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyB);
+
+        final Tag tag = qm.createTag("foo");
+        qm.bind(policyA, List.of(tag));
+        qm.bind(policyB, List.of(tag));
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(List.of(policyA.getUuid(), policyB.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(policyA.getTags()).isEmpty();
+        assertThat(policyB.getTags()).isEmpty();
+    }
+
+    @Test
+    public void untagPoliciesWithTagNotExistsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(List.of(policy.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                {
+                  "status": 404,
+                  "title": "Resource does not exist",
+                  "detail": "A tag with name foo does not exist"
+                }
+                """);
+    }
+
+    @Test
+    public void untagPoliciesWithNoProjectUuidsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(Collections.emptyList()));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [
+                  {
+                    "message": "size must be between 1 and 100",
+                    "messageTemplate": "{jakarta.validation.constraints.Size.message}",
+                    "path": "untagPolicies.arg1",
+                    "invalidValue": "[]"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void untagPoliciesWithTooManyPolicyUuidsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final List<String> policyUuids = IntStream.range(0, 101)
+                .mapToObj(ignored -> UUID.randomUUID())
+                .map(UUID::toString)
+                .toList();
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(policyUuids));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [
+                  {
+                    "message": "size must be between 1 and 100",
+                    "messageTemplate": "{jakarta.validation.constraints.Size.message}",
+                    "path": "untagPolicies.arg1",
+                    "invalidValue": "${json-unit.any-string}"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void untagPoliciesWhenNotTaggedTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policy);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(List.of(policy.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(policy.getTags()).isEmpty();
     }
 }


### PR DESCRIPTION
### Description

Adds the new endpoints:

- `POST /api/v1/tag/{name}/policy`
- `DELETE /api/v1/tag/{name}/policy`

And deprecates the redundant endpoints:

- `POST /api/v1/policy/{uuid}/tag/{name}`
- `DELETE /api/v1/policy/{uuid}/tag/{name}`

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
