### PR TITLE
Port : Add cyclonedx json media type when exporting components

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/BomResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BomResource.java
@@ -190,7 +190,7 @@ public class BomResource extends AlpineResource {
 
     @GET
     @Path("/cyclonedx/component/{uuid}")
-    @Produces(CycloneDxMediaType.APPLICATION_CYCLONEDX_XML)
+    @Produces({CycloneDxMediaType.APPLICATION_CYCLONEDX_XML, CycloneDxMediaType.APPLICATION_CYCLONEDX_JSON})
     @Operation(
             summary = "Returns dependency metadata for a specific component in CycloneDX format",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"


### PR DESCRIPTION
### Description

Adds cyclonedx json media type when exporting components.

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
