### PR TITLE
Reduce logging noise of `PluginManager`

### DIFF
--- a/src/main/java/org/dependencytrack/plugin/PluginManager.java
+++ b/src/main/java/org/dependencytrack/plugin/PluginManager.java
@@ -179,10 +179,10 @@ public class PluginManager {
         final var pluginLoader = ServiceLoader.load(Plugin.class);
         for (final Plugin plugin : pluginLoader) {
             try (var ignoredMdcPlugin = MDC.putCloseable(MDC_PLUGIN, plugin.getClass().getName())) {
-                LOGGER.info("Loading plugin");
+                LOGGER.debug("Loading plugin");
                 loadExtensionsForPlugin(plugin);
 
-                LOGGER.info("Plugin loaded successfully");
+                LOGGER.debug("Plugin loaded successfully");
                 loadedPluginByClass.put(plugin.getClass(), plugin);
             }
         }
@@ -274,7 +274,7 @@ public class PluginManager {
             );
         }
 
-        LOGGER.info("Initializing extension");
+        LOGGER.debug("Initializing extension");
         try {
             extensionFactory.init(configRegistry);
         } catch (RuntimeException e) {
@@ -318,7 +318,7 @@ public class PluginManager {
 
             try (var ignoredMdcExtensionPoint = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointClassName);
                  var ignoredMdcExtensionPointName = MDC.putCloseable(MDC_EXTENSION_POINT_NAME, extensionPointName)) {
-                LOGGER.info("Determining default extension");
+                LOGGER.debug("Determining default extension");
 
                 final SortedSet<? extends ExtensionFactory<?>> factories = getFactories(extensionPointClass);
                 if (factories == null || factories.isEmpty()) {
@@ -331,9 +331,9 @@ public class PluginManager {
 
                 final ExtensionFactory<?> extensionFactory;
                 if (defaultExtensionName.isEmpty()) {
-                    LOGGER.warn("No default extension configured; Choosing based on priority");
+                    LOGGER.debug("No default extension configured; Choosing based on priority");
                     extensionFactory = factories.first();
-                    LOGGER.info("Chose extension %s (%s) with priority %d as default"
+                    LOGGER.debug("Chose extension %s (%s) with priority %d as default"
                             .formatted(extensionFactory.extensionName(), extensionFactory.extensionClass().getName(), extensionFactory.priority()));
                 } else {
                     extensionFactory = factories.stream()
@@ -342,7 +342,7 @@ public class PluginManager {
                             .orElseThrow(() -> new NoSuchElementException("""
                                     No extension named %s exists for extension point %s (%s)"""
                                     .formatted(defaultExtensionName.get(), MDC.get(MDC_EXTENSION_POINT_NAME), MDC.get(MDC_EXTENSION_POINT))));
-                    LOGGER.info("Using extension %s (%s) as default"
+                    LOGGER.debug("Using extension %s (%s) as default"
                             .formatted(extensionFactory.extensionName(), extensionFactory.extensionClass().getName()));
                 }
 
@@ -398,10 +398,10 @@ public class PluginManager {
         // Unload plugins in reverse order in which they were loaded.
         for (final Plugin plugin : loadedPluginByClass.sequencedValues().reversed()) {
             try (var ignoredMdcPlugin = MDC.putCloseable(MDC_PLUGIN, plugin.getClass().getName())) {
-                LOGGER.info("Unloading plugin");
+                LOGGER.debug("Unloading plugin");
                 unloadPlugin(plugin);
 
-                LOGGER.info("Plugin unloaded");
+                LOGGER.debug("Plugin unloaded");
             }
         }
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Reduces logging noise of `PluginManager`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
