### PR TITLE
Port : Removed `docker-compose.yml` version top-level element (obsolote)

### DIFF
--- a/src/main/docker/docker-compose.yml
+++ b/src/main/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 #####################################################
 # This Docker Compose file contains two services
 #    Dependency-Track API Server


### PR DESCRIPTION
### Description

Removed `docker-compose.yml` version top-level element (obsolote)

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4301
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
