### PR TITLE
Restrict portfolio metrics to only include projects a user has access to

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -18,15 +18,58 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
+import org.dependencytrack.model.PortfolioMetrics;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 
 /**
  * @since 5.6.0
  */
 public interface MetricsDao {
+
+    // TODO:
+    //   * Get latest PROJECTMETRICS record for each project for each day.
+    //   * Calculate metrics sums across all projects for each day.
+    //   * Find a way to fill gaps (i.e. when no metrics exist for a project for a specific day)?
+    //   * Cache result for a few min in an unlogged table?
+    @SqlQuery("""
+            with recursive
+            directly_accessible_project as(
+              select "PROJECT_ID" as id
+                from "PROJECT_ACCESS_TEAMS"
+               where "TEAM_ID" = any(:projectAclTeamIds)
+            ),
+            accessible_project_child(id) as(
+              select "ID" as id
+                from "PROJECT"
+               where "PARENT_PROJECT_ID" IN (select id from directly_accessible_project)
+               union all
+              select "PROJECT"."ID" as id
+                from "PROJECT"
+               inner join accessible_project_child
+                  on accessible_project_child.id = "PROJECT"."PARENT_PROJECT_ID"
+            ),
+            accessible_project as(
+              select id
+                from directly_accessible_project
+               union all
+              select id
+                from accessible_project_child
+            )
+            select "PROJECTMETRICS".*
+              from "PROJECT"
+             inner join "PROJECTMETRICS"
+                on "PROJECTMETRICS"."PROJECT_ID" = "PROJECT"."ID"
+             where "PROJECT"."ID" in (select id from accessible_project)
+               and "PROJECT"."INACTIVE_SINCE" IS NULL
+               and "PROJECTMETRICS"."LAST_OCCURRENCE" >= :since;
+            """)
+    List<PortfolioMetrics> getPortfolioMetricsSince(@Bind Instant since);
 
     @SqlUpdate("""
             DELETE


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Restricts portfolio metrics to only include projects a user has access to.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1680

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
