### PR TITLE
Force initialization of `KeyManager` on startup

### DIFF
--- a/src/main/java/org/dependencytrack/common/KeyManagerInitializer.java
+++ b/src/main/java/org/dependencytrack/common/KeyManagerInitializer.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common;
+
+import alpine.common.logging.Logger;
+import alpine.security.crypto.KeyManager;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+
+/**
+ * @since 5.6.0
+ */
+public class KeyManagerInitializer implements ServletContextListener {
+
+    private static final Logger LOGGER = Logger.getLogger(KeyManagerInitializer.class);
+
+    @Override
+    public void contextInitialized(final ServletContextEvent event) {
+        LOGGER.info("Initializing KeyManager");
+
+        // Force initialization of KeyManager, which will cause
+        // the secret, as well as the public-private key pair
+        // to be generated if necessary.
+        final var ignored = KeyManager.getInstance();
+    }
+
+}

--- a/src/main/java/org/dependencytrack/health/HealthCheckInitializer.java
+++ b/src/main/java/org/dependencytrack/health/HealthCheckInitializer.java
@@ -18,9 +18,11 @@
  */
 package org.dependencytrack.health;
 
+import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.server.health.HealthCheckRegistry;
 import alpine.server.health.checks.DatabaseHealthCheck;
+import org.dependencytrack.common.ConfigKey;
 import org.dependencytrack.event.kafka.processor.ProcessorsHealthCheck;
 
 import jakarta.servlet.ServletContextEvent;
@@ -32,6 +34,12 @@ public class HealthCheckInitializer implements ServletContextListener {
 
     @Override
     public void contextInitialized(final ServletContextEvent event) {
+        if (Config.getInstance().getPropertyAsBoolean(ConfigKey.INIT_AND_EXIT)) {
+            LOGGER.debug("Not registering health checks because %s is enabled"
+                    .formatted(ConfigKey.INIT_AND_EXIT.getPropertyName()));
+            return;
+        }
+
         LOGGER.info("Registering health checks");
         HealthCheckRegistry.getInstance().register("database", new DatabaseHealthCheck());
         HealthCheckRegistry.getInstance().register("kafka-processors", new ProcessorsHealthCheck());

--- a/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
+++ b/src/main/java/org/dependencytrack/persistence/migration/MigrationInitializer.java
@@ -60,12 +60,12 @@ public class MigrationInitializer implements ServletContextListener {
     @Override
     public void contextInitialized(final ServletContextEvent event) {
         if (!config.getPropertyAsBoolean(ConfigKey.INIT_TASKS_ENABLED)) {
-            LOGGER.info("Not running migrations because %s is disabled"
+            LOGGER.debug("Not running migrations because %s is disabled"
                     .formatted(ConfigKey.INIT_TASKS_ENABLED.getPropertyName()));
             return;
         }
         if (!config.getPropertyAsBoolean(ConfigKey.DATABASE_RUN_MIGRATIONS)) {
-            LOGGER.info("Not running migrations because %s is disabled"
+            LOGGER.debug("Not running migrations because %s is disabled"
                     .formatted(ConfigKey.DATABASE_RUN_MIGRATIONS.getPropertyName()));
             return;
         }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -30,6 +30,9 @@
         <listener-class>alpine.server.metrics.MetricsInitializer</listener-class>
     </listener>
     <listener>
+        <listener-class>org.dependencytrack.common.KeyManagerInitializer</listener-class>
+    </listener>
+    <listener>
         <listener-class>org.dependencytrack.persistence.migration.MigrationInitializer</listener-class>
     </listener>
     <listener>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Forces initialization of `KeyManager` on startup.

Voids the need for a separate secret key initializer in Docker Compose setups (i.e. https://github.com/DependencyTrack/hyades/blob/348e2c06f901de5b644abb03c863ad546f4894a0/docker-compose.yml#L350-L357), since `KeyManager` will generate it.

`KeyManager` was previously only initialized in `AlpineServlet` (https://github.com/stevespringett/Alpine/blob/7f58a627ed8b476dd780e8b8a1aea14d5a848d7b/alpine-server/src/main/java/alpine/server/AlpineServlet.java#L58-L59), which is not loaded when `init.and.exit` is enabled.

Also reduce log noise when `init.and.exit` is enabled.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
