### PR TITLE
Port : Add REST endpoints to tag and untag policies in bulk

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1427,6 +1427,14 @@ public class QueryManager extends AlpineQueryManager {
         return getTagQueryManager().getTaggedPolicies(tagName);
     }
 
+    public void tagPolicies(final String tagName, final Collection<String> policyUuids) {
+        getTagQueryManager().tagPolicies(tagName, policyUuids);
+    }
+
+    public void untagPolicies(final String tagName, final Collection<String> policyUuids) {
+        getTagQueryManager().untagPolicies(tagName, policyUuids);
+    }
+
     public PaginatedResult getTagsForPolicy(String policyUuid) {
         return getTagQueryManager().getTagsForPolicy(policyUuid);
     }

--- a/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -147,6 +147,9 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
 
     }
 
+    /**
+     * @since 4.12.0
+     */
     public record TagDeletionCandidateRow(
             String name,
             long projectCount,
@@ -166,6 +169,10 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
 
     }
 
+    /**
+     * @since 4.12.0
+     */
+    @Override
     public void deleteTags(final Collection<String> tagNames) {
         runInTransaction(() -> {
             final Map.Entry<String, Map<String, Object>> projectAclConditionAndParams = getProjectAclSqlCondition();
@@ -446,6 +453,54 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
         } finally {
             query.closeAll();
         }
+    }
+
+    /**
+     * @since 4.12.0
+     */
+    @Override
+    public void tagPolicies(final String tagName, final Collection<String> policyUuids) {
+        runInTransaction(() -> {
+            final Tag tag = getTagByName(tagName);
+            if (tag == null) {
+                throw new NoSuchElementException("A tag with name %s does not exist".formatted(tagName));
+            }
+
+            final Query<Policy> policiesQuery = pm.newQuery(Policy.class);
+            policiesQuery.setFilter(":uuids.contains(uuid)");
+            policiesQuery.setParameters(policyUuids);
+            final List<Policy> policies = executeAndCloseList(policiesQuery);
+
+            for (final Policy policy : policies) {
+                bind(policy, List.of(tag));
+            }
+        });
+    }
+
+    /**
+     * @since 4.12.0
+     */
+    @Override
+    public void untagPolicies(final String tagName, final Collection<String> policyUuids) {
+        runInTransaction(() -> {
+            final Tag tag = getTagByName(tagName);
+            if (tag == null) {
+                throw new NoSuchElementException("A tag with name %s does not exist".formatted(tagName));
+            }
+
+            final Query<Policy> policiesQuery = pm.newQuery(Policy.class);
+            policiesQuery.setFilter(":uuids.contains(uuid)");
+            policiesQuery.setParameters(policyUuids);
+            final List<Policy> policies = executeAndCloseList(policiesQuery);
+
+            for (final Policy policy : policies) {
+                if (policy.getTags() == null || policy.getTags().isEmpty()) {
+                    continue;
+                }
+
+                policy.getTags().remove(tag);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -322,7 +322,10 @@ public class PolicyResource extends AlpineResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Adds a tag to a policy",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong> or <strong>POLICY_MANAGEMENT_UPDATE</strong></p>"
+            description = """
+                    <p><strong>Deprecated</strong>. Use <code>POST /api/v1/tag/{name}/policy</code> instead.</p>
+                    <p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -335,6 +338,7 @@ public class PolicyResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The policy or tag could not be found")
     })
     @PermissionRequired({Permissions.Constants.POLICY_MANAGEMENT, Permissions.Constants.POLICY_MANAGEMENT_UPDATE})
+    @Deprecated(forRemoval = true)
     public Response addTagToPolicy(
             @Parameter(description = "The UUID of the policy to add a project to", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("policyUuid") @ValidUuid String policyUuid,
@@ -363,7 +367,10 @@ public class PolicyResource extends AlpineResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Removes a tag from a policy",
-            description = "<p>Requires permission <strong>POLICY_MANAGEMENT</strong> or <strong>POLICY_MANAGEMENT_DELETE</strong></p>"
+            description = """
+                    <p><strong>Deprecated</strong>. Use <code>DELETE /api/v1/tag/{name}/policy</code> instead.</p>
+                    <p>Requires permission <strong>POLICY_MANAGEMENT</strong></p>
+                    """
     )
     @ApiResponses(value = {
             @ApiResponse(
@@ -376,6 +383,7 @@ public class PolicyResource extends AlpineResource {
             @ApiResponse(responseCode = "404", description = "The policy or tag could not be found")
     })
     @PermissionRequired({Permissions.Constants.POLICY_MANAGEMENT, Permissions.Constants.POLICY_MANAGEMENT_DELETE})
+    @Deprecated(forRemoval = true)
     public Response removeTagFromPolicy(
             @Parameter(description = "The UUID of the policy to remove the tag from", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("policyUuid") @ValidUuid String policyUuid,

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -628,14 +628,14 @@ public class TagResourceTest extends ResourceTest {
     @Test
     public void tagProjectsWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
-        final var projectA = new Project();
-        projectA.setName("acme-app-a");
-        qm.persist(projectA);
+        final var project = new Project();
+        project.setName("acme-app-a");
+        qm.persist(project);
 
         final Response response = jersey.target(V1_TAG + "/foo/project")
                 .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.json(List.of(projectA.getUuid())));
+                .post(Entity.json(List.of(project.getUuid())));
         assertThat(response.getStatus()).isEqualTo(404);
         assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
         assertThatJson(getPlainTextBody(response)).isEqualTo("""
@@ -706,21 +706,21 @@ public class TagResourceTest extends ResourceTest {
     @Test
     public void tagProjectsWhenAlreadyTaggedTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
-        final var projectA = new Project();
-        projectA.setName("acme-app-a");
-        qm.persist(projectA);
+        final var project = new Project();
+        project.setName("acme-app-a");
+        qm.persist(project);
 
         final Tag tag = qm.createTag("foo");
-        qm.bind(projectA, List.of(tag));
+        qm.bind(project, List.of(tag));
 
         final Response response = jersey.target(V1_TAG + "/foo/project")
                 .request()
                 .header(X_API_KEY, apiKey)
-                .post(Entity.json(List.of(projectA.getUuid())));
+                .post(Entity.json(List.of(project.getUuid())));
         assertThat(response.getStatus()).isEqualTo(204);
 
         qm.getPersistenceManager().evictAll();
-        assertThat(projectA.getTags()).satisfiesExactly(projectTag -> assertThat(projectTag.getName()).isEqualTo("foo"));
+        assertThat(project.getTags()).satisfiesExactly(projectTag -> assertThat(projectTag.getName()).isEqualTo("foo"));
     }
 
     @Test
@@ -790,15 +790,15 @@ public class TagResourceTest extends ResourceTest {
     @Test
     public void untagProjectsWithTagNotExistsTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
-        final var projectA = new Project();
-        projectA.setName("acme-app-a");
-        qm.persist(projectA);
+        final var project = new Project();
+        project.setName("acme-app-a");
+        qm.persist(project);
 
         final Response response = jersey.target(V1_TAG + "/foo/project")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
-                .method(HttpMethod.DELETE, Entity.json(List.of(projectA.getUuid())));
+                .method(HttpMethod.DELETE, Entity.json(List.of(project.getUuid())));
         assertThat(response.getStatus()).isEqualTo(404);
         assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
         assertThatJson(getPlainTextBody(response)).isEqualTo("""
@@ -864,9 +864,9 @@ public class TagResourceTest extends ResourceTest {
     @Test
     public void untagProjectsWhenNotTaggedTest() {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
-        final var projectA = new Project();
-        projectA.setName("acme-app-a");
-        qm.persist(projectA);
+        final var project = new Project();
+        project.setName("acme-app-a");
+        qm.persist(project);
 
         qm.createTag("foo");
 
@@ -874,11 +874,11 @@ public class TagResourceTest extends ResourceTest {
                 .request()
                 .header(X_API_KEY, apiKey)
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
-                .method(HttpMethod.DELETE, Entity.json(List.of(projectA.getUuid())));
+                .method(HttpMethod.DELETE, Entity.json(List.of(project.getUuid())));
         assertThat(response.getStatus()).isEqualTo(204);
 
         qm.getPersistenceManager().evictAll();
-        assertThat(projectA.getTags()).isEmpty();
+        assertThat(project.getTags()).isEmpty();
     }
 
     @Test
@@ -1003,6 +1003,217 @@ public class TagResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(200);
         assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("0");
         assertThat(getPlainTextBody(response)).isEqualTo("[]");
+    }
+
+    @Test
+    public void tagPoliciesTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policyA = new Policy();
+        policyA.setName("policy-a");
+        policyA.setOperator(Policy.Operator.ALL);
+        policyA.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyA);
+
+        final var policyB = new Policy();
+        policyB.setName("policy-b");
+        policyB.setOperator(Policy.Operator.ALL);
+        policyB.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyB);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(List.of(policyA.getUuid(), policyB.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(policyA.getTags()).satisfiesExactly(policyTag -> assertThat(policyTag.getName()).isEqualTo("foo"));
+        assertThat(policyB.getTags()).satisfiesExactly(policyTag -> assertThat(policyTag.getName()).isEqualTo("foo"));
+    }
+
+    @Test
+    public void tagPoliciesWithTagNotExistsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(List.of(policy.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                {
+                  "status": 404,
+                  "title": "Resource does not exist",
+                  "detail": "A tag with name foo does not exist"
+                }
+                """);
+    }
+
+    @Test
+    public void tagPoliciesWithNoPolicyUuidsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(Collections.emptyList()));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [
+                  {
+                    "message": "size must be between 1 and 100",
+                    "messageTemplate": "{jakarta.validation.constraints.Size.message}",
+                    "path": "tagPolicies.policyUuids",
+                    "invalidValue": "[]"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void untagPoliciesTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policyA = new Policy();
+        policyA.setName("policy-a");
+        policyA.setOperator(Policy.Operator.ALL);
+        policyA.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyA);
+
+        final var policyB = new Policy();
+        policyB.setName("policy-b");
+        policyB.setOperator(Policy.Operator.ALL);
+        policyB.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policyB);
+
+        final Tag tag = qm.createTag("foo");
+        qm.bind(policyA, List.of(tag));
+        qm.bind(policyB, List.of(tag));
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(List.of(policyA.getUuid(), policyB.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(policyA.getTags()).isEmpty();
+        assertThat(policyB.getTags()).isEmpty();
+    }
+
+    @Test
+    public void untagPoliciesWithTagNotExistsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(List.of(policy.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getHeaderString("Content-Type")).isEqualTo("application/problem+json");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                {
+                  "status": 404,
+                  "title": "Resource does not exist",
+                  "detail": "A tag with name foo does not exist"
+                }
+                """);
+    }
+
+    @Test
+    public void untagPoliciesWithNoProjectUuidsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(Collections.emptyList()));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [
+                  {
+                    "message": "size must be between 1 and 100",
+                    "messageTemplate": "{jakarta.validation.constraints.Size.message}",
+                    "path": "untagPolicies.policyUuids",
+                    "invalidValue": "[]"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void untagPoliciesWithTooManyPolicyUuidsTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        qm.createTag("foo");
+
+        final List<String> policyUuids = IntStream.range(0, 101)
+                .mapToObj(ignored -> UUID.randomUUID())
+                .map(UUID::toString)
+                .toList();
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(policyUuids));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [
+                  {
+                    "message": "size must be between 1 and 100",
+                    "messageTemplate": "{jakarta.validation.constraints.Size.message}",
+                    "path": "untagPolicies.policyUuids",
+                    "invalidValue": "${json-unit.any-string}"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void untagPoliciesWhenNotTaggedTest() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ALL);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        qm.persist(policy);
+
+        qm.createTag("foo");
+
+        final Response response = jersey.target(V1_TAG + "/foo/policy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
+                .method(HttpMethod.DELETE, Entity.json(List.of(policy.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        qm.getPersistenceManager().evictAll();
+        assertThat(policy.getTags()).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Description

Adds the new endpoints:

`POST /api/v1/tag/{name}/policy`
`DELETE /api/v1/tag/{name}/policy`

And deprecates the redundant endpoints:

`POST /api/v1/policy/{uuid}/tag/{name}`
`DELETE /api/v1/policy/{uuid}/tag/{name}`

### Addressed Issue

Backport change : https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
