### PR TITLE
Port : Fix vex export returning invalid CycloneDX

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <lib.cpe-parser.version>2.1.0</lib.cpe-parser.version>
         <lib.cvss-calculator.version>1.4.3</lib.cvss-calculator.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
-        <lib.cyclonedx-java.version>9.0.4</lib.cyclonedx-java.version>
+        <lib.cyclonedx-java.version>9.0.5</lib.cyclonedx-java.version>
         <lib.jaxb.runtime.version>4.0.5</lib.jaxb.runtime.version>
         <lib.jdbi.version>3.45.3</lib.jdbi.version>
         <lib.json-unit.version>3.4.1</lib.json-unit.version>

--- a/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -80,14 +80,13 @@ public class CycloneDXExporter {
         }
         final List<org.cyclonedx.model.Component> cycloneComponents = (Variant.VEX != variant && components != null) ? components.stream().map(component -> ModelConverter.convert(qm, component)).collect(Collectors.toList()) : null;
         final List<org.cyclonedx.model.Service> cycloneServices = (Variant.VEX != variant && services != null) ? services.stream().map(service -> ModelConverter.convert(qm, service)).collect(Collectors.toList()) : null;
-        final List<org.cyclonedx.model.vulnerability.Vulnerability> cycloneVulnerabilities = (findings != null) ? findings.stream().map(finding -> ModelConverter.convert(qm, variant, finding)).collect(Collectors.toList()) : null;
         final Bom bom = new Bom();
         bom.setSerialNumber("urn:uuid:" + UUID.randomUUID());
         bom.setVersion(1);
         bom.setMetadata(ModelConverter.createMetadata(project));
         bom.setComponents(cycloneComponents);
         bom.setServices(cycloneServices);
-        bom.setVulnerabilities(cycloneVulnerabilities);
+        bom.setVulnerabilities(ModelConverter.generateVulnerabilities(qm, variant, findings));
         if (cycloneComponents != null) {
             bom.setDependencies(ModelConverter.generateDependencies(project, components));
         }

--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -22,6 +22,10 @@ import alpine.common.logging.Logger;
 import alpine.model.IConfigProperty;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.StringUtils;
@@ -59,10 +63,6 @@ import org.dependencytrack.parser.spdx.expression.model.SpdxExpression;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.VulnerabilityUtil;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.json.JsonValue;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1188,4 +1188,18 @@ public class ModelConverter {
         }
     }
 
+    public static List<org.cyclonedx.model.vulnerability.Vulnerability> generateVulnerabilities(
+            final QueryManager qm,
+            final CycloneDXExporter.Variant variant,
+            final List<Finding> findings
+    ) {
+        if (findings == null) {
+            return Collections.emptyList();
+        }
+        final var vulnerabilitiesSeen = new HashSet<org.cyclonedx.model.vulnerability.Vulnerability>();
+        return findings.stream()
+                .map(finding -> convert(qm, variant, finding))
+                .filter(vulnerabilitiesSeen::add)
+                .toList();
+    }
 }

--- a/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
+++ b/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDxValidatorTest.java
@@ -153,7 +153,7 @@ public class CycloneDxValidatorTest {
                 .extracting(InvalidBomException::getValidationErrors).asList()
                 .containsExactly("""
                         $.components[0].type: does not have a value in the enumeration \
-                        [application, framework, library, container, operating-system, device, firmware, file]\
+                        ["application", "framework", "library", "container", "operating-system", "device", "firmware", "file"]\
                         """);
     }
 

--- a/src/test/java/org/dependencytrack/policy/validation/PolicySchemaValidationTest.java
+++ b/src/test/java/org/dependencytrack/policy/validation/PolicySchemaValidationTest.java
@@ -59,9 +59,9 @@ public class PolicySchemaValidationTest {
         JsonNode jsonNode = objMapper.readTree(policyContent);
         Set<ValidationMessage> validateMsg = schema.validate(jsonNode);
         assertThat(validateMsg).satisfiesExactlyInAnyOrder(
-                error -> assertThat(error.getMessage()).isEqualTo("$.analysis.justification: does not have a value in the enumeration [CODE_NOT_PRESENT, CODE_NOT_REACHABLE, REQUIRES_CONFIGURATION, REQUIRES_DEPENDENCY, REQUIRES_ENVIRONMENT, PROTECTED_BY_COMPILER, PROTECTED_AT_RUNTIME, PROTECTED_AT_PERIMETER, PROTECTED_BY_MITIGATING_CONTROL]"),
-                error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].severity: does not have a value in the enumeration [CRITICAL, HIGH, MEDIUM, LOW, INFO, UNASSIGNED]"),
-                error -> assertThat(error.getMessage()).contains("$.ratings[0].vector: does not match the regex pattern"),
+                error -> assertThat(error.getMessage()).isEqualTo("$.analysis.justification: does not have a value in the enumeration [\"CODE_NOT_PRESENT\", \"CODE_NOT_REACHABLE\", \"REQUIRES_CONFIGURATION\", \"REQUIRES_DEPENDENCY\", \"REQUIRES_ENVIRONMENT\", \"PROTECTED_BY_COMPILER\", \"PROTECTED_AT_RUNTIME\", \"PROTECTED_AT_PERIMETER\", \"PROTECTED_BY_MITIGATING_CONTROL\"]"),
+                error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].severity: does not have a value in the enumeration [\"CRITICAL\", \"HIGH\", \"MEDIUM\", \"LOW\", \"INFO\", \"UNASSIGNED\"]"),
+                error -> assertThat(error.getMessage()).contains("$.ratings[0].vector: does not match the regex pattern (SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d)|(AV:(N|A|L)\\/AC:(L|M|H)\\/A[Uu]:(N|S|M)\\/C:(N|P|C)\\/I:(N|P|C)\\/A:(N|P|C)|AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H))|(AV:(N|A|L|P)\\/AC:(L|H)\\/PR:(N|L|H)\\/UI:(N|R)\\/S:(U|C)\\/C:(N|L|H)\\/I:(N|L|H)\\/A:(N|L|H)\\/E:(F|H|U|P|X)\\/RL:(W|U|T|O|X)\\/RC:(C|R|U|X)\\/CR:(X|L|M|H)\\/IR:(X|L|M|H)\\/AR:(X|L|M|H)\\/MAV:(X|N|A|L|P)\\/MAC:(X|L|H)\\/MPR:(X|N|L|H)\\/MUI:(X|N|R)\\/MS:(X|U|C)\\/MC:(X|N|L|H)\\/MI:(X|N|L|H)\\/MA:(X|N|L|H)"),
                 error -> assertThat(error.getMessage()).isEqualTo("$.ratings[0].score: string found, number expected")
         );
     }

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -1259,7 +1259,7 @@ public class BomResourceTest extends ResourceTest {
                   "title": "The uploaded BOM is invalid",
                   "detail": "Schema validation failed",
                   "errors": [
-                    "$.components[0].type: does not have a value in the enumeration [application, framework, library, container, operating-system, device, firmware, file]"
+                    "$.components[0].type: does not have a value in the enumeration [\\"application\\", \\"framework\\", \\"library\\", \\"container\\", \\"operating-system\\", \\"device\\", \\"firmware\\", \\"file\\"]"
                   ]
                 }
                 """);

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -351,4 +351,224 @@ public class VexResourceTest extends ResourceTest {
                 """);
     }
 
+    @Test
+    public void exportVexWithSameVulnAnalysisValidJsonTest() {
+        var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setClassifier(Classifier.APPLICATION);
+        qm.persist(project);
+
+        var componentAWithVuln = new Component();
+        componentAWithVuln.setProject(project);
+        componentAWithVuln.setName("acme-lib-a");
+        componentAWithVuln.setVersion("1.0.0");
+        componentAWithVuln = qm.createComponent(componentAWithVuln, false);
+
+        var componentBWithVuln = new Component();
+        componentBWithVuln.setProject(project);
+        componentBWithVuln.setName("acme-lib-b");
+        componentBWithVuln.setVersion("1.0.0");
+        componentBWithVuln = qm.createComponent(componentBWithVuln, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, componentAWithVuln, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentAWithVuln, vuln, AnalysisState.RESOLVED, null, AnalysisResponse.UPDATE, null, true);
+        qm.addVulnerability(vuln, componentBWithVuln, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentBWithVuln, vuln, AnalysisState.RESOLVED, null, AnalysisResponse.UPDATE, null, true);
+
+        qm.persist(project);
+
+        final Response response = jersey.target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String jsonResponse = getPlainTextBody(response);
+        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatJson(jsonResponse)
+                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
+                .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .isEqualTo("""
+                        {
+                          "bomFormat": "CycloneDX",
+                          "specVersion": "1.5",
+                          "serialNumber": "${json-unit.any-string}",
+                          "version": 1,
+                          "metadata": {
+                            "timestamp": "${json-unit.any-string}",
+                            "component": {
+                              "type": "application",
+                              "bom-ref": "${json-unit.matches:projectUuid}",
+                              "name": "acme-app",
+                              "version": "1.0.0"
+                            },
+                            "tools": [
+                              {
+                                "vendor": "OWASP",
+                                "name": "Dependency-Track",
+                                "version": "${json-unit.any-string}"
+                              }
+                            ]
+                          },
+                          "vulnerabilities": [
+                            {
+                              "bom-ref": "${json-unit.matches:vulnUuid}",
+                              "id": "INT-001",
+                              "source": {
+                                "name": "INTERNAL"
+                              },
+                              "ratings": [
+                                {
+                                  "source": {
+                                    "name": "INTERNAL"
+                                  },
+                                  "severity": "high",
+                                  "method": "other"
+                                }
+                              ],
+                              "analysis":{
+                                "state": "resolved",
+                                "response": [
+                                  "update"
+                                ]
+                              },
+                              "affects": [
+                                {
+                                  "ref": "${json-unit.matches:projectUuid}"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """);
+    }
+
+    @Test
+    public void exportVexWithDifferentVulnAnalysisValidJsonTest() {
+        var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setClassifier(Classifier.APPLICATION);
+        qm.persist(project);
+
+        var componentAWithVuln = new Component();
+        componentAWithVuln.setProject(project);
+        componentAWithVuln.setName("acme-lib-a");
+        componentAWithVuln.setVersion("1.0.0");
+        componentAWithVuln = qm.createComponent(componentAWithVuln, false);
+
+        var componentBWithVuln = new Component();
+        componentBWithVuln.setProject(project);
+        componentBWithVuln.setName("acme-lib-b");
+        componentBWithVuln.setVersion("1.0.0");
+        componentBWithVuln = qm.createComponent(componentBWithVuln, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, componentAWithVuln, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentAWithVuln, vuln, AnalysisState.IN_TRIAGE, null, AnalysisResponse.UPDATE, null, true);
+        qm.addVulnerability(vuln, componentBWithVuln, AnalyzerIdentity.NONE);
+        qm.makeAnalysis(componentBWithVuln, vuln, AnalysisState.EXPLOITABLE, null, AnalysisResponse.UPDATE, null, true);
+
+        qm.persist(project);
+
+        final Response response = jersey.target("%s/cyclonedx/project/%s".formatted(V1_VEX, project.getUuid()))
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        final String jsonResponse = getPlainTextBody(response);
+        assertThatNoException().isThrownBy(() -> CycloneDxValidator.getInstance().validate(jsonResponse.getBytes()));
+        assertThatJson(jsonResponse)
+                .withMatcher("vulnUuid", equalTo(vuln.getUuid().toString()))
+                .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
+                .isEqualTo("""
+                        {
+                          "bomFormat": "CycloneDX",
+                          "specVersion": "1.5",
+                          "serialNumber": "${json-unit.any-string}",
+                          "version": 1,
+                          "metadata": {
+                            "timestamp": "${json-unit.any-string}",
+                            "component": {
+                              "type": "application",
+                              "bom-ref": "${json-unit.matches:projectUuid}",
+                              "name": "acme-app",
+                              "version": "1.0.0"
+                            },
+                            "tools": [
+                              {
+                                "vendor": "OWASP",
+                                "name": "Dependency-Track",
+                                "version": "${json-unit.any-string}"
+                              }
+                            ]
+                          },
+                          "vulnerabilities": [
+                            {
+                              "bom-ref": "${json-unit.matches:vulnUuid}",
+                              "id": "INT-001",
+                              "source": {
+                                "name": "INTERNAL"
+                              },
+                              "ratings": [
+                                {
+                                  "source": {
+                                    "name": "INTERNAL"
+                                  },
+                                  "severity": "high",
+                                  "method": "other"
+                                }
+                              ],
+                              "analysis":{
+                                "state": "in_triage",
+                                "response": [
+                                  "update"
+                                ]
+                              },
+                              "affects": [
+                                {
+                                  "ref": "${json-unit.matches:projectUuid}"
+                                }
+                              ]
+                            },
+                            {
+                              "bom-ref": "${json-unit.matches:vulnUuid}",
+                              "id": "INT-001",
+                              "source": {
+                                "name": "INTERNAL"
+                              },
+                              "ratings": [
+                                {
+                                  "source": {
+                                    "name": "INTERNAL"
+                                  },
+                                  "severity": "high",
+                                  "method": "other"
+                                }
+                              ],
+                              "analysis":{
+                                "state": "exploitable",
+                                "response": [
+                                  "update"
+                                ]
+                              },
+                              "affects": [
+                                {
+                                  "ref": "${json-unit.matches:projectUuid}"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                        """);
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -271,7 +271,7 @@ public class VexResourceTest extends ResourceTest {
                   "title": "The uploaded BOM is invalid",
                   "detail": "Schema validation failed",
                   "errors": [
-                    "$.components[0].type: does not have a value in the enumeration [application, framework, library, container, operating-system, device, firmware, file]"
+                    "$.components[0].type: does not have a value in the enumeration [\\"application\\", \\"framework\\", \\"library\\", \\"container\\", \\"operating-system\\", \\"device\\", \\"firmware\\", \\"file\\"]"
                   ]
                 }
                 """);


### PR DESCRIPTION
### Description

Back-ports fix for exported VEX and BOMs with duplicate vulnerabilities.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
