### PR TITLE
Enable `reWriteBatchedInserts` Postgres JDBC driver option in tests

### DIFF
--- a/src/main/java/org/dependencytrack/dev/DevServicesInitializer.java
+++ b/src/main/java/org/dependencytrack/dev/DevServicesInitializer.java
@@ -20,12 +20,12 @@ package org.dependencytrack.dev;
 
 import alpine.Config;
 import alpine.common.logging.Logger;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.dependencytrack.event.kafka.KafkaTopics;
 
-import jakarta.servlet.ServletContextEvent;
-import jakarta.servlet.ServletContextListener;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -92,6 +92,7 @@ public class DevServicesInitializer implements ServletContextListener {
             final Class<?> postgresContainerClass = Class.forName("org.testcontainers.containers.PostgreSQLContainer");
             final Constructor<?> postgresContainerConstructor = postgresContainerClass.getDeclaredConstructor(String.class);
             postgresContainer = (AutoCloseable) postgresContainerConstructor.newInstance(getProperty(DEV_SERVICES_IMAGE_POSTGRES));
+            postgresContainerClass.getMethod("withUrlParam", String.class, String.class).invoke(postgresContainer, "reWriteBatchedInserts", "true");
 
             // TODO: Detect when Apache Kafka is requested vs. when Kafka is requested,
             //   and pick the corresponding Testcontainers class accordingly.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -93,9 +93,10 @@ alpine.database.mode=external
 alpine.database.port=9092
 
 # Specifies the JDBC URL to use when connecting to the database.
+# For best performance, set the `reWriteBatchedInserts` query parameter to `true`.
 #
 # @category: Database
-# @example:  jdbc:postgresql://localhost:5432/dtrack
+# @example:  jdbc:postgresql://localhost:5432/dtrack?reWriteBatchedInserts=true
 # @type:     string
 # @required
 alpine.database.url=

--- a/src/test/java/org/dependencytrack/PostgresTestContainer.java
+++ b/src/test/java/org/dependencytrack/PostgresTestContainer.java
@@ -34,6 +34,11 @@ public class PostgresTestContainer extends PostgreSQLContainer<PostgresTestConta
         withPassword("dtrack");
         withDatabaseName("dtrack");
         withLabel("owner", "hyades-apiserver");
+        withUrlParam("reWriteBatchedInserts", "true");
+
+        // Uncomment this to see queries executed by Postgres:
+        //   withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(PostgresTestContainer.class)));
+        //   withCommand("-c log_statement=all");
 
         // NB: Container reuse won't be active unless either:
         //  - The environment variable TESTCONTAINERS_REUSE_ENABLE=true is set


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

As per JDBC driver documentation (https://jdbc.postgresql.org/documentation/use/):

> This will change batch inserts from insert into foo (col1, col2, col3) values (1, 2, 3) into insert into foo (col1, col2, col3) values (1, 2, 3), (4, 5, 6) this provides 2-3x performance improvement

Indeed, per default even batched JDBC statements are executed one-by-one, somewhat defeating the purpose of batching in the first place. This option allows us to get the true benefit out of performing batch operations.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
