### PR TITLE
Fix mapping of `PURL` column to vulnerable components

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -21,8 +21,8 @@ package org.dependencytrack.persistence.jdbi;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.persistence.jdbi.mapping.VulnerabilityRowMapper;
-import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.config.RegisterFieldMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
@@ -230,7 +230,7 @@ public interface VulnerabilityDao {
          WHERE "VULNERABILITY"."ID" = ANY(:vulnerabilityIds)
          and "C"."PROJECT_ID" = :projectId
          """)
-    @RegisterBeanMapper(Component.class)
+    @RegisterFieldMapper(Component.class)
     List<Component> getVulnerableComponents(@Bind long projectId, @Bind List<Long> vulnerabilityIds);
 
     @SqlUpdate("""

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -220,6 +220,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                          "components": [
                              {
                                  "name": "Component 1",
+                                 "purl":"pkg:maven/com.example/component-1@1.0.0",
                                  "md5": "2aaf520d1f19aecf246a0995d91e93a5",
                                  "sha1": "3d5a54669cf8d4ed55b7df5751fa18c3f72f0cfb",
                                  "sha256": "47602d7dfe910ad941fea52e85e6e3f1c175434b0e6e261c31c766fe4c078a25",
@@ -251,6 +252,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                          "components": [
                              {
                                  "name": "Component 1",
+                                 "purl":"pkg:maven/com.example/component-1@1.0.0",
                                  "md5": "2aaf520d1f19aecf246a0995d91e93a5",
                                  "sha1": "3d5a54669cf8d4ed55b7df5751fa18c3f72f0cfb",
                                  "sha256": "47602d7dfe910ad941fea52e85e6e3f1c175434b0e6e261c31c766fe4c078a25",
@@ -286,6 +288,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                          "components": [
                              {
                                  "name": "Component 2",
+                                 "purl":"pkg:maven/com.example/component-2@2.0.0",
                                  "md5": "5eabd62fa03d159a96c77e6eeb6c7027",
                                  "sha1": "108bcf94a1c0e0f915b935c97f6bb9e50fb7c246",
                                  "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
@@ -307,6 +310,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                          "components": [
                              {
                                  "name": "Component 2",
+                                 "purl":"pkg:maven/com.example/component-2@2.0.0",
                                  "md5": "5eabd62fa03d159a96c77e6eeb6c7027",
                                  "sha1": "108bcf94a1c0e0f915b935c97f6bb9e50fb7c246",
                                  "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
@@ -358,6 +362,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                     "components": [
                         {
                             "name": "Component 2",
+                            "purl":"pkg:maven/com.example/component-2@2.0.0",
                             "md5": "5eabd62fa03d159a96c77e6eeb6c7027",
                             "sha1": "108bcf94a1c0e0f915b935c97f6bb9e50fb7c246",
                             "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
@@ -379,6 +384,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                     "components": [
                         {
                             "name": "Component 2",
+                            "purl":"pkg:maven/com.example/component-2@2.0.0",
                             "md5": "5eabd62fa03d159a96c77e6eeb6c7027",
                             "sha1": "108bcf94a1c0e0f915b935c97f6bb9e50fb7c246",
                             "sha256": "418716b003fe0268b6521ef7acbed13f5ba491d593896d5deb2058c42d87002d",
@@ -1063,6 +1069,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
             c1 = new Component();
             c1.setProject(p1);
             c1.setName("Component 1");
+            c1.setPurl("pkg:maven/com.example/component-1@1.0.0");
             c1.setMd5("2AAF520D1F19AECF246A0995D91E93A5");
             c1.setSha1("3D5A54669CF8D4ED55B7DF5751FA18C3F72F0CFB");
             c1.setSha256("47602D7DFE910AD941FEA52E85E6E3F1C175434B0E6E261C31C766FE4C078A25");
@@ -1070,6 +1077,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
             c2 = new Component();
             c2.setProject(p1);
             c2.setName("Component 2");
+            c2.setPurl("pkg:maven/com.example/component-2@2.0.0");
             c2.setMd5("5EABD62FA03D159A96C77E6EEB6C7027");
             c2.setSha1("108BCF94A1C0E0F915B935C97F6BB9E50FB7C246");
             c2.setSha256("418716B003FE0268B6521EF7ACBED13F5BA491D593896D5DEB2058C42D87002D");
@@ -1078,6 +1086,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
             c3 = new Component();
             c3.setProject(p2);
             c3.setName("Component 2");
+            c3.setPurl("pkg:maven/com.example/component-2@2.0.0");
             c3.setMd5("5EABD62FA03D159A96C77E6EEB6C7027");
             c3.setSha1("108BCF94A1C0E0F915B935C97F6BB9E50FB7C246");
             c3.setSha256("418716B003FE0268B6521EF7ACBED13F5BA491D593896D5DEB2058C42D87002D");


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes mapping of `PURL` column to vulnerable components.

JDBI's `BeanMapper` uses setters to map `ResultSet` columns to Java objects. Because the `purl` setter of the `Component` class exists twice with different argument types (once with `PackageURL` and once with `String`), JDBI picked the first, which failed because the `String` value of the `ResultSet` cannot be cast to the `PackageURL` type.

Switching to `FieldMapper` resolves the issue, since the `purl` field is of type `String`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes regression of https://github.com/DependencyTrack/hyades-apiserver/pull/886

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
