### PR TITLE
Specify `metadata-complete="true"` in `web.xml`

### DIFF
--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -21,6 +21,7 @@
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         metadata-complete="true"
          version="3.1">
     <listener>
         <listener-class>org.dependencytrack.dev.DevServicesInitializer</listener-class>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Noticed that there is a significant delay of up to 10sec between Jetty starting, and the DT application being launched, when the API server container is running with few CPU resources available (i.e. in a k8s environment).

Example log:

```
2024-08-27 15:52:49,765 INFO [EmbeddedJettyServer] alpine-executable-war v3.0.1 (da593953-8d16-43f3-8983-e6267664ec88) built on: 2024-08-14T16:20:04Z
2024-08-27 15:52:50,707 INFO [Server] jetty-12.0.12; built: 2024-07-25T21:58:37.668Z; git: cc6f1b74db755fed228b50701ad967aeaa68e83f; jvm 21.0.3+9-LTS
2024-08-27 15:52:58,168 INFO [StandardDescriptorProcessor] NO JSP Support for /, did not find org.eclipse.jetty.ee10.jsp.JettyJspServlet
2024-08-27 15:52:58,307 INFO [Config] --------------------------------------------------------------------------------
2024-08-27 15:52:58,308 INFO [Config] OS Name:      Linux
2024-08-27 15:52:58,308 INFO [Config] OS Version:   6.5.0-1025-azure
2024-08-27 15:52:58,309 INFO [Config] OS Arch:      amd64
2024-08-27 15:52:58,309 INFO [Config] CPU Cores:    1
2024-08-27 15:52:58,365 INFO [Config] Max Memory:   121.8 MB (127,729,664.0 bytes)
2024-08-27 15:52:58,366 INFO [Config] Java Vendor:  Eclipse Adoptium
2024-08-27 15:52:58,366 INFO [Config] Java Version: 21.0.3+9-LTS
2024-08-27 15:52:58,367 INFO [Config] Java Home:    /opt/java/openjdk
2024-08-27 15:52:58,367 INFO [Config] Java Temp:    /tmp
2024-08-27 15:52:58,367 INFO [Config] User:         dtrack
2024-08-27 15:52:58,367 INFO [Config] User Home:    /data/
2024-08-27 15:52:58,367 INFO [Config] --------------------------------------------------------------------------------
2024-08-27 15:52:58,367 INFO [Config] Initializing Configuration
```

At least part of the culprit appears to be that Jetty is scanning all class files on startup for any Java EE servlet annotations, as described here: https://jetty.org/docs/jetty/12/operations-guide/annotations/index.html#scanning

Specifying `metadata-complete` as `true` in `web.xml` disables this behavior. There are more possible tweaks WRT classpath scanning in Jetty, but this is an easy one to start out with.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
