### PR TITLE
Remove `alpine.` prefix from Kafka processor properties

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessorManager.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/api/ProcessorManager.java
@@ -39,6 +39,7 @@ import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.kafka.KafkaTopics.Topic;
+import org.dependencytrack.util.ConfigUtil;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 
 import java.time.Duration;
@@ -93,12 +94,8 @@ public class ProcessorManager implements AutoCloseable {
     private AdminClient adminClient;
 
     public ProcessorManager() {
-        this(UUID.randomUUID(), Config.getInstance());
-    }
-
-    public ProcessorManager(final UUID instanceId, final Config config) {
-        this.instanceId = instanceId;
-        this.config = config;
+        this.instanceId = UUID.randomUUID();
+        this.config = Config.getInstance();
     }
 
     /**
@@ -379,7 +376,7 @@ public class ProcessorManager implements AutoCloseable {
         final String fullPrefix = "kafka.processor.%s".formatted(prefix);
         final Pattern fullPrefixPattern = Pattern.compile(Pattern.quote("%s.".formatted(fullPrefix)));
 
-        final Map<String, String> properties = config.getPassThroughProperties(fullPrefix);
+        final Map<String, String> properties = ConfigUtil.getPassThroughProperties(config, fullPrefix);
         if (properties.isEmpty()) {
             return properties;
         }

--- a/src/main/java/org/dependencytrack/util/ConfigUtil.java
+++ b/src/main/java/org/dependencytrack/util/ConfigUtil.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import alpine.Config;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * @since 5.6.0
+ */
+public final class ConfigUtil {
+
+    private ConfigUtil() {
+    }
+
+    /**
+     * Copy of {@link Config#getPassThroughProperties(String)} that omits the {@code "alpine."} prefix requirement.
+     *
+     * @param config The {@link Config} to use
+     * @param prefix Prefix of the properties to fetch
+     * @return A {@link Map} containing the matched properties
+     * @see Config#getPassThroughProperties(String)
+     */
+    public static Map<String, String> getPassThroughProperties(final Config config, final String prefix) {
+        final Properties properties;
+        try {
+            final Field propertiesField = Config.class.getDeclaredField("properties");
+            propertiesField.setAccessible(true);
+            properties = (Properties) propertiesField.get(config);
+        } catch (final NoSuchFieldException | IllegalAccessException e) {
+            throw new IllegalStateException("Unable to access Config properties", e);
+        }
+
+        final var passThroughProperties = new HashMap<String, String>();
+        try {
+            for (final Map.Entry<String, String> envVar : System.getenv().entrySet()) {
+                if (envVar.getKey().startsWith("%s_".formatted(prefix.toUpperCase().replace(".", "_")))) {
+                    final String key = envVar.getKey().toLowerCase().replace("_", ".");
+                    passThroughProperties.put(key, envVar.getValue());
+                }
+            }
+        } catch (SecurityException e) {
+            throw new IllegalStateException("""
+                    Unable to retrieve pass-through properties for prefix "%s" \
+                    from environment variables""".formatted(prefix), e);
+        }
+
+        for (final Map.Entry<Object, Object> property : properties.entrySet()) {
+            if (property.getKey() instanceof String key
+                && key.startsWith("%s.".formatted(prefix))
+                && property.getValue() instanceof final String value) {
+                if (!passThroughProperties.containsKey(key)) { // Environment variables take precedence
+                    passThroughProperties.put(key, value);
+                }
+            }
+        }
+
+        return passThroughProperties;
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -665,7 +665,7 @@ dt.kafka.topic.prefix=
 #  * partition
 #  * key
 #  * unordered
-# alpine.kafka.processor.<name>.processing.order=partition
+# kafka.processor.<name>.processing.order=partition
 
 # Defines the maximum size of record batches being processed.
 # Batch sizes are further limited by the configured processing order:
@@ -673,257 +673,257 @@ dt.kafka.topic.prefix=
 #  * key:       Number of distinct record keys in current consumer poll
 #  * unordered: Potentially unlimited
 # Will be ignored when the processor is not a batch processor.
-# alpine.kafka.processor.<name>.max.batch.size=10
+# kafka.processor.<name>.max.batch.size=10
 
 # Defines the maximum concurrency with which records are being processed.
 # For batch processors, a smaller number can improve efficiency and throughput.
 # A value of -1 indicates that the maximum concurrency should be equal to
 # the number of partitions in the topic being consumed from.
-# alpine.kafka.processor.<name>.max.concurrency=1
+# kafka.processor.<name>.max.concurrency=1
 
 # Allows for customization of the processor's retry behavior.
-# alpine.kafka.processor.<name>.retry.initial.delay.ms=1000
-# alpine.kafka.processor.<name>.retry.multiplier=1
-# alpine.kafka.processor.<name>.retry.randomization.factor=0.3
-# alpine.kafka.processor.<name>.retry.max.delay.ms=60000
+# kafka.processor.<name>.retry.initial.delay.ms=1000
+# kafka.processor.<name>.retry.multiplier=1
+# kafka.processor.<name>.retry.randomization.factor=0.3
+# kafka.processor.<name>.retry.max.delay.ms=60000
 
 # Defines the timeout to wait for the processor to finish any pending work
 # prior to being shut down.
-# alpine.kafka.processor.<name>.shutdown.timeout.ms=10000
+# kafka.processor.<name>.shutdown.timeout.ms=10000
 
 # Allows for customization of the underlying Kafka consumer.
 # Refer to https://kafka.apache.org/documentation/#consumerconfigs for available options.
-# alpine.kafka.processor.<name>.consumer.<consumer.config.name>=
+# kafka.processor.<name>.consumer.<consumer.config.name>=
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.mirror.max.concurrency=-1
+kafka.processor.vuln.mirror.max.concurrency=-1
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [key, partition, unordered]
 # @required
-alpine.kafka.processor.vuln.mirror.processing.order=partition
+kafka.processor.vuln.mirror.processing.order=partition
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.mirror.retry.initial.delay.ms=3000
+kafka.processor.vuln.mirror.retry.initial.delay.ms=3000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.mirror.retry.multiplier=2
+kafka.processor.vuln.mirror.retry.multiplier=2
 
 # @category: Kafka
 # @type:      double
 # @required
-alpine.kafka.processor.vuln.mirror.retry.randomization.factor=0.3
+kafka.processor.vuln.mirror.retry.randomization.factor=0.3
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.mirror.retry.max.delay.ms=180000
+kafka.processor.vuln.mirror.retry.max.delay.ms=180000
 
 # @category: Kafka
 # @type:     string
 # @required
-alpine.kafka.processor.vuln.mirror.consumer.group.id=dtrack-apiserver-processor
+kafka.processor.vuln.mirror.consumer.group.id=dtrack-apiserver-processor
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [earliest, latest, none]
 # @required
-alpine.kafka.processor.vuln.mirror.consumer.auto.offset.reset=earliest
+kafka.processor.vuln.mirror.consumer.auto.offset.reset=earliest
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.epss.mirror.max.concurrency=-1
+kafka.processor.epss.mirror.max.concurrency=-1
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [key, partition, unordered]
 # @required
-alpine.kafka.processor.epss.mirror.processing.order=key
+kafka.processor.epss.mirror.processing.order=key
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.epss.mirror.retry.initial.delay.ms=3000
+kafka.processor.epss.mirror.retry.initial.delay.ms=3000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.epss.mirror.retry.multiplier=2
+kafka.processor.epss.mirror.retry.multiplier=2
 
 # @category: Kafka
 # @type:     double
 # @required
-alpine.kafka.processor.epss.mirror.retry.randomization.factor=0.3
+kafka.processor.epss.mirror.retry.randomization.factor=0.3
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.epss.mirror.retry.max.delay.ms=180000
+kafka.processor.epss.mirror.retry.max.delay.ms=180000
 
 # @category: Kafka
 # @type:     string
 # @required
-alpine.kafka.processor.epss.mirror.consumer.group.id=dtrack-apiserver-processor
+kafka.processor.epss.mirror.consumer.group.id=dtrack-apiserver-processor
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [earliest, latest, none]
 # @required
-alpine.kafka.processor.epss.mirror.consumer.auto.offset.reset=earliest
+kafka.processor.epss.mirror.consumer.auto.offset.reset=earliest
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.epss.mirror.max.batch.size=500
+kafka.processor.epss.mirror.max.batch.size=500
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.max.concurrency=-1
+kafka.processor.repo.meta.analysis.result.max.concurrency=-1
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [key, partition, unordered]
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.processing.order=key
+kafka.processor.repo.meta.analysis.result.processing.order=key
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.retry.initial.delay.ms=1000
+kafka.processor.repo.meta.analysis.result.retry.initial.delay.ms=1000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.retry.multiplier=2
+kafka.processor.repo.meta.analysis.result.retry.multiplier=2
 
 # @category: Kafka
 # @type:      double
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.retry.randomization.factor=0.3
+kafka.processor.repo.meta.analysis.result.retry.randomization.factor=0.3
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.retry.max.delay.ms=180000
+kafka.processor.repo.meta.analysis.result.retry.max.delay.ms=180000
 
 # @category: Kafka
 # @type:     string
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.consumer.group.id=dtrack-apiserver-processor
+kafka.processor.repo.meta.analysis.result.consumer.group.id=dtrack-apiserver-processor
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [earliest, latest, none]
 # @required
-alpine.kafka.processor.repo.meta.analysis.result.consumer.auto.offset.reset=earliest
+kafka.processor.repo.meta.analysis.result.consumer.auto.offset.reset=earliest
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.max.concurrency=-1
+kafka.processor.vuln.scan.result.max.concurrency=-1
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [key, partition, unordered]
 # @required
-alpine.kafka.processor.vuln.scan.result.processing.order=key
+kafka.processor.vuln.scan.result.processing.order=key
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.retry.initial.delay.ms=1000
+kafka.processor.vuln.scan.result.retry.initial.delay.ms=1000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.retry.multiplier=2
+kafka.processor.vuln.scan.result.retry.multiplier=2
 
 # @category: Kafka
 # @type:      double
 # @required
-alpine.kafka.processor.vuln.scan.result.retry.randomization.factor=0.3
+kafka.processor.vuln.scan.result.retry.randomization.factor=0.3
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.retry.max.delay.ms=180000
+kafka.processor.vuln.scan.result.retry.max.delay.ms=180000
 
 # @category: Kafka
 # @type:     string
 # @required
-alpine.kafka.processor.vuln.scan.result.consumer.group.id=dtrack-apiserver-processor
+kafka.processor.vuln.scan.result.consumer.group.id=dtrack-apiserver-processor
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [earliest, latest, none]
 # @required
-alpine.kafka.processor.vuln.scan.result.consumer.auto.offset.reset=earliest
+kafka.processor.vuln.scan.result.consumer.auto.offset.reset=earliest
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.max.batch.size=1000
+kafka.processor.vuln.scan.result.processed.max.batch.size=1000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.max.concurrency=1
+kafka.processor.vuln.scan.result.processed.max.concurrency=1
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [key, partition, unordered]
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.processing.order=unordered
+kafka.processor.vuln.scan.result.processed.processing.order=unordered
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.retry.initial.delay.ms=3000
+kafka.processor.vuln.scan.result.processed.retry.initial.delay.ms=3000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.retry.multiplier=2
+kafka.processor.vuln.scan.result.processed.retry.multiplier=2
 
 # @category: Kafka
 # @type:      double
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.retry.randomization.factor=0.3
+kafka.processor.vuln.scan.result.processed.retry.randomization.factor=0.3
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.retry.max.delay.ms=180000
+kafka.processor.vuln.scan.result.processed.retry.max.delay.ms=180000
 
 # @category: Kafka
 # @type:     string
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.consumer.group.id=dtrack-apiserver-processor
+kafka.processor.vuln.scan.result.processed.consumer.group.id=dtrack-apiserver-processor
 
 # @category:     Kafka
 # @type:         enum
 # @valid-values: [earliest, latest, none]
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.consumer.auto.offset.reset=earliest
+kafka.processor.vuln.scan.result.processed.consumer.auto.offset.reset=earliest
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.consumer.max.poll.records=10000
+kafka.processor.vuln.scan.result.processed.consumer.max.poll.records=10000
 
 # @category: Kafka
 # @type:     integer
 # @required
-alpine.kafka.processor.vuln.scan.result.processed.consumer.fetch.min.bytes=524288
+kafka.processor.vuln.scan.result.processed.consumer.fetch.min.bytes=524288
 
 # Scheduling tasks after 3 minutes (3*60*1000) of starting application
 #

--- a/src/test/java/org/dependencytrack/util/ConfigUtilTest.java
+++ b/src/test/java/org/dependencytrack/util/ConfigUtilTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.util;
+
+import alpine.Config;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigUtilTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    private static Method configInitMethod;
+    private static Method configResetMethod;
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+        configInitMethod = Config.class.getDeclaredMethod("init");
+        configInitMethod.setAccessible(true);
+
+        configResetMethod = Config.class.getDeclaredMethod("reset");
+        configResetMethod.setAccessible(true);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        configResetMethod.invoke(null);
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+        configInitMethod.invoke(Config.getInstance()); // Ensure we're not affecting other tests
+    }
+
+    @Test
+    public void testGetPassThroughPropertiesEmpty() throws Exception {
+        configInitMethod.invoke(Config.getInstance());
+
+        assertThat(Config.getInstance().getPassThroughProperties("some.prefix")).isEmpty();
+    }
+
+    @Test
+    public void testGetPassThroughProperties() throws Exception {
+        final Path propertiesPath = Files.createTempFile(null, ".properties");
+        Files.writeString(propertiesPath, """
+                foo=fromProps1
+                some.prefix=fromProps2
+                some.prefix.foo=fromProps3
+                some.prefix.foo.bar=fromProps4
+                some.pre.fix.foo=fromProps5
+                prefix.foo=fromProps6
+                some.prefix.from.props=fromProps7
+                SOME.PREFIX.FROM.PROPS.UPPERCASE=fromProps8
+                Some.Prefix.From.Props.MixedCase=fromProps9
+                """);
+
+        System.setProperty("alpine.application.properties", propertiesPath.toString());
+
+        configInitMethod.invoke(Config.getInstance());
+
+        environmentVariables.set("FOO", "fromEnv1");
+        environmentVariables.set("SOME_PREFIX", "fromEnv2");
+        environmentVariables.set("SOME_PREFIX_FOO", "fromEnv3");
+        environmentVariables.set("SOME_PREFIX_FOO_BAR", "fromEnv4");
+        environmentVariables.set("SOME_PRE_FIX_FOO", "fromEnv5");
+        environmentVariables.set("PREFIX_FOO", "fromEnv6");
+        environmentVariables.set("SOME_PREFIX_FROM_ENV", "fromEnv7");
+        environmentVariables.set("some_prefix_from_env_lowercase", "fromEnv8");
+        environmentVariables.set("Some_Prefix_From_Env_MixedCase", "fromEnv9");
+
+        assertThat(ConfigUtil.getPassThroughProperties(Config.getInstance(), "some.prefix"))
+                .containsExactlyInAnyOrderEntriesOf(Map.of(
+                        "some.prefix.foo", "fromEnv3", // ENV takes precedence over properties
+                        "some.prefix.foo.bar", "fromEnv4", // ENV takes precedence over properties
+                        "some.prefix.from.env", "fromEnv7",
+                        "some.prefix.from.props", "fromProps7"
+                ));
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes `alpine.` prefix from Kafka processor properties.

Processors are not configured by Alpine, the mandatory `alpine.` prefix was confusing.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
