### PR TITLE
Don't throw when ordering API params are provided but DAO method has no order-able columns list

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestConfig.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestConfig.java
@@ -20,7 +20,6 @@ package org.dependencytrack.persistence.jdbi;
 
 import org.jdbi.v3.core.config.JdbiConfig;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -29,7 +28,7 @@ import java.util.Set;
  */
 public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
 
-    private Set<OrderingColumn> orderingAllowedColumns = Collections.emptySet();
+    private Set<OrderingColumn> orderingAllowedColumns;
     private String orderingAlwaysBy = "";
 
     // TODO: Make this configurable via annotation when needed (similar to @AllowOrdering).
@@ -42,7 +41,9 @@ public class ApiRequestConfig implements JdbiConfig<ApiRequestConfig> {
     }
 
     private ApiRequestConfig(final ApiRequestConfig that) {
-        this.orderingAllowedColumns = Set.copyOf(that.orderingAllowedColumns);
+        this.orderingAllowedColumns = that.orderingAllowedColumns != null
+                ? Set.copyOf(that.orderingAllowedColumns)
+                : that.orderingAllowedColumns;
         this.orderingAlwaysBy = that.orderingAlwaysBy;
         this.projectTableAlias = that.projectTableAlias;
     }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -102,6 +102,9 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
         }
 
         final var config = ctx.getConfig(ApiRequestConfig.class);
+        if (config.orderingAllowedColumns() == null) {
+            return;
+        }
         if (config.orderingAllowedColumns().isEmpty()) {
             throw new IllegalArgumentException("Ordering is not allowed");
         }

--- a/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
@@ -35,6 +35,7 @@ import org.jdbi.v3.core.statement.StatementCustomizer;
 import org.junit.Test;
 
 import java.sql.PreparedStatement;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -138,8 +139,33 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 /* orderDirection */ OrderDirection.DESCENDING
         );
 
+        useJdbiHandle(request, handle -> handle
+                .addCustomizer(inspectStatement(ctx -> {
+                    assertThat(ctx.getRenderedSql()).isEqualToIgnoringWhitespace("""
+                            SELECT 1 AS "valueA", 2 AS "valueB" FROM "PROJECT" WHERE TRUE
+                            """);
+
+                    assertThat(ctx.getBinding()).hasToString("{}");
+                }))
+                .createQuery(TEST_QUERY_TEMPLATE)
+                .mapTo(Integer.class)
+                .findOne());
+    }
+
+    @Test
+    public void testWithAlpineRequestOrderingEmptyAllowedColumns() {
+        final var request = new AlpineRequest(
+                /* principal */ null,
+                /* pagination */ null,
+                /* filter */ null,
+                /* orderBy */ "value",
+                /* orderDirection */ OrderDirection.DESCENDING
+        );
+
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> useJdbiHandle(request, handle -> handle
+                        .configure(ApiRequestConfig.class, config ->
+                                config.setOrderingAllowedColumns(Collections.emptySet()))
                         .createQuery(TEST_QUERY_TEMPLATE)
                         .mapTo(Integer.class)
                         .findOne()))


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Doesn't throw when ordering API params are provided but DAO method has no order-able columns list.

If a DAO method does not specify a `@AllowApiOrdering` annotation, ignore any order API parameters.

Only if `@AllowApiOrdering` is present, validate incoming parameters against it.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/1698

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
