### PR TITLE
Port : Fix NullPointerException when fetching findings

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/FindingsQueryManager.java
@@ -402,8 +402,10 @@ public class FindingsQueryManager extends QueryManager implements IQueryManager 
                 .forEach(metaComponent -> {
                     final var search = new RepositoryMetaComponentSearch(metaComponent.getRepositoryType(), metaComponent.getNamespace(), metaComponent.getName());
                     final List<Finding> affectedFindings = findingsByMetaComponentSearch.get(search);
-                    for (final Finding finding : affectedFindings) {
-                        finding.getComponent().put("latestVersion", metaComponent.getLatestVersion());
+                    if (affectedFindings != null) {
+                        for (final Finding finding : affectedFindings) {
+                            finding.getComponent().put("latestVersion", metaComponent.getLatestVersion());
+                        }
                     }
                 });
         return findings;


### PR DESCRIPTION
### Description

Fixes NullPointerException when fetching findings.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4380
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
