### PR TITLE
Remove `properties` from `Project`'s default fetch group

### DIFF
--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -255,8 +255,9 @@ public class Project implements Serializable {
     @Persistent(mappedBy = "parent")
     private Collection<Project> children;
 
-    @Persistent(mappedBy = "project", defaultFetchGroup = "true")
+    @Persistent(mappedBy = "project")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "groupName ASC, propertyName ASC"))
+    @JsonIgnore
     private List<ProjectProperty> properties;
 
     @Persistent(table = "PROJECTS_TAGS", defaultFetchGroup = "true", mappedBy = "projects")

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -1372,7 +1372,6 @@ public class ProjectResourceTest extends ResourceTest {
                               "inactiveSince": "${json-unit.any-number}"
                             }
                           ],
-                          "properties": [],
                           "tags": [],
                           "isLatest": false,
                           "active":true,
@@ -2047,7 +2046,6 @@ public class ProjectResourceTest extends ResourceTest {
                             "version": "3.0",
                             "uuid": "${json-unit.matches:parentProjectUuid}"
                           },
-                          "properties": [],
                           "tags": [],
                           "isLatest": false,
                           "active": true
@@ -2234,7 +2232,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "description": "Test project",
                           "version": "1.0",
                           "uuid": "${json-unit.matches:projectUuid}",
-                          "properties": [],
                           "tags": [
                             {
                               "name": "tag4"
@@ -2836,7 +2833,6 @@ public class ProjectResourceTest extends ResourceTest {
                       "active": true
                     }
                   ],
-                  "properties": [],
                   "tags": [],
                   "isLatest": false,
                   "active": true,
@@ -2867,7 +2863,6 @@ public class ProjectResourceTest extends ResourceTest {
                     "uuid": "${json-unit.any-string}"
                   },
                   "children": [],
-                  "properties": [],
                   "tags": [],
                   "isLatest": false,
                   "active": true,
@@ -3316,7 +3311,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "name": "acme-app",
                           "classifier": "APPLICATION",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "active": true,
                           "isLatest": false
@@ -3362,7 +3356,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "name": "acme-app",
                           "classifier": "APPLICATION",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "isLatest":false,
                           "active": true
@@ -3403,7 +3396,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "name": "acme-app",
                           "classifier": "APPLICATION",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "isLatest":false,
                           "active":true
@@ -3485,7 +3477,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "name": "acme-app",
                           "classifier": "APPLICATION",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "isLatest":false,
                           "active":true
@@ -3595,7 +3586,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "name": "acme-app",
                           "classifier": "APPLICATION",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "isLatest":false,
                           "active":true
@@ -3630,7 +3620,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "uuid": "${json-unit.any-string}",
                           "name": "ABC-Updated",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "inactiveSince": "${json-unit.any-number}",
                           "isLatest":false,
@@ -3662,7 +3651,6 @@ public class ProjectResourceTest extends ResourceTest {
                         {
                           "uuid": "${json-unit.any-string}",
                           "name": "ABC-Updated",
-                          "properties": [],
                           "tags": [],
                           "isLatest":false,
                           "active": true
@@ -3695,7 +3683,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "name": "ABC-Updated",
                           "classifier":"APPLICATION",
                           "children": [],
-                          "properties": [],
                           "tags": [],
                           "inactiveSince": "${json-unit.any-number}",
                           "isLatest":false,
@@ -3728,7 +3715,6 @@ public class ProjectResourceTest extends ResourceTest {
                           "uuid": "${json-unit.any-string}",
                           "name": "ABC-Updated",
                           "classifier":"APPLICATION",
-                          "properties": [],
                           "tags": [],
                           "isLatest":false,
                           "active": true


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes `properties` from `Project`'s default fetch group.

Properties are retrieved on demand (i.e., separate REST API endpoint). Fetching them per default merely slows down project retrieval in the majority of cases.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/1706

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
