### PR TITLE
Port : customizable login page

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -108,8 +108,8 @@ public enum ConfigPropertyConstants {
     CUSTOM_RISK_SCORE_MEDIUM("risk-score", "weight.medium", "3", PropertyType.INTEGER, "Medium severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_LOW("risk-score", "weight.low", "1", PropertyType.INTEGER, "Low severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_UNASSIGNED("risk-score", "weight.unassigned", "5", PropertyType.INTEGER, "Unassigned severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
-    WELCOME_MESSAGE("general", "welcome.message.html", "%20%3Chtml%3E%3Ch1%3EYour%20Welcome%20Message%3C%2Fh1%3E%3C%2Fhtml%3E", PropertyType.STRING, "Custom HTML Code that is displayed before login", ConfigPropertyAccessMode.READ_WRITE),
-    IS_WELCOME_MESSAGE("general", "welcome.message.enabled", "false", PropertyType.BOOLEAN, "Bool that says wheter to show the welcome message or not", ConfigPropertyAccessMode.READ_WRITE);
+    WELCOME_MESSAGE("general", "welcome.message.html", "%20%3Chtml%3E%3Ch1%3EYour%20Welcome%20Message%3C%2Fh1%3E%3C%2Fhtml%3E", PropertyType.STRING, "Custom HTML Code that is displayed before login", ConfigPropertyAccessMode.READ_WRITE, true),
+    IS_WELCOME_MESSAGE("general", "welcome.message.enabled", "false", PropertyType.BOOLEAN, "Bool that says wheter to show the welcome message or not", ConfigPropertyAccessMode.READ_WRITE, true);
 
     private final String groupName;
     private final String propertyName;

--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -107,7 +107,9 @@ public enum ConfigPropertyConstants {
     CUSTOM_RISK_SCORE_HIGH("risk-score", "weight.high", "5", PropertyType.INTEGER, "High severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_MEDIUM("risk-score", "weight.medium", "3", PropertyType.INTEGER, "Medium severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
     CUSTOM_RISK_SCORE_LOW("risk-score", "weight.low", "1", PropertyType.INTEGER, "Low severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
-    CUSTOM_RISK_SCORE_UNASSIGNED("risk-score", "weight.unassigned", "5", PropertyType.INTEGER, "Unassigned severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE);
+    CUSTOM_RISK_SCORE_UNASSIGNED("risk-score", "weight.unassigned", "5", PropertyType.INTEGER, "Unassigned severity vulnerability weight (between 1-10)", ConfigPropertyAccessMode.READ_WRITE),
+    WELCOME_MESSAGE("general", "welcome.message.html", "%20%3Chtml%3E%3Ch1%3EYour%20Welcome%20Message%3C%2Fh1%3E%3C%2Fhtml%3E", PropertyType.STRING, "Custom HTML Code that is displayed before login", ConfigPropertyAccessMode.READ_WRITE),
+    IS_WELCOME_MESSAGE("general", "welcome.message.enabled", "false", PropertyType.BOOLEAN, "Bool that says wheter to show the welcome message or not", ConfigPropertyAccessMode.READ_WRITE);
 
     private final String groupName;
     private final String propertyName;
@@ -115,6 +117,7 @@ public enum ConfigPropertyConstants {
     private final PropertyType propertyType;
     private final String description;
     private final ConfigPropertyAccessMode accessMode;
+    private final Boolean isPublic;
 
     ConfigPropertyConstants(final String groupName,
                             final String propertyName,
@@ -128,11 +131,29 @@ public enum ConfigPropertyConstants {
         this.propertyType = propertyType;
         this.description = description;
         this.accessMode = accessMode;
+        this.isPublic = false;
+    }
+
+    ConfigPropertyConstants(final String groupName,
+                            final String propertyName,
+                            final String defaultPropertyValue,
+                            final PropertyType propertyType,
+                            final String description,
+                            final ConfigPropertyAccessMode accessMode,
+                            final Boolean isPublic) {
+        this.groupName = groupName;
+        this.propertyName = propertyName;
+        this.defaultPropertyValue = defaultPropertyValue;
+        this.propertyType = propertyType;
+        this.description = description;
+        this.accessMode = accessMode;
+        this.isPublic = isPublic;
     }
 
     public static ConfigPropertyConstants ofProperty(final IConfigProperty property) {
         return Arrays.stream(values())
-                .filter(value -> value.groupName.equals(property.getGroupName()) && value.propertyName.equals(property.getPropertyName()))
+                .filter(value -> value.groupName.equals(property.getGroupName())
+                        && value.propertyName.equals(property.getPropertyName()))
                 .findFirst()
                 .orElse(null);
     }
@@ -159,5 +180,9 @@ public enum ConfigPropertyConstants {
 
     public ConfigPropertyAccessMode getAccessMode() {
         return accessMode;
+    }
+
+    public Boolean getIsPublic() {
+        return isPublic;
     }
 }

--- a/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.model.ConfigProperty;
+import alpine.server.auth.AuthenticationNotRequired;
 import alpine.server.auth.PermissionRequired;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -166,15 +167,16 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
             @ApiResponse(responseCode = "200", description = "Public ConfigProperty returned", content = @Content(schema = @Schema(implementation = ConfigProperty.class))),
             @ApiResponse(responseCode = "403", description = "This is not a public visible ConfigProperty")
     })
+    @AuthenticationNotRequired
     public Response getPublicConfigProperty(
             @Parameter(description = "The group name of the value to retrieve", required = true)
             @PathParam("groupName") String groupName,
             @Parameter(description = "The property name of the value to retrieve", required = true)
             @PathParam("propertyName") String propertyName) {
-        ConfigProperty sampleProperty = new ConfigProperty();
-        sampleProperty.setGroupName(groupName);
-        sampleProperty.setPropertyName(propertyName);
-        ConfigPropertyConstants publicConfigProperty = ConfigPropertyConstants.ofProperty(sampleProperty);
+        ConfigProperty configProperty = new ConfigProperty();
+        configProperty.setGroupName(groupName);
+        configProperty.setPropertyName(propertyName);
+        ConfigPropertyConstants publicConfigProperty = ConfigPropertyConstants.ofProperty(configProperty);
         if (!publicConfigProperty.getIsPublic()) {
             return Response.status(Response.Status.FORBIDDEN).build();
         }

--- a/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ConfigPropertyResource.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.model.ConfigProperty;
 import alpine.server.auth.PermissionRequired;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,10 +35,12 @@ import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 
 import java.util.ArrayList;
@@ -155,5 +158,29 @@ public class ConfigPropertyResource extends AbstractConfigPropertyResource {
         return Response.ok(returnList).build();
     }
 
-
+    @GET
+    @Path("/public/{groupName}/{propertyName}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Returns a public ConfigProperty", description = "<p></p>")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Public ConfigProperty returned", content = @Content(schema = @Schema(implementation = ConfigProperty.class))),
+            @ApiResponse(responseCode = "403", description = "This is not a public visible ConfigProperty")
+    })
+    public Response getPublicConfigProperty(
+            @Parameter(description = "The group name of the value to retrieve", required = true)
+            @PathParam("groupName") String groupName,
+            @Parameter(description = "The property name of the value to retrieve", required = true)
+            @PathParam("propertyName") String propertyName) {
+        ConfigProperty sampleProperty = new ConfigProperty();
+        sampleProperty.setGroupName(groupName);
+        sampleProperty.setPropertyName(propertyName);
+        ConfigPropertyConstants publicConfigProperty = ConfigPropertyConstants.ofProperty(sampleProperty);
+        if (!publicConfigProperty.getIsPublic()) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            ConfigProperty property = qm.getConfigProperty(groupName, propertyName);
+            return Response.ok(property).build();
+        }
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ConfigPropertyResourceTest.java
@@ -22,6 +22,11 @@ import alpine.model.ConfigProperty;
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.model.ConfigPropertyConstants;
@@ -30,20 +35,15 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_CRITICAL;
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_HIGH;
-import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_MEDIUM;
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_LOW;
+import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_MEDIUM;
 import static org.dependencytrack.model.ConfigPropertyConstants.CUSTOM_RISK_SCORE_UNASSIGNED;
+import static org.junit.Assert.assertEquals;
 
 public class ConfigPropertyResourceTest extends ResourceTest {
 
@@ -61,25 +61,25 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
-        Assert.assertEquals("my.group", json.getJsonObject(0).getString("groupName"));
-        Assert.assertEquals("my.integer", json.getJsonObject(0).getString("propertyName"));
-        Assert.assertEquals("1", json.getJsonObject(0).getString("propertyValue"));
-        Assert.assertEquals("INTEGER", json.getJsonObject(0).getString("propertyType"));
-        Assert.assertEquals("A integer", json.getJsonObject(0).getString("description"));
-        Assert.assertEquals("my.group", json.getJsonObject(2).getString("groupName"));
-        Assert.assertEquals("my.string", json.getJsonObject(2).getString("propertyName"));
-        Assert.assertEquals("ABC", json.getJsonObject(2).getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getJsonObject(2).getString("propertyType"));
-        Assert.assertEquals("A string", json.getJsonObject(2).getString("description"));
-        Assert.assertEquals("my.group", json.getJsonObject(1).getString("groupName"));
-        Assert.assertEquals("my.password", json.getJsonObject(1).getString("propertyName"));
-        Assert.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getJsonObject(1).getString("propertyValue"));
-        Assert.assertEquals("ENCRYPTEDSTRING", json.getJsonObject(1).getString("propertyType"));
-        Assert.assertEquals("A password", json.getJsonObject(1).getString("description"));
+        assertEquals(3, json.size());
+        assertEquals("my.group", json.getJsonObject(0).getString("groupName"));
+        assertEquals("my.integer", json.getJsonObject(0).getString("propertyName"));
+        assertEquals("1", json.getJsonObject(0).getString("propertyValue"));
+        assertEquals("INTEGER", json.getJsonObject(0).getString("propertyType"));
+        assertEquals("A integer", json.getJsonObject(0).getString("description"));
+        assertEquals("my.group", json.getJsonObject(2).getString("groupName"));
+        assertEquals("my.string", json.getJsonObject(2).getString("propertyName"));
+        assertEquals("ABC", json.getJsonObject(2).getString("propertyValue"));
+        assertEquals("STRING", json.getJsonObject(2).getString("propertyType"));
+        assertEquals("A string", json.getJsonObject(2).getString("description"));
+        assertEquals("my.group", json.getJsonObject(1).getString("groupName"));
+        assertEquals("my.password", json.getJsonObject(1).getString("propertyName"));
+        assertEquals("HiddenDecryptedPropertyPlaceholder", json.getJsonObject(1).getString("propertyValue"));
+        assertEquals("ENCRYPTEDSTRING", json.getJsonObject(1).getString("propertyType"));
+        assertEquals("A password", json.getJsonObject(1).getString("description"));
     }
 
     @Test
@@ -90,14 +90,14 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.string", json.getString("propertyName"));
-        Assert.assertEquals("DEF", json.getString("propertyValue"));
-        Assert.assertEquals("STRING", json.getString("propertyType"));
-        Assert.assertEquals("A string", json.getString("description"));
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.string", json.getString("propertyName"));
+        assertEquals("DEF", json.getString("propertyValue"));
+        assertEquals("STRING", json.getString("propertyType"));
+        assertEquals("A string", json.getString("description"));
     }
 
     @Test
@@ -108,14 +108,14 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.boolean", json.getString("propertyName"));
-        Assert.assertEquals("true", json.getString("propertyValue"));
-        Assert.assertEquals("BOOLEAN", json.getString("propertyType"));
-        Assert.assertEquals("A boolean", json.getString("description"));
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.boolean", json.getString("propertyName"));
+        assertEquals("true", json.getString("propertyValue"));
+        assertEquals("BOOLEAN", json.getString("propertyType"));
+        assertEquals("A boolean", json.getString("description"));
     }
 
     @Test
@@ -126,14 +126,14 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.number", json.getString("propertyName"));
-        Assert.assertEquals("5.50", json.getString("propertyValue"));
-        Assert.assertEquals("NUMBER", json.getString("propertyType"));
-        Assert.assertEquals("A number", json.getString("description"));
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.number", json.getString("propertyName"));
+        assertEquals("5.50", json.getString("propertyValue"));
+        assertEquals("NUMBER", json.getString("propertyType"));
+        assertEquals("A number", json.getString("description"));
     }
 
     @Test
@@ -144,9 +144,9 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("A Task scheduler cadence ("+request.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
+        assertEquals("A Task scheduler cadence ("+request.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
     }
 
     @Test
@@ -157,9 +157,9 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(400, response.getStatus(), 0);
+        assertEquals(400, response.getStatus(), 0);
         String body = getPlainTextBody(response);
-        Assert.assertEquals("Lucene index delta threshold ("+request.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of -1 was provided.", body);
+        assertEquals("Lucene index delta threshold ("+request.getPropertyName()+") cannot be inferior to 1 or superior to 100.A value of -1 was provided.", body);
     }
 
     @Test
@@ -170,14 +170,14 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.url", json.getString("propertyName"));
-        Assert.assertEquals("http://localhost/path", json.getString("propertyValue"));
-        Assert.assertEquals("URL", json.getString("propertyType"));
-        Assert.assertEquals("A url", json.getString("description"));
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.url", json.getString("propertyName"));
+        assertEquals("http://localhost/path", json.getString("propertyValue"));
+        assertEquals("URL", json.getString("propertyType"));
+        assertEquals("A url", json.getString("description"));
     }
 
     @Test
@@ -188,14 +188,14 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.uuid", json.getString("propertyName"));
-        Assert.assertEquals("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d", json.getString("propertyValue"));
-        Assert.assertEquals("UUID", json.getString("propertyType"));
-        Assert.assertEquals("A uuid", json.getString("description"));
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.uuid", json.getString("propertyName"));
+        assertEquals("fe03c401-b5a1-4b86-bc3b-1b7a68f0f78d", json.getString("propertyValue"));
+        assertEquals("UUID", json.getString("propertyType"));
+        assertEquals("A uuid", json.getString("description"));
     }
 
     @Test
@@ -206,14 +206,14 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(request, MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("my.group", json.getString("groupName"));
-        Assert.assertEquals("my.encryptedString", json.getString("propertyName"));
-        Assert.assertEquals("HiddenDecryptedPropertyPlaceholder", json.getString("propertyValue"));
-        Assert.assertEquals("ENCRYPTEDSTRING", json.getString("propertyType"));
-        Assert.assertEquals("A encrypted string", json.getString("description"));
+        assertEquals("my.group", json.getString("groupName"));
+        assertEquals("my.encryptedString", json.getString("propertyName"));
+        assertEquals("HiddenDecryptedPropertyPlaceholder", json.getString("propertyValue"));
+        assertEquals("ENCRYPTEDSTRING", json.getString("propertyType"));
+        assertEquals("A encrypted string", json.getString("description"));
     }
 
     @Test
@@ -343,11 +343,11 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(200);
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals("risk-score", json.getString("groupName"));
-        Assert.assertEquals("weight.critical", json.getString("propertyName"));
-        Assert.assertEquals("8", json.getString("propertyValue"));
-        Assert.assertEquals("INTEGER", json.getString("propertyType"));
-        Assert.assertEquals("Critical severity vulnerability weight (between 1-10)", json.getString("description"));
+        assertEquals("risk-score", json.getString("groupName"));
+        assertEquals("weight.critical", json.getString("propertyName"));
+        assertEquals("8", json.getString("propertyValue"));
+        assertEquals("INTEGER", json.getString("propertyType"));
+        assertEquals("Critical severity vulnerability weight (between 1-10)", json.getString("description"));
     }
 
     @Test
@@ -365,17 +365,36 @@ public class ConfigPropertyResourceTest extends ResourceTest {
         Response response = jersey.target(V1_CONFIG_PROPERTY+"/aggregate").request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(Arrays.asList(prop1, prop2, prop3, prop4), MediaType.APPLICATION_JSON));
-        Assert.assertEquals(200, response.getStatus(), 0);
+        assertEquals(200, response.getStatus(), 0);
         JsonArray json = parseJsonArray(response);
         JsonObject modifiedProp = json.getJsonObject(2);
         Assert.assertNotNull(modifiedProp);
-        Assert.assertEquals("my.group", modifiedProp.getString("groupName"));
-        Assert.assertEquals("my.string3", modifiedProp.getString("propertyName"));
-        Assert.assertEquals("XYZ", modifiedProp.getString("propertyValue"));
-        Assert.assertEquals("STRING", modifiedProp.getString("propertyType"));
-        Assert.assertEquals("A string", modifiedProp.getString("description"));
+        assertEquals("my.group", modifiedProp.getString("groupName"));
+        assertEquals("my.string3", modifiedProp.getString("propertyName"));
+        assertEquals("XYZ", modifiedProp.getString("propertyValue"));
+        assertEquals("STRING", modifiedProp.getString("propertyType"));
+        assertEquals("A string", modifiedProp.getString("description"));
         String body = json.getString(3);
-        Assert.assertEquals("A Task scheduler cadence ("+prop4.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
+        assertEquals("A Task scheduler cadence ("+prop4.getPropertyName()+") cannot be inferior to one hour.A value of -2 was provided.", body);
     }
 
+    @Test
+    public void getPublicAllPropertiesTest() {
+        for (ConfigPropertyConstants configProperty : ConfigPropertyConstants.values()) {
+            String groupName = configProperty.getGroupName();
+            String propertyName = configProperty.getPropertyName();
+            qm.createConfigProperty(
+                    groupName,
+                    propertyName,
+                    configProperty.getDefaultPropertyValue(),
+                    configProperty.getPropertyType(),
+                    configProperty.getDescription());
+
+            Response response = jersey.target(V1_CONFIG_PROPERTY + "/public/" + groupName + "/" + propertyName)
+                    .request()
+                    .header(X_API_KEY, apiKey).get();
+            int status = configProperty.getIsPublic() ? 200 : 403;
+            assertEquals(status, response.getStatus());
+        }
+    }
 }


### PR DESCRIPTION
### Description

Currently, the login page does not allow any customization.
Add an API endpoint, open to anyone, which returns custom welcome message given by admins.
Adds 2 ConfigProperties to store the message and if it should be shown.

### Addressed Issue

Backport change https://github.com/DependencyTrack/hyades/issues/1358
Frontend PR : https://github.com/DependencyTrack/hyades-frontend/pull/133

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
