### PR TITLE
Update FK constraints to enable cascading deletes

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -24,6 +24,9 @@ import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
@@ -35,12 +38,8 @@ import org.dependencytrack.model.sqlmapping.ComponentProjection;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.IntegrityMetaInitializerTask;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonValue;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-import javax.jdo.Transaction;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -606,55 +605,6 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             query.deletePersistentAll(project);
         } finally {
             query.closeAll();
-        }
-    }
-
-    /**
-     * Deletes a Component and all objects dependant on the component.
-     *
-     * @param component   the Component to delete
-     * @param commitIndex specifies if the search index should be committed (an expensive operation)
-     */
-    public void recursivelyDelete(Component component, boolean commitIndex) {
-        final Transaction trx = pm.currentTransaction();
-        final boolean isJoiningExistingTrx = trx.isActive();
-        try {
-            if (!isJoiningExistingTrx) {
-                trx.begin();
-            }
-
-            for (final Component child : component.getChildren()) {
-                recursivelyDelete(child, false);
-                pm.flush();
-            }
-
-            // Use bulk DELETE queries to avoid having to fetch every single object from the database first.
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.AnalysisComment WHERE analysis.component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.Analysis WHERE component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.ViolationAnalysisComment WHERE violationAnalysis.component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.ViolationAnalysis WHERE component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.DependencyMetrics WHERE component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.FindingAttribution WHERE component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.PolicyViolation WHERE component == :component"), component);
-            executeAndClose(pm.newQuery(Query.JDOQL, "DELETE FROM org.dependencytrack.model.IntegrityAnalysis WHERE component == :component"), component);
-
-
-            // The component itself must be deleted via deletePersistentAll, otherwise relationships
-            // (e.g. with Vulnerability via COMPONENTS_VULNERABILITIES table) will not be cleaned up properly.
-            final Query<Component> componentQuery = pm.newQuery(Component.class, "this == :component");
-            try {
-                componentQuery.deletePersistentAll(component);
-            } finally {
-                componentQuery.closeAll();
-            }
-
-            if (!isJoiningExistingTrx) {
-                trx.commit();
-            }
-        } finally {
-            if (!isJoiningExistingTrx && trx.isActive()) {
-                trx.rollback();
-            }
         }
     }
 

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -743,10 +743,6 @@ public class QueryManager extends AlpineQueryManager {
         getComponentQueryManager().deleteComponents(project);
     }
 
-    public void recursivelyDelete(Component component, boolean commitIndex) {
-        getComponentQueryManager().recursivelyDelete(component, commitIndex);
-    }
-
     public Map<String, Component> getDependencyGraphForComponents(Project project, List<Component> components) {
         return getComponentQueryManager().getDependencyGraphForComponents(project, components);
     }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.util.UUID;
+
+public interface ComponentDao {
+
+    @SqlUpdate("""
+            DELETE
+              FROM "COMPONENT"
+             WHERE "UUID" = :componentUuid
+            """)
+    int deleteComponent(@Bind final UUID componentUuid);
+}

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -189,4 +189,461 @@
             CREATE INDEX "COMPONENT_SHA3_512_IDX" ON "COMPONENT" ("SHA3_512") WHERE "SHA3_512" IS NOT NULL;
         </sql>
     </changeSet>
+
+    <changeSet id="v5.6.0-12" author="sahibamittal">
+        <dropForeignKeyConstraint baseTableName="AFFECTEDVERSIONATTRIBUTION" constraintName="AFFECTEDVERSIONATTRIBUTION_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY" baseTableName="AFFECTEDVERSIONATTRIBUTION"
+             constraintName="AFFECTEDVERSIONATTRIBUTION_VULNERABILITY_FK" deferrable="true"
+             initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+             referencedColumnNames="ID" referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="AFFECTEDVERSIONATTRIBUTION" constraintName="AFFECTEDVERSIONATTRIBUTION_VULNERABLESOFTWARE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABLE_SOFTWARE" baseTableName="AFFECTEDVERSIONATTRIBUTION"
+                                 constraintName="AFFECTEDVERSIONATTRIBUTION_VULNERABLESOFTWARE_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="VULNERABLESOFTWARE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="ANALYSISCOMMENT" constraintName="ANALYSISCOMMENT_ANALYSIS_FK"/>
+        <addForeignKeyConstraint baseColumnNames="ANALYSIS_ID" baseTableName="ANALYSISCOMMENT"
+                                 constraintName="ANALYSISCOMMENT_ANALYSIS_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="ID"
+                                 referencedTableName="ANALYSIS" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="ANALYSIS" constraintName="ANALYSIS_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="ANALYSIS" constraintName="ANALYSIS_COMPONENT_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="ANALYSIS" constraintName="ANALYSIS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="ANALYSIS" constraintName="ANALYSIS_PROJECT_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="PROJECT" validate="true"/>
+        
+        <dropForeignKeyConstraint baseTableName="ANALYSIS" constraintName="ANALYSIS_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY_ID" baseTableName="ANALYSIS"
+                                 constraintName="ANALYSIS_VULNERABILITY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="ANALYSIS" constraintName="ANALYSIS_VULNERABILITY_POLICY_ID_FK"/>
+        <addForeignKeyConstraint baseTableName="ANALYSIS" baseColumnNames="VULNERABILITY_POLICY_ID"
+                                 constraintName="ANALYSIS_VULNERABILITY_POLICY_ID_FK" referencedTableName="VULNERABILITY_POLICY"
+                                 onDelete="CASCADE" referencedColumnNames="ID"/>
+        
+        <dropForeignKeyConstraint baseTableName="APIKEYS_TEAMS" constraintName="APIKEYS_TEAMS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="APIKEYS_TEAMS"
+                                 constraintName="APIKEYS_TEAMS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+        
+        <dropForeignKeyConstraint baseTableName="APIKEYS_TEAMS" constraintName="APIKEYS_TEAMS_APIKEY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="APIKEY_ID" baseTableName="APIKEYS_TEAMS"
+                                 constraintName="APIKEYS_TEAMS_APIKEY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="APIKEY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="BOM" constraintName="BOM_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="BOM" constraintName="BOM_PROJECT_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="COMPONENTS_VULNERABILITIES" constraintName="COMPONENTS_VULNERABILITIES_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="COMPONENTS_VULNERABILITIES"
+                                 constraintName="COMPONENTS_VULNERABILITIES_COMPONENT_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="COMPONENTS_VULNERABILITIES" constraintName="COMPONENTS_VULNERABILITIES_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY_ID" baseTableName="COMPONENTS_VULNERABILITIES"
+                                 constraintName="COMPONENTS_VULNERABILITIES_VULNERABILITY_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="COMPONENT" constraintName="COMPONENT_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PARENT_COMPONENT_ID" baseTableName="COMPONENT"
+                                 constraintName="COMPONENT_COMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="COMPONENT" constraintName="COMPONENT_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="COMPONENT" constraintName="COMPONENT_PROJECT_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="COMPONENT" constraintName="COMPONENT_LICENSE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="LICENSE_ID" baseTableName="COMPONENT" constraintName="COMPONENT_LICENSE_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="LICENSE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="DEPENDENCYMETRICS" constraintName="DEPENDENCYMETRICS_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="DEPENDENCYMETRICS"
+                                 constraintName="DEPENDENCYMETRICS_COMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="DEPENDENCYMETRICS" constraintName="DEPENDENCYMETRICS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="DEPENDENCYMETRICS"
+                                 constraintName="DEPENDENCYMETRICS_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="FINDINGATTRIBUTION" constraintName="FINDINGATTRIBUTION_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="FINDINGATTRIBUTION"
+                                 constraintName="FINDINGATTRIBUTION_COMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="FINDINGATTRIBUTION" constraintName="FINDINGATTRIBUTION_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="FINDINGATTRIBUTION"
+                                 constraintName="FINDINGATTRIBUTION_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="FINDINGATTRIBUTION" constraintName="FINDINGATTRIBUTION_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY_ID" baseTableName="FINDINGATTRIBUTION"
+                                 constraintName="FINDINGATTRIBUTION_VULNERABILITY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="INTEGRITY_ANALYSIS" constraintName="INTEGRITY_ANALYSIS_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="INTEGRITY_ANALYSIS"
+                                 constraintName="INTEGRITY_ANALYSIS_COMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="LDAPUSERS_PERMISSIONS" constraintName="LDAPUSERS_PERMISSIONS_LDAPUSER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="LDAPUSER_ID" baseTableName="LDAPUSERS_PERMISSIONS"
+                                 constraintName="LDAPUSERS_PERMISSIONS_LDAPUSER_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="LDAPUSER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="LDAPUSERS_PERMISSIONS" constraintName="LDAPUSERS_PERMISSIONS_PERMISSION_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PERMISSION_ID" baseTableName="LDAPUSERS_PERMISSIONS"
+                                 constraintName="LDAPUSERS_PERMISSIONS_PERMISSION_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PERMISSION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="LDAPUSERS_TEAMS" constraintName="LDAPUSERS_TEAMS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="LDAPUSERS_TEAMS"
+                                 constraintName="LDAPUSERS_TEAMS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="LDAPUSERS_TEAMS" constraintName="LDAPUSERS_TEAMS_LDAPUSER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="LDAPUSER_ID" baseTableName="LDAPUSERS_TEAMS"
+                                 constraintName="LDAPUSERS_TEAMS_LDAPUSER_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="LDAPUSER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="LICENSEGROUP_LICENSE" constraintName="LICENSEGROUP_LICENSE_LICENSEGROUP_FK"/>
+        <addForeignKeyConstraint baseColumnNames="LICENSEGROUP_ID" baseTableName="LICENSEGROUP_LICENSE"
+                                 constraintName="LICENSEGROUP_LICENSE_LICENSEGROUP_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="LICENSEGROUP" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="LICENSEGROUP_LICENSE" constraintName="LICENSEGROUP_LICENSE_LICENSE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="LICENSE_ID" baseTableName="LICENSEGROUP_LICENSE"
+                                 constraintName="LICENSEGROUP_LICENSE_LICENSE_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="LICENSE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MANAGEDUSERS_PERMISSIONS" constraintName="MANAGEDUSERS_PERMISSIONS_MANAGEDUSER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="MANAGEDUSER_ID" baseTableName="MANAGEDUSERS_PERMISSIONS"
+                                 constraintName="MANAGEDUSERS_PERMISSIONS_MANAGEDUSER_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="MANAGEDUSER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MANAGEDUSERS_PERMISSIONS" constraintName="MANAGEDUSERS_PERMISSIONS_PERMISSION_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PERMISSION_ID" baseTableName="MANAGEDUSERS_PERMISSIONS"
+                                 constraintName="MANAGEDUSERS_PERMISSIONS_PERMISSION_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="PERMISSION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MANAGEDUSERS_TEAMS" constraintName="MANAGEDUSERS_TEAMS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="MANAGEDUSERS_TEAMS"
+                                 constraintName="MANAGEDUSERS_TEAMS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MANAGEDUSERS_TEAMS" constraintName="MANAGEDUSERS_TEAMS_MANAGEDUSER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="MANAGEDUSER_ID" baseTableName="MANAGEDUSERS_TEAMS"
+                                 constraintName="MANAGEDUSERS_TEAMS_MANAGEDUSER_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="MANAGEDUSER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MAPPEDLDAPGROUP" constraintName="MAPPEDLDAPGROUP_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="MAPPEDLDAPGROUP"
+                                 constraintName="MAPPEDLDAPGROUP_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MAPPEDOIDCGROUP" constraintName="MAPPEDOIDCGROUP_OIDCGROUP_FK"/>
+        <addForeignKeyConstraint baseColumnNames="GROUP_ID" baseTableName="MAPPEDOIDCGROUP"
+                                 constraintName="MAPPEDOIDCGROUP_OIDCGROUP_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="OIDCGROUP" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="MAPPEDOIDCGROUP" constraintName="MAPPEDOIDCGROUP_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="MAPPEDOIDCGROUP"
+                                 constraintName="MAPPEDOIDCGROUP_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE" constraintName="NOTIFICATIONRULE_NOTIFICATIONPUBLISHER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PUBLISHER" baseTableName="NOTIFICATIONRULE"
+                                 constraintName="NOTIFICATIONRULE_NOTIFICATIONPUBLISHER_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="NOTIFICATIONPUBLISHER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE_PROJECTS" constraintName="NOTIFICATIONRULE_PROJECTS_NOTIFICATIONRULE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="NOTIFICATIONRULE_ID" baseTableName="NOTIFICATIONRULE_PROJECTS"
+                                 constraintName="NOTIFICATIONRULE_PROJECTS_NOTIFICATIONRULE_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="NOTIFICATIONRULE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE_PROJECTS" constraintName="NOTIFICATIONRULE_PROJECTS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="NOTIFICATIONRULE_PROJECTS"
+                                 constraintName="NOTIFICATIONRULE_PROJECTS_PROJECT_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE_TAGS" constraintName="NOTIFICATIONRULE_TAGS_TAG_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TAG_ID" baseTableName="NOTIFICATIONRULE_TAGS"
+                                 constraintName="NOTIFICATIONRULE_TAGS_TAG_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TAG" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE_TAGS" constraintName="NOTIFICATIONRULE_TAGS_NOTIFICATIONRULE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="NOTIFICATIONRULE_ID" baseTableName="NOTIFICATIONRULE_TAGS"
+                                 constraintName="NOTIFICATIONRULE_TAGS_NOTIFICATIONRULE_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="NOTIFICATIONRULE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE_TEAMS" constraintName="NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="NOTIFICATIONRULE_ID" baseTableName="NOTIFICATIONRULE_TEAMS"
+                                 constraintName="NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="NOTIFICATIONRULE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="NOTIFICATIONRULE_TEAMS" constraintName="NOTIFICATIONRULE_TEAMS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="NOTIFICATIONRULE_TEAMS"
+                                 constraintName="NOTIFICATIONRULE_TEAMS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="OIDCUSERS_PERMISSIONS" constraintName="OIDCUSERS_PERMISSIONS_PERMISSION_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PERMISSION_ID" baseTableName="OIDCUSERS_PERMISSIONS"
+                                 constraintName="OIDCUSERS_PERMISSIONS_PERMISSION_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PERMISSION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="OIDCUSERS_PERMISSIONS" constraintName="OIDCUSERS_PERMISSIONS_OIDCUSER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="OIDCUSER_ID" baseTableName="OIDCUSERS_PERMISSIONS"
+                                 constraintName="OIDCUSERS_PERMISSIONS_OIDCUSER_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="OIDCUSER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="OIDCUSERS_TEAMS" constraintName="OIDCUSERS_TEAMS_OIDCUSER_FK"/>
+        <addForeignKeyConstraint baseColumnNames="OIDCUSERS_ID" baseTableName="OIDCUSERS_TEAMS"
+                                 constraintName="OIDCUSERS_TEAMS_OIDCUSER_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="OIDCUSER" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="OIDCUSERS_TEAMS" constraintName="OIDCUSERS_TEAMS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="OIDCUSERS_TEAMS"
+                                 constraintName="OIDCUSERS_TEAMS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICYCONDITION" constraintName="POLICYCONDITION_POLICY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="POLICY_ID" baseTableName="POLICYCONDITION"
+                                 constraintName="POLICYCONDITION_POLICY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="POLICY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICYVIOLATION" constraintName="POLICYVIOLATION_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="POLICYVIOLATION"
+                                 constraintName="POLICYVIOLATION_COMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICYVIOLATION" constraintName="POLICYVIOLATION_POLICYCONDITION_FK"/>
+        <addForeignKeyConstraint baseColumnNames="POLICYCONDITION_ID" baseTableName="POLICYVIOLATION"
+                                 constraintName="POLICYVIOLATION_POLICYCONDITION_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="POLICYCONDITION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICYVIOLATION" constraintName="POLICYVIOLATION_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="POLICYVIOLATION"
+                                 constraintName="POLICYVIOLATION_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICY_PROJECTS" constraintName="POLICY_PROJECTS_POLICY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="POLICY_ID" baseTableName="POLICY_PROJECTS"
+                                 constraintName="POLICY_PROJECTS_POLICY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="POLICY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICY_PROJECTS" constraintName="POLICY_PROJECTS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="POLICY_PROJECTS"
+                                 constraintName="POLICY_PROJECTS_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICY_TAGS" constraintName="POLICY_TAGS_POLICY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="POLICY_ID" baseTableName="POLICY_TAGS"
+                                 constraintName="POLICY_TAGS_POLICY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="POLICY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="POLICY_TAGS" constraintName="POLICY_TAGS_TAG_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TAG_ID" baseTableName="POLICY_TAGS" constraintName="POLICY_TAGS_TAG_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="TAG" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECT" constraintName="PROJECT_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PARENT_PROJECT_ID" baseTableName="PROJECT"
+                                 constraintName="PROJECT_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECTMETRICS" constraintName="PROJECTMETRICS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="PROJECTMETRICS"
+                                 constraintName="PROJECTMETRICS_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECTS_TAGS" constraintName="PROJECTS_TAGS_TAG_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TAG_ID" baseTableName="PROJECTS_TAGS"
+                                 constraintName="PROJECTS_TAGS_TAG_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TAG" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECTS_TAGS" constraintName="PROJECTS_TAGS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="PROJECTS_TAGS"
+                                 constraintName="PROJECTS_TAGS_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECT_ACCESS_TEAMS" constraintName="PROJECT_ACCESS_TEAMS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="PROJECT_ACCESS_TEAMS"
+                                 constraintName="PROJECT_ACCESS_TEAMS_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECT_ACCESS_TEAMS" constraintName="PROJECT_ACCESS_TEAMS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="PROJECT_ACCESS_TEAMS"
+                                 constraintName="PROJECT_ACCESS_TEAMS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECT_METADATA" constraintName="PROJECT_METADATA_PROJECT_ID_FK"/>
+        <addForeignKeyConstraint baseTableName="PROJECT_METADATA" baseColumnNames="PROJECT_ID"
+                                 constraintName="PROJECT_METADATA_PROJECT_ID_FK" deferrable="true" initiallyDeferred="true"
+                                 referencedTableName="PROJECT" referencedColumnNames="ID"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="PROJECT_PROPERTY" constraintName="PROJECT_PROPERTY_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="PROJECT_PROPERTY"
+                                 constraintName="PROJECT_PROPERTY_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="SERVICECOMPONENTS_VULNERABILITIES" constraintName="SERVICECOMPONENTS_VULNERABILITIES_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY_ID" baseTableName="SERVICECOMPONENTS_VULNERABILITIES"
+                                 constraintName="SERVICECOMPONENTS_VULNERABILITIES_VULNERABILITY_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="SERVICECOMPONENTS_VULNERABILITIES" constraintName="SERVICECOMPONENTS_VULNERABILITIES_SERVICECOMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="SERVICECOMPONENT_ID" baseTableName="SERVICECOMPONENTS_VULNERABILITIES"
+                                 constraintName="SERVICECOMPONENTS_VULNERABILITIES_SERVICECOMPONENT_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="SERVICECOMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="SERVICECOMPONENT" constraintName="SERVICECOMPONENT_SERVICECOMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PARENT_SERVICECOMPONENT_ID" baseTableName="SERVICECOMPONENT"
+                                 constraintName="SERVICECOMPONENT_SERVICECOMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="SERVICECOMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="SERVICECOMPONENT" constraintName="SERVICECOMPONENT_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="SERVICECOMPONENT"
+                                 constraintName="SERVICECOMPONENT_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="TEAMS_PERMISSIONS" constraintName="TEAMS_PERMISSIONS_TEAM_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TEAM_ID" baseTableName="TEAMS_PERMISSIONS"
+                                 constraintName="TEAMS_PERMISSIONS_TEAM_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TEAM" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="TEAMS_PERMISSIONS" constraintName="TEAMS_PERMISSIONS_PERMISSION_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PERMISSION_ID" baseTableName="TEAMS_PERMISSIONS"
+                                 constraintName="TEAMS_PERMISSIONS_PERMISSION_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PERMISSION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VEX" constraintName="VEX_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="VEX" constraintName="VEX_PROJECT_FK"
+                                 deferrable="true" initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VIOLATIONANALYSISCOMMENT" constraintName="VIOLATIONANALYSISCOMMENT_VIOLATIONANALYSIS_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VIOLATIONANALYSIS_ID" baseTableName="VIOLATIONANALYSISCOMMENT"
+                                 constraintName="VIOLATIONANALYSISCOMMENT_VIOLATIONANALYSIS_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="VIOLATIONANALYSIS" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VIOLATIONANALYSIS" constraintName="VIOLATIONANALYSIS_COMPONENT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="COMPONENT_ID" baseTableName="VIOLATIONANALYSIS"
+                                 constraintName="VIOLATIONANALYSIS_COMPONENT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="COMPONENT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VIOLATIONANALYSIS" constraintName="VIOLATIONANALYSIS_POLICYVIOLATION_FK"/>
+        <addForeignKeyConstraint baseColumnNames="POLICYVIOLATION_ID" baseTableName="VIOLATIONANALYSIS"
+                                 constraintName="VIOLATIONANALYSIS_POLICYVIOLATION_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="POLICYVIOLATION" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VIOLATIONANALYSIS" constraintName="VIOLATIONANALYSIS_PROJECT_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PROJECT_ID" baseTableName="VIOLATIONANALYSIS"
+                                 constraintName="VIOLATIONANALYSIS_PROJECT_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="PROJECT" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VULNERABILITIES_TAGS" constraintName="VULNERABILITIES_TAGS_TAG_FK"/>
+        <addForeignKeyConstraint baseColumnNames="TAG_ID" baseTableName="VULNERABILITIES_TAGS"
+                                 constraintName="VULNERABILITIES_TAGS_TAG_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="TAG" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VULNERABILITIES_TAGS" constraintName="VULNERABILITIES_TAGS_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY_ID" baseTableName="VULNERABILITIES_TAGS"
+                                 constraintName="VULNERABILITIES_TAGS_VULNERABILITY_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VULNERABLESOFTWARE_VULNERABILITIES" constraintName="VULNERABLESOFTWARE_VULNERABILITIES_VULNERABILITY_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABILITY_ID" baseTableName="VULNERABLESOFTWARE_VULNERABILITIES"
+                                 constraintName="VULNERABLESOFTWARE_VULNERABILITIES_VULNERABILITY_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="VULNERABILITY" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="VULNERABLESOFTWARE_VULNERABILITIES" constraintName="VULNERABLESOFTWARE_VULNERABILITIES_VULNERABLESOFTWARE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="VULNERABLESOFTWARE_ID"
+                                 baseTableName="VULNERABLESOFTWARE_VULNERABILITIES"
+                                 constraintName="VULNERABLESOFTWARE_VULNERABILITIES_VULNERABLESOFTWARE_FK" deferrable="true"
+                                 initiallyDeferred="true" onDelete="CASCADE" onUpdate="NO ACTION"
+                                 referencedColumnNames="ID" referencedTableName="VULNERABLESOFTWARE" validate="true"/>
+
+        <dropForeignKeyConstraint baseTableName="WORKFLOW_STATE" constraintName="WORKFLOW_STATE_WORKFLOW_STATE_FK"/>
+        <addForeignKeyConstraint baseColumnNames="PARENT_STEP_ID" baseTableName="WORKFLOW_STATE"
+                                 constraintName="WORKFLOW_STATE_WORKFLOW_STATE_FK" deferrable="true" initiallyDeferred="true"
+                                 onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
+                                 referencedTableName="WORKFLOW_STATE" validate="true"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/persistence/ComponentQueryManagerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/ComponentQueryManagerTest.java
@@ -19,126 +19,15 @@
 package org.dependencytrack.persistence;
 
 import org.dependencytrack.PersistenceCapableTest;
-import org.dependencytrack.model.Analysis;
-import org.dependencytrack.model.AnalysisJustification;
-import org.dependencytrack.model.AnalysisResponse;
-import org.dependencytrack.model.AnalysisState;
-import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
-import org.dependencytrack.model.DependencyMetrics;
-import org.dependencytrack.model.IntegrityAnalysis;
-import org.dependencytrack.model.IntegrityMatchStatus;
-import org.dependencytrack.model.Policy;
-import org.dependencytrack.model.PolicyCondition;
-import org.dependencytrack.model.PolicyViolation;
 import org.dependencytrack.model.Project;
-import org.dependencytrack.model.ViolationAnalysis;
-import org.dependencytrack.model.ViolationAnalysisState;
-import org.dependencytrack.model.Vulnerability;
 import org.junit.Test;
 
-import javax.jdo.JDOObjectNotFoundException;
-import java.util.Date;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class ComponentQueryManagerTest extends PersistenceCapableTest {
-
-    @Test
-    public void recursivelyDeleteTest() {
-        final var project = new Project();
-        project.setName("acme-app");
-        project.setVersion("1.0.0");
-        qm.persist(project);
-
-        final var component = new Component();
-        component.setProject(project);
-        component.setName("acme-lib");
-        component.setVersion("2.0.0");
-        qm.persist(component);
-
-        // Assign a vulnerability and an accompanying analysis with comments to component.
-        final var vuln = new Vulnerability();
-        vuln.setVulnId("INT-123");
-        vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.persist(vuln);
-        qm.addVulnerability(vuln, component, AnalyzerIdentity.INTERNAL_ANALYZER);
-        final Analysis analysis = qm.makeAnalysis(component, vuln,
-                AnalysisState.NOT_AFFECTED,
-                AnalysisJustification.CODE_NOT_REACHABLE,
-                AnalysisResponse.WORKAROUND_AVAILABLE,
-                "analysisDetails", false);
-        qm.makeAnalysisComment(analysis, "someComment", "someCommenter");
-
-        // Create a child component to validate that deletion is indeed recursive.
-        final var componentChild = new Component();
-        componentChild.setProject(project);
-        componentChild.setParent(component);
-        componentChild.setName("acme-sub-lib");
-        componentChild.setVersion("3.0.0");
-        qm.persist(componentChild);
-
-        // Assign a policy violation and an accompanying analysis with comments to componentChild.
-        final var policy = new Policy();
-        policy.setName("Test Policy");
-        policy.setViolationState(Policy.ViolationState.WARN);
-        policy.setOperator(Policy.Operator.ALL);
-        qm.persist(policy);
-        final var policyCondition = new PolicyCondition();
-        policyCondition.setPolicy(policy);
-        policyCondition.setSubject(PolicyCondition.Subject.COORDINATES);
-        policyCondition.setOperator(PolicyCondition.Operator.MATCHES);
-        policyCondition.setValue("someValue");
-        qm.persist(policyCondition);
-        final var policyViolation = new PolicyViolation();
-        policyViolation.setPolicyCondition(policyCondition);
-        policyViolation.setComponent(componentChild);
-        policyViolation.setType(PolicyViolation.Type.OPERATIONAL);
-        policyViolation.setTimestamp(new Date());
-        qm.persist(policyViolation);
-        final ViolationAnalysis violationAnalysis = qm.makeViolationAnalysis(componentChild, policyViolation,
-                ViolationAnalysisState.REJECTED, false);
-        qm.makeViolationAnalysisComment(violationAnalysis, "someComment", "someCommenter");
-
-        // Assign am integrity analysis to componentChild
-        final var integrityAnalysis = new IntegrityAnalysis();
-        integrityAnalysis.setComponent(componentChild);
-        integrityAnalysis.setMd5HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        integrityAnalysis.setSha1HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        integrityAnalysis.setSha256HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        integrityAnalysis.setSha512HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        integrityAnalysis.setIntegrityCheckStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
-        integrityAnalysis.setUpdatedAt(new Date());
-        qm.persist(integrityAnalysis);
-
-        // Create metrics for component.
-        final var metrics = new DependencyMetrics();
-        metrics.setProject(project);
-        metrics.setComponent(component);
-        metrics.setFirstOccurrence(new Date());
-        metrics.setLastOccurrence(new Date());
-        qm.persist(metrics);
-
-        assertThatNoException()
-                .isThrownBy(() -> qm.recursivelyDelete(component, false));
-
-        // Ensure everything has been deleted as expected.
-        assertThat(qm.getAllComponents(project)).isEmpty();
-        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(Component.class, component.getId()));
-        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(Component.class, componentChild.getId()));
-        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(DependencyMetrics.class, metrics.getId()));
-        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(PolicyViolation.class, policyViolation.getId()));
-        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(IntegrityAnalysis.class, integrityAnalysis.getId()));
-
-        // Ensure associated objects were NOT deleted.
-        assertThatNoException().isThrownBy(() -> qm.getObjectById(Project.class, project.getId()));
-        assertThatNoException().isThrownBy(() -> qm.getObjectById(Vulnerability.class, vuln.getId()));
-        assertThatNoException().isThrownBy(() -> qm.getObjectById(PolicyCondition.class, policyCondition.getId()));
-        assertThatNoException().isThrownBy(() -> qm.getObjectById(Policy.class, policy.getId()));
-    }
 
     @Test
     public void testGetComponentsByPurl() {

--- a/src/test/java/org/dependencytrack/persistence/jdbi/ComponentDaoTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/ComponentDaoTest.java
@@ -1,0 +1,162 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
+import org.dependencytrack.model.AnalysisState;
+import org.dependencytrack.model.AnalyzerIdentity;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.DependencyMetrics;
+import org.dependencytrack.model.IntegrityAnalysis;
+import org.dependencytrack.model.IntegrityMatchStatus;
+import org.dependencytrack.model.Policy;
+import org.dependencytrack.model.PolicyCondition;
+import org.dependencytrack.model.PolicyViolation;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ViolationAnalysis;
+import org.dependencytrack.model.ViolationAnalysisState;
+import org.dependencytrack.model.Vulnerability;
+import org.jdbi.v3.core.Handle;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.jdo.JDOObjectNotFoundException;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
+
+public class ComponentDaoTest extends PersistenceCapableTest {
+
+    private Handle jdbiHandle;
+    private ComponentDao componentDao;
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+        jdbiHandle = openJdbiHandle();
+        componentDao = jdbiHandle.attach(ComponentDao.class);
+    }
+
+    @After
+    public void after() {
+        if (jdbiHandle != null) {
+            jdbiHandle.close();
+        }
+        super.after();
+    }
+
+    @Test
+    public void testCascadeDeleteComponent() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("2.0.0");
+        qm.persist(component);
+
+        // Assign a vulnerability and an accompanying analysis with comments to component.
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        qm.persist(vuln);
+        qm.addVulnerability(vuln, component, AnalyzerIdentity.INTERNAL_ANALYZER);
+        final Analysis analysis = qm.makeAnalysis(component, vuln,
+                AnalysisState.NOT_AFFECTED,
+                AnalysisJustification.CODE_NOT_REACHABLE,
+                AnalysisResponse.WORKAROUND_AVAILABLE,
+                "analysisDetails", false);
+        qm.makeAnalysisComment(analysis, "someComment", "someCommenter");
+
+        // Create a child component to validate that deletion is indeed recursive.
+        final var componentChild = new Component();
+        componentChild.setProject(project);
+        componentChild.setParent(component);
+        componentChild.setName("acme-sub-lib");
+        componentChild.setVersion("3.0.0");
+        qm.persist(componentChild);
+
+        // Assign a policy violation and an accompanying analysis with comments to componentChild.
+        final var policy = new Policy();
+        policy.setName("Test Policy");
+        policy.setViolationState(Policy.ViolationState.WARN);
+        policy.setOperator(Policy.Operator.ALL);
+        qm.persist(policy);
+        final var policyCondition = new PolicyCondition();
+        policyCondition.setPolicy(policy);
+        policyCondition.setSubject(PolicyCondition.Subject.COORDINATES);
+        policyCondition.setOperator(PolicyCondition.Operator.MATCHES);
+        policyCondition.setValue("someValue");
+        qm.persist(policyCondition);
+        final var policyViolation = new PolicyViolation();
+        policyViolation.setPolicyCondition(policyCondition);
+        policyViolation.setComponent(componentChild);
+        policyViolation.setType(PolicyViolation.Type.OPERATIONAL);
+        policyViolation.setTimestamp(new Date());
+        qm.persist(policyViolation);
+        final ViolationAnalysis violationAnalysis = qm.makeViolationAnalysis(componentChild, policyViolation,
+                ViolationAnalysisState.REJECTED, false);
+        qm.makeViolationAnalysisComment(violationAnalysis, "someComment", "someCommenter");
+
+        // Assign am integrity analysis to componentChild
+        final var integrityAnalysis = new IntegrityAnalysis();
+        integrityAnalysis.setComponent(componentChild);
+        integrityAnalysis.setMd5HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setSha1HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setSha256HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setSha512HashMatchStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setIntegrityCheckStatus(IntegrityMatchStatus.HASH_MATCH_PASSED);
+        integrityAnalysis.setUpdatedAt(new Date());
+        qm.persist(integrityAnalysis);
+
+        // Create metrics for component.
+        final var metrics = new DependencyMetrics();
+        metrics.setProject(project);
+        metrics.setComponent(component);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(new Date());
+        qm.persist(metrics);
+
+        componentDao.deleteComponent(component.getUuid());
+
+        // Ensure everything has been deleted as expected.
+        assertThat(qm.getAllComponents(project)).isEmpty();
+        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(Component.class, component.getId()));
+        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(Component.class, componentChild.getId()));
+        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(DependencyMetrics.class, metrics.getId()));
+        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(PolicyViolation.class, policyViolation.getId()));
+        assertThatExceptionOfType(JDOObjectNotFoundException.class).isThrownBy(() -> qm.getObjectById(IntegrityAnalysis.class, integrityAnalysis.getId()));
+
+        // Ensure associated objects were NOT deleted.
+        assertThatNoException().isThrownBy(() -> qm.getObjectById(Project.class, project.getId()));
+        assertThatNoException().isThrownBy(() -> qm.getObjectById(Vulnerability.class, vuln.getId()));
+        assertThatNoException().isThrownBy(() -> qm.getObjectById(PolicyCondition.class, policyCondition.getId()));
+        assertThatNoException().isThrownBy(() -> qm.getObjectById(Policy.class, policy.getId()));
+    }
+}


### PR DESCRIPTION
### Description

Recreate FK constraints to include the ON DELETE CASCADE clause.
Refactor the relevant application code of manual deletion logic.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1641

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
