### PR TITLE
Add SQL function to query vuln aliases as `JSONB`

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -132,7 +132,7 @@ public interface NotificationSubjectDao extends SqlObject {
               END                              AS "vulnOwaspRrVector",
               COALESCE("A"."SEVERITY", "V"."SEVERITY") AS "vulnSeverity",
               STRING_TO_ARRAY("V"."CWES", ',') AS "vulnCwes",
-              "vulnAliasesJson",
+              JSONB_VULN_ALIASES("V"."SOURCE", "V"."VULNID") AS "vulnAliasesJson",
               :vulnAnalysisLevel               AS "vulnAnalysisLevel",
               '/api/v1/vulnerability/source/' || "V"."SOURCE" || '/vuln/' || "V"."VULNID" || '/projects' AS "affectedProjectsApiUrl",
               '/vulnerabilities/' || "V"."SOURCE" || '/' || "V"."VULNID" || '/affectedProjects'          AS "affectedProjectsFrontendUrl"
@@ -146,30 +146,6 @@ public interface NotificationSubjectDao extends SqlObject {
               "VULNERABILITY" AS "V" ON "V"."ID" = "CV"."VULNERABILITY_ID"
             LEFT JOIN
               "ANALYSIS" AS "A" ON "A"."COMPONENT_ID" = "C"."ID" AND "A"."VULNERABILITY_ID" = "V"."ID"
-            LEFT JOIN LATERAL (
-              SELECT
-                CAST(JSONB_AGG(DISTINCT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
-                  'cveId',      "VA"."CVE_ID",
-                  'ghsaId',     "VA"."GHSA_ID",
-                  'gsdId',      "VA"."GSD_ID",
-                  'internalId', "VA"."INTERNAL_ID",
-                  'osvId',      "VA"."OSV_ID",
-                  'sonatypeId', "VA"."SONATYPE_ID",
-                  'snykId',     "VA"."SNYK_ID",
-                  'vulnDbId',   "VA"."VULNDB_ID"
-                ))) AS TEXT) AS "vulnAliasesJson"
-              FROM
-                "VULNERABILITYALIAS" AS "VA"
-              WHERE
-                ("V"."SOURCE" = 'NVD' AND "VA"."CVE_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'GITHUB' AND "VA"."GHSA_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'GSD' AND "VA"."GSD_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'INTERNAL' AND "VA"."INTERNAL_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'OSV' AND "VA"."OSV_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'SONATYPE' AND "VA"."SONATYPE_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'SNYK' AND "VA"."SNYK_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'VULNDB' AND "VA"."VULNDB_ID" = "V"."VULNID")
-            ) AS "vulnAliases" ON TRUE
             WHERE
               "C"."UUID" = :componentUuid AND "V"."UUID" = ANY(:vulnUuids)
               AND ("A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
@@ -246,7 +222,7 @@ public interface NotificationSubjectDao extends SqlObject {
               END                              AS "vulnOwaspRrVector",
               COALESCE("A"."SEVERITY", "V"."SEVERITY") AS "vulnSeverity",
               STRING_TO_ARRAY("V"."CWES", ',') AS "vulnCwes",
-              "vulnAliasesJson"
+              JSONB_VULN_ALIASES("V"."SOURCE", "V"."VULNID") AS "vulnAliasesJson"
             FROM
               "COMPONENT" AS "C"
             INNER JOIN
@@ -257,30 +233,6 @@ public interface NotificationSubjectDao extends SqlObject {
               "VULNERABILITY" AS "V" ON "V"."ID" = "CV"."VULNERABILITY_ID"
             LEFT JOIN
               "ANALYSIS" AS "A" ON "A"."COMPONENT_ID" = "C"."ID" AND "A"."VULNERABILITY_ID" = "V"."ID"
-            LEFT JOIN LATERAL (
-              SELECT
-                CAST(JSONB_AGG(DISTINCT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
-                  'cveId',      "VA"."CVE_ID",
-                  'ghsaId',     "VA"."GHSA_ID",
-                  'gsdId',      "VA"."GSD_ID",
-                  'internalId', "VA"."INTERNAL_ID",
-                  'osvId',      "VA"."OSV_ID",
-                  'sonatypeId', "VA"."SONATYPE_ID",
-                  'snykId',     "VA"."SNYK_ID",
-                  'vulnDbId',   "VA"."VULNDB_ID"
-                ))) AS TEXT) AS "vulnAliasesJson"
-              FROM
-                "VULNERABILITYALIAS" AS "VA"
-              WHERE
-                ("V"."SOURCE" = 'NVD' AND "VA"."CVE_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'GITHUB' AND "VA"."GHSA_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'GSD' AND "VA"."GSD_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'INTERNAL' AND "VA"."INTERNAL_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'OSV' AND "VA"."OSV_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'SONATYPE' AND "VA"."SONATYPE_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'SNYK' AND "VA"."SNYK_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'VULNDB' AND "VA"."VULNDB_ID" = "V"."VULNID")
-            ) AS "vulnAliases" ON TRUE
             WHERE
               "C"."UUID" = :componentUuid
               AND ("A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
@@ -356,7 +308,7 @@ public interface NotificationSubjectDao extends SqlObject {
               END                              AS "vulnOwaspRrVector",
               COALESCE("A"."SEVERITY", "V"."SEVERITY") AS "vulnSeverity",
               STRING_TO_ARRAY("V"."CWES", ',') AS "vulnCwes",
-              "vulnAliasesJson",
+              JSONB_VULN_ALIASES("V"."SOURCE", "V"."VULNID") AS "vulnAliasesJson",
               :isSuppressed              AS "isVulnAnalysisSuppressed",
               :analysisState             AS "vulnAnalysisState",
               '/api/v1/vulnerability/source/' || "V"."SOURCE" || '/vuln/' || "V"."VULNID" || '/projects' AS "affectedProjectsApiUrl",
@@ -371,30 +323,6 @@ public interface NotificationSubjectDao extends SqlObject {
               "VULNERABILITY" AS "V" ON "V"."ID" = "CV"."VULNERABILITY_ID"
             LEFT JOIN
               "ANALYSIS" AS "A" ON "A"."COMPONENT_ID" = "C"."ID" AND "A"."VULNERABILITY_ID" = "V"."ID"
-            LEFT JOIN LATERAL (
-              SELECT
-                CAST(JSONB_AGG(DISTINCT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
-                  'cveId',      "VA"."CVE_ID",
-                  'ghsaId',     "VA"."GHSA_ID",
-                  'gsdId',      "VA"."GSD_ID",
-                  'internalId', "VA"."INTERNAL_ID",
-                  'osvId',      "VA"."OSV_ID",
-                  'sonatypeId', "VA"."SONATYPE_ID",
-                  'snykId',     "VA"."SNYK_ID",
-                  'vulnDbId',   "VA"."VULNDB_ID"
-                ))) AS TEXT) AS "vulnAliasesJson"
-              FROM
-                "VULNERABILITYALIAS" AS "VA"
-              WHERE
-                ("V"."SOURCE" = 'NVD' AND "VA"."CVE_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'GITHUB' AND "VA"."GHSA_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'GSD' AND "VA"."GSD_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'INTERNAL' AND "VA"."INTERNAL_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'OSV' AND "VA"."OSV_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'SONATYPE' AND "VA"."SONATYPE_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'SNYK' AND "VA"."SNYK_ID" = "V"."VULNID")
-                  OR ("V"."SOURCE" = 'VULNDB' AND "VA"."VULNDB_ID" = "V"."VULNID")
-            ) AS "vulnAliases" ON TRUE
             WHERE
               "C"."UUID" = :componentUuid AND "V"."UUID" = :vulnUuid
             """)
@@ -506,32 +434,11 @@ public interface NotificationSubjectDao extends SqlObject {
                                END AS "vulnOwaspRrVector"
                              , COALESCE("A"."SEVERITY", "V"."SEVERITY") AS "vulnSeverity"
                              , STRING_TO_ARRAY("V"."CWES", ',') AS "vulnCwes"
-                             , "vulnAliasesJson"
+                             , JSONB_VULN_ALIASES("V"."SOURCE", "V"."VULNID") AS "vulnAliasesJson"
                          FROM "COMPONENT" AS "C"
                         INNER JOIN "COMPONENTS_VULNERABILITIES" AS "CV" ON "CV"."COMPONENT_ID" = "C"."ID"
                         INNER JOIN "VULNERABILITY" AS "V" ON "V"."ID" = "CV"."VULNERABILITY_ID"
                          LEFT JOIN "ANALYSIS" AS "A" ON "A"."COMPONENT_ID" = "C"."ID" AND "A"."VULNERABILITY_ID" = "V"."ID"
-                         LEFT JOIN LATERAL (
-                           SELECT CAST(JSONB_AGG(DISTINCT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
-                                                 'cveId',      "VA"."CVE_ID",
-                                                 'ghsaId',     "VA"."GHSA_ID",
-                                                 'gsdId',      "VA"."GSD_ID",
-                                                 'internalId', "VA"."INTERNAL_ID",
-                                                 'osvId',      "VA"."OSV_ID",
-                                                 'sonatypeId', "VA"."SONATYPE_ID",
-                                                 'snykId',     "VA"."SNYK_ID",
-                                                 'vulnDbId',   "VA"."VULNDB_ID"
-                                      ))) AS TEXT) AS "vulnAliasesJson"
-                             FROM "VULNERABILITYALIAS" AS "VA"
-                            WHERE ("V"."SOURCE" = 'NVD' AND "VA"."CVE_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'GITHUB' AND "VA"."GHSA_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'GSD' AND "VA"."GSD_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'INTERNAL' AND "VA"."INTERNAL_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'OSV' AND "VA"."OSV_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'SONATYPE' AND "VA"."SONATYPE_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'SNYK' AND "VA"."SNYK_ID" = "V"."VULNID")
-                               OR ("V"."SOURCE" = 'VULNDB' AND "VA"."VULNDB_ID" = "V"."VULNID")
-                         ) AS "vulnAliases" ON TRUE
                         WHERE "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
                           AND ("A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
                         """)

--- a/src/main/resources/migration/changelog-procedures.xml
+++ b/src/main/resources/migration/changelog-procedures.xml
@@ -11,6 +11,9 @@
     <changeSet id="function_calc-risk-score" author="nscuro@protonmail.com" runOnChange="true">
         <createProcedure path="procedures/function_calc-risk-score.sql" relativeToChangelogFile="true"/>
     </changeSet>
+    <changeSet id="function_jsonb-vuln-aliases" author="nscuro" runOnChange="true">
+        <createProcedure path="procedures/function_jsonb-vuln-aliases.sql" relativeToChangelogFile="true"/>
+    </changeSet>
     <changeSet id="procedure_update-component-metrics" author="nscuro@protonmail.com" runOnChange="true">
         <createProcedure path="procedures/procedure_update-component-metrics.sql" relativeToChangelogFile="true"/>
     </changeSet>

--- a/src/main/resources/migration/procedures/function_jsonb-vuln-aliases.sql
+++ b/src/main/resources/migration/procedures/function_jsonb-vuln-aliases.sql
@@ -1,0 +1,29 @@
+CREATE OR REPLACE FUNCTION JSONB_VULN_ALIASES(
+  "vuln_source" TEXT
+, "vuln_id" TEXT
+) RETURNS JSONB
+  LANGUAGE "sql"
+  PARALLEL SAFE
+  STABLE
+AS
+$$
+SELECT JSONB_AGG(DISTINCT JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
+         'cveId', "VA"."CVE_ID"
+       , 'ghsaId', "VA"."GHSA_ID"
+       , 'gsdId', "VA"."GSD_ID"
+       , 'internalId', "VA"."INTERNAL_ID"
+       , 'osvId', "VA"."OSV_ID"
+       , 'sonatypeId', "VA"."SONATYPE_ID"
+       , 'snykId', "VA"."SNYK_ID"
+       , 'vulnDbId', "VA"."VULNDB_ID"
+       )))
+  FROM "VULNERABILITYALIAS" AS "VA"
+ WHERE ("vuln_source" = 'NVD' AND "VA"."CVE_ID" = "vuln_id")
+    OR ("vuln_source" = 'GITHUB' AND "VA"."GHSA_ID" = "vuln_id")
+    OR ("vuln_source" = 'GSD' AND "VA"."GSD_ID" = "vuln_id")
+    OR ("vuln_source" = 'INTERNAL' AND "VA"."INTERNAL_ID" = "vuln_id")
+    OR ("vuln_source" = 'OSV' AND "VA"."OSV_ID" = "vuln_id")
+    OR ("vuln_source" = 'SONATYPE' AND "VA"."SONATYPE_ID" = "vuln_id")
+    OR ("vuln_source" = 'SNYK' AND "VA"."SNYK_ID" = "vuln_id")
+    OR ("vuln_source" = 'VULNDB' AND "VA"."VULNDB_ID" = "vuln_id")
+$$;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds a SQL function to query vulnerability aliases as `JSONB` array.

Removes quite a bit of repetition in our SQL queries, and voids the need to do `LATERAL JOIN`s to acquire this information. The new function can simply be executed in the `SELECT` clause of a query.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
