### PR TITLE
Port : Fix onlyOutdated ungrouped component filtering

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -255,7 +255,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                         AND NOT (NOT EXISTS (
                         SELECT "M"."ID"
                         FROM "REPOSITORY_META_COMPONENT" "M" WHERE "M"."NAME" = "A0"."NAME"
-                        AND "M"."NAMESPACE" = "A0"."GROUP"
+                        AND ("M"."NAMESPACE" = "A0"."GROUP" OR "M"."NAMESPACE" IS NULL OR "A0"."GROUP" IS NULL)
                         AND "M"."LATEST_VERSION" <> "A0"."VERSION"
                         AND "A0"."PURL" LIKE (('pkg:' || LOWER("M"."REPOSITORY_TYPE")) || '/%') ESCAPE E'\\\\'))
                     """;


### PR DESCRIPTION
### Description

ix onlyOutdated ungrouped component filtering.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4513
Port change https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
