### PR TITLE
Fix `PortfolioMetricsUpdateTask` refreshing too many project metrics concurrently

### DIFF
--- a/src/test/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTaskTest.java
+++ b/src/test/java/org/dependencytrack/tasks/metrics/PortfolioMetricsUpdateTaskTest.java
@@ -40,10 +40,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.time.Instant;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.tasks.metrics.PortfolioMetricsUpdateTask.partition;
 
 @NotThreadSafe
 public class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTest {
@@ -361,6 +363,38 @@ public class PortfolioMetricsUpdateTaskTest extends AbstractMetricsUpdateTaskTes
         assertThat(componentUnaudited.getLastInheritedRiskScore()).isZero();
         assertThat(componentAudited.getLastInheritedRiskScore()).isZero();
         assertThat(componentSuppressed.getLastInheritedRiskScore()).isZero();
+    }
+
+    @Test
+    public void testPartitionWithNull() {
+        final List<Integer> list = null;
+        final List<List<Integer>> partitions = partition(list, 4);
+        assertThat(partitions).isEmpty();
+    }
+
+    @Test
+    public void testPartitionWithEmptyList() {
+        final List<Integer> list = Collections.emptyList();
+        final List<List<Integer>> partitions = partition(list, 4);
+        assertThat(partitions).isEmpty();
+    }
+
+    @Test
+    public void testPartitionWithSmallList() {
+        final List<Integer> list = List.of(1, 2);
+        final List<List<Integer>> partitions = partition(list, 4);
+        assertThat(partitions).hasSize(2);
+    }
+
+    @Test
+    public void testPartitionWithUnevenSizeList() {
+        final List<Integer> list = List.of(1, 2, 3, 4, 5);
+        final List<List<Integer>> partitions = partition(list, 4);
+        assertThat(partitions).satisfiesExactlyInAnyOrder(
+                partition -> assertThat(partition).hasSize(2),
+                partition -> assertThat(partition).hasSize(1),
+                partition -> assertThat(partition).hasSize(1),
+                partition -> assertThat(partition).hasSize(1));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `PortfolioMetricsUpdateTask` refreshing too many project metrics concurrently.

In order to avoid a high impact on application and database, only up to `$CPU_CORE_COUNT` project metrics are supposed to be refreshed concurrently, when the `PortfolioMetricsUpdateTask` is running.

To achieve this, projects are supposed to be partitioned into at most `$CPU_CORE_COUNT` partitions. Unfortunately, the method used for partitioning divided the list of projects into N partitions of at most `$CPU_CORE_COUNT` elements.

This caused too many projects/partitions to be processed concurrently, claiming too many database connections of the connection pool.

I was unable to find an off-the-shelf implementation of the desired partitioning logic in any of the libraries we use, so built a custom one.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
