### PR TITLE
Port : Fix incompatibility of swagger-core with newer jackson-databind versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,8 +95,12 @@
         <lib.cyclonedx-java.version>9.1.0</lib.cyclonedx-java.version>
         <lib.datanucleus-postgresql.version>0.3.0</lib.datanucleus-postgresql.version>
         <lib.jaxb.runtime.version>4.0.5</lib.jaxb.runtime.version>
-        <lib.jackson.version>2.18.0</lib.jackson.version>
-        <lib.jackson-databind.version>2.18.0</lib.jackson-databind.version>
+        <!--
+            Downgraded from 2.18.2 due to incompatibility with swagger-core.
+            https://github.com/swagger-api/swagger-core/issues/4755
+        -->
+        <lib.jackson.version>2.17.3</lib.jackson.version>
+        <lib.jackson-databind.version>2.17.3</lib.jackson-databind.version>
         <lib.jdbi.version>3.47.0</lib.jdbi.version>
         <lib.json-unit.version>4.1.0</lib.json-unit.version>
         <lib.junit.version>4.13.2</lib.junit.version>
@@ -112,6 +116,11 @@
         <lib.protobuf-java.version>4.29.3</lib.protobuf-java.version>
         <lib.testcontainers.version>1.20.4</lib.testcontainers.version>
         <lib.resilience4j.version>2.2.0</lib.resilience4j.version>
+        <!--
+            Downgraded from 2.2.26 due to incompatibilities with newer jackson-databind versions.
+            https://github.com/swagger-api/swagger-core/issues/4755
+        -->
+        <lib.swagger.version>2.2.25</lib.swagger.version>
         <lib.swagger-parser.version>2.1.23</lib.swagger-parser.version>
         <lib.system-rules.version>1.19.0</lib.system-rules.version>
         <lib.versatile.version>0.7.0</lib.versatile.version>
@@ -168,6 +177,15 @@
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-stdlib-jdk8</artifactId>
                 <version>${lib.kotlin-stdlib.version}</version>
+            </dependency>
+            <!--
+                Downgraded from 2.18.2 due to incompatibility with swagger-core.
+                https://github.com/swagger-api/swagger-core/issues/4755
+            -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-xml</artifactId>
+                <version>${lib.jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Description

Fixes incompatibility of swagger-core with newer jackson-databind versions.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4442
Issue https://github.com/DependencyTrack/hyades/issues/1358

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
