### PR TITLE
Port : Handle existing duplicate component properties & empty component and service names

### DIFF
--- a/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -77,6 +77,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.trim;
 import static org.apache.commons.lang3.StringUtils.trimToNull;
@@ -190,7 +191,7 @@ public class ModelConverter {
         component.setBomRef(trimToNull(cdxComponent.getBomRef()));
         component.setClassifier(convertClassifier(cdxComponent.getType()).orElse(Classifier.LIBRARY));
         component.setGroup(trimToNull(cdxComponent.getGroup()));
-        component.setName(trimToNull(cdxComponent.getName()));
+        component.setName(requireNonNullElse(trimToNull(cdxComponent.getName()), "-"));
         component.setVersion(trimToNull(cdxComponent.getVersion()));
         component.setDescription(trimToNull(cdxComponent.getDescription()));
         component.setCopyright(trimToNull(cdxComponent.getCopyright()));
@@ -464,7 +465,7 @@ public class ModelConverter {
         service.setBomRef(useOrGenerateRandomBomRef(cdxService.getBomRef()));
         service.setProvider(convert(cdxService.getProvider()));
         service.setGroup(trimToNull(cdxService.getGroup()));
-        service.setName(trimToNull(cdxService.getName()));
+        service.setName(requireNonNullElse(trimToNull(cdxService.getName()), "-"));
         service.setVersion(trimToNull(cdxService.getVersion()));
         service.setDescription(trimToNull(cdxService.getDescription()));
         service.setAuthenticated(cdxService.getAuthenticated());

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -1073,10 +1073,30 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
 
         // Group properties by group, name, and value. Because CycloneDX supports duplicate
         // property names, uniqueness can only be determined by also considering the value.
+        final var existingPropertyIdentitiesSeen = new HashSet<ComponentProperty.Identity>();
+        final var existingDuplicateProperties = new HashSet<ComponentProperty>();
         final var existingPropertiesByIdentity = component.getProperties().stream()
+                // The legacy BOM processing in <= 4.11.x allowed duplicates to be persisted.
+                // Collectors#toMap fails upon encounter of duplicate keys.
+                // Prevent existing duplicates from breaking this.
+                // https://github.com/DependencyTrack/dependency-track/issues/4027
+                .filter(property -> {
+                    final var identity = new ComponentProperty.Identity(property);
+                    final boolean isUnique = existingPropertyIdentitiesSeen.add(identity);
+                    if (!isUnique) {
+                        existingDuplicateProperties.add(property);
+                    }
+                    return isUnique;
+                })
                 .collect(Collectors.toMap(ComponentProperty.Identity::new, Function.identity()));
+        final var incomingPropertyIdentitiesSeen = new HashSet<ComponentProperty.Identity>();
         final var incomingPropertiesByIdentity = properties.stream()
+                .filter(property -> incomingPropertyIdentitiesSeen.add(new ComponentProperty.Identity(property)))
                 .collect(Collectors.toMap(ComponentProperty.Identity::new, Function.identity()));
+
+        if (!existingDuplicateProperties.isEmpty()) {
+            pm.deletePersistentAll(existingDuplicateProperties);
+        }
 
         final var propertyIdentities = new HashSet<ComponentProperty.Identity>();
         propertyIdentities.addAll(existingPropertiesByIdentity.keySet());

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -691,33 +691,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals("Provided vector SL:1/M:1/O:a/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3 does not match OWASP RR Vector pattern SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d", body);
     }
 
-    /**
-     * Ensure that pre-v4.5.0 behavior of setting CWE via a single object
-     * still works, and both "cwe" and "cwes" fields are returned in the response.
-     */
-    @Test
-    public void createVulnerabilityCwePreV450CompatTest() {
-        JsonObject payload = Json.createObjectBuilder()
-                .add("vulnId", "ACME-1")
-                .add("cwe", Json.createObjectBuilder().add("cweId", 80))
-                .build();
-        Response response = jersey.target(V1_VULNERABILITY).request()
-                .header(X_API_KEY, apiKey)
-                .put(Entity.json(payload.toString()));
-        Assert.assertEquals(201, response.getStatus(), 0);
-        JsonObject json = parseJsonObject(response);
-        Assert.assertNotNull(json);
-        Assert.assertEquals("ACME-1", json.getString("vulnId"));
-        Assert.assertEquals("INTERNAL", json.getString("source"));
-        Assert.assertNotNull(json.getJsonObject("cwe"));
-        Assert.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonObject("cwe").getString("name"));
-        Assert.assertEquals(1, json.getJsonArray("cwes").size());
-        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
-        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
-        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-    }
-
     @Test
     public void createVulnerabilityDuplicateTest() {
         Vulnerability vuln = new Vulnerability();

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -691,6 +691,33 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertEquals("Provided vector SL:1/M:1/O:a/S:2/ED:1/EE:1/A:1/ID:1/LC:2/LI:1/LAV:1/LAC:1/FD:1/RD:1/NC:2/PV:3 does not match OWASP RR Vector pattern SL:\\d/M:\\d/O:\\d/S:\\d/ED:\\d/EE:\\d/A:\\d/ID:\\d/LC:\\d/LI:\\d/LAV:\\d/LAC:\\d/FD:\\d/RD:\\d/NC:\\d/PV:\\d", body);
     }
 
+    /**
+     * Ensure that pre-v4.5.0 behavior of setting CWE via a single object
+     * still works, and both "cwe" and "cwes" fields are returned in the response.
+     */
+    @Test
+    public void createVulnerabilityCwePreV450CompatTest() {
+        JsonObject payload = Json.createObjectBuilder()
+                .add("vulnId", "ACME-1")
+                .add("cwe", Json.createObjectBuilder().add("cweId", 80))
+                .build();
+        Response response = jersey.target(V1_VULNERABILITY).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(payload.toString()));
+        Assert.assertEquals(201, response.getStatus(), 0);
+        JsonObject json = parseJsonObject(response);
+        Assert.assertNotNull(json);
+        Assert.assertEquals("ACME-1", json.getString("vulnId"));
+        Assert.assertEquals("INTERNAL", json.getString("source"));
+        Assert.assertNotNull(json.getJsonObject("cwe"));
+        Assert.assertEquals(80, json.getJsonObject("cwe").getInt("cweId"));
+        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonObject("cwe").getString("name"));
+        Assert.assertEquals(1, json.getJsonArray("cwes").size());
+        Assert.assertEquals(80, json.getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
+        Assert.assertEquals("Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)", json.getJsonArray("cwes").getJsonObject(0).getString("name"));
+        Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
+    }
+
     @Test
     public void createVulnerabilityDuplicateTest() {
         Vulnerability vuln = new Vulnerability();

--- a/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -19,7 +19,6 @@
 package org.dependencytrack.tasks;
 
 import alpine.model.IConfigProperty.PropertyType;
-
 import com.github.packageurl.PackageURL;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.dependencytrack.PersistenceCapableTest;
@@ -44,6 +43,7 @@ import org.dependencytrack.proto.notification.v1.Notification;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.jdo.JDOObjectNotFoundException;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -69,6 +69,7 @@ import static org.apache.commons.io.IOUtils.resourceToURL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.dependencytrack.model.WorkflowStatus.CANCELLED;
 import static org.dependencytrack.model.WorkflowStatus.COMPLETED;
 import static org.dependencytrack.model.WorkflowStatus.FAILED;
@@ -1433,6 +1434,74 @@ public class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 i++;
             }
         }
+    }
+
+    @Test
+    public void informWithExistingDuplicateComponentPropertiesAndBomWithDuplicateComponentProperties() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setClassifier(Classifier.LIBRARY);
+        qm.persist(component);
+
+        final var componentPropertyA = new ComponentProperty();
+        componentPropertyA.setComponent(component);
+        componentPropertyA.setPropertyName("foo");
+        componentPropertyA.setPropertyValue("bar");
+        componentPropertyA.setPropertyType(PropertyType.STRING);
+        qm.persist(componentPropertyA);
+
+        final var componentPropertyB = new ComponentProperty();
+        componentPropertyB.setComponent(component);
+        componentPropertyB.setPropertyName("foo");
+        componentPropertyB.setPropertyValue("bar");
+        componentPropertyB.setPropertyType(PropertyType.STRING);
+        qm.persist(componentPropertyB);
+
+        final byte[] bomBytes = """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "serialNumber": "urn:uuid:3e671687-395b-41f5-a30f-a58921a69b79",
+                  "version": 1,
+                  "components": [
+                    {
+                      "type": "library",
+                      "name": "acme-lib",
+                      "properties": [
+                        {
+                          "name": "foo",
+                          "value": "bar"
+                        },
+                        {
+                          "name": "foo",
+                          "value": "bar"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        final var bomUploadEvent = new BomUploadEvent(qm.detach(Project.class, project.getId()), createTempBomFile(bomBytes));
+        qm.createWorkflowSteps(bomUploadEvent.getChainIdentifier());
+        new BomUploadProcessingTask().inform(bomUploadEvent);
+        assertBomProcessedNotification();
+
+        qm.getPersistenceManager().evictAll();
+        assertThatNoException()
+                .isThrownBy(() -> qm.getPersistenceManager().refresh(componentPropertyA));
+        assertThatExceptionOfType(JDOObjectNotFoundException.class)
+                .isThrownBy(() -> qm.getPersistenceManager().refresh(componentPropertyB));
+        assertThat(component.getProperties()).satisfiesExactly(property -> {
+            assertThat(property.getGroupName()).isNull();
+            assertThat(property.getPropertyName()).isEqualTo("foo");
+            assertThat(property.getPropertyValue()).isEqualTo("bar");
+            assertThat(property.getUuid()).isEqualTo(componentPropertyA.getUuid());
+        });
     }
 
     private void assertBomProcessedNotification() throws Exception {


### PR DESCRIPTION
### Description

1. Handles existing duplicate component properties, fixing Duplicate Key exceptions during BOM processing.
2. Handle empty component and service names.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
