### PR TITLE
Port : Fix nullable metrics fields having getters of primitive type

### DIFF
--- a/src/main/java/org/dependencytrack/model/DependencyMetrics.java
+++ b/src/main/java/org/dependencytrack/model/DependencyMetrics.java
@@ -251,7 +251,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getUnassigned() {
-        return unassigned;
+        return unassigned != null ? unassigned : 0;
     }
 
     public void setUnassigned(int unassigned) {
@@ -275,7 +275,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getFindingsTotal() {
-        return findingsTotal;
+        return findingsTotal != null ? findingsTotal : 0;
     }
 
     public void setFindingsTotal(int findingsTotal) {
@@ -283,7 +283,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getFindingsAudited() {
-        return findingsAudited;
+        return findingsAudited != null ? findingsAudited : 0;
     }
 
     public void setFindingsAudited(int findingsAudited) {
@@ -291,7 +291,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getFindingsUnaudited() {
-        return findingsUnaudited;
+        return findingsUnaudited != null ? findingsUnaudited : 0;
     }
 
     public void setFindingsUnaudited(int findingsUnaudited) {
@@ -307,7 +307,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsFail() {
-        return policyViolationsFail;
+        return policyViolationsFail != null ? policyViolationsFail : 0;
     }
 
     public void setPolicyViolationsFail(int policyViolationsFail) {
@@ -315,7 +315,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsWarn() {
-        return policyViolationsWarn;
+        return policyViolationsWarn != null ? policyViolationsWarn : 0;
     }
 
     public void setPolicyViolationsWarn(int policyViolationsWarn) {
@@ -323,7 +323,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsInfo() {
-        return policyViolationsInfo;
+        return policyViolationsInfo != null ? policyViolationsInfo : 0;
     }
 
     public void setPolicyViolationsInfo(int policyViolationsInfo) {
@@ -331,7 +331,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsTotal() {
-        return policyViolationsTotal;
+        return policyViolationsTotal != null ? policyViolationsTotal : 0;
     }
 
     public void setPolicyViolationsTotal(int policyViolationsTotal) {
@@ -339,7 +339,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsAudited() {
-        return policyViolationsAudited;
+        return policyViolationsAudited != null ? policyViolationsAudited : 0;
     }
 
     public void setPolicyViolationsAudited(int policyViolationsAudited) {
@@ -347,7 +347,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsUnaudited() {
-        return policyViolationsUnaudited;
+        return policyViolationsUnaudited != null ? policyViolationsUnaudited : 0;
     }
 
     public void setPolicyViolationsUnaudited(int policyViolationsUnaudited) {
@@ -355,7 +355,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityTotal() {
-        return policyViolationsSecurityTotal;
+        return policyViolationsSecurityTotal != null ? policyViolationsSecurityTotal : 0;
     }
 
     public void setPolicyViolationsSecurityTotal(int policyViolationsSecurityTotal) {
@@ -363,7 +363,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityAudited() {
-        return policyViolationsSecurityAudited;
+        return policyViolationsSecurityAudited != null ? policyViolationsSecurityAudited : 0;
     }
 
     public void setPolicyViolationsSecurityAudited(int policyViolationsSecurityAudited) {
@@ -371,7 +371,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityUnaudited() {
-        return policyViolationsSecurityUnaudited;
+        return policyViolationsSecurityUnaudited != null ? policyViolationsSecurityUnaudited : 0;
     }
 
     public void setPolicyViolationsSecurityUnaudited(int policyViolationsSecurityUnaudited) {
@@ -379,7 +379,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseTotal() {
-        return policyViolationsLicenseTotal;
+        return policyViolationsLicenseTotal != null ? policyViolationsLicenseTotal : 0;
     }
 
     public void setPolicyViolationsLicenseTotal(int policyViolationsLicenseTotal) {
@@ -387,7 +387,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseAudited() {
-        return policyViolationsLicenseAudited;
+        return policyViolationsLicenseAudited != null ? policyViolationsLicenseAudited : 0;
     }
 
     public void setPolicyViolationsLicenseAudited(int policyViolationsLicenseAudited) {
@@ -395,7 +395,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseUnaudited() {
-        return policyViolationsLicenseUnaudited;
+        return policyViolationsLicenseUnaudited != null ? policyViolationsLicenseUnaudited : 0;
     }
 
     public void setPolicyViolationsLicenseUnaudited(int policyViolationsLicenseUnaudited) {
@@ -403,7 +403,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalTotal() {
-        return policyViolationsOperationalTotal;
+        return policyViolationsOperationalTotal != null ? policyViolationsOperationalTotal : 0;
     }
 
     public void setPolicyViolationsOperationalTotal(int policyViolationsOperationalTotal) {
@@ -411,7 +411,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalAudited() {
-        return policyViolationsOperationalAudited;
+        return policyViolationsOperationalAudited != null ? policyViolationsOperationalAudited : 0;
     }
 
     public void setPolicyViolationsOperationalAudited(int policyViolationsOperationalAudited) {
@@ -419,7 +419,7 @@ public class DependencyMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalUnaudited() {
-        return policyViolationsOperationalUnaudited;
+        return policyViolationsOperationalUnaudited != null ? policyViolationsOperationalUnaudited : 0;
     }
 
     public void setPolicyViolationsOperationalUnaudited(int policyViolationsOperationalUnaudited) {

--- a/src/main/java/org/dependencytrack/model/PortfolioMetrics.java
+++ b/src/main/java/org/dependencytrack/model/PortfolioMetrics.java
@@ -241,7 +241,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getUnassigned() {
-        return unassigned;
+        return unassigned != null ? unassigned : 0;
     }
 
     public void setUnassigned(int unassigned) {
@@ -297,7 +297,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getFindingsTotal() {
-        return findingsTotal;
+        return findingsTotal != null ? findingsTotal : 0;
     }
 
     public void setFindingsTotal(int findingsTotal) {
@@ -305,7 +305,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getFindingsAudited() {
-        return findingsAudited;
+        return findingsAudited != null ? findingsAudited : 0;
     }
 
     public void setFindingsAudited(int findingsAudited) {
@@ -313,7 +313,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getFindingsUnaudited() {
-        return findingsUnaudited;
+        return findingsUnaudited != null ? findingsUnaudited : 0;
     }
 
     public void setFindingsUnaudited(int findingsUnaudited) {
@@ -329,7 +329,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsFail() {
-        return policyViolationsFail;
+        return policyViolationsFail != null ? policyViolationsFail : 0;
     }
 
     public void setPolicyViolationsFail(int policyViolationsFail) {
@@ -337,7 +337,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsWarn() {
-        return policyViolationsWarn;
+        return policyViolationsWarn != null ? policyViolationsWarn : 0;
     }
 
     public void setPolicyViolationsWarn(int policyViolationsWarn) {
@@ -345,7 +345,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsInfo() {
-        return policyViolationsInfo;
+        return policyViolationsInfo != null ? policyViolationsInfo : 0;
     }
 
     public void setPolicyViolationsInfo(int policyViolationsInfo) {
@@ -353,7 +353,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsTotal() {
-        return policyViolationsTotal;
+        return policyViolationsTotal != null ? policyViolationsTotal : 0;
     }
 
     public void setPolicyViolationsTotal(int policyViolationsTotal) {
@@ -361,7 +361,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsAudited() {
-        return policyViolationsAudited;
+        return policyViolationsAudited != null ? policyViolationsAudited : 0;
     }
 
     public void setPolicyViolationsAudited(int policyViolationsAudited) {
@@ -369,7 +369,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsUnaudited() {
-        return policyViolationsUnaudited;
+        return policyViolationsUnaudited != null ? policyViolationsUnaudited : 0;
     }
 
     public void setPolicyViolationsUnaudited(int policyViolationsUnaudited) {
@@ -377,7 +377,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityTotal() {
-        return policyViolationsSecurityTotal;
+        return policyViolationsSecurityTotal != null ? policyViolationsSecurityTotal : 0;
     }
 
     public void setPolicyViolationsSecurityTotal(int policyViolationsSecurityTotal) {
@@ -385,7 +385,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityAudited() {
-        return policyViolationsSecurityAudited;
+        return policyViolationsSecurityAudited != null ? policyViolationsSecurityAudited : 0;
     }
 
     public void setPolicyViolationsSecurityAudited(int policyViolationsSecurityAudited) {
@@ -393,7 +393,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityUnaudited() {
-        return policyViolationsSecurityUnaudited;
+        return policyViolationsSecurityUnaudited != null ? policyViolationsSecurityUnaudited : 0;
     }
 
     public void setPolicyViolationsSecurityUnaudited(int policyViolationsSecurityUnaudited) {
@@ -401,7 +401,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseTotal() {
-        return policyViolationsLicenseTotal;
+        return policyViolationsLicenseTotal != null ? policyViolationsLicenseTotal : 0;
     }
 
     public void setPolicyViolationsLicenseTotal(int policyViolationsLicenseTotal) {
@@ -409,7 +409,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseAudited() {
-        return policyViolationsLicenseAudited;
+        return policyViolationsLicenseAudited != null ? policyViolationsLicenseAudited : 0;
     }
 
     public void setPolicyViolationsLicenseAudited(int policyViolationsLicenseAudited) {
@@ -417,7 +417,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseUnaudited() {
-        return policyViolationsLicenseUnaudited;
+        return policyViolationsLicenseUnaudited != null ? policyViolationsLicenseUnaudited : 0;
     }
 
     public void setPolicyViolationsLicenseUnaudited(int policyViolationsLicenseUnaudited) {
@@ -425,7 +425,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalTotal() {
-        return policyViolationsOperationalTotal;
+        return policyViolationsOperationalTotal != null ? policyViolationsOperationalTotal : 0;
     }
 
     public void setPolicyViolationsOperationalTotal(int policyViolationsOperationalTotal) {
@@ -433,7 +433,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalAudited() {
-        return policyViolationsOperationalAudited;
+        return policyViolationsOperationalAudited != null ? policyViolationsOperationalAudited : 0;
     }
 
     public void setPolicyViolationsOperationalAudited(int policyViolationsOperationalAudited) {
@@ -441,7 +441,7 @@ public class PortfolioMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalUnaudited() {
-        return policyViolationsOperationalUnaudited;
+        return policyViolationsOperationalUnaudited != null ? policyViolationsOperationalUnaudited : 0;
     }
 
     public void setPolicyViolationsOperationalUnaudited(int policyViolationsOperationalUnaudited) {

--- a/src/main/java/org/dependencytrack/model/ProjectMetrics.java
+++ b/src/main/java/org/dependencytrack/model/ProjectMetrics.java
@@ -245,7 +245,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getUnassigned() {
-        return unassigned;
+        return unassigned != null ? unassigned : 0;
     }
 
     public void setUnassigned(int unassigned) {
@@ -285,7 +285,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getFindingsTotal() {
-        return findingsTotal;
+        return findingsTotal != null ? findingsTotal : 0;
     }
 
     public void setFindingsTotal(int findingsTotal) {
@@ -293,7 +293,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getFindingsAudited() {
-        return findingsAudited;
+        return findingsAudited != null ? findingsAudited : 0;
     }
 
     public void setFindingsAudited(int findingsAudited) {
@@ -301,7 +301,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getFindingsUnaudited() {
-        return findingsUnaudited;
+        return findingsUnaudited != null ? findingsUnaudited : 0;
     }
 
     public void setFindingsUnaudited(int findingsUnaudited) {
@@ -317,7 +317,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsFail() {
-        return policyViolationsFail;
+        return policyViolationsFail != null ? policyViolationsFail : 0;
     }
 
     public void setPolicyViolationsFail(int policyViolationsFail) {
@@ -325,7 +325,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsWarn() {
-        return policyViolationsWarn;
+        return policyViolationsWarn != null ? policyViolationsWarn : 0;
     }
 
     public void setPolicyViolationsWarn(int policyViolationsWarn) {
@@ -333,7 +333,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsInfo() {
-        return policyViolationsInfo;
+        return policyViolationsInfo != null ? policyViolationsInfo : 0;
     }
 
     public void setPolicyViolationsInfo(int policyViolationsInfo) {
@@ -341,7 +341,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsTotal() {
-        return policyViolationsTotal;
+        return policyViolationsTotal != null ? policyViolationsTotal : 0;
     }
 
     public void setPolicyViolationsTotal(int policyViolationsTotal) {
@@ -349,7 +349,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsAudited() {
-        return policyViolationsAudited;
+        return policyViolationsAudited != null ? policyViolationsAudited : 0;
     }
 
     public void setPolicyViolationsAudited(int policyViolationsAudited) {
@@ -357,7 +357,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsUnaudited() {
-        return policyViolationsUnaudited;
+        return policyViolationsUnaudited != null ? policyViolationsUnaudited : 0;
     }
 
     public void setPolicyViolationsUnaudited(int policyViolationsUnaudited) {
@@ -365,7 +365,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityTotal() {
-        return policyViolationsSecurityTotal;
+        return policyViolationsSecurityTotal != null ? policyViolationsSecurityTotal : 0;
     }
 
     public void setPolicyViolationsSecurityTotal(int policyViolationsSecurityTotal) {
@@ -373,7 +373,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityAudited() {
-        return policyViolationsSecurityAudited;
+        return policyViolationsSecurityAudited != null ? policyViolationsSecurityAudited : 0;
     }
 
     public void setPolicyViolationsSecurityAudited(int policyViolationsSecurityAudited) {
@@ -381,7 +381,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsSecurityUnaudited() {
-        return policyViolationsSecurityUnaudited;
+        return policyViolationsSecurityUnaudited != null ? policyViolationsSecurityUnaudited : 0;
     }
 
     public void setPolicyViolationsSecurityUnaudited(int policyViolationsSecurityUnaudited) {
@@ -389,7 +389,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseTotal() {
-        return policyViolationsLicenseTotal;
+        return policyViolationsLicenseTotal != null ? policyViolationsLicenseTotal : 0;
     }
 
     public void setPolicyViolationsLicenseTotal(int policyViolationsLicenseTotal) {
@@ -397,7 +397,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseAudited() {
-        return policyViolationsLicenseAudited;
+        return policyViolationsLicenseAudited != null ? policyViolationsLicenseAudited : 0;
     }
 
     public void setPolicyViolationsLicenseAudited(int policyViolationsLicenseAudited) {
@@ -405,7 +405,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsLicenseUnaudited() {
-        return policyViolationsLicenseUnaudited;
+        return policyViolationsLicenseUnaudited != null ? policyViolationsLicenseUnaudited : 0;
     }
 
     public void setPolicyViolationsLicenseUnaudited(int policyViolationsLicenseUnaudited) {
@@ -413,7 +413,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalTotal() {
-        return policyViolationsOperationalTotal;
+        return policyViolationsOperationalTotal != null ? policyViolationsOperationalTotal : 0;
     }
 
     public void setPolicyViolationsOperationalTotal(int policyViolationsOperationalTotal) {
@@ -421,7 +421,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalAudited() {
-        return policyViolationsOperationalAudited;
+        return policyViolationsOperationalAudited != null ? policyViolationsOperationalAudited : 0;
     }
 
     public void setPolicyViolationsOperationalAudited(int policyViolationsOperationalAudited) {
@@ -429,7 +429,7 @@ public class ProjectMetrics implements Serializable {
     }
 
     public int getPolicyViolationsOperationalUnaudited() {
-        return policyViolationsOperationalUnaudited;
+        return policyViolationsOperationalUnaudited != null ? policyViolationsOperationalUnaudited : 0;
     }
 
     public void setPolicyViolationsOperationalUnaudited(int policyViolationsOperationalUnaudited) {


### PR DESCRIPTION
### Description

Fixes nullable metrics fields having getters of primitive type.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4382
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
