### PR TITLE
Port : Search component by group

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -240,8 +240,8 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         queryParams.put("projectId", project.getId());
         if (filter != null) {
             queryString += """
-                    AND LOWER("A0"."NAME") LIKE ('%' || LOWER(:nameFilter) || '%')
-                    OR LOWER("A0"."GROUP") LIKE ('%' || LOWER(:nameFilter) || '%')
+                    AND (LOWER("A0"."NAME") LIKE ('%' || LOWER(:nameFilter) || '%')
+                    OR LOWER("A0"."GROUP") LIKE ('%' || LOWER(:nameFilter) || '%'))
                     """;
             queryParams.put("nameFilter", filter);
         }

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -241,6 +241,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         if (filter != null) {
             queryString += """
                     AND LOWER("A0"."NAME") LIKE ('%' || LOWER(:nameFilter) || '%')
+                    OR LOWER("A0"."GROUP") LIKE ('%' || LOWER(:nameFilter) || '%')
                     """;
             queryParams.put("nameFilter", filter);
         }

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourcePostgresTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourcePostgresTest.java
@@ -151,6 +151,38 @@ public class ComponentResourcePostgresTest extends ResourceTest {
         );
     }
 
+    @Test
+    public void getComponentsByNameTest() throws MalformedPackageURLException {
+        final Project project = prepareProject();
+
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
+                .queryParam("searchText", "name-1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("111"); // 75 outdated direct dependencies
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(100);
+    }
+
+    @Test
+    public void getComponentsByGroupTest() throws MalformedPackageURLException {
+        final Project project = prepareProject();
+
+        final Response response = jersey.target(V1_COMPONENT + "/project/" + project.getUuid())
+                .queryParam("searchText", "group")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1000"); // 75 outdated direct dependencies
+
+        final JsonArray json = parseJsonArray(response);
+        assertThat(json).hasSize(100);
+    }
+
     private Project prepareProject() throws MalformedPackageURLException {
         final Project project = qm.createProject("Acme Application", null, null, null, null, null, true, false);
         final List<String> directDepencencies = new ArrayList<>();


### PR DESCRIPTION
### Description

On the `Components` tab, search components also by group. Today it only searches by name but some components use generic names and differentiate themselves by group. For example, `@angular/corehas` group `https://github.com/angular` and name `core`, so searching for `angular` I don't get all the Angular packages on the results.

### Addressed Issue

Backport : https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
