### PR TITLE
Fix metrics stored procs to only ever update the latest unchanged record

### DIFF
--- a/src/main/resources/migration/procedures/procedure_update-component-metrics.sql
+++ b/src/main/resources/migration/procedures/procedure_update-component-metrics.sql
@@ -202,10 +202,15 @@ BEGIN
     + "v_policy_violations_security_audited";
   "v_policy_violations_unaudited" = "v_policy_violations_total" - "v_policy_violations_audited";
 
+  WITH "CTE_LATEST_METRICS" AS (
+    SELECT *
+      FROM "DEPENDENCYMETRICS"
+     WHERE "COMPONENT_ID" = "v_component"."ID"
+     ORDER BY "LAST_OCCURRENCE" DESC
+     LIMIT 1)
   SELECT "ID"
-  FROM "DEPENDENCYMETRICS"
-  WHERE "COMPONENT_ID" = "v_component"."ID"
-    AND "VULNERABILITIES" = "v_vulnerabilities"
+  FROM "CTE_LATEST_METRICS"
+  WHERE "VULNERABILITIES" = "v_vulnerabilities"
     AND "CRITICAL" = "v_critical"
     AND "HIGH" = "v_high"
     AND "MEDIUM" = "v_medium"
@@ -231,7 +236,6 @@ BEGIN
     AND "POLICYVIOLATIONS_SECURITY_TOTAL" = "v_policy_violations_security_total"
     AND "POLICYVIOLATIONS_SECURITY_AUDITED" = "v_policy_violations_security_audited"
     AND "POLICYVIOLATIONS_SECURITY_UNAUDITED" = "v_policy_violations_security_unaudited"
-  ORDER BY "LAST_OCCURRENCE" DESC
   LIMIT 1
   INTO "v_existing_id";
 

--- a/src/main/resources/migration/procedures/procedure_update-portfolio-metrics.sql
+++ b/src/main/resources/migration/procedures/procedure_update-portfolio-metrics.sql
@@ -106,8 +106,13 @@ BEGIN
 
   "v_risk_score" = "CALC_RISK_SCORE"("v_critical", "v_high", "v_medium", "v_low", "v_unassigned");
 
+  WITH "CTE_LATEST_METRICS" AS (
+    SELECT *
+      FROM "PORTFOLIOMETRICS"
+     ORDER BY "LAST_OCCURRENCE" DESC
+     LIMIT 1)
   SELECT "ID"
-  FROM "PORTFOLIOMETRICS"
+  FROM "CTE_LATEST_METRICS"
   WHERE "PROJECTS" = "v_projects"
     AND "VULNERABLEPROJECTS" = "v_vulnerable_projects"
     AND "COMPONENTS" = "v_components"
@@ -138,7 +143,6 @@ BEGIN
     AND "POLICYVIOLATIONS_SECURITY_TOTAL" = "v_policy_violations_security_total"
     AND "POLICYVIOLATIONS_SECURITY_AUDITED" = "v_policy_violations_security_audited"
     AND "POLICYVIOLATIONS_SECURITY_UNAUDITED" = "v_policy_violations_security_unaudited"
-  ORDER BY "LAST_OCCURRENCE" DESC
   LIMIT 1
   INTO "v_existing_id";
 

--- a/src/main/resources/migration/procedures/procedure_update-project-metrics.sql
+++ b/src/main/resources/migration/procedures/procedure_update-project-metrics.sql
@@ -112,10 +112,15 @@ BEGIN
 
   "v_risk_score" = "CALC_RISK_SCORE"("v_critical", "v_high", "v_medium", "v_low", "v_unassigned");
 
+  WITH "CTE_LATEST_METRICS" AS (
+    SELECT *
+      FROM "PROJECTMETRICS"
+     WHERE "PROJECT_ID" = "v_project_id"
+     ORDER BY "LAST_OCCURRENCE" DESC
+     LIMIT 1)
   SELECT "ID"
-  FROM "PROJECTMETRICS"
-  WHERE "PROJECT_ID" = "v_project_id"
-    AND "COMPONENTS" = "v_components"
+  FROM "CTE_LATEST_METRICS"
+  WHERE "COMPONENTS" = "v_components"
     AND "VULNERABLECOMPONENTS" = "v_vulnerable_components"
     AND "VULNERABILITIES" = "v_vulnerabilities"
     AND "CRITICAL" = "v_critical"
@@ -143,7 +148,6 @@ BEGIN
     AND "POLICYVIOLATIONS_SECURITY_TOTAL" = "v_policy_violations_security_total"
     AND "POLICYVIOLATIONS_SECURITY_AUDITED" = "v_policy_violations_security_audited"
     AND "POLICYVIOLATIONS_SECURITY_UNAUDITED" = "v_policy_violations_security_unaudited"
-  ORDER BY "LAST_OCCURRENCE" DESC
   LIMIT 1
   INTO "v_existing_id";
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes metrics stored procedures to only ever update the latest unchanged record.

The previous version of the stored procedures had a bug where they would update the `LAST_OCCURRENCE` timestamp on existing records, as long as their values matched the calculated ones. It would do so despite the matching records not being the most recent.

As per the old Java-based implementation, only the most recent metrics entry is supposed to be re-used when all values match.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
