### PR TITLE
Ingest component occurrences

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <lib.cpe-parser.version>2.1.0</lib.cpe-parser.version>
         <lib.cvss-calculator.version>1.4.3</lib.cvss-calculator.version>
         <lib.owasp-rr-calculator.version>1.0.1</lib.owasp-rr-calculator.version>
-        <lib.cyclonedx-java.version>9.1.0</lib.cyclonedx-java.version>
+        <lib.cyclonedx-java.version>10.1.0</lib.cyclonedx-java.version>
         <lib.datanucleus-postgresql.version>0.3.0</lib.datanucleus-postgresql.version>
         <lib.jaxb.runtime.version>4.0.5</lib.jaxb.runtime.version>
         <!--

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -35,6 +35,10 @@ import org.dependencytrack.persistence.converter.OrganizationalContactsJsonConve
 import org.dependencytrack.persistence.converter.OrganizationalEntityJsonConverter;
 import org.dependencytrack.resources.v1.serializers.CustomPackageURLSerializer;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
 import javax.jdo.annotations.Element;
@@ -51,13 +55,10 @@ import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Serialized;
 import javax.jdo.annotations.Unique;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -80,6 +81,7 @@ import java.util.UUID;
                 @Persistent(name = "vulnerabilities"),
         }),
         @FetchGroup(name = "BOM_UPLOAD_PROCESSING", members = {
+                @Persistent(name = "occurrences"),
                 @Persistent(name = "properties")
         }),
         @FetchGroup(name = "IDENTITY", members = {
@@ -357,6 +359,10 @@ public class Component implements Serializable {
     private Collection<Component> children;
 
     @Persistent(mappedBy = "component", defaultFetchGroup = "false")
+    @JsonIgnore
+    private Set<ComponentOccurrence> occurrences;
+
+    @Persistent(mappedBy = "component", defaultFetchGroup = "false")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "groupName ASC, propertyName ASC, id ASC"))
     private List<ComponentProperty> properties;
 
@@ -405,6 +411,10 @@ public class Component implements Serializable {
     private transient Set<String> dependencyGraph;
     private transient boolean expandDependencyGraph;
     private transient String author;
+
+    // TODO: Move this to another class, similar to ConciseProjectListItem.
+    //  This is only relevant when listing components.
+    private transient Long occurrenceCount;
 
     public Component(){}
 
@@ -751,12 +761,34 @@ public class Component implements Serializable {
         this.children = children;
     }
 
+    public Set<ComponentOccurrence> getOccurrences() {
+        return occurrences;
+    }
+
+    public void setOccurrences(final Set<ComponentOccurrence> occurrences) {
+        this.occurrences = occurrences;
+    }
+
+    public void addOccurrence(final ComponentOccurrence occurrence) {
+        if (occurrences == null) {
+            occurrences = new HashSet<>();
+        }
+        occurrences.add(occurrence);
+    }
+
     public List<ComponentProperty> getProperties() {
         return properties;
     }
 
     public void setProperties(List<ComponentProperty> properties) {
         this.properties = properties;
+    }
+
+    public void addProperty(final ComponentProperty property) {
+        if (properties == null) {
+            properties = new ArrayList<>();
+        }
+        properties.add(property);
     }
 
     public List<Vulnerability> getVulnerabilities() {
@@ -889,6 +921,14 @@ public class Component implements Serializable {
 
     public void setAuthor(String author){
         this.author=author;
+    }
+
+    public Long getOccurrenceCount() {
+        return occurrenceCount;
+    }
+
+    public void setOccurrenceCount(final Long occurrenceCount) {
+        this.occurrenceCount = occurrenceCount;
     }
 
     @Override

--- a/src/main/java/org/dependencytrack/model/ComponentOccurrence.java
+++ b/src/main/java/org/dependencytrack/model/ComponentOccurrence.java
@@ -1,0 +1,168 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.model;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.datanucleus.api.jdo.annotations.CreateTimestamp;
+
+import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
+import javax.jdo.annotations.Index;
+import javax.jdo.annotations.NotPersistent;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+import javax.jdo.annotations.PrimaryKey;
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * @since 5.6.0
+ */
+@PersistenceCapable(table = "COMPONENT_OCCURRENCE")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ComponentOccurrence {
+
+    public record Identity(
+            String location,
+            Integer line,
+            Integer offset,
+            String symbol) {
+
+        public static Identity of(final ComponentOccurrence occurrence) {
+            return new Identity(
+                    occurrence.getLocation(),
+                    occurrence.getLine(),
+                    occurrence.getOffset(),
+                    occurrence.getSymbol());
+        }
+
+    }
+
+    @PrimaryKey(name = "COMPONENT_OCCURRENCE_PK")
+    @Persistent(customValueStrategy = "uuid-v7")
+    @Column(name = "ID", sqlType = "UUID")
+    private UUID id;
+
+    @Persistent
+    @ForeignKey(
+            name = "COMPONENT_OCCURRENCE_COMPONENT_FK",
+            deferred = "true",
+            deleteAction = ForeignKeyAction.CASCADE,
+            updateAction = ForeignKeyAction.NONE)
+    @Index(name = "COMPONENT_OCCURRENCE_COMPONENT_ID_IDX")
+    @Column(name = "COMPONENT_ID", allowsNull = "false")
+    @JsonIgnore
+    private Component component;
+
+    @Persistent
+    @Column(name = "LOCATION")
+    private String location;
+
+    @Persistent
+    @Column(name = "LINE")
+    private Integer line;
+
+    @Persistent
+    @Column(name = "OFFSET")
+    private Integer offset;
+
+    @Persistent
+    @Column(name = "SYMBOL")
+    private String symbol;
+
+    @Persistent
+    @CreateTimestamp
+    @Column(name = "CREATED_AT")
+    @JsonFormat(
+            shape = JsonFormat.Shape.NUMBER_INT,
+            without = JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS)
+    private Instant createdAt;
+
+    @NotPersistent
+    @JsonIgnore
+    private transient Integer totalCount;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(final UUID id) {
+        this.id = id;
+    }
+
+    public Component getComponent() {
+        return component;
+    }
+
+    public void setComponent(final Component component) {
+        this.component = component;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(final String location) {
+        this.location = location;
+    }
+
+    public Integer getLine() {
+        return line;
+    }
+
+    public void setLine(final Integer line) {
+        this.line = line;
+    }
+
+    public Integer getOffset() {
+        return offset;
+    }
+
+    public void setOffset(final Integer offset) {
+        this.offset = offset;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(final String symbol) {
+        this.symbol = symbol;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(final Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Integer getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(final Integer totalCount) {
+        this.totalCount = totalCount;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/model/sqlmapping/ComponentProjection.java
+++ b/src/main/java/org/dependencytrack/model/sqlmapping/ComponentProjection.java
@@ -159,6 +159,7 @@ public class ComponentProjection {
 
     public Boolean isCustomLicense;
 
+    public long occurrenceCount;
     public Long totalCount;
 
     public static Component mapToComponent(ComponentProjection result) {
@@ -197,6 +198,7 @@ public class ComponentProjection {
         if (result.externalReferences != null) {
             componentPersistent.setExternalReferences(SerializationUtils.deserialize(result.externalReferences));
         }
+        componentPersistent.setOccurrenceCount(result.occurrenceCount);
         componentPersistent.setPurl(result.purl);
         componentPersistent.setPurlCoordinates(result.purlCoordinates);
         componentPersistent.setVersion(result.version);

--- a/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -24,12 +24,10 @@ import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonValue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
+import org.dependencytrack.model.ComponentOccurrence;
 import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.RepositoryMetaComponent;
@@ -38,10 +36,14 @@ import org.dependencytrack.model.sqlmapping.ComponentProjection;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.IntegrityMetaInitializerTask;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -226,6 +228,7 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                         "I0"."PUBLISHED_AT" AS "publishedAt",
                         "IA"."INTEGRITY_CHECK_STATUS" AS "integrityCheckStatus",
                         "I0"."REPOSITORY_URL" AS "integrityRepoUrl",
+                        (SELECT COUNT(*) FROM "COMPONENT_OCCURRENCE" WHERE "COMPONENT_ID" = "A0"."ID") AS "occurrenceCount",
                         COUNT(*) OVER() AS "totalCount"
                 FROM "COMPONENT" "A0"
                 INNER JOIN "PROJECT" "B0" ON "A0"."PROJECT_ID" = "B0"."ID"
@@ -307,6 +310,9 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                         """
                             ORDER BY "integrityCheckStatus"
                         """;
+            }
+            if (orderBy.equalsIgnoreCase("occurrenceCount")) {
+                queryString += "ORDER BY \"occurrenceCount\"";
             }
             if (queryString.contains("ORDER BY")) {
                 if (orderDirection == OrderDirection.ASCENDING) {
@@ -875,17 +881,24 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             //   modified manually.
             if (component.getProperties() != null && !component.getProperties().isEmpty()) {
                 pm.deletePersistentAll(component.getProperties());
+                component.setProperties(null);
             }
 
             return;
         }
 
-        properties.forEach(property -> assertNonPersistent(property, "property must not be persistent"));
+        // Map and de-duplicate incoming properties by their identity.
+        final var incomingPropertyIdentitiesSeen = new HashSet<ComponentProperty.Identity>();
+        final var incomingPropertiesByIdentity = properties.stream()
+                .peek(property -> assertNonPersistent(property, "property must not be persistent"))
+                .filter(property -> incomingPropertyIdentitiesSeen.add(new ComponentProperty.Identity(property)))
+                .collect(Collectors.toMap(ComponentProperty.Identity::new, Function.identity()));
 
         if (component.getProperties() == null || component.getProperties().isEmpty()) {
-            for (final ComponentProperty property : properties) {
+            for (final ComponentProperty property : incomingPropertiesByIdentity.values()) {
                 property.setComponent(component);
                 pm.makePersistent(property);
+                component.addProperty(property);
             }
 
             return;
@@ -909,13 +922,10 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
                     return isUnique;
                 })
                 .collect(Collectors.toMap(ComponentProperty.Identity::new, Function.identity()));
-        final var incomingPropertyIdentitiesSeen = new HashSet<ComponentProperty.Identity>();
-        final var incomingPropertiesByIdentity = properties.stream()
-                .filter(property -> incomingPropertyIdentitiesSeen.add(new ComponentProperty.Identity(property)))
-                .collect(Collectors.toMap(ComponentProperty.Identity::new, Function.identity()));
 
         if (!existingDuplicateProperties.isEmpty()) {
             pm.deletePersistentAll(existingDuplicateProperties);
+            component.getProperties().removeAll(existingDuplicateProperties);
         }
 
         final var propertyIdentities = new HashSet<ComponentProperty.Identity>();
@@ -929,9 +939,72 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             if (existingProperty == null) {
                 incomingProperty.setComponent(component);
                 pm.makePersistent(incomingProperty);
+                component.addProperty(incomingProperty);
             } else if (incomingProperty == null) {
                 pm.deletePersistent(existingProperty);
+                component.getProperties().remove(existingProperty);
             }
         }
     }
+
+    /**
+     * @since 5.6.0
+     */
+    @Override
+    public void synchronizeComponentOccurrences(final Component component, final Collection<ComponentOccurrence> occurrences) {
+        assertPersistent(component, "component must be persistent");
+
+        // No incoming occurrences. Remove existing occurrences from the component if there are any.
+        if (occurrences == null || occurrences.isEmpty()) {
+            if (component.getOccurrences() != null && !component.getOccurrences().isEmpty()) {
+                pm.deletePersistentAll(component.getProperties());
+                component.setOccurrences(null);
+            }
+
+            return;
+        }
+
+        // Map and de-duplicate incoming occurrences by their identity.
+        final var incomingOccurrenceIdentitiesSeen = new HashSet<ComponentOccurrence.Identity>();
+        final var incomingOccurrenceByIdentity = occurrences.stream()
+                .peek(occurrence -> assertNonPersistent(occurrence, "occurrence must not be persistent"))
+                .filter(occurrence -> incomingOccurrenceIdentitiesSeen.add(ComponentOccurrence.Identity.of(occurrence)))
+                .collect(Collectors.toMap(ComponentOccurrence.Identity::of, Function.identity(), (left, right) -> left));
+
+        // No existing occurrences. Add them all.
+        if (component.getOccurrences() == null || component.getOccurrences().isEmpty()) {
+            for (final ComponentOccurrence occurrence : incomingOccurrenceByIdentity.values()) {
+                occurrence.setComponent(component);
+                pm.makePersistent(occurrence);
+                component.addOccurrence(occurrence);
+            }
+
+            return;
+        }
+
+        // Map existing occurrences by their identity.
+        final var existingOccurrenceIdentitiesSeen = new HashSet<ComponentOccurrence.Identity>();
+        final var existingOccurrenceByIdentity = component.getOccurrences().stream()
+                .filter(occurrence -> existingOccurrenceIdentitiesSeen.add(ComponentOccurrence.Identity.of(occurrence)))
+                .collect(Collectors.toMap(ComponentOccurrence.Identity::of, Function.identity()));
+
+        final var identities = new HashSet<ComponentOccurrence.Identity>();
+        identities.addAll(existingOccurrenceByIdentity.keySet());
+        identities.addAll(incomingOccurrenceByIdentity.keySet());
+
+        for (final ComponentOccurrence.Identity identity : identities) {
+            final ComponentOccurrence existingOccurrence = existingOccurrenceByIdentity.get(identity);
+            final ComponentOccurrence incomingOccurrence = incomingOccurrenceByIdentity.get(identity);
+
+            if (existingOccurrence == null) {
+                incomingOccurrence.setComponent(component);
+                pm.makePersistent(incomingOccurrence);
+                component.addOccurrence(incomingOccurrence);
+            } else if (incomingOccurrence == null) {
+                component.getOccurrences().remove(existingOccurrence);
+                pm.deletePersistent(existingOccurrence);
+            }
+        }
+    }
+
 }

--- a/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -53,6 +53,7 @@ import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
 import org.dependencytrack.model.ComponentMetaInformation;
+import org.dependencytrack.model.ComponentOccurrence;
 import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.DependencyMetrics;
@@ -2030,6 +2031,10 @@ public class QueryManager extends AlpineQueryManager {
 
     public void synchronizeComponentProperties(final Component component, final List<ComponentProperty> properties) {
         getComponentQueryManager().synchronizeComponentProperties(component, properties);
+    }
+
+    public void synchronizeComponentOccurrences(final Component component, final Collection<ComponentOccurrence> occurrences) {
+        getComponentQueryManager().synchronizeComponentOccurrences(component, occurrences);
     }
 
     /**

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestConfig.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestConfig.java
@@ -31,10 +31,7 @@ public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
 
     private Set<OrderingColumn> orderingAllowedColumns = Collections.emptySet();
     private String orderingAlwaysBy = "";
-
-    // TODO: Make this configurable via annotation when needed (similar to @AllowOrdering).
-    //   In some queries the PROJECT table may be aliased (e.g. as P).
-    private String projectTableAlias = "PROJECT";
+    private String projectIdColumn = "\"PROJECT\".\"ID\"";
 
     @SuppressWarnings("unused")
     public ApiRequestConfig() {
@@ -44,7 +41,7 @@ public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
     private ApiRequestConfig(final ApiRequestConfig that) {
         this.orderingAllowedColumns = Set.copyOf(that.orderingAllowedColumns);
         this.orderingAlwaysBy = that.orderingAlwaysBy;
-        this.projectTableAlias = that.projectTableAlias;
+        this.projectIdColumn = that.projectIdColumn;
     }
 
     @Override
@@ -74,8 +71,8 @@ public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
         this.orderingAlwaysBy = orderingAlwaysBy;
     }
 
-    String projectAclProjectTableName() {
-        return projectTableAlias;
+    String projectAclProjectIdColumn() {
+        return projectIdColumn;
     }
 
     public record OrderingColumn(String name, String queryName) {

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -67,11 +67,10 @@ import static org.jdbi.v3.core.generic.GenericTypes.parameterizeClass;
  *
  * @since 5.5.0
  */
-@SuppressWarnings("JavadocReference")
 class ApiRequestStatementCustomizer implements StatementCustomizer {
 
     static final String PARAMETER_PROJECT_ACL_TEAM_IDS = "projectAclTeamIds";
-    static final String TEMPLATE_PROJECT_ACL_CONDITION = "HAS_PROJECT_ACCESS(\"%s\".\"ID\", :projectAclTeamIds)";
+    static final String TEMPLATE_PROJECT_ACL_CONDITION = "HAS_PROJECT_ACCESS(%s, :projectAclTeamIds)";
 
     private final AlpineRequest apiRequest;
 
@@ -167,13 +166,11 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
     }
 
     private void defineProjectAclCondition(final StatementContext ctx) throws SQLException {
-        if (apiRequest == null) {
-            return;
-        }
-
-        if (apiRequest.getPrincipal() == null
+        if (apiRequest == null
+            || apiRequest.getPrincipal() == null
             || !isAclEnabled(ctx)
             || hasAccessManagementPermission(ctx, apiRequest.getPrincipal())) {
+            ctx.define(ATTRIBUTE_API_PROJECT_ACL_CONDITION, "TRUE");
             return;
         }
 
@@ -187,7 +184,7 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
 
         ctx.define(
                 ATTRIBUTE_API_PROJECT_ACL_CONDITION,
-                TEMPLATE_PROJECT_ACL_CONDITION.formatted(config.projectAclProjectTableName())
+                TEMPLATE_PROJECT_ACL_CONDITION.formatted(config.projectAclProjectIdColumn())
         );
         ctx.getBinding().addNamed(PARAMETER_PROJECT_ACL_TEAM_IDS, principalTeamIds,
                 QualifiedType.of(parameterizeClass(Set.class, Long.class)));

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
@@ -18,9 +18,13 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
+import org.dependencytrack.model.ComponentOccurrence;
+import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
+import java.util.List;
 import java.util.UUID;
 
 public interface ComponentDao {
@@ -31,4 +35,37 @@ public interface ComponentDao {
              WHERE "UUID" = :componentUuid
             """)
     int deleteComponent(@Bind final UUID componentUuid);
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
+            SELECT ${apiProjectAclCondition}
+              FROM "COMPONENT"
+             WHERE "UUID" = :componentUuid
+            """)
+    @DefineApiProjectAclCondition(projectIdColumn = "\"PROJECT_ID\"")
+    Boolean isAccessible(@Bind UUID componentUuid);
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiFilterParameter" type="String" -->
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            SELECT "COMPONENT_OCCURRENCE"."ID"
+                 , "LOCATION"
+                 , "LINE"
+                 , "OFFSET"
+                 , "SYMBOL"
+                 , "CREATED_AT"
+                 , COUNT(*) OVER() AS "TOTAL_COUNT"
+              FROM "COMPONENT"
+             INNER JOIN "COMPONENT_OCCURRENCE"
+                ON "COMPONENT_OCCURRENCE"."COMPONENT_ID" = "COMPONENT"."ID"
+             WHERE "COMPONENT"."UUID" = :componentUuid
+            <#if apiFilterParameter??>
+               AND LOWER("LOCATION") LIKE ('%' || LOWER(${apiFilterParameter}) || '%')
+            </#if>
+            ORDER BY "LOCATION", "COMPONENT_OCCURRENCE"."ID"
+            ${apiOffsetLimitClause!}
+            """)
+    @RegisterBeanMapper(ComponentOccurrence.class)
+    List<ComponentOccurrence> getOccurrences(@Bind UUID componentUuid);
+
 }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
@@ -58,7 +58,7 @@ public class JdbiFactory {
     }
 
     public static <X extends Exception> void useJdbiHandle(final HandleConsumer<X> handleConsumer) throws X {
-        createJdbi().useHandle(handleConsumer);
+        useJdbiHandle(/* apiRequest */ null, handleConsumer);
     }
 
     public static <X extends Exception> void useJdbiHandle(final AlpineRequest apiRequest, final HandleConsumer<X> handleConsumer) throws X {
@@ -66,7 +66,7 @@ public class JdbiFactory {
     }
 
     public static <T, X extends Exception> T withJdbiHandle(final HandleCallback<T, X> handleCallback) throws X {
-        return createJdbi().withHandle(handleCallback);
+        return withJdbiHandle(/* apiRequest */  null, handleCallback);
     }
 
     public static <T, X extends Exception> T withJdbiHandle(final AlpineRequest apiRequest, final HandleCallback<T, X> handleCallback) throws X {
@@ -74,7 +74,7 @@ public class JdbiFactory {
     }
 
     public static <X extends Exception> void useJdbiTransaction(final HandleConsumer<X> handleConsumer) throws X {
-        createJdbi().useTransaction(handleConsumer);
+        useJdbiTransaction(/* apiRequest */ null, handleConsumer);
     }
 
     public static <X extends Exception> void useJdbiTransaction(final AlpineRequest apiRequest, final HandleConsumer<X> handleConsumer) throws X {
@@ -82,7 +82,7 @@ public class JdbiFactory {
     }
 
     public static <T, X extends Exception> T inJdbiTransaction(final HandleCallback<T, X> handleCallback) throws X {
-        return createJdbi().inTransaction(handleCallback);
+        return inJdbiTransaction(/* apiRequest */  null, handleCallback);
     }
 
     public static <T, X extends Exception> T inJdbiTransaction(final AlpineRequest apiRequest, final HandleCallback<T, X> handleCallback) throws X {

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -105,7 +105,7 @@ public interface ProjectDao {
                  LIMIT 1
               ) AS "metrics" ON TRUE
             </#if>
-             WHERE ${apiProjectAclCondition!"TRUE"}
+             WHERE ${apiProjectAclCondition}
             <#if nameFilter>
                AND "PROJECT"."NAME" = :nameFilter
             </#if>
@@ -141,7 +141,7 @@ public interface ProjectDao {
                        FROM "PROJECT" AS "PARENT_PROJECT"
                       WHERE "PARENT_PROJECT"."ID" = "PROJECT"."PARENT_PROJECT_ID"
                         AND "PARENT_PROJECT"."UUID" = :parentUuidFilter
-                        AND ${apiParentProjectAclCondition!"TRUE"})
+                        AND ${apiParentProjectAclCondition})
             </#if>
             <#if apiFilterParameter??>
                AND (LOWER("PROJECT"."NAME") LIKE ('%' || LOWER(${apiFilterParameter}) || '%')
@@ -157,7 +157,7 @@ public interface ProjectDao {
     @DefineNamedBindings
     @DefineApiProjectAclCondition(
             name = "apiParentProjectAclCondition",
-            projectTableAlias = "PARENT_PROJECT"
+            projectIdColumn = "\"PARENT_PROJECT\".\"ID\""
     )
     @AllowApiOrdering(alwaysBy = "id", by = {
             @AllowApiOrdering.Column(name = "id"),

--- a/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -170,7 +170,7 @@ public interface VulnerabilityDao {
                   ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
                INNER JOIN "VULNERABILITY"
                   ON "VULNERABILITY"."ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
-               WHERE ${apiProjectAclCondition!"TRUE"}
+               WHERE ${apiProjectAclCondition}
                  AND "VULNERABILITY"."SOURCE" = :source
                  AND "VULNERABILITY"."VULNID" = :vulnId
             <#if activeFilter>
@@ -304,7 +304,7 @@ public interface VulnerabilityDao {
             <#if !includeSuppressed>
                AND ("ANALYSIS"."SUPPRESSED" IS NULL OR NOT "ANALYSIS"."SUPPRESSED")
             </#if>
-               AND ${apiProjectAclCondition!"TRUE"}
+               AND ${apiProjectAclCondition}
              GROUP BY "VULNERABILITY"."ID"
             """)
     @RegisterConstructorMapper(AffectedProjectCountRow.class)

--- a/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
+++ b/src/main/java/org/dependencytrack/tasks/BomUploadProcessingTask.java
@@ -611,6 +611,7 @@ public class BomUploadProcessingTask implements Subscriber {
                 applyIfChanged(persistentComponent, component, Component::isInternal, persistentComponent::setInternal);
                 applyIfChanged(persistentComponent, component, Component::getExternalReferences, persistentComponent::setExternalReferences);
 
+                qm.synchronizeComponentOccurrences(persistentComponent, component.getOccurrences());
                 qm.synchronizeComponentProperties(persistentComponent, component.getProperties());
                 idsOfComponentsToDelete.remove(persistentComponent.getId());
             }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -26,6 +26,7 @@
     <class>org.dependencytrack.model.AnalysisComment</class>
     <class>org.dependencytrack.model.Bom</class>
     <class>org.dependencytrack.model.Component</class>
+    <class>org.dependencytrack.model.ComponentOccurrence</class>
     <class>org.dependencytrack.model.ComponentProperty</class>
     <class>org.dependencytrack.model.IntegrityMetaComponent</class>
     <class>org.dependencytrack.model.DependencyMetrics</class>

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -636,4 +636,42 @@
                                  onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="ID"
                                  referencedTableName="WORKFLOW_STATE" validate="true"/>
     </changeSet>
+
+    <changeSet id="v5.6.0-13" author="nscuro">
+        <createTable tableName="COMPONENT_OCCURRENCE">
+            <column name="ID" type="UUID">
+                <constraints primaryKey="true" primaryKeyName="COMPONENT_OCCURRENCE_PK"/>
+            </column>
+            <column name="COMPONENT_ID" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="LOCATION" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="LINE" type="INT"/>
+            <column name="OFFSET" type="INT"/>
+            <column name="SYMBOL" type="TEXT"/>
+            <column name="CREATED_AT" type="TIMESTAMPTZ(3)" defaultValue="NOW()">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addForeignKeyConstraint
+                baseTableName="COMPONENT_OCCURRENCE"
+                baseColumnNames="COMPONENT_ID"
+                constraintName="COMPONENT_OCCURRENCE_COMPONENT_FK"
+                referencedTableName="COMPONENT"
+                referencedColumnNames="ID"
+                deferrable="true"
+                initiallyDeferred="true"
+                onDelete="CASCADE"
+                onUpdate="NO ACTION"
+                validate="true"/>
+
+        <createIndex
+                tableName="COMPONENT_OCCURRENCE"
+                indexName="COMPONENT_OCCURRENCE_COMPONENT_ID_IDX">
+            <column name="COMPONENT_ID"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
@@ -55,12 +55,9 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
             SELECT 1 AS "valueA"
                  , 2 AS "valueB"
               FROM "PROJECT"
-             WHERE TRUE
+             WHERE ${apiProjectAclCondition}
             <#if apiFilterParameter??>
                AND 'foo' = ${apiFilterParameter}
-            </#if>
-            <#if apiProjectAclCondition??>
-               AND ${apiProjectAclCondition}
             </#if>
             ${apiOrderByClause!}
             ${apiOffsetLimitClause!}
@@ -372,7 +369,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
         useJdbiHandle(request, handle -> handle
                 .addCustomizer(inspectStatement(ctx -> {
                     assertThat(ctx.getRenderedSql()).isEqualToIgnoringWhitespace("""
-                            SELECT 1 AS "valueA", 2 AS "valueB" FROM "PROJECT" WHERE TRUE AND FALSE
+                            SELECT 1 AS "valueA", 2 AS "valueB" FROM "PROJECT" WHERE FALSE
                             """);
 
                     assertThat(ctx.getBinding()).hasToString("{}");
@@ -565,8 +562,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                             SELECT 1 AS "valueA"
                                  , 2 AS "valueB"
                               FROM "PROJECT"
-                             WHERE TRUE
-                               AND HAS_PROJECT_ACCESS("PROJECT"."ID", :projectAclTeamIds)
+                             WHERE HAS_PROJECT_ACCESS("PROJECT"."ID", :projectAclTeamIds)
                             """);
 
                     assertThat(ctx.getBinding()).hasToString("{named:{projectAclTeamIds:[%s]}}".formatted(team.getId()));

--- a/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -40,6 +40,7 @@ import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.BomValidationMode;
 import org.dependencytrack.model.Classifier;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.ComponentOccurrence;
 import org.dependencytrack.model.ComponentProperty;
 import org.dependencytrack.model.OrganizationalContact;
 import org.dependencytrack.model.OrganizationalEntity;
@@ -233,6 +234,16 @@ public class BomResourceTest extends ResourceTest {
         componentWithoutVuln.setDirectDependencies("[]");
         componentWithoutVuln = qm.createComponent(componentWithoutVuln, false);
 
+        // NB: Line, offset, and symbol are only supported since CycloneDX v1.6,
+        // and will not show up in this export since it's still in v1.5 format.
+        final var componentOccurrence = new ComponentOccurrence();
+        componentOccurrence.setComponent(componentWithoutVuln);
+        componentOccurrence.setLocation("/foo/bar");
+        componentOccurrence.setLine(666);
+        componentOccurrence.setOffset(123);
+        componentOccurrence.setSymbol("someSymbol");
+        qm.persist(componentOccurrence);
+
         final var componentProperty = new ComponentProperty();
         componentProperty.setComponent(componentWithoutVuln);
         componentProperty.setGroupName("foo");
@@ -294,7 +305,7 @@ public class BomResourceTest extends ResourceTest {
                 .withMatcher("componentWithoutVulnUuid", equalTo(componentWithoutVuln.getUuid().toString()))
                 .withMatcher("componentWithVulnUuid", equalTo(componentWithVuln.getUuid().toString()))
                 .withMatcher("componentWithVulnAndAnalysisUuid", equalTo(componentWithVulnAndAnalysis.getUuid().toString()))
-                .isEqualTo(json("""
+                .isEqualTo(json(/* language=JSON */ """
                         {
                             "bomFormat": "CycloneDX",
                             "specVersion": "1.5",
@@ -340,6 +351,13 @@ public class BomResourceTest extends ResourceTest {
                                     },
                                     "name": "acme-lib-a",
                                     "version": "1.0.0",
+                                    "evidence": {
+                                      "occurrences": [
+                                        {
+                                          "location": "/foo/bar"
+                                        }
+                                      ]
+                                    },
                                     "properties": [
                                       {
                                         "name": "foo:bar",

--- a/src/test/java/org/dependencytrack/resources/v1/ComponentResourcePostgresTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ComponentResourcePostgresTest.java
@@ -97,7 +97,8 @@ public class ComponentResourcePostgresTest extends ResourceTest {
                             "lastCheck": "${json-unit.any-number}"
                           },
                           "expandDependencyGraph": false,
-                          "isInternal": false
+                          "isInternal": false,
+                          "occurrenceCount": 0
                         }
                         """);
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ingests component occurrences.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1691

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/hyades-frontend/pull/252

---

The [`additionalContext`](https://cyclonedx.org/docs/1.6/json/#components_items_evidence_occurrences_items_additionalContext) field is not considered for now. I have not yet seen any generator populating this field. Since its description is rather vague, I decided to opt for waiting until we know what kind of data to expect.

---

The primary key `ID` column of the new `COMPONENT_OCCURRENCE` table uses [UUIDv7](https://uuid7.com/). There are no separate `ID` and `UUID` column like in other legacy tables. This reduces storage requirements and overhead of maintaining two separate `UNIQUE` indexes.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
