### PR TITLE
Port : Visible Endpoint returns only Visible Teams(name, uuid)

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -232,7 +232,6 @@ public class TeamResource extends AlpineResource {
             @ApiResponse(responseCode = "200", description = "The Visible Teams", content = @Content(array = @ArraySchema(schema = @Schema(implementation = VisibleTeams.class)))),
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
-    @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_READ})
     public Response availableTeams() {
         try (QueryManager qm = new QueryManager()) {
             Principal user = getPrincipal();

--- a/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -22,6 +22,7 @@ import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
 import alpine.model.Team;
+import alpine.model.UserPrincipal;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
 import io.swagger.v3.oas.annotations.Operation;
@@ -50,8 +51,11 @@ import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.vo.TeamSelfResponse;
+import org.dependencytrack.resources.v1.vo.VisibleTeams;
 import org.owasp.security.logging.SecurityMarkers;
 
+import java.security.Principal;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.datanucleus.PropertyNames.PROPERTY_RETAIN_VALUES;
@@ -217,6 +221,38 @@ public class TeamResource extends AlpineResource {
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
             }
+        }
+    }
+
+    @GET
+    @Path("/visible")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Returns a list of Teams that are visible", description = "<p></p>")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "The Visible Teams", content = @Content(array = @ArraySchema(schema = @Schema(implementation = VisibleTeams.class)))),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_READ})
+    public Response availableTeams() {
+        try (QueryManager qm = new QueryManager()) {
+            Principal user = getPrincipal();
+            boolean isAllTeams = qm.hasAccessManagementPermission(user);
+            List<Team> teams = new ArrayList<>();
+            if (isAllTeams) {
+                teams = qm.getTeams();
+            } else {
+                if (user instanceof final UserPrincipal userPrincipal) {
+                    teams = userPrincipal.getTeams();
+                } else if (user instanceof final ApiKey apiKey) {
+                    teams = apiKey.getTeams();
+                }
+            }
+
+            List<VisibleTeams> response = new ArrayList<>();
+            for (Team team : teams) {
+                response.add(new VisibleTeams(team.getName(), team.getUuid()));
+            }
+            return Response.ok(response).build();
         }
     }
 

--- a/src/main/java/org/dependencytrack/resources/v1/vo/VisibleTeams.java
+++ b/src/main/java/org/dependencytrack/resources/v1/vo/VisibleTeams.java
@@ -1,0 +1,24 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.vo;
+
+import java.util.UUID;
+
+public record VisibleTeams(String name, UUID uuid) {
+}


### PR DESCRIPTION
### Description

Add endpoint `/team/visible` to return only team name and uuid.

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
