### PR TITLE
Port : Fix redundant ConfigProperty queries in BadgeResource

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -19,9 +19,7 @@
 package org.dependencytrack.resources.v1;
 
 import alpine.common.logging.Logger;
-import alpine.common.util.BooleanUtil;
 import alpine.model.ApiKey;
-import alpine.model.ConfigProperty;
 import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
@@ -78,12 +76,6 @@ public class BadgeResource extends AlpineResource {
     private static final String SVG_MEDIA_TYPE = "image/svg+xml";
 
     private final Logger LOGGER = Logger.getLogger(AuthenticationFilter.class);
-
-    private boolean isUnauthenticatedBadgeAccessEnabled(final QueryManager qm) {
-        ConfigProperty property = qm.getConfigProperty(
-                GENERAL_BADGE_ENABLED.getGroupName(), GENERAL_BADGE_ENABLED.getPropertyName());
-        return BooleanUtil.valueOf(property.getPropertyValue());
-    }
 
     // Stand-in methods for alpine.server.filters.AuthenticationFilter and
     // alpine.server.filters.AuthorizationFilter to allow enabling and disabling of
@@ -190,15 +182,16 @@ public class BadgeResource extends AlpineResource {
             @Parameter(description = "The UUID of the project to retrieve metrics for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
         try (QueryManager qm = new QueryManager()) {
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+            final boolean shouldBypassAuth = qm.isEnabled(GENERAL_BADGE_ENABLED);
+            if (!shouldBypassAuth && !passesAuthentication()) {
                 return Response.status(Response.Status.UNAUTHORIZED).build();
             }
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+            if (!shouldBypassAuth && !passesAuthorization(qm)) {
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
+                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
@@ -234,15 +227,16 @@ public class BadgeResource extends AlpineResource {
             @Parameter(description = "The version of the project to query on", required = true)
             @PathParam("version") String version) {
         try (QueryManager qm = new QueryManager()) {
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+            final boolean shouldBypassAuth = qm.isEnabled(GENERAL_BADGE_ENABLED);
+            if (!shouldBypassAuth && !passesAuthentication()) {
                 return Response.status(Response.Status.UNAUTHORIZED).build();
             }
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+            if (!shouldBypassAuth && !passesAuthorization(qm)) {
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
+                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
@@ -276,15 +270,16 @@ public class BadgeResource extends AlpineResource {
             @Parameter(description = "The UUID of the project to retrieve a badge for", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
         try (QueryManager qm = new QueryManager()) {
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+            final boolean shouldBypassAuth = qm.isEnabled(GENERAL_BADGE_ENABLED);
+            if (!shouldBypassAuth && !passesAuthentication()) {
                 return Response.status(Response.Status.UNAUTHORIZED).build();
             }
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+            if (!shouldBypassAuth && !passesAuthorization(qm)) {
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
+                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
@@ -320,15 +315,16 @@ public class BadgeResource extends AlpineResource {
             @Parameter(description = "The version of the project to query on", required = true)
             @PathParam("version") String version) {
         try (QueryManager qm = new QueryManager()) {
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthentication()) {
+            final boolean shouldBypassAuth = qm.isEnabled(GENERAL_BADGE_ENABLED);
+            if (!shouldBypassAuth && !passesAuthentication()) {
                 return Response.status(Response.Status.UNAUTHORIZED).build();
             }
-            if (!isUnauthenticatedBadgeAccessEnabled(qm) && !passesAuthorization(qm)) {
+            if (!shouldBypassAuth && !passesAuthorization(qm)) {
                 return Response.status(Response.Status.FORBIDDEN).build();
             }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                if (!isUnauthenticatedBadgeAccessEnabled(qm) && !qm.hasAccess(super.getPrincipal(), project)) {
+                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
                     return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);


### PR DESCRIPTION
### Description

Fixes redundant ConfigProperty queries in BadgeResource.

If unauthenticated badge access is enabled, the same ConfigProperty was previously queried three times. Since badges are embedded in public places, it'd be beneficial if the respective resources avoided unnecessary work.

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
