### PR TITLE
Port : Fix NPE when cloning projects with broken dependency graph

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -690,7 +690,19 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 String directDependencies = project.getDirectDependencies();
                 for (final UUID sourceComponentUuid : projectDirectDepsSourceComponentUuids) {
                     final UUID clonedComponentUuid = clonedComponentUuidBySourceComponentUuid.get(sourceComponentUuid);
-                    directDependencies = directDependencies.replace(sourceComponentUuid.toString(), clonedComponentUuid.toString());
+                    if (clonedComponentUuid != null) {
+                        directDependencies = directDependencies.replace(
+                                sourceComponentUuid.toString(), clonedComponentUuid.toString());
+                    } else {
+                        // NB: This may happen when the source project itself is a clone,
+                        // and it was cloned before DT v4.12.0.
+                        // https://github.com/DependencyTrack/dependency-track/pull/4171
+                        LOGGER.warn("""
+                                The source project's directDependencies refer to a component with UUID \
+                                %s, which does not exist in the project. The cloned project's dependency graph \
+                                may be broken as a result. A BOM upload will resolve the issue.\
+                                """.formatted(sourceComponentUuid));
+                    }
                 }
 
                 project.setDirectDependencies(directDependencies);
@@ -703,7 +715,16 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 String directDependencies = component.getDirectDependencies();
                 for (final UUID sourceComponentUuid : sourceComponentUuids) {
                     final UUID clonedComponentUuid = clonedComponentUuidBySourceComponentUuid.get(sourceComponentUuid);
-                    directDependencies = directDependencies.replace(sourceComponentUuid.toString(), clonedComponentUuid.toString());
+                    if (clonedComponentUuid != null) {
+                        directDependencies = directDependencies.replace(
+                                sourceComponentUuid.toString(), clonedComponentUuid.toString());
+                    } else {
+                        LOGGER.warn("""
+                                The directDependencies of component %s refer to a component with UUID \
+                                %s, which does not exist in the source project. The cloned project's dependency graph \
+                                may be broken as a result. A BOM upload will resolve the issue.\
+                                """.formatted(component, sourceComponentUuid));
+                    }
                 }
 
                 component.setDirectDependencies(directDependencies);

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -2455,6 +2455,51 @@ public class ProjectResourceTest extends ResourceTest {
         }
     }
 
+    @Test // https://github.com/DependencyTrack/dependency-track/issues/4413
+    public void cloneProjectWithBrokenDependencyGraphTest() {
+        EventService.getInstance().subscribe(CloneProjectEvent.class, CloneProjectTask.class);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        project.setDirectDependencies("[{\"uuid\":\"d6b6f140-f547-4fe2-a98c-f4942ad51f86\"}]");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("2.0.0");
+        component.setDirectDependencies("[{\"uuid\":\"61503628-d2a2-447b-b99c-701b9d492cbd\"}]");
+        qm.persist(component);
+
+        final Response response = jersey.target("%s/clone".formatted(V1_PROJECT)).request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "project": "%s",
+                          "version": "1.1.0",
+                          "includeComponents": true,
+                          "includeServices": true
+                        }
+                        """.formatted(project.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(202);
+
+        await("Cloning completion")
+                .atMost(Duration.ofSeconds(15))
+                .pollInterval(Duration.ofMillis(50))
+                .untilAsserted(() -> {
+                    final Project clonedProject = qm.getProject("acme-app", "1.1.0");
+                    assertThat(clonedProject).isNotNull();
+                });
+
+        final Project clonedProject = qm.getProject("acme-app", "1.1.0");
+        assertThat(clonedProject.getDirectDependencies()).isEqualTo(
+                "[{\"uuid\": \"d6b6f140-f547-4fe2-a98c-f4942ad51f86\"}]");
+
+        assertThat(qm.getAllComponents(clonedProject).getFirst().getDirectDependencies()).isEqualTo(
+                "[{\"uuid\": \"61503628-d2a2-447b-b99c-701b9d492cbd\"}]");
+    }
+
     @Test // https://github.com/DependencyTrack/dependency-track/issues/3883
     public void issue3883RegressionTest() {
         Response response = jersey.target(V1_PROJECT)


### PR DESCRIPTION
### Description

Fixes a `NullPointerException` when cloning projects with broken dependency graph.

### Addressed Issue

Port change https://github.com/DependencyTrack/hyades/issues/1358
Ports https://github.com/DependencyTrack/dependency-track/pull/4419

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
