### PR TITLE
Migrate `DIRECT_DEPENDENCIES` from `TEXT` to `JSONB`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,7 @@
         <lib.cvss-calculator.version>1.4.3</lib.cvss-calculator.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
         <lib.cyclonedx-java.version>9.0.5</lib.cyclonedx-java.version>
+        <lib.datanucleus-postgresql.version>0.2.0</lib.datanucleus-postgresql.version>
         <lib.jaxb.runtime.version>4.0.5</lib.jaxb.runtime.version>
         <lib.jdbi.version>3.45.4</lib.jdbi.version>
         <lib.json-unit.version>3.4.1</lib.json-unit.version>
@@ -263,6 +264,13 @@
             <artifactId>cyclonedx-core-java</artifactId>
             <version>${lib.cyclonedx-java.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.github.nscuro</groupId>
+            <artifactId>datanucleus-postgresql</artifactId>
+            <version>${lib.datanucleus-postgresql.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.activation</groupId>
             <artifactId>jakarta.activation-api</artifactId>

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -39,6 +39,7 @@ import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.Extensions;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
 import javax.jdo.annotations.IdGeneratorStrategy;
@@ -330,6 +331,10 @@ public class Component implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "DIRECT_DEPENDENCIES", jdbcType = "CLOB")
+    @Extensions(value = {
+            @Extension(vendorName = "datanucleus", key = "insert-function", value = "CAST(? AS JSONB)"),
+            @Extension(vendorName = "datanucleus", key = "update-function", value = "CAST(? AS JSONB)")
+    })
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String directDependencies; // This will be a JSON string
 

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -46,6 +46,7 @@ import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.Extensions;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
 import javax.jdo.annotations.IdGeneratorStrategy;
@@ -231,6 +232,10 @@ public class Project implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "DIRECT_DEPENDENCIES", jdbcType = "CLOB")
+    @Extensions(value = {
+            @Extension(vendorName = "datanucleus", key = "insert-function", value = "CAST(? AS JSONB)"),
+            @Extension(vendorName = "datanucleus", key = "update-function", value = "CAST(? AS JSONB)")
+    })
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
     private String directDependencies; // This will be a JSON string
 

--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -510,7 +510,7 @@ public class CelCommonPolicyLibrary implements Library {
                             -- Short-circuit the recursive query if we don't have any matches at all.
                             EXISTS(SELECT 1 FROM "CTE_MATCHES")
                             -- Otherwise, find components of which the given leaf component is a direct dependency.
-                            AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || :leafComponentUuid || '%')
+                            AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                           UNION ALL
                           SELECT
                             "C"."UUID"                                       AS "UUID",
@@ -527,7 +527,7 @@ public class CelCommonPolicyLibrary implements Library {
                             -- Also, ensure we haven't seen this component before, to prevent cycles.
                             AND NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
                             -- Otherwise, the previous component must appear in the current direct dependencies.
-                            AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || "PREVIOUS"."UUID" || '%')
+                            AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                         )
                         SELECT BOOL_OR("FOUND") FROM "CTE_DEPENDENCIES";
                         """);
@@ -586,7 +586,7 @@ public class CelCommonPolicyLibrary implements Library {
                         -- Short-circuit the recursive query if we don't have any matches at all.
                         EXISTS(SELECT 1 FROM "CTE_MATCHES")
                         -- Otherwise, find components of which the given leaf component is a direct dependency.
-                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || :leafComponentUuid || '%')
+                        AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                       UNION ALL
                       SELECT
                         "C"."UUID"                                       AS "UUID",
@@ -612,7 +612,7 @@ public class CelCommonPolicyLibrary implements Library {
                         -- Ensure we haven't seen this component before, to prevent cycles.
                         NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
                         -- Otherwise, the previous component must appear in the current direct dependencies.
-                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || "PREVIOUS"."UUID" || '%')
+                        AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                     )
                     SELECT ${selectColumnNames?join(", ")} FROM "CTE_DEPENDENCIES" WHERE "FOUND";
                     """);
@@ -700,7 +700,7 @@ public class CelCommonPolicyLibrary implements Library {
                         -- Short-circuit the recursive query if we don't have any matches at all.
                         EXISTS(SELECT 1 FROM "CTE_MATCHES")
                         -- Otherwise, find components of which the given leaf component is a direct dependency.
-                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || :leafComponentUuid || '%')
+                        AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                       UNION ALL
                       SELECT
                         "C"."ID"                                         AS "ID",
@@ -727,7 +727,7 @@ public class CelCommonPolicyLibrary implements Library {
                         -- Ensure we haven't seen this component before, to prevent cycles.
                         NOT ("C"."ID" = ANY("PREVIOUS"."PATH"))
                         -- Otherwise, the previous component must appear in the current direct dependencies.
-                        AND "C"."DIRECT_DEPENDENCIES" LIKE ('%' || "PREVIOUS"."UUID" || '%')
+                        AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                     )
                     SELECT "ID", ${selectColumnNames?join(", ", "", ", ")} "FOUND", "PATH" FROM "CTE_DEPENDENCIES";
                      """);
@@ -969,7 +969,7 @@ public class CelCommonPolicyLibrary implements Library {
                   "PROJECT" AS "P" ON "P"."ID" = "C"."PROJECT_ID"
                 WHERE
                   "C"."UUID" = :leafComponentUuid
-                  AND "P"."DIRECT_DEPENDENCIES" LIKE ('%' || :leafComponentUuid || '%')
+                  AND "P"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                 """);
 
         return query

--- a/src/main/java/org/dependencytrack/policy/cel/CelPolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelPolicyQueryManager.java
@@ -649,14 +649,16 @@ class CelPolicyQueryManager implements AutoCloseable {
     }
 
     boolean isDirectDependency(final org.dependencytrack.proto.policy.v1.Component component) {
-        String queryString = """
-                SELECT COUNT(*) FROM "COMPONENT" "C" 
-                INNER JOIN "PROJECT" "P" ON "P"."ID"="C"."PROJECT_ID" 
-                AND "P"."DIRECT_DEPENDENCIES" LIKE :wildcard WHERE "C"."UUID"= :uuid;
+        String queryString = /* language=SQL */ """
+                SELECT COUNT(*)
+                  FROM "COMPONENT" "C"
+                 INNER JOIN "PROJECT" "P"
+                    ON "P"."ID" = "C"."PROJECT_ID"
+                   AND "P"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :uuid))
+                 WHERE "C"."UUID" = :uuid
                 """;
         final Query<?> query = pm.newQuery(Query.SQL, queryString);
-        query.setNamedParameters(Map.of("uuid", UUID.fromString(component.getUuid()),
-                "wildcard", "%" + component.getUuid() + "%"));
+        query.setNamedParameters(Map.of("uuid", UUID.fromString(component.getUuid())));
         long result;
         try {
             result = query.executeResultUnique(Long.class);

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -64,4 +64,16 @@
             <column name="AUTHOR"/>
         </dropColumn>
     </changeSet>
+    
+    <changeSet id="v5.6.0-4" author="nscuro">
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_DIRECT_DEPENDENCIES_GIN_IDX"/>
+        <modifyDataType tableName="COMPONENT" columnName="DIRECT_DEPENDENCIES" newDataType="JSONB"/>
+        <modifyDataType tableName="PROJECT" columnName="DIRECT_DEPENDENCIES" newDataType="JSONB"/>
+        <sql splitStatements="true">
+            CREATE
+             INDEX "COMPONENT_DIRECT_DEPENDENCIES_JSONB_IDX"
+                ON "COMPONENT"
+             USING GIN("DIRECT_DEPENDENCIES" JSONB_PATH_OPS);
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/persistence/ComponentQueryManangerPostgresTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ComponentQueryManangerPostgresTest.java
@@ -146,7 +146,7 @@ public class ComponentQueryManangerPostgresTest extends PersistenceCapableTest {
         }});
         project.setAuthors(authors);
         project.setDescription("projectDescription");
-        project.setDirectDependencies("{7e5f6465-d2f2-424f-b1a4-68d186fa2b46}");
+        project.setDirectDependencies("[{\"uuid\":\"7e5f6465-d2f2-424f-b1a4-68d186fa2b46\"}]");
         project.setExternalReferences(List.of(new ExternalReference()));
         project.setLastBomImport(new java.util.Date());
         project.setLastBomImportFormat("projectBomFormat");
@@ -181,7 +181,7 @@ public class ComponentQueryManangerPostgresTest extends PersistenceCapableTest {
         component.setPurl("pkg:maven/a/b@1.0");
         component.setPublisher("componentPublisher");
         component.setPurlCoordinates("componentPurlCoordinates");
-        component.setDirectDependencies("componentDirectDependencies");
+        component.setDirectDependencies("[]");
         component.setExtension("componentExtension");
         component.setExternalReferences(List.of(new ExternalReference()));
         component.setFilename("componentFilename");


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Migrates `DIRECT_DEPENDENCIES` columns from `TEXT` to `JSONB`.

Drops the old [`GIN_TRGM_OPS`](https://www.postgresql.org/docs/current/pgtrgm.html#PGTRGM-INDEX)-based index in favor of new [`JSONB_PATH_OPS`](https://www.postgresql.org/docs/current/gin-builtin-opclasses.html) indexes. Note that `PROJECT.DIRECT_DEPENDENCIES` is not indexed because projects are not currently queried by `DIRECT_DEPENDENCIES` contents.

Refactors queries using `LIKE` on the `DIRECT_DEPENDENCIES` columns with the `JSONB` *contains* operator `@>`.

Introduces [`datanucleus-postgresql`](https://github.com/nscuro/datanucleus-postgresql) to support the `@>` in DataNucleus JDOQL queries (via `jsonbContains`).

> [!NOTE]
> Due to how the [DataNucleus plugin mechanism](https://www.datanucleus.org/products/accessplatform_6_0/extensions/extensions.html#_plugin_mechanism) works, it was not possible to keep the code in the API server codebase.

Refer to https://github.com/DependencyTrack/hyades/issues/1416 for more details on the background and impact of this change.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1416

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Hyades PR: https://github.com/DependencyTrack/hyades/pull/1516

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
