### PR TITLE
Fix unintended manual flushing mode due to DataNucleus `ExecutionContext` pooling

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -201,6 +201,16 @@ alpine.database.pool.max.lifetime=600000
 # @hidden
 alpine.datanucleus.cache.level2.type=none
 
+# Controls the maximum number of ExecutionContext objects that are pooled by DataNucleus.
+# The default defined by DataNucleus is 20. However, since Dependency-Track occasionally
+# tweaks ExecutionContexts (e.g. to disable auto-flushing for insert-heavy tasks),
+# they are not safe for reuse. We thus disable EC pooling completely.
+#
+# @category: Database
+# @type:     integer
+# @hidden
+alpine.datanucleus.executioncontext.maxidle=0
+
 # Defines whether database migrations should be executed on startup.
 # <br/><br/>
 # From v5.6.0 onwards, migrations are considered part of the initialization tasks.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/4233

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/1358

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
