### PR TITLE
Port : Fix incorrect CWE schema in OpenAPI spec

### DIFF
--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
@@ -225,6 +227,7 @@ public class Vulnerability implements Serializable {
     @Convert(CollectionIntegerConverter.class)
     @JsonSerialize(using = CweSerializer.class)
     @JsonDeserialize(using = CweDeserializer.class)
+    @ArraySchema(schema = @Schema(implementation = Cwe.class))
     private List<Integer> cwes;
 
     @Persistent


### PR DESCRIPTION
### Description

Fixes incorrect CWE schema in OpenAPI spec.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4379
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
