### PR TITLE
Update `@ValidUuid` validator to support UUID v7

### DIFF
--- a/src/main/java/org/dependencytrack/model/validation/ValidUuidValidator.java
+++ b/src/main/java/org/dependencytrack/model/validation/ValidUuidValidator.java
@@ -18,28 +18,28 @@
  */
 package org.dependencytrack.model.validation;
 
-import jakarta.validation.Constraint;
-import jakarta.validation.Payload;
-import jakarta.validation.ReportAsSingleViolation;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.UUID;
 
 /**
- * @since 4.11.0
+ * @since 5.6.0
  */
-@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
-@Constraint(validatedBy = ValidUuidValidator.class)
-@Retention(RUNTIME)
-@ReportAsSingleViolation
-public @interface ValidUuid {
+public class ValidUuidValidator implements ConstraintValidator<ValidUuid, String> {
 
-    String message() default "Invalid UUID";
+    @Override
+    public boolean isValid(final String uuidString, final ConstraintValidatorContext validatorContext) {
+        if (uuidString == null) {
+            // null-ness is expected to be validated using @NotNull
+            return true;
+        }
 
-    Class<?>[] groups() default {};
-
-    Class<? extends Payload>[] payload() default {};
+        try {
+            UUID.fromString(uuidString);
+            return true;
+        } catch (IllegalArgumentException e) {
+            return false;
+        }
+    }
 
 }

--- a/src/test/java/org/dependencytrack/model/validation/ValidUuidValidatorTest.java
+++ b/src/test/java/org/dependencytrack/model/validation/ValidUuidValidatorTest.java
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model.validation;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidUuidValidatorTest {
+
+    private Validator validator;
+
+    private record TestRecord(@ValidUuid String uuid) {
+    }
+
+    @Before
+    public void setUp() {
+        final ValidatorFactory validatorFactory = Validation.buildDefaultValidatorFactory();
+        validator = validatorFactory.getValidator();
+    }
+
+    @Test
+    public void testWithValidUuidV4() {
+        final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord("6a80b854-8083-47ea-869c-321018c0ff76"));
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testWithValidUuidV7() {
+        final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord("01942307-ebc3-7ec8-a66e-1a40d595c097"));
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testWithInvalidUuid() {
+        final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord("invalid-uuid"));
+        assertThat(violations).isNotEmpty();
+    }
+
+    @Test
+    public void testWithNullUuid() {
+        final Set<ConstraintViolation<TestRecord>> violations = validator.validate(new TestRecord(null));
+        assertThat(violations).isEmpty();
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Updates `@ValidUuid` validator to support UUID v7.

The previous regex-based implementation worked for UUID v4, but not for v7. We will make heavy usage of v7 in the future. Java's `UUID` class supports all UUID versions, making it a better fit for validation purposes than regex.

For more details on UUID v7: https://uuid7.com/

Extracted from https://github.com/DependencyTrack/hyades-apiserver/tree/workflow-v2

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
