### PR TITLE
Port : fix notification rule test for rule not found

### DIFF
--- a/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationPublisherResource.java
@@ -283,14 +283,18 @@ public class NotificationPublisherResource extends AlpineResource {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Test notification dispatched successfully"),
-            @ApiResponse(responseCode = "401", description = "Unauthorized")
+            @ApiResponse(responseCode = "401", description = "Unauthorized"),
+            @ApiResponse(responseCode = "404", description = "Notification rule not found")
     })
     @PermissionRequired(Permissions.Constants.SYSTEM_CONFIGURATION)
-    public Response testSlackPublisherConfig(
+    public Response testNotificationRule(
             @Parameter(description = "The UUID of the rule to test", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String ruleUuid) {
         try (QueryManager qm = new QueryManager()) {
             NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
+            if (rule == null) {
+                return Response.status(Response.Status.NOT_FOUND).build();
+            }
             final KafkaEventDispatcher eventDispatcher = new KafkaEventDispatcher();
             for(NotificationGroup group : rule.getNotifyOn()){
                 eventDispatcher.dispatchNotification(new Notification()

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationPublisherResourceTest.java
@@ -344,4 +344,12 @@ public class NotificationPublisherResourceTest extends ResourceTest {
         Assert.assertEquals(200, response.getStatus());
         assertThat(kafkaMockProducer.history().size()).isEqualTo(11);
     }
+
+    @Test
+    public void testNotificationRuleNotFoundTest() {
+        final Response response = jersey.target(V1_NOTIFICATION_PUBLISHER + "/test/" + UUID.randomUUID()).request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
 }


### PR DESCRIPTION
### Description

Fix notification rule test for rule not found.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4460
Issue https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
