### PR TITLE
Use native UUID type for UUID colums

### DIFF
--- a/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
+++ b/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
@@ -89,7 +89,7 @@ public class AffectedVersionAttribution implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "AFFECTEDVERSIONATTRIBUTION_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     private UUID uuid;
 
     public AffectedVersionAttribution() {

--- a/src/main/java/org/dependencytrack/model/Bom.java
+++ b/src/main/java/org/dependencytrack/model/Bom.java
@@ -100,7 +100,7 @@ public class Bom implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "BOM_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -380,7 +380,7 @@ public class Component implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "COMPONENT_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/ComponentProperty.java
+++ b/src/main/java/org/dependencytrack/model/ComponentProperty.java
@@ -110,7 +110,7 @@ public class ComponentProperty implements IConfigProperty, Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "COMPONENT_PROPERTY_UUID_IDX")
-    @Column(name = "UUID", allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/FindingAttribution.java
+++ b/src/main/java/org/dependencytrack/model/FindingAttribution.java
@@ -87,7 +87,7 @@ public class FindingAttribution implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "FINDINGATTRIBUTION_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/License.java
+++ b/src/main/java/org/dependencytrack/model/License.java
@@ -216,7 +216,7 @@ public class License implements Serializable {
      */
     @Persistent(defaultFetchGroup = "true", customValueStrategy = "uuid")
     @Unique(name = "LICENSE_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/LicenseGroup.java
+++ b/src/main/java/org/dependencytrack/model/LicenseGroup.java
@@ -90,7 +90,7 @@ public class LicenseGroup implements Serializable {
      */
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "LICENSEGROUP_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/NotificationPublisher.java
+++ b/src/main/java/org/dependencytrack/model/NotificationPublisher.java
@@ -110,7 +110,7 @@ public class NotificationPublisher implements Serializable {
 
     @Persistent(defaultFetchGroup = "true", customValueStrategy = "uuid")
     @Unique(name = "NOTIFICATIONPUBLISHER_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -144,7 +144,7 @@ public class NotificationRule implements Serializable {
 
     @Persistent(defaultFetchGroup = "true", customValueStrategy = "uuid")
     @Unique(name = "NOTIFICATIONRULE_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/Policy.java
+++ b/src/main/java/org/dependencytrack/model/Policy.java
@@ -131,7 +131,7 @@ public class Policy implements Serializable {
      */
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "POLICY_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -130,7 +130,7 @@ public class PolicyCondition implements Serializable {
      */
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "POLICYCONDITION_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/PolicyViolation.java
+++ b/src/main/java/org/dependencytrack/model/PolicyViolation.java
@@ -100,7 +100,7 @@ public class PolicyViolation implements Serializable {
      */
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "POLICYVIOLATION_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -234,7 +234,7 @@ public class Project implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "PROJECT_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/Repository.java
+++ b/src/main/java/org/dependencytrack/model/Repository.java
@@ -103,8 +103,7 @@ public class Repository implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Index(name = "REPOSITORY_UUID_IDX") // Cannot be @Unique. Microsoft SQL Server throws an exception
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "true")
-    // New column, must allow nulls on existing databases
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "true")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/ServiceComponent.java
+++ b/src/main/java/org/dependencytrack/model/ServiceComponent.java
@@ -190,7 +190,7 @@ public class ServiceComponent implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "SERVICECOMPONENT_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/Vex.java
+++ b/src/main/java/org/dependencytrack/model/Vex.java
@@ -99,7 +99,7 @@ public class Vex implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "VEX_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -316,7 +316,7 @@ public class Vulnerability implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "VULNERABILITY_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
+++ b/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
@@ -112,7 +112,7 @@ public class VulnerabilityAlias implements Serializable {
 
     @Persistent(customValueStrategy = "uuid")
     @Unique(name = "VULNERABILITYALIAS_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID uuid;
 

--- a/src/main/java/org/dependencytrack/model/VulnerabilityScan.java
+++ b/src/main/java/org/dependencytrack/model/VulnerabilityScan.java
@@ -68,7 +68,7 @@ public class VulnerabilityScan {
      * Unique identifier of the entity targeted by this scan.
      */
     @Persistent
-    @Column(name = "TARGET_IDENTIFIER", allowsNull = "false")
+    @Column(name = "TARGET_IDENTIFIER", sqlType = "UUID", allowsNull = "false")
     private UUID targetIdentifier;
 
     /**

--- a/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -170,7 +170,7 @@ public class VulnerableSoftware implements ICpe, Serializable {
 
     @Persistent(defaultFetchGroup = "true", customValueStrategy = "uuid")
     @Unique(name = "VULNERABLESOFTWARE_UUID_IDX")
-    @Column(name = "UUID", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
     private UUID uuid;
 
     private transient List<AffectedVersionAttribution> affectedVersionAttributions;

--- a/src/main/java/org/dependencytrack/model/WorkflowState.java
+++ b/src/main/java/org/dependencytrack/model/WorkflowState.java
@@ -49,7 +49,7 @@ public class WorkflowState implements Serializable {
     private WorkflowState parent;
 
     @Persistent
-    @Column(name = "TOKEN", jdbcType = "VARCHAR", length = 36, allowsNull = "false")
+    @Column(name = "TOKEN", sqlType = "UUID", allowsNull = "false")
     @NotNull
     private UUID token;
 

--- a/src/main/resources/migration/changelog-v5.5.0.xml
+++ b/src/main/resources/migration/changelog-v5.5.0.xml
@@ -170,4 +170,28 @@
         <addDefaultValue tableName="VULNERABILITY_POLICY" columnName="OPERATION_MODE" defaultValue="APPLY"/>
         <addNotNullConstraint tableName="VULNERABILITY_POLICY" columnName="OPERATION_MODE"/>
     </changeSet>
+
+    <changeSet id="v5.5.0-15" author="sahibamittal">
+        <modifyDataType tableName="AFFECTEDVERSIONATTRIBUTION" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="BOM" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="COMPONENT" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="COMPONENT_PROPERTY" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="FINDINGATTRIBUTION" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="LICENSE" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="LICENSEGROUP" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="NOTIFICATIONPUBLISHER" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="NOTIFICATIONRULE" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="POLICY" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="POLICYCONDITION" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="POLICYVIOLATION" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="PROJECT" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="REPOSITORY" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="SERVICECOMPONENT" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="VEX" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="VULNERABILITY" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="VULNERABILITYALIAS" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="VULNERABILITYSCAN" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="VULNERABLESOFTWARE" columnName="UUID" newDataType="UUID"/>
+        <modifyDataType tableName="WORKFLOW_STATE" columnName="UUID" newDataType="UUID"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

Replace `UUID` columns type from `VARCHAR` to Postgres native `UUID`.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1417

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
