### PR TITLE
Fix PURL mismatch of `INTEGRITY_META_COMPONENT` records

### DIFF
--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -1032,9 +1032,9 @@ public class BomUploadProcessingTask implements Subscriber {
     }
 
     private static boolean prepareIntegrityMetaComponent(final QueryManager qm, final Component component) {
-        final IntegrityMetaComponent integrityMetaComponent = qm.getIntegrityMetaComponent(component.getPurlCoordinates().toString());
+        final IntegrityMetaComponent integrityMetaComponent = qm.getIntegrityMetaComponent(component.getPurl().toString());
         if (integrityMetaComponent == null) {
-            qm.createIntegrityMetaHandlingConflict(AbstractMetaHandler.createIntegrityMetaComponent(component.getPurlCoordinates().toString()));
+            qm.createIntegrityMetaHandlingConflict(AbstractMetaHandler.createIntegrityMetaComponent(component.getPurl().toString()));
             return true;
         } else if (integrityMetaComponent.getStatus() == null
                 || (integrityMetaComponent.getStatus() == FetchStatus.IN_PROGRESS


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes PURL mismatch of `INTEGRITY_META_COMPONENT` records.

When initializing records prior to event dispatch, the API server would use the PURL *coordinates* (i.e., excluding qualifiers etc.). However, analysis results arrive for the full PURL (which is correct).

When processing results, the API server failed to correlate the received result with the INTEGRITY_META_COMPONENT record it had created earlier.

As a result, integrity analysis did not work for component with PURLs that have qualifiers.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
