### PR TITLE
Support pagination and improve performance of `/api/v1/vulnerability/source/{source}/vuln/{vuln}/projects` endpoint

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * @since 5.6.0
+ */
+public interface VulnerabilityDao {
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="activeFilter" type="Boolean" -->
+            <#-- @ftlvariable name="apiOrderByClause" type="String" -->
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
+            WITH "CTE_AFFECTED_COMPONENTS" AS (
+              SELECT "COMPONENT"."UUID" AS "UUID"
+                   , "PROJECT"."ID" AS "PROJECT_ID"
+                FROM "COMPONENT"
+               INNER JOIN "PROJECT"
+                  ON "PROJECT"."ID" = "COMPONENT"."PROJECT_ID"
+               INNER JOIN "COMPONENTS_VULNERABILITIES"
+                  ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
+               INNER JOIN "VULNERABILITY"
+                  ON "VULNERABILITY"."ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
+               WHERE ${apiProjectAclCondition!"TRUE"}
+                 AND "VULNERABILITY"."SOURCE" = :source
+                 AND "VULNERABILITY"."VULNID" = :vulnId
+            <#if activeFilter>
+                 AND "PROJECT"."ACTIVE" = :activeFilter
+            </#if>
+            )
+            SELECT "UUID" AS "uuid"
+                 , "NAME" AS "name"
+                 , "VERSION" AS "version"
+                 , "ACTIVE" AS "active"
+                 , ("DIRECT_DEPENDENCIES" IS NOT NULL) AS "dependencyGraphAvailable"
+                 , (SELECT ARRAY_AGG("UUID")
+                      FROM "CTE_AFFECTED_COMPONENTS"
+                     WHERE "PROJECT_ID" = "PROJECT"."ID") AS "affectedComponentUuids"
+                 , COUNT(*) OVER() AS "totalCount"
+              FROM "PROJECT"
+             WHERE EXISTS(
+                 SELECT 1
+                   FROM "CTE_AFFECTED_COMPONENTS"
+                  WHERE "PROJECT_ID" = "PROJECT"."ID")
+            <#if apiOrderByClause??>
+              ${apiOrderByClause}
+            <#else>
+             ORDER BY "NAME" ASC, "VERSION" DESC
+            </#if>
+            ${apiOffsetLimitClause!}
+            """)
+    @DefineNamedBindings
+    @AllowApiOrdering(by = {
+            @AllowApiOrdering.Column(name = "name"),
+            @AllowApiOrdering.Column(name = "version"),
+            @AllowApiOrdering.Column(name = "active")
+    })
+    @RegisterConstructorMapper(AffectedProjectListRow.class)
+    List<AffectedProjectListRow> getAffectedProjects(
+            @Bind String source,
+            @Bind String vulnId,
+            @Bind Boolean activeFilter);
+
+    record AffectedProjectListRow(
+            UUID uuid,
+            String name,
+            String version,
+            boolean active,
+            boolean dependencyGraphAvailable,
+            List<UUID> affectedComponentUuids,
+            long totalCount) {
+    }
+
+}

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -55,6 +55,8 @@ import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
+import org.dependencytrack.persistence.jdbi.VulnerabilityDao.AffectedProjectListRow;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
 import org.dependencytrack.resources.v1.vo.AffectedProject;
@@ -67,6 +69,8 @@ import us.springett.owasp.riskrating.OwaspRiskRating;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 /**
  * JAX-RS resources for processing vulnerabilities.
@@ -233,36 +237,35 @@ public class VulnerabilityResource extends AlpineResource {
             summary = "Returns a list of all projects affected by a specific vulnerability",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
+    @PaginatedApi
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
                     description = "A list of all projects affected by a specific vulnerability",
                     headers = @Header(name = TOTAL_COUNT_HEADER, description = "The total number of projects", schema = @Schema(format = "integer")),
-                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = Project.class)))
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = AffectedProject.class)))
             ),
-            @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "404", description = "The vulnerability could not be found")
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
     public Response getAffectedProject(@PathParam("source") String source,
                                        @PathParam("vuln") String vuln,
                                        @Parameter(description = "Optionally excludes inactive projects from being returned", required = false)
                                        @QueryParam("excludeInactive") boolean excludeInactive) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final Vulnerability vulnerability = qm.getVulnerabilityByVulnId(source, vuln);
-            if (vulnerability != null) {
-                if (excludeInactive) {
-                    final List<AffectedProject> filteredProjects = qm.getAffectedProjects(vulnerability).stream().filter(AffectedProject::getActive).toList();
-                    final long filteredCount = filteredProjects.size();
-                    return Response.ok(filteredProjects).header(TOTAL_COUNT_HEADER, filteredCount).build();
-                }
-                final List<AffectedProject> projects = qm.getAffectedProjects(vulnerability);
-                final long totalCount = projects.size();
-                return Response.ok(projects).header(TOTAL_COUNT_HEADER, totalCount).build();
-            } else {
-                return Response.status(Response.Status.NOT_FOUND).entity("The vulnerability could not be found.").build();
-            }
-        }
+        final List<AffectedProjectListRow> affectedProjectRows = withJdbiHandle(getAlpineRequest(), handle ->
+                handle.attach(VulnerabilityDao.class).getAffectedProjects(source, vuln, excludeInactive ? true : null));
+
+        final long totalCount = affectedProjectRows.isEmpty() ? 0 : affectedProjectRows.getFirst().totalCount();
+        final List<AffectedProject> affectedProjects = affectedProjectRows.stream()
+                .map(row -> new AffectedProject(
+                        row.uuid(),
+                        row.dependencyGraphAvailable(),
+                        row.name(),
+                        row.version(),
+                        row.active(),
+                        row.affectedComponentUuids()))
+                .toList();
+        return Response.ok(affectedProjects).header(TOTAL_COUNT_HEADER, totalCount).build();
     }
 
     @GET

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -21,6 +21,12 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.AffectedVersionAttribution;
@@ -40,14 +46,11 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.hamcrest.CoreMatchers.equalTo;
 
 public class VulnerabilityResourceTest extends ResourceTest {
 
@@ -244,34 +247,45 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
-    public void getAffectedProjectTest() throws Exception {
+    public void getAffectedProjectTest() {
         SampleData sampleData = new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/" + sampleData.v1.getSource() + "/vuln/" + sampleData.v1.getVulnId() + "/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Project 1", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals(sampleData.p1.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
-        Assert.assertEquals(sampleData.c1.getUuid().toString(), json.getJsonObject(0).getJsonArray("affectedComponentUuids").getJsonString(0).getString());
+        assertThatJson(getPlainTextBody(response))
+                .withMatcher("projectUuid", equalTo(sampleData.p1.getUuid().toString()))
+                .withMatcher("componentUuid", equalTo(sampleData.c1.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
+                        [
+                          {
+                            "active": true,
+                            "affectedComponentUuids": [
+                              "${json-unit.matches:componentUuid}"
+                            ],
+                            "dependencyGraphAvailable": false,
+                            "name": "Project 1",
+                            "uuid": "${json-unit.matches:projectUuid}",
+                            "version": null
+                          }
+                        ]
+                        """);
     }
 
     @Test
-    public void getAffectedProjectInvalidTest() throws Exception {
+    public void getAffectedProjectWithVulnerabilityNotExistingTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/projects").request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(404, response.getStatus(), 0);
-        Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
-        String body = getPlainTextBody(response);
-        Assert.assertEquals("The vulnerability could not be found.", body);
+        Assert.assertEquals(200, response.getStatus(), 0);
+        Assert.assertEquals("0", response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals("[]", getPlainTextBody(response));
     }
 
     @Test
-    public void getAffectedProjectWithAclEnabledTest() throws Exception {
+    public void getAffectedProjectWithAclEnabledTest() {
         qm.createConfigProperty(
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -289,10 +303,23 @@ public class VulnerabilityResourceTest extends ResourceTest {
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
         Assert.assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
-        JsonArray json = parseJsonArray(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("Project 2", json.getJsonObject(0).getString("name"));
-        Assert.assertEquals(sampleData.p2.getUuid().toString(), json.getJsonObject(0).getString("uuid"));
+        assertThatJson(getPlainTextBody(response))
+                .withMatcher("projectUuid", equalTo(sampleData.p2.getUuid().toString()))
+                .withMatcher("componentUuid", equalTo(sampleData.c3.getUuid().toString()))
+                .isEqualTo(/* language=JSON */ """
+                        [
+                          {
+                            "uuid": "${json-unit.matches:projectUuid}",
+                            "dependencyGraphAvailable": false,
+                            "name": "Project 2",
+                            "version": null,
+                            "active": true,
+                            "affectedComponentUuids": [
+                              "${json-unit.matches:componentUuid}"
+                            ]
+                          }
+                        ]
+                        """);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports pagination and improves performance of `/api/v1/vulnerability/source/{source}/vuln/{vuln}/projects` endpoint.

The endpoint is now served by a single SQL query, that only fetches a small subset of required fields, and supports pagination as well as sorting.

Technically, this is a breaking change to the REST API, because:

* Responses are now paginated, inheriting the application-wide default of 100 items per page unless specified otherwise.
* The endpoint no longer returns a 404 response when the requested vulnerability does not exist. Instead, an empty array is returned.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/hyades-frontend/pull/126

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
