### PR TITLE
Avoid redundant defaultobject generation

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 public enum ConfigPropertyConstants {
 
     INTERNAL_CLUSTER_ID("internal", "cluster.id", UUID.randomUUID().toString(), PropertyType.STRING, "Unique identifier of the cluster", ConfigPropertyAccessMode.READ_ONLY),
+    INTERNAL_DEFAULT_OBJECTS_VERSION("internal", "default.objects.version", null, PropertyType.STRING, "Version of the default objects in the database", ConfigPropertyAccessMode.READ_ONLY),
     GENERAL_BASE_URL("general", "base.url", null, PropertyType.URL, "URL used to construct links back to Dependency-Track from external systems", ConfigPropertyAccessMode.READ_WRITE),
     GENERAL_BADGE_ENABLED("general", "badge.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable SVG badge support from metrics", ConfigPropertyAccessMode.READ_WRITE),
     EMAIL_SMTP_ENABLED("email", "smtp.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable SMTP", ConfigPropertyAccessMode.READ_WRITE),

--- a/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -61,6 +62,23 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
         assertThat(qm.getRepositories().getList(Repository.class)).isEmpty();
         assertThat(qm.getConfigProperties()).isEmpty();
         assertThat(qm.getAllNotificationPublishers()).isEmpty();
+    }
+
+    @Test
+    public void testWithDefaultObjectsAlreadyPopulated() {
+        new DefaultObjectGenerator().contextInitialized(null);
+
+        List<License> licenses = qm.getLicenses().getList(License.class);
+        assertThat(licenses).isNotEmpty();
+
+        qm.delete(licenses);
+
+        new DefaultObjectGenerator().contextInitialized(null);
+
+        // Default objects must not have been populated again, since their
+        // version is already current for this application build.
+        licenses = qm.getLicenses().getList(License.class);
+        assertThat(licenses).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Description

> [!WARNING]
> This PR is based on #877.

Instead of re-running the default object generation, keep track of their version (currently, the build UUID of the application) in the `CONFIGPROPERTY` table. If the current application's build UUID matches that in the database, no action is performed.

This improved startup performance, since tasks like the synchronization of ~700 licenses is not cheap to do.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/helm-charts/issues/136

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
