### PR TITLE
Consider project hierarchies for portfolio ACL checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -568,6 +568,7 @@
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
                 <includes>
+                    <include>META-INF/MANIFEST.MF</include>
                     <include>application.version</include>
                     <include>openapi-configuration.yaml</include>
                 </includes>

--- a/src/main/java/org/dependencytrack/persistence/datanucleus/method/ProjectIsAccessibleByMethod.java
+++ b/src/main/java/org/dependencytrack/persistence/datanucleus/method/ProjectIsAccessibleByMethod.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.datanucleus.method;
+
+import org.datanucleus.store.query.expression.Expression;
+import org.datanucleus.store.rdbms.mapping.java.JavaTypeMapping;
+import org.datanucleus.store.rdbms.sql.SQLStatement;
+import org.datanucleus.store.rdbms.sql.expression.ArrayLiteral;
+import org.datanucleus.store.rdbms.sql.expression.BooleanExpression;
+import org.datanucleus.store.rdbms.sql.expression.BooleanLiteral;
+import org.datanucleus.store.rdbms.sql.expression.ObjectExpression;
+import org.datanucleus.store.rdbms.sql.expression.SQLExpression;
+import org.datanucleus.store.rdbms.sql.expression.StringExpression;
+import org.datanucleus.store.rdbms.sql.expression.StringLiteral;
+import org.datanucleus.store.rdbms.sql.method.SQLMethod;
+import org.dependencytrack.model.Project;
+
+import java.util.List;
+import java.util.StringJoiner;
+
+/**
+ * @since 5.6.0
+ */
+public class ProjectIsAccessibleByMethod implements SQLMethod {
+
+    @Override
+    public SQLExpression getExpression(
+            final SQLStatement stmt,
+            final SQLExpression expr,
+            final List<SQLExpression> args) {
+        if (!(expr instanceof final ObjectExpression objectExpr)) {
+            // DataNucleus should prevent this from ever happening since
+            // the method is explicitly registered for java.lang.Object.
+            throw new IllegalStateException(
+                    "Expected expression to be of type %s, but got: %s".formatted(
+                            ObjectExpression.class.getName(), expr.getClass().getName()));
+        }
+
+        final String objectTypeName = objectExpr.getJavaTypeMapping().getType();
+        if (!Project.class.getName().equals(objectTypeName)) {
+            throw new IllegalStateException(
+                    "isAccessibleBy is only allowed for objects of type %s, but was called on %s".formatted(
+                            Project.class.getName(), objectTypeName));
+        }
+
+        if (args == null) {
+            throw new IllegalArgumentException();
+        } else if (args.size() != 1) {
+            throw new IllegalArgumentException("Expected exactly one argument, but got " + args.size());
+        }
+
+        // TODO: When a list, set, etc. is passed as argument, it will be of type CollectionLiteral.
+        //  Array literals are easier to verify the type of, hence we're focusing on that for now.
+
+        if (!(args.getFirst() instanceof final ArrayLiteral arrayLiteralArg)) {
+            throw new IllegalArgumentException(
+                    "Expected argument to be of type %s, but got %s".formatted(
+                            ArrayLiteral.class.getName(), args.getFirst().getClass().getName()));
+        }
+        if (!(arrayLiteralArg.getValue() instanceof final Long[] teamIds)) {
+            throw new IllegalArgumentException(
+                    "Expected array argument to be of type %s, but got %s".formatted(
+                            Long[].class.getName(), arrayLiteralArg.getValue().getClass().getName()));
+        }
+
+        final JavaTypeMapping booleanTypeMapping = stmt.getSQLExpressionFactory().getMappingForType(Boolean.class);
+        final JavaTypeMapping stringTypeMapping = stmt.getSQLExpressionFactory().getMappingForType(String.class);
+
+        // Transform the array literal to have the correct type for Postgres.
+        // Will result in the following expression: cast('{1,2,3}' as bigint[])
+        final StringJoiner joiner = new StringJoiner(",", "{", "}");
+        for (final Long teamId : teamIds) {
+            joiner.add(String.valueOf(teamId));
+        }
+        final var teamIdsLiteral = new StringLiteral(
+                stmt, stringTypeMapping, joiner.toString(), null);
+        final var teamIdsExpr = new StringExpression(
+                stmt, stringTypeMapping, "cast", List.of(teamIdsLiteral), List.of("bigint[]"));
+
+        // NB: objectExpr will compile to a reference of the object table's ID column, e.g.:
+        //   * "A0"."ID"
+        //   * "B0"."PROJECT_ID"
+        final var hasProjectAccessFunctionExpr = new StringExpression(
+                stmt, stringTypeMapping, "has_project_access", List.of(objectExpr, teamIdsExpr));
+
+        // Wrap the function call in a boolean expression. Final result(s) will be:
+        //   * has_project_access("A0"."ID", cast('{1,2,3}' as bigint[])) = TRUE
+        //   * has_project_access("B0"."PROJECT_ID", cast('{1,2,3}' as bigint[])) = TRUE
+        final var booleanTrueLiteral = new BooleanLiteral(stmt, booleanTypeMapping, Boolean.TRUE, null);
+        return new BooleanExpression(hasProjectAccessFunctionExpr, Expression.OP_EQ, booleanTrueLiteral);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -71,13 +71,7 @@ import static org.jdbi.v3.core.generic.GenericTypes.parameterizeClass;
 class ApiRequestStatementCustomizer implements StatementCustomizer {
 
     static final String PARAMETER_PROJECT_ACL_TEAM_IDS = "projectAclTeamIds";
-    static final String TEMPLATE_PROJECT_ACL_CONDITION = """
-            EXISTS (
-              SELECT 1
-                FROM "PROJECT_ACCESS_TEAMS"
-               WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "%s"."ID"
-                 AND "PROJECT_ACCESS_TEAMS"."TEAM_ID" = ANY(:projectAclTeamIds)
-            )""";
+    static final String TEMPLATE_PROJECT_ACL_CONDITION = "HAS_PROJECT_ACCESS(\"%s\".\"ID\", :projectAclTeamIds)";
 
     private final AlpineRequest apiRequest;
 
@@ -214,9 +208,9 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
     }
 
     private boolean hasAccessManagementPermission(final StatementContext ctx, final Principal principal) throws SQLException {
-        // NB: This could be simplified if Alpine's AuthenticationFilter would load all
-        // effective permissions of the authenticated user, and make them available in
-        // the Principal object. Then, we wouldn't need to perform any database queries here.
+        // TODO: After upgrading to Alpine >= 3.2.0, this should become:
+        //   apiRequest.getEffectivePermission().contains(Permissions.ACCESS_MANAGEMENT.name())
+        // https://github.com/stevespringett/Alpine/pull/764
 
         return switch (principal) {
             case ApiKey apiKey -> hasAccessManagementPermission(ctx, apiKey);

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-Description: DataNucleus plugin for Dependency-Track-specific functionality
+Bundle-License: https://apache.org/licenses/LICENSE-2.0.txt
+Bundle-ManifestVersion: 2
+Bundle-Name: datanucleus-dependencytrack
+Bundle-SymbolicName: org.dependencytrack.persistence.datanucleus;singleton:=true
+Bundle-Version: ${project.version}

--- a/src/main/resources/migration/changelog-procedures.xml
+++ b/src/main/resources/migration/changelog-procedures.xml
@@ -23,4 +23,7 @@
     <changeSet id="procedure_update-portfolio-metrics" author="nscuro@protonmail.com" runOnChange="true">
         <createProcedure path="procedures/procedure_update-portfolio-metrics.sql" relativeToChangelogFile="true"/>
     </changeSet>
+    <changeSet id="function_has-project-access" author="nscuro" runOnChange="true">
+        <createProcedure path="procedures/function_has-project-access.sql" relativeToChangelogFile="true"/>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migration/procedures/function_has-project-access.sql
+++ b/src/main/resources/migration/procedures/function_has-project-access.sql
@@ -1,0 +1,29 @@
+create or replace function has_project_access(
+  project_id bigint
+, team_ids bigint[]
+) returns bool
+  language "sql"
+  parallel safe
+  stable
+as
+$$
+with recursive project_hierarchy(id, parent_id) as(
+  select "ID" as id
+       , "PARENT_PROJECT_ID" as parent_id
+    from "PROJECT"
+   where "ID" = project_id
+   union all
+  select "PROJECT"."ID" as id
+       , "PROJECT"."PARENT_PROJECT_ID" as parent_id
+    from "PROJECT"
+   inner join project_hierarchy
+      on project_hierarchy.parent_id = "PROJECT"."ID"
+)
+select exists(
+  select 1
+    from project_hierarchy
+   inner join "PROJECT_ACCESS_TEAMS"
+      on "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = project_hierarchy.id
+   where "PROJECT_ACCESS_TEAMS"."TEAM_ID" = any(team_ids)
+)
+$$;

--- a/src/main/resources/plugin.xml
+++ b/src/main/resources/plugin.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<!--
+  TODO: This should live in a separate JAR to avoid conflicts.
+   META-INF/MANIFEST.MF is also part of this plugin.
+
+  https://www.datanucleus.org/products/accessplatform_6_0/extensions/extensions.html
+-->
+<plugin id="datanucleus-dependencytrack" name="Dependency-Track" provider-name="OWASP">
+    <extension point="org.datanucleus.store.rdbms.sql_method">
+        <sql-method
+                class="java.lang.Object"
+                method="isAccessibleBy"
+                evaluator="org.dependencytrack.persistence.datanucleus.method.ProjectIsAccessibleByMethod"/>
+    </extension>
+</plugin>

--- a/src/test/java/org/dependencytrack/persistence/datanucleus/method/ProjectIsAccessibleByMethodTest.java
+++ b/src/test/java/org/dependencytrack/persistence/datanucleus/method/ProjectIsAccessibleByMethodTest.java
@@ -1,0 +1,239 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.datanucleus.method;
+
+import alpine.model.Team;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.junit.Test;
+
+import javax.jdo.Query;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ProjectIsAccessibleByMethodTest extends PersistenceCapableTest {
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldEvaluateToTrueWhenProjectIsAccessible() {
+        final var teamA = new Team();
+        teamA.setName("team-a");
+        qm.persist(teamA);
+
+        final var teamB = new Team();
+        teamB.setName("team-b");
+        qm.persist(teamB);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setAccessTeams(List.of(teamA, teamB));
+        qm.persist(project);
+
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("this.isAccessibleBy(:teamIds)");
+        query.setNamedParameters(Map.of("teamIds", new Long[]{teamA.getId(), teamB.getId()}));
+
+        final List<Project> projects = query.executeList();
+        assertThat(projects).hasSize(1);
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldEvaluateToTrueWhenProjectParentIsAccessible() {
+        final var team = new Team();
+        team.setName("team");
+        qm.persist(team);
+
+        final var parentProject = new Project();
+        parentProject.setName("acme-app-parent");
+        parentProject.setAccessTeams(List.of(team));
+        qm.persist(parentProject);
+
+        final var project = new Project();
+        project.setParent(parentProject);
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("name == 'acme-app' && this.isAccessibleBy(:teamIds)");
+        query.setNamedParameters(Map.of("teamIds", new Long[]{team.getId()}));
+
+        final List<Project> projects = query.executeList();
+        assertThat(projects).hasSize(1);
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldEvaluateToTrueWhenProjectGrandParentIsAccessible() {
+        final var team = new Team();
+        team.setName("team");
+        qm.persist(team);
+
+        final var grandParentProject = new Project();
+        grandParentProject.setName("acme-app-grand-parent");
+        grandParentProject.setAccessTeams(List.of(team));
+        qm.persist(grandParentProject);
+
+        final var parentProject = new Project();
+        parentProject.setParent(grandParentProject);
+        parentProject.setName("acme-app-parent");
+        qm.persist(parentProject);
+
+        final var project = new Project();
+        project.setParent(parentProject);
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("name == 'acme-app' && this.isAccessibleBy(:teamIds)");
+        query.setNamedParameters(Map.of("teamIds", new Long[]{team.getId()}));
+
+        final List<Project> projects = query.executeList();
+        assertThat(projects).hasSize(1);
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldEvaluateToFalseWhenProjectIsNotAccessible() {
+        final var teamA = new Team();
+        teamA.setName("team-a");
+        qm.persist(teamA);
+
+        final var teamB = new Team();
+        teamB.setName("team-b");
+        qm.persist(teamB);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setAccessTeams(List.of(teamA));
+        qm.persist(project);
+
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("this.isAccessibleBy(:teamIds)");
+        query.setNamedParameters(Map.of("teamIds", new Long[]{teamB.getId()}));
+
+        final List<Project> projects = query.executeList();
+        assertThat(projects).isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldEvaluateToFalseWhenOnlyChildProjectIsAccessible() {
+        final var team = new Team();
+        team.setName("team");
+        qm.persist(team);
+
+        final var parentProject = new Project();
+        parentProject.setName("acme-app-parent");
+        qm.persist(parentProject);
+
+        final var project = new Project();
+        project.setParent(parentProject);
+        project.setName("acme-app");
+        project.setAccessTeams(List.of(team));
+        qm.persist(project);
+
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("name == 'acme-app-parent' && this.isAccessibleBy(:teamIds)");
+        query.setNamedParameters(Map.of("teamIds", new Long[]{team.getId()}));
+
+        final List<Project> projects = query.executeList();
+        assertThat(projects).hasSize(0);
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldBeAllowedOnProjectMembersOfNonProjectObjects() {
+        final var team = new Team();
+        team.setName("team");
+        qm.persist(team);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setAccessTeams(List.of(team));
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class);
+        query.setFilter("project.isAccessibleBy(:teamIds)");
+        query.setNamedParameters(Map.of("teamIds", new Long[]{team.getId()}));
+
+        final List<Component> components = query.executeList();
+        assertThat(components).hasSize(1);
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldThrowWhenCalledOnNonProjectObject() {
+        final Query<Component> query = qm.getPersistenceManager().newQuery(Component.class);
+        query.setFilter("this.isAccessibleBy(:teamIds)");
+        query.setParameters(Arrays.asList(1L, 2L, 3L));
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(query::execute)
+                .withMessage("""
+                        isAccessibleBy is only allowed for objects of type org.dependencytrack.model.Project, \
+                        but was called on org.dependencytrack.model.Component""");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldThrowWhenNoArgs() {
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("this.isAccessibleBy()");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(query::execute)
+                .withMessage("Expected exactly one argument, but got 0");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldThrowWhenArgIsOfUnexpectedType() {
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("this.isAccessibleBy(:teamIdsString)");
+        query.setParameters("1, 2, 3");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(query::execute)
+                .withMessage("""
+                        Expected argument to be of type org.datanucleus.store.rdbms.sql.expression.ArrayLiteral, \
+                        but got org.datanucleus.store.rdbms.sql.expression.ParameterLiteral""");
+    }
+
+    @Test
+    @SuppressWarnings("resource")
+    public void shouldThrowWhenArgIsOfUnexpectedArrayType() {
+        final Query<Project> query = qm.getPersistenceManager().newQuery(Project.class);
+        query.setFilter("this.isAccessibleBy(:teamIdStrings)");
+        query.setNamedParameters(Map.of("teamIdsStrings", new String[]{"1", "2", "3"}));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(query::execute)
+                .withMessage("""
+                        Expected argument to be of type org.datanucleus.store.rdbms.sql.expression.ArrayLiteral, \
+                        but got org.datanucleus.store.rdbms.sql.expression.ParameterLiteral""");
+    }
+
+}

--- a/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
@@ -566,11 +566,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                                  , 2 AS "valueB"
                               FROM "PROJECT"
                              WHERE TRUE
-                               AND EXISTS (SELECT 1
-                                             FROM "PROJECT_ACCESS_TEAMS"
-                                            WHERE "PROJECT_ACCESS_TEAMS"."PROJECT_ID" = "PROJECT"."ID"
-                                              AND "PROJECT_ACCESS_TEAMS"."TEAM_ID" = ANY(:projectAclTeamIds)
-                                           )
+                               AND HAS_PROJECT_ACCESS("PROJECT"."ID", :projectAclTeamIds)
                             """);
 
                     assertThat(ctx.getBinding()).hasToString("{named:{projectAclTeamIds:[%s]}}".formatted(team.getId()));

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -53,7 +53,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static net.javacrumbs.jsonunit.assertj.JsonAssertions.json;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.WorkflowStatus.PENDING;
 import static org.dependencytrack.resources.v1.FindingResource.MEDIA_TYPE_SARIF_JSON;
@@ -516,10 +515,10 @@ public class FindingResourceTest extends ResourceTest {
                 .header(X_API_KEY, team.getApiKeys().get(0).getKey())
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
-        Assert.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assert.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(3, json.size());
+        Assert.assertEquals(4, json.size());
         Assert.assertEquals(date.getTime() ,json.getJsonObject(0).getJsonObject("vulnerability").getJsonNumber("published").longValue());
         Assert.assertEquals(p1.getName() ,json.getJsonObject(0).getJsonObject("component").getString("projectName"));
         Assert.assertEquals(p1.getVersion() ,json.getJsonObject(0).getJsonObject("component").getString("projectVersion"));
@@ -532,6 +531,12 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
         Assert.assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
         Assert.assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
+
+        // Findings of p1_child are returned because team was given access to its parent project p1.
+        Assert.assertEquals(date.getTime(), json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        Assert.assertEquals(p1_child.getName(), json.getJsonObject(3).getJsonObject("component").getString("projectName"));
+        Assert.assertEquals(p1_child.getVersion(), json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
+        Assert.assertEquals(p1_child.getUuid().toString(), json.getJsonObject(3).getJsonObject("component").getString("project"));
     }
 
     @Test
@@ -672,7 +677,7 @@ public class FindingResourceTest extends ResourceTest {
         Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").size());
         Assert.assertEquals(80, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(0).getInt("cweId"));
         Assert.assertEquals(666, json.getJsonObject(1).getJsonObject("vulnerability").getJsonArray("cwes").getJsonObject(1).getInt("cweId"));
-        Assert.assertEquals(1, json.getJsonObject(1).getJsonObject("vulnerability").getInt("affectedProjectCount"));
+        Assert.assertEquals(2, json.getJsonObject(1).getJsonObject("vulnerability").getInt("affectedProjectCount")); // p1 and p1_child.
 
         Assert.assertEquals("INTERNAL", json.getJsonObject(2).getJsonObject("vulnerability").getString("source"));
         Assert.assertEquals("Vuln-3", json.getJsonObject(2).getJsonObject("vulnerability").getString("vulnId"));

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -906,8 +906,25 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("0");
-        assertThat(getPlainTextBody(response)).isEqualTo("[]");
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("2");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "active": true,
+                    "hasChildren": false,
+                    "isLatest": false,
+                    "name": "acme-child-app-a",
+                    "uuid": "${json-unit.any-string}"
+                  },
+                  {
+                    "active": true,
+                    "hasChildren": false,
+                    "isLatest": false,
+                    "name": "acme-child-app-b",
+                    "uuid": "${json-unit.any-string}"
+                  }
+                ]
+                """);
 
         // Additionally grant access to acme-child-app-a.
         childProjectA.addAccessTeam(team);
@@ -917,8 +934,8 @@ public class ProjectResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get();
         assertThat(response.getStatus()).isEqualTo(200);
-        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
-        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("2");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
                 [
                   {
                     "uuid": "${json-unit.any-string}",
@@ -930,6 +947,13 @@ public class ProjectResourceTest extends ResourceTest {
                         "name": "%s"
                       }
                     ],
+                    "hasChildren": false
+                  },
+                  {
+                    "uuid": "${json-unit.any-string}",
+                    "name": "acme-child-app-b",
+                    "active": true,
+                    "isLatest": false,
                     "hasChildren": false
                   }
                 ]


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Considers project hierarchies for portfolio ACL checks.

Introduces a new `has_project_access(project_id bigint, team_ids bigint[])` SQL function that encapsulates a recursive ACL check. Calling this method requires knowledge of which teams the current principal is a member of.

To bridge with the DataNucleus ORM, a [plugin](https://www.datanucleus.org/products/accessplatform_6_0/extensions/extensions.html) is introduced, which adds a `isAccessibleBy(Long[] teamIds)` method to objects of type `Project`. This allows us to leverage the efficient SQL function while avoiding a major refactoring of the code base.

Access checks can then be included in JDOQL as follows:

```java
var teamIds = new Long[]{1, 2, 3};

// When querying for projects directly.
Query<Project> query = pm.newQuery(Project.class);
query.setFilter("this.isAccessibleBy(:teamIds)");
query.setParameters(teamIds);

// When querying for objects with a project field.
Query<Component> query = pm.newQuery(Component.class);
query.setFilter("project.isAccessibleBy(:teamIds)");
query.setParameters(teamIds);
```

> [!NOTE]
> DataNucleus plugins should usually live in their own module / JAR. The way the plugin was added here is not great, but it works for now. Ideally, we would refactor this repository into a multi-module project at some point.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1674

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
