### PR TITLE
Reduce database round-trips during BOM processing

### DIFF
--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -79,6 +79,9 @@ import java.util.UUID;
                 @Persistent(name = "properties"),
                 @Persistent(name = "vulnerabilities"),
         }),
+        @FetchGroup(name = "BOM_UPLOAD_PROCESSING", members = {
+                @Persistent(name = "properties")
+        }),
         @FetchGroup(name = "IDENTITY", members = {
                 @Persistent(name = "id"),
                 @Persistent(name = "uuid")
@@ -94,6 +97,7 @@ public class Component implements Serializable {
      */
     public enum FetchGroup {
         ALL,
+        BOM_UPLOAD_PROCESSING,
         IDENTITY
     }
 

--- a/src/main/java/org/dependencytrack/model/ComponentIdentity.java
+++ b/src/main/java/org/dependencytrack/model/ComponentIdentity.java
@@ -72,6 +72,13 @@ public class ComponentIdentity {
         this.objectType = ObjectType.COMPONENT;
     }
 
+    public ComponentIdentity(final Component component, final boolean excludeUuid) {
+        this(component);
+        if (excludeUuid) {
+            this.uuid = null;
+        }
+    }
+
     public ComponentIdentity(final org.cyclonedx.model.Component component) {
         try {
             this.purl = new PackageURL(component.getPurl());
@@ -93,6 +100,13 @@ public class ComponentIdentity {
         this.version = service.getVersion();
         this.uuid = service.getUuid();
         this.objectType = ObjectType.SERVICE;
+    }
+
+    public ComponentIdentity(final ServiceComponent service, final boolean excludeUuid) {
+        this(service);
+        if (excludeUuid) {
+            this.uuid = null;
+        }
     }
 
     public ComponentIdentity(final org.cyclonedx.model.Service service) {

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -24,9 +24,6 @@ import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonValue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
@@ -38,6 +35,9 @@ import org.dependencytrack.model.sqlmapping.ComponentProjection;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.IntegrityMetaInitializerTask;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
@@ -658,55 +658,6 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
     }
 
     /**
-     * Returns a component by matching its identity information.
-     * <p>
-     * Note that this method employs a stricter matching logic than {@link #matchIdentity(Project, ComponentIdentity)}.
-     * For example, if {@code purl} of the given {@link ComponentIdentity} is {@code null}, this method will use a
-     * query that explicitly checks for the {@code purl} column to be {@code null}.
-     * Whereas other methods will simply not include {@code purl} in the query in such cases.
-     *
-     * @param project the Project the component is a dependency of
-     * @param cid     the identity values of the component
-     * @return a Component object, or null if not found
-     * @since 4.11.0
-     */
-    public Component matchSingleIdentityExact(final Project project, final ComponentIdentity cid) {
-        final Pair<String, Map<String, Object>> queryFilterParamsPair = buildExactComponentIdentityQuery(project, cid);
-        final Query<Component> query = pm.newQuery(Component.class, queryFilterParamsPair.getKey());
-        query.setNamedParameters(queryFilterParamsPair.getRight());
-        try {
-            return query.executeUnique();
-        } finally {
-            query.closeAll();
-        }
-    }
-
-    /**
-     * Returns the first component matching a given {@link ComponentIdentity} in a {@link Project}.
-     *
-     * @param project the Project the component is a dependency of
-     * @param cid     the identity values of the component
-     * @return a Component object, or null if not found
-     * @since 4.11.0
-     */
-    public Component matchFirstIdentityExact(final Project project, final ComponentIdentity cid) {
-        final Pair<String, Map<String, Object>> queryFilterParamsPair = buildExactComponentIdentityQuery(project, cid);
-        final Query<Component> query = pm.newQuery(Component.class, queryFilterParamsPair.getKey());
-        query.setNamedParameters(queryFilterParamsPair.getRight());
-        query.setRange(0, 1);
-        try {
-            final List<Component> result = query.executeList();
-            if (result.isEmpty()) {
-                return null;
-            }
-
-            return result.getFirst();
-        } finally {
-            query.closeAll();
-        }
-    }
-
-    /**
      * Returns a list of components by matching its identity information.
      *
      * @param project the Project the component is a dependency of
@@ -794,88 +745,6 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
         final String filter = "project == :project && (%s)".formatted(String.join(" || ", filterParts));
         params.put("project", project);
         return Pair.of(filter, params);
-    }
-
-    private static Pair<String, Map<String, Object>> buildExactComponentIdentityQuery(final Project project, final ComponentIdentity cid) {
-        var filterParts = new ArrayList<String>();
-        final var params = new HashMap<String, Object>();
-
-        if (cid.getPurl() != null) {
-            filterParts.add("(purl != null && purl == :purl)");
-            params.put("purl", cid.getPurl().canonicalize());
-        } else {
-            filterParts.add("purl == null");
-        }
-
-        if (cid.getCpe() != null) {
-            filterParts.add("(cpe != null && cpe == :cpe)");
-            params.put("cpe", cid.getCpe());
-        } else {
-            filterParts.add("cpe == null");
-        }
-
-        if (cid.getSwidTagId() != null) {
-            filterParts.add("(swidTagId != null && swidTagId == :swidTagId)");
-            params.put("swidTagId", cid.getSwidTagId());
-        } else {
-            filterParts.add("swidTagId == null");
-        }
-
-        var coordinatesFilter = "(";
-        if (cid.getGroup() != null) {
-            coordinatesFilter += "group == :group";
-            params.put("group", cid.getGroup());
-        } else {
-            coordinatesFilter += "group == null";
-        }
-        coordinatesFilter += " && name == :name";
-        params.put("name", cid.getName());
-        if (cid.getVersion() != null) {
-            coordinatesFilter += " && version == :version";
-            params.put("version", cid.getVersion());
-        } else {
-            coordinatesFilter += " && version == null";
-        }
-        coordinatesFilter += ")";
-        filterParts.add(coordinatesFilter);
-
-        final var filter = "project == :project && (" + String.join(" && ", filterParts) + ")";
-        params.put("project", project);
-
-        return Pair.of(filter, params);
-    }
-
-    /**
-     * Intelligently adds dependencies for components that are not already a dependency
-     * of the specified project and removes the dependency relationship for components
-     * that are not in the list of specified components.
-     *
-     * @param project                   the project to bind components to
-     * @param existingProjectComponents the complete list of existing dependent components
-     * @param components                the complete list of components that should be dependencies of the project
-     */
-    public void reconcileComponents(Project project, List<Component> existingProjectComponents, List<Component> components) {
-        // Removes components as dependencies to the project for all
-        // components not included in the list provided
-        List<Component> markedForDeletion = new ArrayList<>();
-        for (final Component existingComponent : existingProjectComponents) {
-            boolean keep = false;
-            for (final Component component : components) {
-                if (component.getId() == existingComponent.getId()) {
-                    keep = true;
-                    break;
-                }
-            }
-            if (!keep) {
-                markedForDeletion.add(existingComponent);
-            }
-        }
-        if (!markedForDeletion.isEmpty()) {
-            for (Component c : markedForDeletion) {
-                this.recursivelyDelete(c, false);
-            }
-            //this.delete(markedForDeletion);
-        }
     }
 
     public Map<String, Component> getDependencyGraphForComponents(Project project, List<Component> components) {
@@ -1053,7 +922,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             //   counter-intuitive to some users, who might expect their manual changes to persist.
             //   If we want to support that, we need a way to track which properties were added and / or
             //   modified manually.
-            if (component.getProperties() != null) {
+            if (component.getProperties() != null && !component.getProperties().isEmpty()) {
                 pm.deletePersistentAll(component.getProperties());
             }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1063,24 +1063,12 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerableSoftwareQueryManager().getAllVulnerableSoftware(cpePart, cpeVendor, cpeProduct, purl);
     }
 
-    public Component matchSingleIdentityExact(final Project project, final ComponentIdentity cid) {
-        return getComponentQueryManager().matchSingleIdentityExact(project, cid);
-    }
-
-    public Component matchFirstIdentityExact(final Project project, final ComponentIdentity cid) {
-        return getComponentQueryManager().matchFirstIdentityExact(project, cid);
-    }
-
     public List<Component> matchIdentity(final Project project, final ComponentIdentity cid) {
         return getComponentQueryManager().matchIdentity(project, cid);
     }
 
     public List<Component> matchIdentity(final ComponentIdentity cid) {
         return getComponentQueryManager().matchIdentity(cid);
-    }
-
-    public void reconcileComponents(Project project, List<Component> existingProjectComponents, List<Component> components) {
-        getComponentQueryManager().reconcileComponents(project, existingProjectComponents, components);
     }
 
     public List<Component> getAllComponents(Project project) {
@@ -1097,10 +1085,6 @@ public class QueryManager extends AlpineQueryManager {
 
     public ServiceComponent matchServiceIdentity(final Project project, final ComponentIdentity cid) {
         return getServiceComponentQueryManager().matchServiceIdentity(project, cid);
-    }
-
-    public void reconcileServiceComponents(Project project, List<ServiceComponent> existingProjectServices, List<ServiceComponent> services) {
-        getServiceComponentQueryManager().reconcileServiceComponents(project, existingProjectServices, services);
     }
 
     public ServiceComponent createServiceComponent(ServiceComponent service, boolean commitIndex) {

--- a/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ServiceComponentQueryManager.java
@@ -28,7 +28,6 @@ import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -61,38 +60,6 @@ final class ServiceComponentQueryManager extends QueryManager implements IQueryM
         final Query<ServiceComponent> query = pm.newQuery(ServiceComponent.class, "project == :project && group == :group && name == :name && version == :version");
         query.setRange(0, 1);
         return singleResult(query.executeWithArray(project, cid.getGroup(), cid.getName(), cid.getVersion()));
-    }
-
-    /**
-     * Intelligently adds service components that are not already a dependency
-     * of the specified project and removes the dependency relationship for service components
-     * that are not in the list of specified components.
-     * @param project the project to bind components to
-     * @param existingProjectServices the complete list of existing dependent service components
-     * @param services the complete list of service components that should be dependencies of the project
-     */
-    public void reconcileServiceComponents(Project project, List<ServiceComponent> existingProjectServices, List<ServiceComponent> services) {
-        // Removes components as dependencies to the project for all
-        // components not included in the list provided
-        List<ServiceComponent> markedForDeletion = new ArrayList<>();
-        for (final ServiceComponent existingService: existingProjectServices) {
-            boolean keep = false;
-            for (final ServiceComponent service: services) {
-                if (service.getId() == existingService.getId()) {
-                    keep = true;
-                    break;
-                }
-            }
-            if (!keep) {
-                markedForDeletion.add(existingService);
-            }
-        }
-        if (!markedForDeletion.isEmpty()) {
-            for (ServiceComponent sc: markedForDeletion) {
-                this.recursivelyDelete(sc, false);
-            }
-            //this.delete(markedForDeletion);
-        }
     }
 
     /**


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Reduces database round-trips during BOM processing.

In the previous implementation, a `SELECT` query was issued for every single component and service in a BOM, in order to find existing components that match their identity.

In retrospect, this causes a lot of unnecessary database round-trips and puts the database under unnecessary stress, in particular for new projects where no components and services exist yet.

Now, we query all existing components and services of the project once in bulk.

A situation where this approach can perform worse, is when a BOM is uploaded to an existing project, and the content differs wildly between BOM and project. We would then load many components into memory, only to delete them shortly after. However, this scenario should be less common. Usually, projects are either empty, or have significant overlap with the uploaded BOM.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Profiling the bloated BOM test, it's visible we previously spent a large chunk of CPU time waiting for Postgres to respond to identity matching queries:

![image](https://github.com/user-attachments/assets/2704b133-79cc-4b8e-bd63-f5d86357c8b2)

In fact, performing these queries was more expensive than flushing new changes, despite the project initially being completely empty.

This overhead is now entirely gone:

![image](https://github.com/user-attachments/assets/fb6cfe4e-212e-4515-aae3-7f2ae7426a25)

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
