### PR TITLE
Add `init.and.exit` and `init.tasks.enabled` options

### DIFF
--- a/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -99,6 +99,8 @@ public enum ConfigKey implements Config.Key {
     DATABASE_MIGRATION_PASSWORD("database.migration.password", null),
     DATABASE_RUN_MIGRATIONS("database.run.migrations", true),
     DATABASE_RUN_MIGRATIONS_ONLY("database.run.migrations.only", false),
+    INIT_TASKS_ENABLED("init.tasks.enabled", true),
+    INIT_AND_EXIT("init.and.exit", false),
 
     DEV_SERVICES_ENABLED("dev.services.enabled", false),
     DEV_SERVICES_IMAGE_FRONTEND("dev.services.image.frontend", "ghcr.io/dependencytrack/hyades-frontend:snapshot"),

--- a/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
@@ -22,6 +22,8 @@ import alpine.Config;
 import alpine.common.logging.Logger;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 import liquibase.Liquibase;
 import liquibase.Scope;
 import liquibase.UpdateSummaryOutputEnum;
@@ -36,8 +38,6 @@ import liquibase.resource.ClassLoaderResourceAccessor;
 import liquibase.ui.LoggerUIService;
 import org.dependencytrack.common.ConfigKey;
 
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
 import javax.sql.DataSource;
 import java.util.HashMap;
 import java.util.Optional;
@@ -59,8 +59,14 @@ public class MigrationInitializer implements ServletContextListener {
 
     @Override
     public void contextInitialized(final ServletContextEvent event) {
+        if (!config.getPropertyAsBoolean(ConfigKey.INIT_TASKS_ENABLED)) {
+            LOGGER.info("Not running migrations because %s is disabled"
+                    .formatted(ConfigKey.INIT_TASKS_ENABLED.getPropertyName()));
+            return;
+        }
         if (!config.getPropertyAsBoolean(ConfigKey.DATABASE_RUN_MIGRATIONS)) {
-            LOGGER.info("Migrations are disabled; Skipping");
+            LOGGER.info("Not running migrations because %s is disabled"
+                    .formatted(ConfigKey.DATABASE_RUN_MIGRATIONS.getPropertyName()));
             return;
         }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -241,6 +241,10 @@ alpine.database.pool.max.lifetime=600000
 alpine.datanucleus.cache.level2.type=none
 
 # Defines whether database migrations should be executed on startup.
+# <br/><br/>
+# From v5.6.0 onwards, migrations are considered part of the initialization tasks.
+# Setting init.tasks.enabled to `false` will disable migrations,
+# even if database.run.migrations is enabled.
 #
 # @category: Database
 # @type:     boolean
@@ -249,6 +253,8 @@ database.run.migrations=true
 # Defines whether the application should exit upon successful execution of database migrations.
 # Enabling this option makes the application suitable for running as k8s init container.
 # Has no effect unless database.run.migrations is `true`.
+# <br/><br/>
+# From v5.6.0 onwards, usage of init.and.exit should be preferred.
 #
 # @category: Database
 # @type:     boolean
@@ -1290,6 +1296,23 @@ vulnerability.policy.s3.bundle.name=
 # @category: General
 # @type:     string
 vulnerability.policy.s3.region=
+
+# Whether to execute initialization tasks on startup.
+# Initialization tasks include:
+# <ul>
+#   <li>Execution of database migrations</li>
+#   <li>Populating the database with default objects (permissions, users, licenses, etc.)</li>
+# </ul>
+#
+# @category: General
+# @type:     boolean
+init.tasks.enabled=true
+
+# Whether to only execute initialization tasks and exit.
+#
+# @category: General
+# @type:     boolean
+init.and.exit=false
 
 # Whether dev services shall be enabled.
 # <br/><br/>

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -20,17 +20,24 @@ package org.dependencytrack.persistence;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.License;
+import org.dependencytrack.model.Repository;
 import org.dependencytrack.notification.publisher.DefaultNotificationPublishers;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
+
+    @Rule
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Test
     public void testContextInitialized() throws Exception {
@@ -40,6 +47,20 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
         testLoadDefaultRepositories();
         testLoadDefaultConfigProperties();
         testLoadDefaultNotificationPublishers();
+    }
+
+    @Test
+    public void testWithInitTasksDisabled() {
+        environmentVariables.set(ConfigKey.INIT_TASKS_ENABLED.name(), "false");
+
+        new DefaultObjectGenerator().contextInitialized(null);
+
+        assertThat(qm.getPermissions()).isEmpty();
+        assertThat(qm.getManagedUsers()).isEmpty();
+        assertThat(qm.getLicenses().getList(License.class)).isEmpty();
+        assertThat(qm.getRepositories().getList(Repository.class)).isEmpty();
+        assertThat(qm.getConfigProperties()).isEmpty();
+        assertThat(qm.getAllNotificationPublishers()).isEmpty();
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/persistence/migration/MigrationInitializerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/migration/MigrationInitializerTest.java
@@ -20,12 +20,16 @@ package org.dependencytrack.persistence.migration;
 
 import alpine.Config;
 import org.dependencytrack.common.ConfigKey;
+import org.jdbi.v3.core.Jdbi;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -33,11 +37,18 @@ import static org.mockito.Mockito.when;
 public class MigrationInitializerTest {
 
     private PostgreSQLContainer<?> postgresContainer;
+    private Jdbi jdbi;
 
     @Before
     public void setUp() {
         postgresContainer = new PostgreSQLContainer<>(DockerImageName.parse("postgres:11-alpine"));
         postgresContainer.start();
+
+        jdbi = Jdbi.create(
+                postgresContainer.getJdbcUrl(),
+                postgresContainer.getUsername(),
+                postgresContainer.getPassword()
+        );
     }
 
     @After
@@ -54,9 +65,12 @@ public class MigrationInitializerTest {
         when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(postgresContainer.getDriverClassName());
         when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn(postgresContainer.getUsername());
         when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn(postgresContainer.getPassword());
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.INIT_TASKS_ENABLED))).thenReturn(true);
         when(configMock.getPropertyAsBoolean(eq(ConfigKey.DATABASE_RUN_MIGRATIONS))).thenReturn(true);
 
         new MigrationInitializer(configMock).contextInitialized(null);
+
+        assertMigrationExecuted(/* expectExecuted */ true);
     }
 
     @Test
@@ -66,11 +80,60 @@ public class MigrationInitializerTest {
         when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(postgresContainer.getDriverClassName());
         when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn("username");
         when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn("password");
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.INIT_TASKS_ENABLED))).thenReturn(true);
         when(configMock.getPropertyAsBoolean(eq(ConfigKey.DATABASE_RUN_MIGRATIONS))).thenReturn(true);
         when(configMock.getProperty(eq(ConfigKey.DATABASE_MIGRATION_USERNAME))).thenReturn(postgresContainer.getUsername());
         when(configMock.getProperty(eq(ConfigKey.DATABASE_MIGRATION_PASSWORD))).thenReturn(postgresContainer.getPassword());
 
         new MigrationInitializer(configMock).contextInitialized(null);
+
+        assertMigrationExecuted(/* expectExecuted */ true);
+    }
+
+    @Test
+    public void testWithRunMigrationsDisabled() {
+        final var configMock = mock(Config.class);
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_URL))).thenReturn(postgresContainer.getJdbcUrl());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(postgresContainer.getDriverClassName());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn(postgresContainer.getUsername());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn(postgresContainer.getPassword());
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.INIT_TASKS_ENABLED))).thenReturn(true);
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.DATABASE_RUN_MIGRATIONS))).thenReturn(false);
+
+        new MigrationInitializer(configMock).contextInitialized(null);
+
+        assertMigrationExecuted(/* expectExecuted */ false);
+    }
+
+    @Test
+    public void testWithInitTasksDisabled() {
+        final var configMock = mock(Config.class);
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_URL))).thenReturn(postgresContainer.getJdbcUrl());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_DRIVER))).thenReturn(postgresContainer.getDriverClassName());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_USERNAME))).thenReturn(postgresContainer.getUsername());
+        when(configMock.getProperty(eq(Config.AlpineKey.DATABASE_PASSWORD))).thenReturn(postgresContainer.getPassword());
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.INIT_TASKS_ENABLED))).thenReturn(false);
+        when(configMock.getPropertyAsBoolean(eq(ConfigKey.DATABASE_RUN_MIGRATIONS))).thenReturn(true);
+
+        new MigrationInitializer(configMock).contextInitialized(null);
+
+        assertMigrationExecuted(/* expectExecuted */ false);
+    }
+
+    private void assertMigrationExecuted(final boolean expectExecuted) {
+        final List<String> tableNames = jdbi.withHandle(handle -> handle.createQuery("""
+                        SELECT "table_name"
+                          FROM "information_schema"."tables"
+                         WHERE "table_schema" NOT IN ('pg_catalog', 'information_schema')
+                        """)
+                .mapTo(String.class)
+                .list());
+
+        if (expectExecuted) {
+            assertThat(tableNames).isNotEmpty();
+        } else {
+            assertThat(tableNames).isEmpty();
+        }
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds `init.and.exit` and `init.tasks.enabled` options.

These new options enable the API server to be used as Kubernetes `Job` to perform initialization tasks that multiple services rely on. See https://github.com/DependencyTrack/helm-charts/issues/136

The property naming is aligned to Quarkus' conventions as per https://quarkus.io/guides/init-tasks

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
