### PR TITLE
Improve coverage of portfolio ACL checks in REST API endpoints

### DIFF
--- a/src/main/java/org/dependencytrack/common/MdcScope.java
+++ b/src/main/java/org/dependencytrack/common/MdcScope.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common;
+
+import org.slf4j.MDC;
+import org.slf4j.MDC.MDCCloseable;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @since 5.6.0
+ */
+public class MdcScope implements Closeable {
+
+    private final List<MDCCloseable> mdcCloseables = new ArrayList<>();
+
+    public MdcScope(final Map<String, String> variables) {
+        for (final Map.Entry<String, String> entry : variables.entrySet()) {
+            if (MDC.get(entry.getKey()) == null) {
+                mdcCloseables.add(MDC.putCloseable(entry.getKey(), entry.getValue()));
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        mdcCloseables.forEach(MDCCloseable::close);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/exception/ProjectAccessDeniedException.java
+++ b/src/main/java/org/dependencytrack/exception/ProjectAccessDeniedException.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.exception;
+
+/**
+ * @since 5.6.0
+ */
+public class ProjectAccessDeniedException extends RuntimeException {
+
+    public ProjectAccessDeniedException(final String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/PolicyQueryManager.java
@@ -18,13 +18,9 @@
  */
 package org.dependencytrack.persistence;
 
-import alpine.model.ApiKey;
-import alpine.model.Team;
-import alpine.model.UserPrincipal;
 import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import org.dependencytrack.model.Component;
-import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.License;
 import org.dependencytrack.model.LicenseGroup;
 import org.dependencytrack.model.Policy;
@@ -804,43 +800,4 @@ final class PolicyQueryManager extends QueryManager implements IQueryManager {
         }
     }
 
-    @Override
-    void preprocessACLs(final Query<?> query, final String inputFilter, final Map<String, Object> params, final boolean bypass) {
-        if (super.principal != null && isEnabled(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED) && !bypass) {
-            final List<Team> teams;
-            if (super.principal instanceof UserPrincipal) {
-                final UserPrincipal userPrincipal = ((UserPrincipal) super.principal);
-                teams = userPrincipal.getTeams();
-                if (super.hasAccessManagementPermission(userPrincipal)) {
-                    query.setFilter(inputFilter);
-                    return;
-                }
-            } else {
-                final ApiKey apiKey = ((ApiKey) super.principal);
-                teams = apiKey.getTeams();
-                if (super.hasAccessManagementPermission(apiKey)) {
-                    query.setFilter(inputFilter);
-                    return;
-                }
-            }
-            if (teams != null && teams.size() > 0) {
-                final StringBuilder sb = new StringBuilder();
-                for (int i = 0, teamsSize = teams.size(); i < teamsSize; i++) {
-                    final Team team = super.getObjectById(Team.class, teams.get(i).getId());
-                    sb.append(" project.accessTeams.contains(:team").append(i).append(") ");
-                    params.put("team" + i, team);
-                    if (i < teamsSize-1) {
-                        sb.append(" || ");
-                    }
-                }
-                if (inputFilter != null) {
-                    query.setFilter(inputFilter + " && (" + sb.toString() + ")");
-                } else {
-                    query.setFilter(sb.toString());
-                }
-            }
-        } else {
-            query.setFilter(inputFilter);
-        }
-    }
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -97,7 +97,6 @@ import org.dependencytrack.notification.publisher.PublisherClass;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanStatus;
 import org.dependencytrack.proto.vulnanalysis.v1.ScannerResult;
-import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.IntegrityMetaInitializerTask;
 
@@ -1167,10 +1166,6 @@ public class QueryManager extends AlpineQueryManager {
 
     public long getSuppressedCount(Project project, Component component) {
         return getFindingsQueryManager().getSuppressedCount(project, component);
-    }
-
-    public List<AffectedProject> getAffectedProjects(Vulnerability vulnerability) {
-        return getVulnerabilityQueryManager().getAffectedProjects(vulnerability);
     }
 
     public VulnerabilityAlias synchronizeVulnerabilityAlias(VulnerabilityAlias alias) {

--- a/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -25,7 +25,6 @@ import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Analysis;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
-import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Epss;
 import org.dependencytrack.model.FindingAttribution;
 import org.dependencytrack.model.Project;
@@ -36,7 +35,6 @@ import org.dependencytrack.model.VulnerabilityAlias;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao.AffectedProjectCountRow;
-import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.jdbi.v3.core.Handle;
 
 import javax.jdo.PersistenceManager;
@@ -49,13 +47,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
-import static org.dependencytrack.util.PrincipalUtil.getPrincipalTeamIds;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 final class VulnerabilityQueryManager extends QueryManager implements IQueryManager {
 
@@ -316,9 +312,19 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             result = execute(query);
         }
         Map<String, Epss> matchedEpssList = getEpssForCveIds(
-                result.getList(Vulnerability.class).stream().map(vuln -> vuln.getVulnId()).distinct().toList());
+                result.getList(Vulnerability.class).stream().map(Vulnerability::getVulnId).distinct().toList());
+        final Map<Long, AffectedProjectCountRow> affectedProjectCountRows = withJdbiHandle(
+                this.request,
+                jdbiHandle -> jdbiHandle.attach(VulnerabilityDao.class).getAffectedProjectCount(
+                        result.getList(Vulnerability.class).stream().map(Vulnerability::getId).toList(),
+                        /* includeSuppressed */ false)).stream()
+                .collect(Collectors.toMap(AffectedProjectCountRow::id, Function.identity()));
         for (final Vulnerability vulnerability : result.getList(Vulnerability.class)) {
-            vulnerability.setAffectedProjectCount(this.getAffectedProjectCount(vulnerability));
+            final AffectedProjectCountRow affectedProjects = affectedProjectCountRows.get(vulnerability.getId());
+            if (affectedProjects != null) {
+                vulnerability.setAffectedProjectCount(affectedProjects.totalProjectCount());
+                vulnerability.setAffectedInactiveProjectCount(affectedProjects.totalProjectCount() - affectedProjects.activeProjectCount());
+            }
             vulnerability.setAliases(getVulnerabilityAliases(vulnerability));
             vulnerability.setEpss(matchedEpssList.get(vulnerability.getVulnId()));
         }
@@ -343,10 +349,12 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         List<Vulnerability> componentVulnerabilities;
         List<AffectedProjectCountRow> affectedProjectCounts;
 
-        try (final Handle jdbiHandle = openJdbiHandle((this.request))) {
+        try (final Handle jdbiHandle = openJdbiHandle(this.request)) {
             final var dao = jdbiHandle.attach(VulnerabilityDao.class);
             componentVulnerabilities = dao.getVulnerabilitiesByComponent(component.getId(), includeSuppressed);
-            affectedProjectCounts = dao.getAffectedProjectCount(componentVulnerabilities.stream().map(Vulnerability::getId).toList());
+            affectedProjectCounts = dao.getAffectedProjectCount(
+                    componentVulnerabilities.stream().map(Vulnerability::getId).toList(),
+                    includeSuppressed);
         }
         Map<Long, Vulnerability> vulnById = componentVulnerabilities.stream().collect(Collectors.toMap(Vulnerability::getId, vulnerability -> vulnerability));
         for (var vulnerabilityProjectCount : affectedProjectCounts) {
@@ -474,145 +482,6 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             excludeClause = " && (" + excludeClause.substring(0, excludeClause.lastIndexOf(" && ")) + ")";
         }
         return excludeClause;
-    }
-
-    /**
-     * Generates partial JDOQL statement excluding suppressed vulnerabilities for this project.
-     * @param project the project to query on
-     * @return a partial where clause
-     */
-    private String generateExcludeSuppressed(Project project) {
-        return generateExcludeSuppressed(project, null);
-    }
-
-    /**
-     * Returns a {@link List} of {@link Project}s affected by a given {@link Vulnerability}.
-     *
-     * @param vulnerability The {@link Vulnerability} to query on
-     * @param fetchGroups   The fetch groups to use
-     * @return A {@link List} of {@link Project}s
-     */
-    public List<Project> getProjects(final Vulnerability vulnerability, final Set<String> fetchGroups) {
-        // It is not possible to select distinct objects, so select IDs instead
-        // and fetch objects in a second step. This is still a lot more efficient
-        // than fetching objects first and then de-duplicating them in memory.
-        var queryStr = """
-                SELECT DISTINCT this.project.id
-                FROM org.dependencytrack.model.Component
-                WHERE this.vulnerabilities.contains(:vuln)
-                    && (SELECT FROM org.dependencytrack.model.Analysis a
-                        WHERE a.component == this
-                            && a.vulnerability == :vuln
-                            && a.suppressed == true).isEmpty()
-                """;
-        final var params = new HashMap<String, Object>();
-        params.put("vuln", vulnerability);
-
-        if (isEnabled(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED)
-                && !hasAccessManagementPermission(principal)) {
-            queryStr += """
-                        && this.project.accessTeams.contains(team)
-                        && :teamIds.contains(team.id)
-                    VARIABLES alpine.model.Team team
-                    """;
-            params.put("teamIds", getPrincipalTeamIds(super.principal));
-        }
-
-        // TODO: This query should support pagination
-
-        final Query<?> query = pm.newQuery(Query.JDOQL, queryStr);
-        final List<Long> affectedProjectIds;
-        try {
-            query.setNamedParameters(params);
-            affectedProjectIds = List.copyOf(query.executeResultList(Long.class));
-        } finally {
-            query.closeAll();
-        }
-
-        return getObjectsById(Project.class, affectedProjectIds, fetchGroups);
-    }
-
-    /**
-     * Returns a List of Projects affected by a specific vulnerability.
-     * @param vulnerability the vulnerability to query on
-     * @return a List of AffectedProjects
-     */
-    public List<AffectedProject> getAffectedProjects(Vulnerability vulnerability) {
-        // Fetch all projects affected by the given vulnerability.
-        // Group them by their UUID to ease additional enrichment.
-        final Map<String, AffectedProject> affectedProjects = getProjects(vulnerability, Set.of(Project.FetchGroup.IDENTIFIERS.name())).stream()
-            .map(project -> new AffectedProject(
-                project.getUuid(),
-                project.getDirectDependencies() != null,
-                project.getName(),
-                project.getVersion(), project.isActive(),
-                null
-            ))
-            .collect(Collectors.toMap(affectedProject -> affectedProject.getUuid().toString(), Function.identity()));
-    
-        // Fetch UUIDs of components that are part of the affected projects,
-        // and affected by the given vulnerability. Return both the component's UUID,
-        // but also the UUID of the project it belongs to, so we can correlate.
-        final Query<Component> query = pm.newQuery(Component.class);
-        query.setFilter(":projectUuids.contains(project.uuid) && vulnerabilities.contains(:vulnerability)");
-        query.setParameters(affectedProjects.keySet(), vulnerability);
-        query.setResult("uuid, project.uuid");
-        final List<Object[]> resultRows;
-        try {
-            resultRows = List.copyOf(query.executeResultList(Object[].class));
-        } finally {
-            query.closeAll();
-        }
-    
-        // "Enrich" affectedProjects with component UUIDs.
-        for (final Object[] resultRow : resultRows) {
-            final String componentUuid = String.valueOf(resultRow[0]);
-            final String projectUuid = String.valueOf(resultRow[1]);
-            affectedProjects.get(projectUuid).getAffectedComponentUuids().add(UUID.fromString(componentUuid));
-        }
-    
-        return new ArrayList<>(affectedProjects.values());
-    }
-
-    /**
-     * Returns the number of {@link Project}s affected by a given {@link Vulnerability}.
-     *
-     * @param vulnerability The {@link Vulnerability} to query on
-     * @return Number of affected {@link Project}s
-     */
-    public int getAffectedProjectCount(final Vulnerability vulnerability) {
-        var queryStr = """
-                SELECT COUNT(DISTINCT this.project.id)
-                FROM org.dependencytrack.model.Component
-                WHERE this.vulnerabilities.contains(:vuln)
-                    && (SELECT FROM org.dependencytrack.model.Analysis a
-                        WHERE a.component == this
-                            && a.vulnerability == :vuln
-                            && a.suppressed == true).isEmpty()
-                """;
-        final var params = new HashMap<String, Object>();
-        params.put("vuln", vulnerability);
-
-        if (isEnabled(ConfigPropertyConstants.ACCESS_MANAGEMENT_ACL_ENABLED)
-                && !hasAccessManagementPermission(principal)) {
-            queryStr += """
-                        && this.project.accessTeams.contains(team)
-                        && :teamIds.contains(team.id)
-                    VARIABLES alpine.model.Team team
-                    """;
-            params.put("teamIds", getPrincipalTeamIds(super.principal));
-        }
-
-        final Query<?> query = pm.newQuery(Query.JDOQL, queryStr);
-        final long affectedProjectCount;
-        try {
-            query.setNamedParameters(params);
-            affectedProjectCount = query.executeResultUnique(Long.class);
-        } finally {
-            query.closeAll();
-        }
-
-        return Math.toIntExact(affectedProjectCount);
     }
 
     public synchronized VulnerabilityAlias synchronizeVulnerabilityAlias(final VulnerabilityAlias alias) {

--- a/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -31,6 +31,7 @@ import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterFieldMapper;
 import org.jdbi.v3.sqlobject.config.RegisterRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -281,7 +282,9 @@ public interface VulnerabilityDao {
     @RegisterRowMapper(VulnerabilityRowMapper.class)
     List<Vulnerability> getVulnerabilitiesByComponent(@Bind Long componentId, @Bind boolean includeSuppressed);
 
-    @SqlQuery("""
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
             SELECT "VULNERABILITY"."ID" AS "id"
                  , COUNT("PROJECT"."ID") AS "totalProjectCount"
                  , COUNT(*) FILTER (WHERE "PROJECT"."INACTIVE_SINCE" IS NULL) AS "activeProjectCount"
@@ -292,11 +295,22 @@ public interface VulnerabilityDao {
               	ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
              INNER JOIN "PROJECT"
             	ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
+            <#if !includeSuppressed>
+              LEFT JOIN "ANALYSIS"
+                ON "ANALYSIS"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+               AND "ANALYSIS"."COMPONENT_ID" = "COMPONENT"."ID"
+            </#if>
              WHERE "VULNERABILITY"."ID" = ANY(:vulnerabilityIds)
+            <#if !includeSuppressed>
+               AND ("ANALYSIS"."SUPPRESSED" IS NULL OR NOT "ANALYSIS"."SUPPRESSED")
+            </#if>
+               AND ${apiProjectAclCondition!"TRUE"}
              GROUP BY "VULNERABILITY"."ID"
             """)
     @RegisterConstructorMapper(AffectedProjectCountRow.class)
-    List<AffectedProjectCountRow> getAffectedProjectCount(@Bind List<Long> vulnerabilityIds);
+    List<AffectedProjectCountRow> getAffectedProjectCount(
+            @Bind List<Long> vulnerabilityIds,
+            @Define boolean includeSuppressed);
 
     record AffectedProjectCountRow(
             long id,

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractApiResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractApiResource.java
@@ -1,0 +1,78 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1;
+
+import alpine.common.logging.Logger;
+import alpine.server.resources.AlpineResource;
+import org.dependencytrack.common.MdcScope;
+import org.dependencytrack.exception.ProjectAccessDeniedException;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.persistence.QueryManager;
+import org.owasp.security.logging.SecurityMarkers;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNullElse;
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_NAME;
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_VERSION;
+
+/**
+ * @since 5.6.0
+ */
+abstract class AbstractApiResource extends AlpineResource {
+
+    private final Logger logger = Logger.getLogger(this.getClass());
+
+    /**
+     * @see #requireAccess(QueryManager, Project, String)
+     */
+    void requireAccess(final QueryManager qm, final Project project) {
+        requireAccess(qm, project, null);
+    }
+
+    /**
+     * Asserts that the authenticated {@link java.security.Principal} has access to a given {@link Project}.
+     *
+     * @param qm      The {@link QueryManager} to use.
+     * @param project The {@link Project} to verify access permission for.
+     * @param message The message to use if a {@link ProjectAccessDeniedException} is thrown.
+     * @throws ProjectAccessDeniedException When the authenticated {@link java.security.Principal}
+     *                                      does not have access to the given {@link Project}.
+     */
+    void requireAccess(final QueryManager qm, final Project project, final String message) {
+        // TODO: Could make sense to cache the result for at least a few seconds.
+        //  Frontend and API clients tend to make multiple successive requests targeting
+        //  the same project. If we can avoid this overhead for even a few of those
+        //  requests, that would already help under high traffic conditions.
+
+        if (!qm.hasAccess(super.getPrincipal(), project)) {
+            try (var ignored = new MdcScope(Map.ofEntries(
+                    Map.entry(MDC_PROJECT_UUID, project.getUuid().toString()),
+                    Map.entry(MDC_PROJECT_NAME, project.getName()),
+                    Map.entry(MDC_PROJECT_VERSION, String.valueOf(project.getVersion()))))) {
+                logSecurityEvent(logger, SecurityMarkers.SECURITY_FAILURE, "Unauthorized project access attempt");
+            }
+
+            throw new ProjectAccessDeniedException(requireNonNullElse(
+                    message, "Access to the requested project is forbidden"));
+        }
+    }
+
+}

--- a/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/AbstractConfigPropertyResource.java
@@ -23,18 +23,17 @@ import alpine.common.util.BooleanUtil;
 import alpine.common.util.UuidUtil;
 import alpine.model.IConfigProperty;
 import alpine.security.crypto.DataEncryption;
-import alpine.server.resources.AlpineResource;
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonReader;
-import jakarta.json.JsonString;
-import jakarta.ws.rs.core.Response;
 import org.dependencytrack.model.BomValidationMode;
 import org.dependencytrack.model.ConfigPropertyAccessMode;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
 import org.owasp.security.logging.SecurityMarkers;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonString;
+import jakarta.ws.rs.core.Response;
 import java.io.StringReader;
 import java.math.BigDecimal;
 import java.net.MalformedURLException;
@@ -42,7 +41,7 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-abstract class AbstractConfigPropertyResource extends AlpineResource {
+abstract class AbstractConfigPropertyResource extends AbstractApiResource {
 
     private final Logger LOGGER = Logger.getLogger(this.getClass()); // Use the classes that extend this, not this class itself
     static final String ENCRYPTED_PLACEHOLDER = "HiddenDecryptedPropertyPlaceholder";

--- a/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -28,7 +28,6 @@ import alpine.server.auth.ApiKeyAuthenticationService;
 import alpine.server.auth.AuthenticationNotRequired;
 import alpine.server.auth.JwtAuthenticationService;
 import alpine.server.filters.AuthenticationFilter;
-import alpine.server.resources.AlpineResource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -38,21 +37,22 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.resources.v1.misc.Badger;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.owasp.security.logging.SecurityMarkers;
 
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Response;
 import javax.naming.AuthenticationException;
 import java.security.Principal;
 
@@ -71,7 +71,7 @@ import static org.dependencytrack.model.ConfigPropertyConstants.GENERAL_BADGE_EN
         @SecurityRequirement(name = "BearerAuth"),
         @SecurityRequirement(name = "ApiKeyQueryAuth")
 })
-public class BadgeResource extends AlpineResource {
+public class BadgeResource extends AbstractApiResource {
 
     private static final String SVG_MEDIA_TYPE = "image/svg+xml";
 
@@ -174,7 +174,10 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @AuthenticationNotRequired
@@ -191,8 +194,8 @@ public class BadgeResource extends AlpineResource {
             }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                if (!shouldBypassAuth) {
+                    requireAccess(qm, project);
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
@@ -217,7 +220,10 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @AuthenticationNotRequired
@@ -236,8 +242,8 @@ public class BadgeResource extends AlpineResource {
             }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                if (!shouldBypassAuth) {
+                    requireAccess(qm, project);
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
@@ -262,7 +268,10 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @AuthenticationNotRequired
@@ -279,8 +288,8 @@ public class BadgeResource extends AlpineResource {
             }
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                if (!shouldBypassAuth) {
+                    requireAccess(qm, project);
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();
@@ -305,7 +314,10 @@ public class BadgeResource extends AlpineResource {
                     content = @Content(schema = @Schema(type = "string"))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @AuthenticationNotRequired
@@ -324,8 +336,8 @@ public class BadgeResource extends AlpineResource {
             }
             final Project project = qm.getProject(name, version);
             if (project != null) {
-                if (!shouldBypassAuth && !qm.hasAccess(super.getPrincipal(), project)) {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
+                if (!shouldBypassAuth) {
+                    requireAccess(qm, project);
                 }
                 final ProjectMetrics metrics = qm.getMostRecentProjectMetrics(project);
                 final Badger badger = new Badger();

--- a/src/main/java/org/dependencytrack/resources/v1/ComponentPropertyResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/ComponentPropertyResource.java
@@ -29,6 +29,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.commons.lang3.StringUtils;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ComponentProperty;
+import org.dependencytrack.model.validation.ValidUuid;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+
 import jakarta.validation.Validator;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -39,13 +47,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.model.Component;
-import org.dependencytrack.model.ComponentProperty;
-import org.dependencytrack.model.validation.ValidUuid;
-import org.dependencytrack.persistence.QueryManager;
-
 import java.util.List;
 import java.util.UUID;
 
@@ -73,7 +74,10 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = ComponentProperty.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified project is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
@@ -83,22 +87,19 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    final List<ComponentProperty> properties = qm.getComponentProperties(component);
-                    // Detaches the objects and closes the persistence manager so that if/when encrypted string
-                    // values are replaced by the placeholder, they are not erroneously persisted to the database.
-                    qm.getPersistenceManager().detachCopyAll(properties);
-                    qm.close();
-                    for (final ComponentProperty property : properties) {
-                        // Replace the value of encrypted strings with the pre-defined placeholder
-                        if (ComponentProperty.PropertyType.ENCRYPTEDSTRING == property.getPropertyType()) {
-                            property.setPropertyValue(ENCRYPTED_PLACEHOLDER);
-                        }
+                requireAccess(qm, component.getProject());
+                final List<ComponentProperty> properties = qm.getComponentProperties(component);
+                // Detaches the objects and closes the persistence manager so that if/when encrypted string
+                // values are replaced by the placeholder, they are not erroneously persisted to the database.
+                qm.getPersistenceManager().detachCopyAll(properties);
+                qm.close();
+                for (final ComponentProperty property : properties) {
+                    // Replace the value of encrypted strings with the pre-defined placeholder
+                    if (ComponentProperty.PropertyType.ENCRYPTEDSTRING == property.getPropertyType()) {
+                        property.setPropertyValue(ENCRYPTED_PLACEHOLDER);
                     }
-                    return Response.ok(properties).build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
                 }
+                return Response.ok(properties).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
@@ -119,7 +120,10 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
                     content = @Content(schema = @Schema(implementation = ComponentProperty.class))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The component could not be found"),
             @ApiResponse(responseCode = "409", description = "A property with the specified component/group/name combination already exists")
     })
@@ -138,27 +142,24 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
         try (QueryManager qm = new QueryManager()) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    final List<ComponentProperty> existingProperties = qm.getComponentProperties(component,
-                            StringUtils.trimToNull(json.getGroupName()), StringUtils.trimToNull(json.getPropertyName()));
-                    final var jsonPropertyIdentity = new ComponentProperty.Identity(json);
-                    final boolean isDuplicate = existingProperties.stream()
-                            .map(ComponentProperty.Identity::new)
-                            .anyMatch(jsonPropertyIdentity::equals);
-                    if (existingProperties.isEmpty() || !isDuplicate) {
-                        final ComponentProperty property = qm.createComponentProperty(component,
-                                StringUtils.trimToNull(json.getGroupName()),
-                                StringUtils.trimToNull(json.getPropertyName()),
-                                null, // Set value to null - this will be taken care of by updatePropertyValue below
-                                json.getPropertyType(),
-                                StringUtils.trimToNull(json.getDescription()));
-                        updatePropertyValue(qm, json, property);
-                        return Response.status(Response.Status.CREATED).entity(property).build();
-                    } else {
-                        return Response.status(Response.Status.CONFLICT).entity("A property with the specified component/group/name/value combination already exists.").build();
-                    }
+                requireAccess(qm, component.getProject());
+                final List<ComponentProperty> existingProperties = qm.getComponentProperties(component,
+                        StringUtils.trimToNull(json.getGroupName()), StringUtils.trimToNull(json.getPropertyName()));
+                final var jsonPropertyIdentity = new ComponentProperty.Identity(json);
+                final boolean isDuplicate = existingProperties.stream()
+                        .map(ComponentProperty.Identity::new)
+                        .anyMatch(jsonPropertyIdentity::equals);
+                if (existingProperties.isEmpty() || !isDuplicate) {
+                    final ComponentProperty property = qm.createComponentProperty(component,
+                            StringUtils.trimToNull(json.getGroupName()),
+                            StringUtils.trimToNull(json.getPropertyName()),
+                            null, // Set value to null - this will be taken care of by updatePropertyValue below
+                            json.getPropertyType(),
+                            StringUtils.trimToNull(json.getDescription()));
+                    updatePropertyValue(qm, json, property);
+                    return Response.status(Response.Status.CREATED).entity(property).build();
                 } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
+                    return Response.status(Response.Status.CONFLICT).entity("A property with the specified component/group/name/value combination already exists.").build();
                 }
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
@@ -177,7 +178,10 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Property removed successfully"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The component or component property could not be found"),
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
@@ -189,15 +193,12 @@ public class ComponentPropertyResource extends AbstractConfigPropertyResource {
         try (QueryManager qm = new QueryManager()) {
             final Component component = qm.getObjectByUuid(Component.class, componentUuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    final long propertiesDeleted = qm.deleteComponentPropertyByUuid(component, UUID.fromString(propertyUuid));
-                    if (propertiesDeleted > 0) {
-                        return Response.status(Response.Status.NO_CONTENT).build();
-                    } else {
-                        return Response.status(Response.Status.NOT_FOUND).entity("The component property could not be found.").build();
-                    }
+                requireAccess(qm, component.getProject());
+                final long propertiesDeleted = qm.deleteComponentPropertyByUuid(component, UUID.fromString(propertyUuid));
+                if (propertiesDeleted > 0) {
+                    return Response.status(Response.Status.NO_CONTENT).build();
                 } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
+                    return Response.status(Response.Status.NOT_FOUND).entity("The component property could not be found.").build();
                 }
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();

--- a/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
-import alpine.server.resources.AlpineResource;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -31,19 +30,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
-import jakarta.validation.Validator;
-import jakarta.ws.rs.ClientErrorException;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Component;
@@ -58,6 +44,7 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao.AffectedProjectListRow;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
 import org.dependencytrack.resources.v1.vo.AffectedProject;
 import org.dependencytrack.util.VulnerabilityUtil;
@@ -67,6 +54,19 @@ import us.springett.cvss.Score;
 import us.springett.owasp.riskrating.MissingFactorException;
 import us.springett.owasp.riskrating.OwaspRiskRating;
 
+import jakarta.validation.Validator;
+import jakarta.ws.rs.ClientErrorException;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -87,7 +87,7 @@ import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
         @SecurityRequirement(name = "ApiKeyAuth"),
         @SecurityRequirement(name = "BearerAuth")
 })
-public class VulnerabilityResource extends AlpineResource {
+public class VulnerabilityResource extends AbstractApiResource {
 
     @GET
     @Path("/component/{uuid}")
@@ -105,7 +105,10 @@ public class VulnerabilityResource extends AlpineResource {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = Vulnerability.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The component could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
@@ -116,12 +119,9 @@ public class VulnerabilityResource extends AlpineResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Component component = qm.getObjectByUuid(Component.class, uuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    final PaginatedResult result = qm.getVulnerabilities(component, suppressed);
-                    return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
-                }
+                requireAccess(qm, component.getProject());
+                final PaginatedResult result = qm.getVulnerabilities(component, suppressed);
+                return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
@@ -143,7 +143,10 @@ public class VulnerabilityResource extends AlpineResource {
                     content = @Content(array = @ArraySchema(schema = @Schema(implementation = Vulnerability.class)))
             ),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified project is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The project could not be found")
     })
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
@@ -154,13 +157,11 @@ public class VulnerabilityResource extends AlpineResource {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
-                if (qm.hasAccess(super.getPrincipal(), project)) {
-                    // TODO: This should honor pagination but it doesn't.
-                    final List<Vulnerability> vulnerabilities = qm.getVulnerabilities(project, suppressed);
-                    return Response.ok(vulnerabilities).header(TOTAL_COUNT_HEADER, vulnerabilities.size()).build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified project is forbidden").build();
-                }
+                requireAccess(qm, project);
+
+                // TODO: This should honor pagination but it doesn't.
+                final List<Vulnerability> vulnerabilities = qm.getVulnerabilities(project, suppressed);
+                return Response.ok(vulnerabilities).header(TOTAL_COUNT_HEADER, vulnerabilities.size()).build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
             }
@@ -582,7 +583,10 @@ public class VulnerabilityResource extends AlpineResource {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Assignment successful"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The vulnerability or component could not be found")
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_UPDATE})
@@ -599,12 +603,9 @@ public class VulnerabilityResource extends AlpineResource {
             }
             final Component component = qm.getObjectByUuid(Component.class, componentUuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
-                    return Response.ok().build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
-                }
+                requireAccess(qm, component.getProject());
+                qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
+                return Response.ok().build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
@@ -622,7 +623,10 @@ public class VulnerabilityResource extends AlpineResource {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Assignment successful"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The vulnerability or component could not be found")
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_UPDATE})
@@ -637,12 +641,9 @@ public class VulnerabilityResource extends AlpineResource {
             }
             final Component component = qm.getObjectByUuid(Component.class, componentUuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
-                    return Response.ok().build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
-                }
+                requireAccess(qm, component.getProject());
+                qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
+                return Response.ok().build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
@@ -660,7 +661,10 @@ public class VulnerabilityResource extends AlpineResource {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Assignment removal successful"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The vulnerability or component could not be found")
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
@@ -677,12 +681,9 @@ public class VulnerabilityResource extends AlpineResource {
             }
             final Component component = qm.getObjectByUuid(Component.class, componentUuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    qm.removeVulnerability(vulnerability, component);
-                    return Response.ok().build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
-                }
+                requireAccess(qm, component.getProject());
+                qm.removeVulnerability(vulnerability, component);
+                return Response.ok().build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
@@ -700,7 +701,10 @@ public class VulnerabilityResource extends AlpineResource {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Assignment removal successful"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
-            @ApiResponse(responseCode = "403", description = "Access to the specified component is forbidden"),
+            @ApiResponse(
+                    responseCode = "403",
+                    description = "Access to the requested project is forbidden",
+                    content = @Content(schema = @Schema(implementation = ProblemDetails.class), mediaType = ProblemDetails.MEDIA_TYPE_JSON)),
             @ApiResponse(responseCode = "404", description = "The vulnerability or component could not be found")
     })
     @PermissionRequired({Permissions.Constants.PORTFOLIO_MANAGEMENT, Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE})
@@ -715,12 +719,9 @@ public class VulnerabilityResource extends AlpineResource {
             }
             Component component = qm.getObjectByUuid(Component.class, componentUuid);
             if (component != null) {
-                if (qm.hasAccess(super.getPrincipal(), component.getProject())) {
-                    qm.removeVulnerability(vulnerability, component);
-                    return Response.ok().build();
-                } else {
-                    return Response.status(Response.Status.FORBIDDEN).entity("Access to the specified component is forbidden").build();
-                }
+                requireAccess(qm, component.getProject());
+                qm.removeVulnerability(vulnerability, component);
+                return Response.ok().build();
             } else {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }

--- a/src/main/java/org/dependencytrack/resources/v1/exception/ProjectAccessDeniedExceptionMapper.java
+++ b/src/main/java/org/dependencytrack/resources/v1/exception/ProjectAccessDeniedExceptionMapper.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1.exception;
+
+import org.dependencytrack.exception.ProjectAccessDeniedException;
+import org.dependencytrack.resources.v1.problems.ProblemDetails;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.ExceptionMapper;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * @since 5.6.0
+ */
+@Provider
+public class ProjectAccessDeniedExceptionMapper implements ExceptionMapper<ProjectAccessDeniedException> {
+
+    @Override
+    public Response toResponse(final ProjectAccessDeniedException exception) {
+        final var problemDetails = new ProblemDetails();
+        problemDetails.setStatus(403);
+        problemDetails.setTitle("Project access denied");
+        problemDetails.setDetail(exception.getMessage());
+        return problemDetails.toResponse();
+    }
+
+}

--- a/src/test/java/org/dependencytrack/JerseyTestRule.java
+++ b/src/test/java/org/dependencytrack/JerseyTestRule.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack;
 
+import org.dependencytrack.resources.v1.exception.ClientErrorExceptionMapper;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.grizzly.connector.GrizzlyConnectorProvider;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -56,7 +57,9 @@ public class JerseyTestRule extends ExternalResource {
 
             @Override
             protected DeploymentContext configureDeployment() {
-                return ServletDeploymentContext.forServlet(new ServletContainer(resourceConfig)).build();
+                return ServletDeploymentContext.forServlet(new ServletContainer(
+                        // Ensure exception mappers are registered.
+                        resourceConfig.packages(ClientErrorExceptionMapper.class.getPackageName()))).build();
             }
 
         };

--- a/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BadgeResourceTest.java
@@ -20,7 +20,6 @@ package org.dependencytrack.resources.v1;
 
 import alpine.model.IConfigProperty;
 import alpine.server.filters.ApiFilter;
-import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
@@ -31,6 +30,7 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import jakarta.ws.rs.core.Response;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;

--- a/src/test/java/org/dependencytrack/resources/v1/MetricsResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/MetricsResourceTest.java
@@ -1,0 +1,316 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v1;
+
+import alpine.server.filters.ApiFilter;
+import alpine.server.filters.AuthenticationFilter;
+import alpine.server.filters.AuthorizationFilter;
+import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import jakarta.ws.rs.core.Response;
+import java.util.function.Supplier;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricsResourceTest extends ResourceTest {
+
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig(MetricsResource.class)
+                    .register(ApiFilter.class)
+                    .register(AuthenticationFilter.class)
+                    .register(AuthorizationFilter.class));
+
+    @Test
+    public void getProjectCurrentMetricsAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + project.getUuid() + "/current")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void getProjectMetricsSinceAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + project.getUuid() + "/since/20250101")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void getProjectMetricsXDaysAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + project.getUuid() + "/days/666")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void refreshProjectMetricsAclTest() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + project.getUuid() + "/refresh")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void getComponentCurrentMetricsAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/component/" + component.getUuid() + "/current")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void getComponentMetricsSinceAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/component/" + component.getUuid() + "/since/20250101")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void getComponentMetricsXDaysAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/component/" + component.getUuid() + "/days/666")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void refreshComponentMetricsAclTest() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/component/" + component.getUuid() + "/refresh")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+}

--- a/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -21,10 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
-import jakarta.json.JsonArray;
-import jakarta.ws.rs.HttpMethod;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
@@ -34,15 +30,16 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.NotificationScope;
-import org.dependencytrack.resources.v1.exception.ConstraintViolationExceptionMapper;
-import org.dependencytrack.resources.v1.exception.NoSuchElementExceptionMapper;
-import org.dependencytrack.resources.v1.exception.TagOperationFailedExceptionMapper;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.HttpMethod;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -60,10 +57,7 @@ public class TagResourceTest extends ResourceTest {
             new ResourceConfig(TagResource.class)
                     .register(ApiFilter.class)
                     .register(AuthenticationFilter.class)
-                    .register(AuthorizationFilter.class)
-                    .register(ConstraintViolationExceptionMapper.class)
-                    .register(NoSuchElementExceptionMapper.class)
-                    .register(TagOperationFailedExceptionMapper.class));
+                    .register(AuthorizationFilter.class));
 
     @Test
     public void getTagsTest() {

--- a/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -21,12 +21,6 @@ package org.dependencytrack.resources.v1;
 import alpine.common.util.UuidUtil;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
-import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import net.javacrumbs.jsonunit.core.Option;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
@@ -47,8 +41,15 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -981,6 +982,86 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    public void assignVulnerabilityAclTest() {
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        qm.persist(vuln);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_VULNERABILITY + "/source/INTERNAL/vuln/INT-001/component/" + component.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void assignVulnerabilityByUuidAclTest() {
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        qm.persist(vuln);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_VULNERABILITY + "/" + vuln.getUuid() + "/component/" + component.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
     public void unassignVulnerabilityTest() {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
@@ -1076,6 +1157,88 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         String body = getPlainTextBody(response);
         Assert.assertEquals("The component could not be found.", body);
+    }
+
+    @Test
+    public void unassignVulnerabilityAclTest() {
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setComponents(List.of(component));
+        qm.persist(vuln);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_VULNERABILITY + "/source/INTERNAL/vuln/INT-001/component/" + component.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void unassignVulnerabilityByUuidAclTest() {
+        enablePortfolioAccessControl();
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-001");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setComponents(List.of(component));
+        qm.persist(vuln);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_VULNERABILITY + "/" + vuln.getUuid() + "/component/" + component.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(403);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     private class SampleData {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves coverage of portfolio ACL checks in REST API endpoints.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1679

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

To reduce code duplication, `if (!qm.hasAccess(super.getPrincipal(), project)) {} else {}` checks are replaced with simple `requireAccess(project)` calls. The call will throw an `ProjectAccessDeniedException` if project access is not given, which is then transparently mapped to a `HTTP 403` response.

---

Access control failures now return a JSON response in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457.html) format:

```json
{
  "status": 403,
  "title": "Project access denied",
  "detail": "Access to the requested project is forbidden"
}
```

Previously, a plaintext response was returned.

---

Access control failure are now logged. The logs' MDC context always contains the project UUID, name, and version. For example:

```
Unauthorized project access attempt by: odt_****************************WXUY / IP Address: 127.0.0.1 / User Agent: Jersey/3.1.9 (Async HTTP Grizzly Connector 3.1.9) [projectName=acme-app, projectVersion=null, projectUuid=4ab3c54a-fcf2-41dc-8190-9e92324f55f5]
```

> [!NOTE]
> With Alpine >= 3.2.0 (https://github.com/stevespringett/Alpine/pull/771), `requestMethod` and `requestUri` will also be part of logs.

---

ACL tests are added for all resources that perform ACL checks. The general test structure is:

1. Enable portfolio ACL
2. Attempt request without project access
3. Expect a `403` response
4. Assign project access
5. Re-attempt request
6. Expect a success response

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
