### PR TITLE
Suppress rejected vulnerabilities (records with empty data) by SNYK

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
+++ b/src/main/java/org/dependencytrack/event/kafka/KafkaEventConverter.java
@@ -78,7 +78,7 @@ public final class KafkaEventConverter {
         };
     }
 
-    static KafkaEvent<?, ?> convert(final alpine.notification.Notification notification) {
+    public static KafkaEvent<?, ?> convert(final alpine.notification.Notification notification) {
         final Notification protoNotification = NotificationModelConverter.convert(notification);
         return convert(protoNotification);
     }

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -246,7 +246,8 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
         final var syncedVulns = new HashSet<Vulnerability>();
 
         for (final org.cyclonedx.proto.v1_6.Vulnerability reportedVuln : scannerResult.getBom().getVulnerabilitiesList()) {
-            if (reportedVuln.getRejected() != null && scannerResult.getScanner() == SCANNER_SNYK) {
+            if (reportedVuln.getRejected() != null && !reportedVuln.getRejected().toString().isEmpty()
+                    && scannerResult.getScanner() == SCANNER_SNYK) {
                 // If vulnerability has rejected field, component is no longer vulnerable by SNYK, suppress it.
                 suppressComponentVulnbySnyk(qm, component);
             } else {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -950,7 +950,6 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                       AND "A"."VULNERABILITY_ID" = "CV"."VULNERABILITY_ID"
                     WHERE "CV"."COMPONENT_ID" = :componentId
                       AND "V"."SOURCE" = 'SNYK'
-                      AND NOT "A"."SUPPRESSED"
                      <#if vulnIdsToExclude>
                        AND "V"."VULNID" != ANY(:vulnIdsToExclude)
                      </#if>
@@ -966,6 +965,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                  -- Update existing record if not already suppressed.
                  ON CONFLICT ("PROJECT_ID", "COMPONENT_ID", "VULNERABILITY_ID")
                  DO UPDATE SET "SUPPRESSED" = TRUE, "STATE" = 'FALSE_POSITIVE'
+                 WHERE NOT "ANALYSIS"."SUPPRESSED"
                  RETURNING "ID"
             """)
         @DefineNamedBindings

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -206,7 +206,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
             return;
         }
 
-        final Set<Vulnerability> syncedVulns = syncVulnerabilities(qm, scanKey, scannerResult);
+        final Set<Vulnerability> syncedVulns = syncVulnerabilities(qm, component, scanKey, scannerResult);
         LOGGER.debug("Synchronized %d vulnerabilities reported by %s for %s (scanKey: %s)"
                 .formatted(syncedVulns.size(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)));
 
@@ -243,11 +243,8 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
      * @param scannerResult The {@link ScannerResult} to synchronize vulnerabilities from
      * @return A {@link Set} of synchronized {@link Vulnerability}s
      */
-    private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final ScanKey scanKey, final ScannerResult scannerResult) {
+    private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final Component component, final ScanKey scanKey, final ScannerResult scannerResult) {
         final var syncedVulns = new HashSet<Vulnerability>();
-
-        final Component component = withJdbiHandle(handle ->
-                handle.attach(Dao.class).getComponentByUuid(UUID.fromString(scanKey.getComponentUuid())));
 
         if (scannerResult.getScanner() == SCANNER_SNYK && component.hasSnykVulns()) {
             // Compare component's Snyk vulnerabilities and suppress those which are longer vulnerable by SNYK.
@@ -301,7 +298,8 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
         useJdbiTransaction(handle -> {
             final var dao = handle.attach(Dao.class);
             analysisIds.addAll(dao.suppressSnykAnalyses(component.id,
-                    vulnList.isEmpty() ? null : vulnList.stream().map(vuln -> vuln.getId()).toList()));
+                    vulnList.isEmpty() ? null : vulnList.stream().map(vuln -> vuln.getId()).toList(),
+                    component.projectId));
         });
         for (var analysisId : analysisIds) {
             var analysis = qm.getObjectById(org.dependencytrack.model.Analysis.class, analysisId);
@@ -939,22 +937,40 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
         void createAnalysisComments(@BindMethods final Iterable<AnalysisComment> comment);
 
         @SqlQuery("""
-                UPDATE "ANALYSIS"
-                    SET "SUPPRESSED" = TRUE
-                        , "STATE" = 'FALSE_POSITIVE'
-                    FROM "VULNERABILITY"
-                    WHERE "ANALYSIS"."COMPONENT_ID" = :componentId
-                       AND "ANALYSIS"."SUPPRESSED" = 'false'
-                       AND "ANALYSIS"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
-                       AND "VULNERABILITY"."SOURCE" = 'SNYK'
-                    <#if vulnIdsToExclude>
-                       AND "VULNERABILITY"."VULNID" != ANY(:vulnIdsToExclude)
-                    </#if>
-                RETURNING "ANALYSIS"."ID"
+                 -- Find the IDs of all Snyk vulns currently assigned to the component,
+                 -- that are not suppressed or have no analysis at all,
+                 -- and are not excluded by vulnIdsToExclude.
+                 WITH "CTE_VULNERABILITY" AS (
+                   SELECT "V"."ID"
+                     FROM "VULNERABILITY" AS "V"
+                    INNER JOIN "COMPONENTS_VULNERABILITIES" AS "CV"
+                       ON "CV"."VULNERABILITY_ID" = "V"."ID"
+                     LEFT JOIN "ANALYSIS" AS "A"
+                       ON "A"."COMPONENT_ID" = "CV"."COMPONENT_ID"
+                      AND "A"."VULNERABILITY_ID" = "CV"."VULNERABILITY_ID"
+                    WHERE "CV"."COMPONENT_ID" = :componentId
+                      AND "V"."SOURCE" = 'SNYK'
+                      AND NOT "A"."SUPPRESSED"
+                     <#if vulnIdsToExclude>
+                       AND "V"."VULNID" != ANY(:vulnIdsToExclude)
+                     </#if>
+                 )
+                 -- Try to create suppression analyses for all Snyk vulns identified above.
+                 INSERT INTO "ANALYSIS" ("COMPONENT_ID", "PROJECT_ID", "VULNERABILITY_ID", "SUPPRESSED", "STATE")
+                 SELECT :componentId AS "COMPONENT_ID"
+                      , :projectId AS "PROJECT_ID"
+                      , "CTE_VULNERABILITY"."ID" AS "VULNERABILITY_ID"
+                      , TRUE AS "SUPPRESSED"
+                      , 'FALSE_POSITIVE' AS "STATE"
+                 FROM "CTE_VULNERABILITY"
+                 -- Update existing record if not already suppressed.
+                 ON CONFLICT ("PROJECT_ID", "COMPONENT_ID", "VULNERABILITY_ID")
+                 DO UPDATE SET "SUPPRESSED" = TRUE, "STATE" = 'FALSE_POSITIVE'
+                 RETURNING "ID"
             """)
         @DefineNamedBindings
         @RegisterBeanMapper(org.dependencytrack.model.Analysis.class)
-        List<Long> suppressSnykAnalyses(@Bind final long componentId, @Bind final List<String> vulnIdsToExclude);
+        List<Long> suppressSnykAnalyses(@Bind final long componentId, @Bind final List<String> vulnIdsToExclude, @Bind final long projectId);
     }
 
     public static class Analysis {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -25,6 +25,7 @@ import alpine.notification.NotificationLevel;
 import com.google.protobuf.Any;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
 import org.dependencytrack.event.kafka.KafkaEvent;
@@ -46,7 +47,6 @@ import org.dependencytrack.model.mapping.PolicyProtoMapper;
 import org.dependencytrack.notification.NotificationConstants;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
-import org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.NotificationSubjectDao;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicy;
@@ -54,17 +54,20 @@ import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyEvaluator;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyOperation;
 import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyRating;
 import org.dependencytrack.proto.notification.v1.Group;
+import org.dependencytrack.proto.policy.v1.Project;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
 import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
 import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
 import org.dependencytrack.util.AnalysisCommentFormatter.AnalysisCommentField;
+import org.dependencytrack.util.NotificationUtil;
 import org.dependencytrack.util.PersistenceUtil;
 import org.dependencytrack.util.PersistenceUtil.Differ;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
@@ -73,7 +76,7 @@ import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.slf4j.MDC;
 
 import javax.jdo.Query;
-import jakarta.ws.rs.core.MultivaluedHashMap;
+import javax.jdo.Transaction;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -98,6 +101,7 @@ import static org.dependencytrack.common.MdcKeys.MDC_SCAN_TOKEN;
 import static org.dependencytrack.parser.dependencytrack.ModelConverterCdxToVuln.convert;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABILITY;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_NEW_VULNERABLE_DEPENDENCY;
@@ -106,6 +110,7 @@ import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONA
 import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
 import static org.dependencytrack.proto.vulnanalysis.v1.ScanStatus.SCAN_STATUS_FAILED;
 import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_INTERNAL;
+import static org.dependencytrack.proto.vulnanalysis.v1.Scanner.SCANNER_SNYK;
 import static org.dependencytrack.util.AnalysisCommentFormatter.formatComment;
 import static org.dependencytrack.util.NotificationUtil.generateNotificationContent;
 import static org.dependencytrack.util.NotificationUtil.generateNotificationTitle;
@@ -200,7 +205,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
             return;
         }
 
-        final Set<Vulnerability> syncedVulns = syncVulnerabilities(qm, scanKey, scannerResult);
+        final Set<Vulnerability> syncedVulns = syncVulnerabilities(qm, component, scanKey, scannerResult);
         LOGGER.debug("Synchronized %d vulnerabilities reported by %s for %s (scanKey: %s)"
                 .formatted(syncedVulns.size(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)));
 
@@ -237,64 +242,80 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
      * @param scannerResult The {@link ScannerResult} to synchronize vulnerabilities from
      * @return A {@link Set} of synchronized {@link Vulnerability}s
      */
-    private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final ScanKey scanKey, final ScannerResult scannerResult) {
+    private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final Component component, final ScanKey scanKey, final ScannerResult scannerResult) {
         final var syncedVulns = new HashSet<Vulnerability>();
 
         for (final org.cyclonedx.proto.v1_6.Vulnerability reportedVuln : scannerResult.getBom().getVulnerabilitiesList()) {
-            final Vulnerability vuln;
-            try {
-                vuln = ModelConverterCdxToVuln.convert(qm, scannerResult.getBom(), reportedVuln, true);
-            } catch (RuntimeException e) {
-                LOGGER.error("Failed to convert vulnerability %s/%s (reported by %s for component %s) to internal model (scanKey: %s)"
-                        .formatted(reportedVuln.getSource(), reportedVuln.getId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
-                continue;
-            }
-
-            try {
-                final Vulnerability syncedVuln = syncVulnerability(qm, vuln, scannerResult.getScanner());
-
-                // Detach vulnerabilities from JDO persistence context.
-                // We do not want to trigger any DB interactions by accessing their fields later.
-                // Note that even PersistenceManager#detachCopy will load / unload fields based
-                // on the current FetchPlan. But we just want to keep the data we already have,
-                // and #makeTransientAll does exactly that.
-                qm.getPersistenceManager().makeTransient(syncedVuln);
-
-                if (vuln.getAliases() != null && !vuln.getAliases().isEmpty()) {
-                    final var syncedAliases = new ArrayList<VulnerabilityAlias>();
-                    for (VulnerabilityAlias alias : vuln.getAliases()) {
-                        final VulnerabilityAlias syncedAlias = qm.synchronizeVulnerabilityAlias(alias);
-                        qm.getPersistenceManager().makeTransient(syncedAlias);
-                        syncedAliases.add(syncedAlias);
-                    }
-                    syncedVuln.setAliases(syncedAliases);
+            if (reportedVuln.getRejected() != null && scannerResult.getScanner() == SCANNER_SNYK) {
+                // If vulnerability has rejected field, component is no longer vulnerable by SNYK, suppress it.
+                suppressComponentVulnbySnyk(qm, component);
+            } else {
+                final Vulnerability vuln;
+                try {
+                    vuln = convert(qm, scannerResult.getBom(), reportedVuln, true);
+                } catch (RuntimeException e) {
+                    LOGGER.error("Failed to convert vulnerability %s/%s (reported by %s for component %s) to internal model (scanKey: %s)"
+                            .formatted(reportedVuln.getSource(), reportedVuln.getId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
+                    continue;
                 }
 
-                syncedVulns.add(syncedVuln);
-            } catch (RuntimeException e) {
-                // Use a broad catch here, so we can still try to process other
-                // vulnerabilities, even though processing one of them failed.
+                try {
+                    final Vulnerability syncedVuln = syncVulnerability(qm, vuln, scannerResult.getScanner());
 
-                LOGGER.warn("Failed to synchronize vulnerability %s/%s (reported by %s for component %s; scanKey: %s)"
-                        .formatted(vuln.getSource(), vuln.getVulnId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
+                    // Detach vulnerabilities from JDO persistence context.
+                    // We do not want to trigger any DB interactions by accessing their fields later.
+                    // Note that even PersistenceManager#detachCopy will load / unload fields based
+                    // on the current FetchPlan. But we just want to keep the data we already have,
+                    // and #makeTransientAll does exactly that.
+                    qm.getPersistenceManager().makeTransient(syncedVuln);
+
+                    if (vuln.getAliases() != null && !vuln.getAliases().isEmpty()) {
+                        final var syncedAliases = new ArrayList<VulnerabilityAlias>();
+                        for (VulnerabilityAlias alias : vuln.getAliases()) {
+                            final VulnerabilityAlias syncedAlias = qm.synchronizeVulnerabilityAlias(alias);
+                            qm.getPersistenceManager().makeTransient(syncedAlias);
+                            syncedAliases.add(syncedAlias);
+                        }
+                        syncedVuln.setAliases(syncedAliases);
+                    }
+
+                    syncedVulns.add(syncedVuln);
+                } catch (RuntimeException e) {
+                    // Use a broad catch here, so we can still try to process other
+                    // vulnerabilities, even though processing one of them failed.
+
+                    LOGGER.warn("Failed to synchronize vulnerability %s/%s (reported by %s for component %s; scanKey: %s)"
+                            .formatted(vuln.getSource(), vuln.getVulnId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
+                }
             }
         }
-
         return syncedVulns;
+    }
+
+    private void suppressComponentVulnbySnyk(QueryManager qm, Component component) {
+        final var analysisIds = new ArrayList<Long>();
+        useJdbiTransaction(handle -> {
+            final var dao = handle.attach(Dao.class);
+            analysisIds.addAll(dao.suppressSnykAnalyses(component.id));
+        });
+        for (var analysisId : analysisIds) {
+            var analysis = qm.getObjectById(org.dependencytrack.model.Analysis.class, analysisId);
+            NotificationUtil.analyzeNotificationCriteria(qm, analysis, true, true);
+        }
     }
 
     /**
      * Synchronize a given {@link Vulnerability} as reported by a given {@link Scanner} with the datastore.
      * <p>
      * This method differs from {@link QueryManager#synchronizeVulnerability(Vulnerability, boolean)} in that it expects
-     * an active {@link javax.jdo.Transaction}, and only calls setters of existing vulnerabilities when the respective
+     * an active {@link Transaction}, and only calls setters of existing vulnerabilities when the respective
      * value actually changed, saving network round-trips.
      *
      * @param qm      The {@link QueryManager} to use
      * @param vuln    The {@link Vulnerability} to synchronize
      * @param scanner The {@link AnalyzerIdentity} that reported the vulnerability
      * @return The synchronized {@link Vulnerability}
-     * @throws IllegalStateException  When no {@link javax.jdo.Transaction} is active
+     * @throws IllegalStateException  When no {@link Transaction} is active
      * @throws NoSuchElementException When the reported vulnerability is internal, but does not exist in the datastore
      */
     private Vulnerability syncVulnerability(final QueryManager qm, final Vulnerability vuln, final Scanner scanner) {
@@ -372,7 +393,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
             return Collections.emptyMap();
         }
 
-        final var policyProject = org.dependencytrack.proto.policy.v1.Project.newBuilder()
+        final var policyProject = Project.newBuilder()
                 .setUuid(component.projectUuid().toString())
                 .build();
         final var policyComponent = org.dependencytrack.proto.policy.v1.Component.newBuilder()
@@ -904,6 +925,18 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                 """)
         void createAnalysisComments(@BindMethods final Iterable<AnalysisComment> comment);
 
+        @SqlQuery("""
+                UPDATE "ANALYSIS"
+                    SET "SUPPRESSED" = true, "STATE" = 'NOT_AFFECTED'
+                    WHERE "COMPONENT_ID" = :componentId
+                    AND "VULNERABILITY_ID" IN
+                        ( SELECT "VULNERABILITY"."ID"
+                            FROM "VULNERABILITY"
+                            WHERE "VULNERABILITY"."SOURCE" = 'SNYK')
+                    RETURNING "ANALYSIS"."ID"
+            """)
+        @RegisterBeanMapper(org.dependencytrack.model.Analysis.class)
+        List<Long> suppressSnykAnalyses(@Bind final long componentId);
     }
 
     public static class Analysis {
@@ -1228,5 +1261,4 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
 
     public record FindingAttribution(long vulnId, long componentId, long projectId, String analyzer, UUID uuid) {
     }
-
 }

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -70,6 +70,7 @@ import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindMethods;
+import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -245,59 +246,59 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
     private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final Component component, final ScanKey scanKey, final ScannerResult scannerResult) {
         final var syncedVulns = new HashSet<Vulnerability>();
 
+        if (scannerResult.getScanner() == SCANNER_SNYK) {
+            // Compare component's Snyk vulnerabilities and suppress those which are longer vulnerable by SNYK.
+            compareAndSuppressVulnBySnyk(qm, component, scannerResult.getBom().getVulnerabilitiesList());
+        }
+
         for (final org.cyclonedx.proto.v1_6.Vulnerability reportedVuln : scannerResult.getBom().getVulnerabilitiesList()) {
-            if (reportedVuln.getRejected() != null && !reportedVuln.getRejected().toString().isEmpty()
-                    && scannerResult.getScanner() == SCANNER_SNYK) {
-                // If vulnerability has rejected field, component is no longer vulnerable by SNYK, suppress it.
-                suppressComponentVulnbySnyk(qm, component);
-            } else {
-                final Vulnerability vuln;
-                try {
-                    vuln = convert(qm, scannerResult.getBom(), reportedVuln, true);
-                } catch (RuntimeException e) {
-                    LOGGER.error("Failed to convert vulnerability %s/%s (reported by %s for component %s) to internal model (scanKey: %s)"
-                            .formatted(reportedVuln.getSource(), reportedVuln.getId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
-                    continue;
-                }
+            final Vulnerability vuln;
+            try {
+                vuln = convert(qm, scannerResult.getBom(), reportedVuln, true);
+            } catch (RuntimeException e) {
+                LOGGER.error("Failed to convert vulnerability %s/%s (reported by %s for component %s) to internal model (scanKey: %s)"
+                        .formatted(reportedVuln.getSource(), reportedVuln.getId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
+                continue;
+            }
 
-                try {
-                    final Vulnerability syncedVuln = syncVulnerability(qm, vuln, scannerResult.getScanner());
+            try {
+                final Vulnerability syncedVuln = syncVulnerability(qm, vuln, scannerResult.getScanner());
 
-                    // Detach vulnerabilities from JDO persistence context.
-                    // We do not want to trigger any DB interactions by accessing their fields later.
-                    // Note that even PersistenceManager#detachCopy will load / unload fields based
-                    // on the current FetchPlan. But we just want to keep the data we already have,
-                    // and #makeTransientAll does exactly that.
-                    qm.getPersistenceManager().makeTransient(syncedVuln);
+                // Detach vulnerabilities from JDO persistence context.
+                // We do not want to trigger any DB interactions by accessing their fields later.
+                // Note that even PersistenceManager#detachCopy will load / unload fields based
+                // on the current FetchPlan. But we just want to keep the data we already have,
+                // and #makeTransientAll does exactly that.
+                qm.getPersistenceManager().makeTransient(syncedVuln);
 
-                    if (vuln.getAliases() != null && !vuln.getAliases().isEmpty()) {
-                        final var syncedAliases = new ArrayList<VulnerabilityAlias>();
-                        for (VulnerabilityAlias alias : vuln.getAliases()) {
-                            final VulnerabilityAlias syncedAlias = qm.synchronizeVulnerabilityAlias(alias);
-                            qm.getPersistenceManager().makeTransient(syncedAlias);
-                            syncedAliases.add(syncedAlias);
-                        }
-                        syncedVuln.setAliases(syncedAliases);
+                if (vuln.getAliases() != null && !vuln.getAliases().isEmpty()) {
+                    final var syncedAliases = new ArrayList<VulnerabilityAlias>();
+                    for (VulnerabilityAlias alias : vuln.getAliases()) {
+                        final VulnerabilityAlias syncedAlias = qm.synchronizeVulnerabilityAlias(alias);
+                        qm.getPersistenceManager().makeTransient(syncedAlias);
+                        syncedAliases.add(syncedAlias);
                     }
-
-                    syncedVulns.add(syncedVuln);
-                } catch (RuntimeException e) {
-                    // Use a broad catch here, so we can still try to process other
-                    // vulnerabilities, even though processing one of them failed.
-
-                    LOGGER.warn("Failed to synchronize vulnerability %s/%s (reported by %s for component %s; scanKey: %s)"
-                            .formatted(vuln.getSource(), vuln.getVulnId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
+                    syncedVuln.setAliases(syncedAliases);
                 }
+
+                syncedVulns.add(syncedVuln);
+            } catch (RuntimeException e) {
+                // Use a broad catch here, so we can still try to process other
+                // vulnerabilities, even though processing one of them failed.
+
+                LOGGER.warn("Failed to synchronize vulnerability %s/%s (reported by %s for component %s; scanKey: %s)"
+                        .formatted(vuln.getSource(), vuln.getVulnId(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)), e);
             }
         }
         return syncedVulns;
     }
 
-    private void suppressComponentVulnbySnyk(QueryManager qm, Component component) {
+    private void compareAndSuppressVulnBySnyk(QueryManager qm, Component component, List<org.cyclonedx.proto.v1_6.Vulnerability> vulnList) {
         final var analysisIds = new ArrayList<Long>();
         useJdbiTransaction(handle -> {
             final var dao = handle.attach(Dao.class);
-            analysisIds.addAll(dao.suppressSnykAnalyses(component.id));
+            analysisIds.addAll(dao.suppressSnykAnalyses(component.id,
+                    vulnList.isEmpty() ? null : vulnList.stream().map(vuln -> vuln.getId()).toList()));
         });
         for (var analysisId : analysisIds) {
             var analysis = qm.getObjectById(org.dependencytrack.model.Analysis.class, analysisId);
@@ -930,14 +931,20 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                 UPDATE "ANALYSIS"
                     SET "SUPPRESSED" = true, "STATE" = 'NOT_AFFECTED'
                     WHERE "COMPONENT_ID" = :componentId
+                    AND "SUPPRESSED" = 'false'
                     AND "VULNERABILITY_ID" IN
                         ( SELECT "VULNERABILITY"."ID"
                             FROM "VULNERABILITY"
-                            WHERE "VULNERABILITY"."SOURCE" = 'SNYK')
+                            WHERE "VULNERABILITY"."SOURCE" = 'SNYK'
+                            <#if vulnIdsToExclude>
+                                AND "VULNERABILITY"."VULNID" != ANY(:vulnIdsToExclude)
+                            </#if>
+                        )
                     RETURNING "ANALYSIS"."ID"
             """)
+        @DefineNamedBindings
         @RegisterBeanMapper(org.dependencytrack.model.Analysis.class)
-        List<Long> suppressSnykAnalyses(@Bind final long componentId);
+        List<Long> suppressSnykAnalyses(@Bind final long componentId, @Bind final List<String> vulnIdsToExclude);
     }
 
     public static class Analysis {

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -950,6 +950,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                       AND "A"."VULNERABILITY_ID" = "CV"."VULNERABILITY_ID"
                     WHERE "CV"."COMPONENT_ID" = :componentId
                       AND "V"."SOURCE" = 'SNYK'
+                      AND ("A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
                      <#if vulnIdsToExclude>
                        AND "V"."VULNID" != ANY(:vulnIdsToExclude)
                      </#if>
@@ -965,7 +966,6 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                  -- Update existing record if not already suppressed.
                  ON CONFLICT ("PROJECT_ID", "COMPONENT_ID", "VULNERABILITY_ID")
                  DO UPDATE SET "SUPPRESSED" = TRUE, "STATE" = 'FALSE_POSITIVE'
-                 WHERE NOT "ANALYSIS"."SUPPRESSED"
                  RETURNING "ID"
             """)
         @DefineNamedBindings

--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -206,7 +206,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
             return;
         }
 
-        final Set<Vulnerability> syncedVulns = syncVulnerabilities(qm, component, scanKey, scannerResult);
+        final Set<Vulnerability> syncedVulns = syncVulnerabilities(qm, scanKey, scannerResult);
         LOGGER.debug("Synchronized %d vulnerabilities reported by %s for %s (scanKey: %s)"
                 .formatted(syncedVulns.size(), scannerResult.getScanner(), scanKey.getComponentUuid(), prettyPrint(scanKey)));
 
@@ -243,10 +243,13 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
      * @param scannerResult The {@link ScannerResult} to synchronize vulnerabilities from
      * @return A {@link Set} of synchronized {@link Vulnerability}s
      */
-    private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final Component component, final ScanKey scanKey, final ScannerResult scannerResult) {
+    private Set<Vulnerability> syncVulnerabilities(final QueryManager qm, final ScanKey scanKey, final ScannerResult scannerResult) {
         final var syncedVulns = new HashSet<Vulnerability>();
 
-        if (scannerResult.getScanner() == SCANNER_SNYK) {
+        final Component component = withJdbiHandle(handle ->
+                handle.attach(Dao.class).getComponentByUuid(UUID.fromString(scanKey.getComponentUuid())));
+
+        if (scannerResult.getScanner() == SCANNER_SNYK && component.hasSnykVulns()) {
             // Compare component's Snyk vulnerabilities and suppress those which are longer vulnerable by SNYK.
             compareAndSuppressVulnBySnyk(qm, component, scannerResult.getBom().getVulnerabilitiesList());
         }
@@ -302,7 +305,9 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
         });
         for (var analysisId : analysisIds) {
             var analysis = qm.getObjectById(org.dependencytrack.model.Analysis.class, analysisId);
-            NotificationUtil.analyzeNotificationCriteria(qm, analysis, true, true);
+            var notification = NotificationUtil.generateAnalysisNotification(qm, analysis, true, true);
+            final var event = KafkaEventConverter.convert(notification);
+            eventsToDispatch.get().add(event);
         }
     }
 
@@ -817,7 +822,13 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                   "C"."ID"   AS "id",
                   "C"."UUID" AS "uuid",
                   "P"."ID"   AS "projectId",
-                  "P"."UUID" AS "projectUuid"
+                  "P"."UUID" AS "projectUuid",
+                   (SELECT EXISTS(SELECT 1
+                        FROM "COMPONENTS_VULNERABILITIES" AS "CV"
+                    INNER JOIN "VULNERABILITY" AS "V"
+                        ON "V"."ID" = "CV"."VULNERABILITY_ID"
+                    WHERE "CV"."COMPONENT_ID" = "C"."ID"
+                        AND "V"."SOURCE" = 'SNYK')) AS "hasSnykVulns"
                 FROM
                   "COMPONENT" AS "C"
                 INNER JOIN
@@ -929,18 +940,17 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
 
         @SqlQuery("""
                 UPDATE "ANALYSIS"
-                    SET "SUPPRESSED" = true, "STATE" = 'NOT_AFFECTED'
-                    WHERE "COMPONENT_ID" = :componentId
-                    AND "SUPPRESSED" = 'false'
-                    AND "VULNERABILITY_ID" IN
-                        ( SELECT "VULNERABILITY"."ID"
-                            FROM "VULNERABILITY"
-                            WHERE "VULNERABILITY"."SOURCE" = 'SNYK'
-                            <#if vulnIdsToExclude>
-                                AND "VULNERABILITY"."VULNID" != ANY(:vulnIdsToExclude)
-                            </#if>
-                        )
-                    RETURNING "ANALYSIS"."ID"
+                    SET "SUPPRESSED" = TRUE
+                        , "STATE" = 'FALSE_POSITIVE'
+                    FROM "VULNERABILITY"
+                    WHERE "ANALYSIS"."COMPONENT_ID" = :componentId
+                       AND "ANALYSIS"."SUPPRESSED" = 'false'
+                       AND "ANALYSIS"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+                       AND "VULNERABILITY"."SOURCE" = 'SNYK'
+                    <#if vulnIdsToExclude>
+                       AND "VULNERABILITY"."VULNID" != ANY(:vulnIdsToExclude)
+                    </#if>
+                RETURNING "ANALYSIS"."ID"
             """)
         @DefineNamedBindings
         @RegisterBeanMapper(org.dependencytrack.model.Analysis.class)
@@ -1264,7 +1274,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
 
     }
 
-    public record Component(long id, UUID uuid, long projectId, UUID projectUuid) {
+    public record Component(long id, UUID uuid, long projectId, UUID projectUuid, boolean hasSnykVulns) {
     }
 
     public record FindingAttribution(long vulnId, long componentId, long projectId, String analyzer, UUID uuid) {

--- a/src/main/java/org/dependencytrack/util/NotificationUtil.java
+++ b/src/main/java/org/dependencytrack/util/NotificationUtil.java
@@ -394,7 +394,7 @@ public final class NotificationUtil {
 
     public static String generateNotificationTitle(String messageType, Project project) {
         if (project != null) {
-            return messageType + " on Project: [" + project.toString() + "]";
+            return messageType + " on Project: [" + project + "]";
         }
         return messageType;
     }

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -1443,7 +1443,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
     }
 
     @Test
-    public void processSuccessfulScanResultWithRejectedVulnerabilityTest() {
+    public void processSuccessfulScanResultWithNoSnykVulnerabilityTest() {
         final var project = new Project();
         project.setName("acme-app");
         project.setVersion("1.0.0");
@@ -1477,8 +1477,69 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
                 .addScannerResults(ScannerResult.newBuilder()
                         .setScanner(SCANNER_SNYK)
                         .setStatus(SCAN_STATUS_SUCCESSFUL)
-                        .setBom(Bom.newBuilder().addVulnerabilities(org.cyclonedx.proto.v1_6.Vulnerability.newBuilder()
-                                .setRejected(Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build()).build())))
+                        .setBom(Bom.newBuilder()))
+                .build();
+
+        processor.process(aConsumerRecord(scanKey, scanResult).build());
+
+        // Project audit change notification must be sent.
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(record -> {
+            assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
+            final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+            assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
+            final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+            assertThat(notification).isNotNull();
+            assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+            assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
+            assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED, project));
+            assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+
+        }, record -> {
+            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
+            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordKey).isEqualTo(scanToken);
+            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
+        });
+    }
+
+    @Test
+    public void processSuccessfulScanResultWithSnykVulnerabilityTest() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-lib");
+        component.setVersion("1.1.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        final var vulnerabilityS1 = new Vulnerability();
+        vulnerabilityS1.setVulnId("SNYK-001");
+        vulnerabilityS1.setSource(Vulnerability.Source.SNYK);
+        qm.persist(vulnerabilityS1);
+        qm.addVulnerability(vulnerabilityS1, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        qm.makeAnalysis(component, vulnerabilityS1, EXPLOITABLE, null, null, null, false);
+
+        // SNYK vulnerability to be suppressed
+        final var vulnerabilityS2 = new Vulnerability();
+        vulnerabilityS2.setVulnId("SNYK-002");
+        vulnerabilityS2.setSource(Vulnerability.Source.SNYK);
+        qm.persist(vulnerabilityS2);
+        qm.addVulnerability(vulnerabilityS2, component, AnalyzerIdentity.SNYK_ANALYZER);
+        var analysis = qm.makeAnalysis(component, vulnerabilityS2, EXPLOITABLE, null, null, null, false);
+
+        final var scanToken = UUID.randomUUID().toString();
+        final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(component.getUuid().toString()).build();
+        final var scanResult = ScanResult.newBuilder()
+                .setKey(scanKey)
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_SNYK)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .setBom(Bom.newBuilder().addVulnerabilities(createVuln("SNYK-001", "SNYK"))))
                 .build();
 
         processor.process(aConsumerRecord(scanKey, scanResult).build());

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -65,6 +65,7 @@ import org.dependencytrack.proto.vulnanalysis.v1.ScanKey;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
 import org.dependencytrack.proto.vulnanalysis.v1.Scanner;
 import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
+import org.dependencytrack.util.NotificationUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -82,6 +83,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.cyclonedx.proto.v1_6.ScoreMethod.SCORE_METHOD_CVSSV2;
 import static org.cyclonedx.proto.v1_6.ScoreMethod.SCORE_METHOD_CVSSV3;
 import static org.cyclonedx.proto.v1_6.ScoreMethod.SCORE_METHOD_OWASP;
+import static org.dependencytrack.model.AnalysisState.EXPLOITABLE;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_ANALYZER;
@@ -1438,6 +1440,69 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
 
         qm.getPersistenceManager().evictAll();
         assertThat(qm.getAnalysis(component, vuln)).isNull();
+    }
+
+    @Test
+    public void processSuccessfulScanResultWithRejectedVulnerabilityTest() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setName("acme-lib");
+        component.setVersion("1.1.0");
+        component.setProject(project);
+        qm.persist(component);
+
+        final var vulnerabilityNvd = new Vulnerability();
+        vulnerabilityNvd.setVulnId("CVE-001");
+        vulnerabilityNvd.setSource(Vulnerability.Source.NVD);
+        qm.persist(vulnerabilityNvd);
+        qm.addVulnerability(vulnerabilityNvd, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        qm.makeAnalysis(component, vulnerabilityNvd, EXPLOITABLE, null, null, null, false);
+
+        // To be suppressed
+        final var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("SNYK-001");
+        vulnerability.setSource(Vulnerability.Source.SNYK);
+        qm.persist(vulnerability);
+        qm.addVulnerability(vulnerability, component, AnalyzerIdentity.SNYK_ANALYZER);
+        var analysis = qm.makeAnalysis(component, vulnerability, EXPLOITABLE, null, null, null, false);
+
+        final var scanToken = UUID.randomUUID().toString();
+        final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(component.getUuid().toString()).build();
+        final var scanResult = ScanResult.newBuilder()
+                .setKey(scanKey)
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_SNYK)
+                        .setStatus(SCAN_STATUS_SUCCESSFUL)
+                        .setBom(Bom.newBuilder().addVulnerabilities(org.cyclonedx.proto.v1_6.Vulnerability.newBuilder()
+                                .setRejected(Timestamp.newBuilder().setSeconds(Instant.now().getEpochSecond()).build()).build())))
+                .build();
+
+        processor.process(aConsumerRecord(scanKey, scanResult).build());
+
+        // Project audit change notification must be sent.
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(record -> {
+            assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
+            final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+            assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
+            final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+            assertThat(notification).isNotNull();
+            assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+            assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
+            assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED, project));
+            assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+
+        }, record -> {
+            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
+            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordKey).isEqualTo(scanToken);
+            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
+        });
     }
 
     private org.cyclonedx.proto.v1_6.Vulnerability createVuln(final String id, final String source) {

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -1516,11 +1516,12 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
         component.setProject(project);
         qm.persist(component);
 
+        // SNYK vulnerability to NOT be suppressed
         final var vulnerabilityS1 = new Vulnerability();
         vulnerabilityS1.setVulnId("SNYK-001");
         vulnerabilityS1.setSource(Vulnerability.Source.SNYK);
         qm.persist(vulnerabilityS1);
-        qm.addVulnerability(vulnerabilityS1, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        qm.addVulnerability(vulnerabilityS1, component, AnalyzerIdentity.SNYK_ANALYZER);
         qm.makeAnalysis(component, vulnerabilityS1, EXPLOITABLE, null, null, null, false);
 
         // SNYK vulnerability to be suppressed
@@ -1530,6 +1531,13 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
         qm.persist(vulnerabilityS2);
         qm.addVulnerability(vulnerabilityS2, component, AnalyzerIdentity.SNYK_ANALYZER);
         var analysis = qm.makeAnalysis(component, vulnerabilityS2, EXPLOITABLE, null, null, null, false);
+
+        // SNYK vulnerability not analyzed yet
+        final var vulnerabilityS3 = new Vulnerability();
+        vulnerabilityS3.setVulnId("SNYK-003");
+        vulnerabilityS3.setSource(Vulnerability.Source.SNYK);
+        qm.persist(vulnerabilityS3);
+        qm.addVulnerability(vulnerabilityS3, component, AnalyzerIdentity.SNYK_ANALYZER);
 
         final var scanToken = UUID.randomUUID().toString();
         final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(component.getUuid().toString()).build();
@@ -1545,25 +1553,35 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
 
         // Project audit change notification must be sent.
         assertThat(kafkaMockProducer.history()).satisfiesExactly(record -> {
-            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
-            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
-            assertThat(recordKey).isEqualTo(scanToken);
-            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
-            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
+                assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
+                final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+                assertThat(recordKey).isEqualTo(scanToken);
+                final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+                assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
             }, record -> {
-            assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
-            final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
-            assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
-            final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
-            assertThat(notification).isNotNull();
-            assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
-            assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
-            assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
-            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE, project));
-            assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
-
-        });
-    }
+                assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
+                final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+                assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
+                final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+                assertThat(notification).isNotNull();
+                assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+                assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
+                assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE, project));
+                assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+            }, record -> {
+                assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
+                final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+                assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
+                final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
+                assertThat(notification).isNotNull();
+                assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+                assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
+                assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE, project));
+                assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
+            });
+        }
 
     private org.cyclonedx.proto.v1_6.Vulnerability createVuln(final String id, final String source) {
         return org.cyclonedx.proto.v1_6.Vulnerability.newBuilder()

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -1484,6 +1484,12 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
 
         // Project audit change notification must be sent.
         assertThat(kafkaMockProducer.history()).satisfiesExactly(record -> {
+            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
+            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordKey).isEqualTo(scanToken);
+            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
+            }, record -> {
             assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
             final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
             assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
@@ -1492,15 +1498,8 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
             assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
             assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
             assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
-            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED, project));
+            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE, project));
             assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
-
-        }, record -> {
-            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
-            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
-            assertThat(recordKey).isEqualTo(scanToken);
-            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
-            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
         });
     }
 
@@ -1546,6 +1545,12 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
 
         // Project audit change notification must be sent.
         assertThat(kafkaMockProducer.history()).satisfiesExactly(record -> {
+            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
+            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordKey).isEqualTo(scanToken);
+            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
+            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
+            }, record -> {
             assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE.name());
             final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_PROJECT_AUDIT_CHANGE, record);
             assertThat(recordKey).isEqualTo(analysis.getProject().getUuid().toString());
@@ -1554,15 +1559,9 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
             assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
             assertThat(notification.getGroup()).isEqualTo(GROUP_PROJECT_AUDIT_CHANGE);
             assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
-            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_NOT_AFFECTED, project));
+            assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE, project));
             assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
 
-        }, record -> {
-            assertThat(record.topic()).isEqualTo(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED.name());
-            final String recordKey = deserializeKey(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
-            assertThat(recordKey).isEqualTo(scanToken);
-            final ScanResult recordValue = deserializeValue(KafkaTopics.VULN_ANALYSIS_RESULT_PROCESSED, record);
-            assertThat(recordValue.getScannerResultsList()).noneMatch(ScannerResult::hasBom);
         });
     }
 


### PR DESCRIPTION
### Description

When SNYK sends records with empty data, apiserver receives vulnerability with rejected set by vulnerability analyser.
This change is to find SNYK vulnerabilities for the project component and suppress them.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1620

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
