### PR TITLE
Exclude `NULL`s from component hash indexes

### DIFF
--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -159,4 +159,34 @@
             <column name="PROJECT_ID"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="v5.6.0-11" author="nscuro">
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_BLAKE2B_256_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_BLAKE2B_384_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_BLAKE2B_512_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_BLAKE3_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_MD5_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA1_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA3_256_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA3_384_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA3_512_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA256_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA384_IDX"/>
+        <dropIndex tableName="COMPONENT" indexName="COMPONENT_SHA512_IDX"/>
+
+        <sql splitStatements="true">
+            CREATE INDEX "COMPONENT_BLAKE2B_256_IDX" ON "COMPONENT" ("BLAKE2B_256") WHERE "BLAKE2B_256" IS NOT NULL;
+            CREATE INDEX "COMPONENT_BLAKE2B_384_IDX" ON "COMPONENT" ("BLAKE2B_384") WHERE "BLAKE2B_384" IS NOT NULL;
+            CREATE INDEX "COMPONENT_BLAKE2B_512_IDX" ON "COMPONENT" ("BLAKE2B_512") WHERE "BLAKE2B_512" IS NOT NULL;
+            CREATE INDEX "COMPONENT_BLAKE3_IDX" ON "COMPONENT" ("BLAKE3") WHERE "BLAKE3" IS NOT NULL;
+            CREATE INDEX "COMPONENT_MD5_IDX" ON "COMPONENT" ("MD5") WHERE "MD5" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA1_IDX" ON "COMPONENT" ("SHA1") WHERE "SHA1" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA_256_IDX" ON "COMPONENT" ("SHA_256") WHERE "SHA_256" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA_384_IDX" ON "COMPONENT" ("SHA_384") WHERE "SHA_384" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA_512_IDX" ON "COMPONENT" ("SHA_512") WHERE "SHA_512" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA3_256_IDX" ON "COMPONENT" ("SHA3_256") WHERE "SHA3_256" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA3_384_IDX" ON "COMPONENT" ("SHA3_384") WHERE "SHA3_384" IS NOT NULL;
+            CREATE INDEX "COMPONENT_SHA3_512_IDX" ON "COMPONENT" ("SHA3_512") WHERE "SHA3_512" IS NOT NULL;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Excludes `NULL`s from component hash indexes.

Component hashes are only queried via the component search. This implicates that parameters to those queries are never `NULL`.

We never sort by hashes since that would be pointless.

Chances are extremely high that not all hash types will be populated for any given component.

There is thus no benefit to indexing `NULL` values. Excluding `NULL`s will keep indexes sizes smaller, and make index updates faster, while still allowing for performant lookups.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1642

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
