### PR TITLE
Fix erroneous over-suppression of Snyk findings

### DIFF
--- a/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
+++ b/src/main/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessor.java
@@ -952,7 +952,7 @@ public class VulnerabilityScanResultProcessor implements Processor<ScanKey, Scan
                       AND "V"."SOURCE" = 'SNYK'
                       AND ("A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
                      <#if vulnIdsToExclude>
-                       AND "V"."VULNID" != ANY(:vulnIdsToExclude)
+                       AND "V"."VULNID" != ALL(:vulnIdsToExclude)
                      </#if>
                  )
                  -- Try to create suppression analyses for all Snyk vulns identified above.

--- a/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
+++ b/src/test/java/org/dependencytrack/event/kafka/processor/VulnerabilityScanResultProcessorTest.java
@@ -1539,6 +1539,13 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
         qm.persist(vulnerabilityS3);
         qm.addVulnerability(vulnerabilityS3, component, AnalyzerIdentity.SNYK_ANALYZER);
 
+        // Another SNYK vulnerability to NOT be suppressed, that doesn't yet have an analysis.
+        final var vulnerabilityS4 = new Vulnerability();
+        vulnerabilityS4.setVulnId("SNYK-004");
+        vulnerabilityS4.setSource(Vulnerability.Source.SNYK);
+        qm.persist(vulnerabilityS4);
+        qm.addVulnerability(vulnerabilityS4, component, AnalyzerIdentity.SNYK_ANALYZER);
+
         final var scanToken = UUID.randomUUID().toString();
         final var scanKey = ScanKey.newBuilder().setScanToken(scanToken).setComponentUuid(component.getUuid().toString()).build();
         final var scanResult = ScanResult.newBuilder()
@@ -1546,10 +1553,33 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
                 .addScannerResults(ScannerResult.newBuilder()
                         .setScanner(SCANNER_SNYK)
                         .setStatus(SCAN_STATUS_SUCCESSFUL)
-                        .setBom(Bom.newBuilder().addVulnerabilities(createVuln("SNYK-001", "SNYK"))))
+                        .setBom(Bom.newBuilder()
+                                .addVulnerabilities(createVuln("SNYK-001", "SNYK"))
+                                .addVulnerabilities(createVuln("SNYK-004", "SNYK"))))
                 .build();
 
         processor.process(aConsumerRecord(scanKey, scanResult).build());
+
+        // Existing analyses are still in L1 cache. Wipe it.
+        qm.getPersistenceManager().evictAll();
+
+        assertThat(qm.getAllVulnerabilities(component, true)).satisfiesExactlyInAnyOrder(
+                vuln -> {
+                    assertThat(vuln.getVulnId()).isEqualTo("SNYK-001");
+                    assertThat(qm.getAnalysis(component, vuln).isSuppressed()).isFalse();
+                },
+                vuln -> {
+                    assertThat(vuln.getVulnId()).isEqualTo("SNYK-002");
+                    assertThat(qm.getAnalysis(component, vuln).isSuppressed()).isTrue();
+                },
+                vuln -> {
+                    assertThat(vuln.getVulnId()).isEqualTo("SNYK-003");
+                    assertThat(qm.getAnalysis(component, vuln).isSuppressed()).isTrue();
+                },
+                vuln -> {
+                    assertThat(vuln.getVulnId()).isEqualTo("SNYK-004");
+                    assertThat(qm.getAnalysis(component, vuln)).isNull();
+                });
 
         // Project audit change notification must be sent.
         assertThat(kafkaMockProducer.history()).satisfiesExactly(record -> {
@@ -1581,7 +1611,7 @@ public class VulnerabilityScanResultProcessorTest extends AbstractProcessorTest 
                 assertThat(notification.getTitle()).isEqualTo(NotificationUtil.generateNotificationTitle(NotificationConstants.Title.ANALYSIS_DECISION_FALSE_POSITIVE, project));
                 assertThat(notification.getContent()).isEqualTo("An analysis decision was made to a finding affecting a project");
             });
-        }
+    }
 
     private org.cyclonedx.proto.v1_6.Vulnerability createVuln(final String id, final String source) {
         return org.cyclonedx.proto.v1_6.Vulnerability.newBuilder()


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes erroneous over-suppression of Snyk findings.

A mix-up of `"V"."VULNID" != ANY(:vulnIdsToExclude)` and `"V"."VULNID" != ALL(:vulnIdsToExclude)` caused all but one Snyk vulnerability to be suppressed for a component.

https://stackoverflow.com/a/11730845

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
