### PR TITLE
Fix deletions performed via DataNucleus not honouring FK constraints

### DIFF
--- a/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
+++ b/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import org.dependencytrack.model.Vulnerability.Source;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.PersistenceCapable;
@@ -78,11 +80,13 @@ public class AffectedVersionAttribution implements Serializable {
     private Source source;
 
     @Persistent
+    @ForeignKey(name = "AFFECTEDVERSIONATTRIBUTION_VULNERABILITY_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "VULNERABILITY", allowsNull = "false")
     @JsonIgnore
     private Vulnerability vulnerability;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "AFFECTEDVERSIONATTRIBUTION_VULNERABLESOFTWARE_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "VULNERABLE_SOFTWARE", allowsNull = "false")
     @JsonIgnore
     private VulnerableSoftware vulnerableSoftware;

--- a/src/main/java/org/dependencytrack/model/Analysis.java
+++ b/src/main/java/org/dependencytrack/model/Analysis.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Order;
 import javax.jdo.annotations.PersistenceCapable;
@@ -53,16 +55,19 @@ public class Analysis implements Serializable {
     private long id;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "ANALYSIS_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID")
     @JsonIgnore
     private Project project;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "ANALYSIS_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "COMPONENT_ID")
     @JsonIgnore
     private Component component;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "ANALYSIS_VULNERABILITY_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "VULNERABILITY_ID", allowsNull = "false")
     @NotNull
     @JsonIgnore

--- a/src/main/java/org/dependencytrack/model/AnalysisComment.java
+++ b/src/main/java/org/dependencytrack/model/AnalysisComment.java
@@ -26,6 +26,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -50,6 +52,7 @@ public class AnalysisComment implements Serializable {
     private long id;
 
     @Persistent(defaultFetchGroup = "true", dependent = "true")
+    @ForeignKey(name = "ANALYSISCOMMENT_ANALYSIS_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "ANALYSIS_ID", allowsNull = "false")
     @NotNull
     @JsonIgnore

--- a/src/main/java/org/dependencytrack/model/Bom.java
+++ b/src/main/java/org/dependencytrack/model/Bom.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -94,6 +96,7 @@ public class Bom implements Serializable {
     private String serialNumber;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "BOM_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @NotNull
     private Project project;

--- a/src/main/java/org/dependencytrack/model/Component.java
+++ b/src/main/java/org/dependencytrack/model/Component.java
@@ -46,6 +46,8 @@ import javax.jdo.annotations.Extension;
 import javax.jdo.annotations.Extensions;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -351,6 +353,7 @@ public class Component implements Serializable {
     private List<ExternalReference> externalReferences;
 
     @Persistent
+    @ForeignKey(name = "COMPONENT_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PARENT_COMPONENT_ID")
     private Component parent;
 
@@ -367,12 +370,13 @@ public class Component implements Serializable {
     private List<ComponentProperty> properties;
 
     @Persistent(table = "COMPONENTS_VULNERABILITIES")
-    @Join(column = "COMPONENT_ID")
-    @Element(column = "VULNERABILITY_ID")
+    @Join(column = "COMPONENT_ID", foreignKey = "COMPONENTS_VULNERABILITIES_COMPONENT_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "VULNERABILITY_ID", foreignKey = "COMPONENTS_VULNERABILITIES_VULNERABILITY_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "id ASC"))
     private List<Vulnerability> vulnerabilities;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "COMPONENT_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Index(name = "COMPONENT_PROJECT_ID_IDX")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @NotNull

--- a/src/main/java/org/dependencytrack/model/DependencyMetrics.java
+++ b/src/main/java/org/dependencytrack/model/DependencyMetrics.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.PersistenceCapable;
@@ -51,11 +53,13 @@ public class DependencyMetrics implements Serializable {
     private long id;
 
     @Persistent
+    @ForeignKey(name = "DEPENDENCYMETRICS_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @NotNull
     private Project project;
 
     @Persistent
+    @ForeignKey(name = "DEPENDENCYMETRICS_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "COMPONENT_ID", allowsNull = "false")
     @NotNull
     private Component component;

--- a/src/main/java/org/dependencytrack/model/FindingAttribution.java
+++ b/src/main/java/org/dependencytrack/model/FindingAttribution.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.PersistenceCapable;
@@ -63,16 +65,19 @@ public class FindingAttribution implements Serializable {
     private AnalyzerIdentity analyzerIdentity;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "FINDINGATTRIBUTION_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "COMPONENT_ID", allowsNull = "false")
     @NotNull
     private Component component;
 
     @Persistent(defaultFetchGroup = "false")
+    @ForeignKey(name = "FINDINGATTRIBUTION_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @NotNull
     private Project project;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "FINDINGATTRIBUTION_VULNERABILITY_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "VULNERABILITY_ID", allowsNull = "false")
     @NotNull
     private Vulnerability vulnerability;

--- a/src/main/java/org/dependencytrack/model/IntegrityAnalysis.java
+++ b/src/main/java/org/dependencytrack/model/IntegrityAnalysis.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -39,6 +41,7 @@ public class IntegrityAnalysis {
     private long id;
 
     @Persistent
+    @ForeignKey(name = "INTEGRITY_ANALYSIS_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "COMPONENT_ID", allowsNull = "false")
     @NotNull
     private Component component;

--- a/src/main/java/org/dependencytrack/model/LicenseGroup.java
+++ b/src/main/java/org/dependencytrack/model/LicenseGroup.java
@@ -23,9 +23,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -34,10 +39,6 @@ import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.List;
 import java.util.UUID;
@@ -73,8 +74,8 @@ public class LicenseGroup implements Serializable {
      * A list of zero-to-n licenses that are part of this license group.
      */
     @Persistent(table = "LICENSEGROUP_LICENSE", defaultFetchGroup = "true")
-    @Join(column = "LICENSEGROUP_ID")
-    @Element(column = "LICENSE_ID")
+    @Join(column = "LICENSEGROUP_ID", foreignKey = "LICENSEGROUP_LICENSE_LICENSEGROUP_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "LICENSE_ID", foreignKey = "LICENSEGROUP_LICENSE_LICENSE_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<License> licenses;
 

--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -26,17 +26,19 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
 import org.apache.commons.collections4.CollectionUtils;
 import org.dependencytrack.notification.NotificationGroup;
 import org.dependencytrack.notification.NotificationScope;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Join;
 import javax.jdo.annotations.Order;
@@ -111,20 +113,20 @@ public class NotificationRule implements Serializable {
     private NotificationLevel notificationLevel;
 
     @Persistent(table = "NOTIFICATIONRULE_PROJECTS", defaultFetchGroup = "true")
-    @Join(column = "NOTIFICATIONRULE_ID")
-    @Element(column = "PROJECT_ID")
+    @Join(column = "NOTIFICATIONRULE_ID", foreignKey = "NOTIFICATIONRULE_PROJECTS_NOTIFICATIONRULE_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "PROJECT_ID", foreignKey = "NOTIFICATIONRULE_PROJECTS_PROJECT_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC, version ASC"))
     private List<Project> projects;
 
     @Persistent(table = "NOTIFICATIONRULE_TAGS", defaultFetchGroup = "true", mappedBy = "notificationRules")
-    @Join(column = "NOTIFICATIONRULE_ID")
-    @Element(column = "TAG_ID")
+    @Join(column = "NOTIFICATIONRULE_ID", foreignKey = "NOTIFICATIONRULE_TAGS_NOTIFICATIONRULE_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "TAG_ID", foreignKey = "NOTIFICATIONRULE_TAGS_TAG_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Tag> tags;
 
     @Persistent(table = "NOTIFICATIONRULE_TEAMS", defaultFetchGroup = "true")
-    @Join(column = "NOTIFICATIONRULE_ID")
-    @Element(column = "TEAM_ID")
+    @Join(column = "NOTIFICATIONRULE_ID", foreignKey = "NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "TEAM_ID", foreignKey = "NOTIFICATIONRULE_TEAMS_TEAM_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Team> teams;
 
@@ -140,6 +142,7 @@ public class NotificationRule implements Serializable {
     private String message;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "NOTIFICATIONRULE_NOTIFICATIONPUBLISHER_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PUBLISHER")
     private NotificationPublisher publisher;
 

--- a/src/main/java/org/dependencytrack/model/Policy.java
+++ b/src/main/java/org/dependencytrack/model/Policy.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -112,8 +113,8 @@ public class Policy implements Serializable {
      * A list of zero-to-n projects
      */
     @Persistent(table = "POLICY_PROJECTS", defaultFetchGroup = "true")
-    @Join(column = "POLICY_ID")
-    @Element(column = "PROJECT_ID")
+    @Join(column = "POLICY_ID", foreignKey = "POLICY_PROJECTS_POLICY_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "PROJECT_ID", foreignKey = "POLICY_PROJECTS_PROJECT_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC, version ASC"))
     private List<Project> projects;
 
@@ -121,8 +122,8 @@ public class Policy implements Serializable {
      * A list of zero-to-n tags
      */
     @Persistent(table = "POLICY_TAGS", defaultFetchGroup = "true", mappedBy = "policies")
-    @Join(column = "POLICY_ID")
-    @Element(column = "TAG_ID")
+    @Join(column = "POLICY_ID", foreignKey = "POLICY_TAGS_POLICY_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "TAG_ID", foreignKey = "POLICY_TAGS_TAG_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Tag> tags;
 

--- a/src/main/java/org/dependencytrack/model/PolicyCondition.java
+++ b/src/main/java/org/dependencytrack/model/PolicyCondition.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -95,6 +97,7 @@ public class PolicyCondition implements Serializable {
     private long id;
 
     @Persistent
+    @ForeignKey(name = "POLICYCONDITION_POLICY_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "POLICY_ID", allowsNull = "false")
     private Policy policy;
 

--- a/src/main/java/org/dependencytrack/model/PolicyViolation.java
+++ b/src/main/java/org/dependencytrack/model/PolicyViolation.java
@@ -28,6 +28,8 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.PersistenceCapable;
@@ -68,16 +70,19 @@ public class PolicyViolation implements Serializable {
     private Type type;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "POLICYVIOLATION_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @Index(name = "POLICYVIOLATION_PROJECT_IDX")
     private Project project;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "POLICYVIOLATION_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "COMPONENT_ID", allowsNull = "false")
     @Index(name = "POLICYVIOLATION_COMPONENT_IDX")
     private Component component;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "POLICYVIOLATION_POLICYCONDITION_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "POLICYCONDITION_ID", allowsNull = "false")
     private PolicyCondition policyCondition;
 

--- a/src/main/java/org/dependencytrack/model/Project.java
+++ b/src/main/java/org/dependencytrack/model/Project.java
@@ -50,6 +50,8 @@ import javax.jdo.annotations.Extension;
 import javax.jdo.annotations.Extensions;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -249,6 +251,7 @@ public class Project implements Serializable {
     private UUID uuid;
 
     @Persistent
+    @ForeignKey(name = "PROJECT_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PARENT_PROJECT_ID")
     @JsonIncludeProperties(value = {"name", "version", "uuid"})
     private Project parent;
@@ -262,8 +265,8 @@ public class Project implements Serializable {
     private List<ProjectProperty> properties;
 
     @Persistent(table = "PROJECTS_TAGS", defaultFetchGroup = "true", mappedBy = "projects")
-    @Join(column = "PROJECT_ID")
-    @Element(column = "TAG_ID")
+    @Join(column = "PROJECT_ID", foreignKey = "PROJECTS_TAGS_PROJECT_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "TAG_ID", foreignKey = "PROJECTS_TAGS_TAG_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Tag> tags;
 

--- a/src/main/java/org/dependencytrack/model/ProjectMetadata.java
+++ b/src/main/java/org/dependencytrack/model/ProjectMetadata.java
@@ -27,6 +27,8 @@ import org.dependencytrack.persistence.converter.ToolsJsonConverter;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -52,6 +54,7 @@ public class ProjectMetadata {
     private long id;
 
     @Persistent
+    @ForeignKey(name = "PROJECT_METADATA_PROJECT_ID_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Unique(name = "PROJECT_METADATA_PROJECT_ID_IDX")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @JsonIgnore

--- a/src/main/java/org/dependencytrack/model/ProjectMetrics.java
+++ b/src/main/java/org/dependencytrack/model/ProjectMetrics.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.PersistenceCapable;
@@ -50,6 +52,7 @@ public class ProjectMetrics implements Serializable {
     private long id;
 
     @Persistent
+    @ForeignKey(name = "PROJECTMETRICS_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Project project;

--- a/src/main/java/org/dependencytrack/model/ProjectProperty.java
+++ b/src/main/java/org/dependencytrack/model/ProjectProperty.java
@@ -29,6 +29,8 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -55,6 +57,7 @@ public class ProjectProperty implements IConfigProperty, Serializable {
     private long id;
 
     @Persistent
+    @ForeignKey(name = "PROJECT_PROPERTY_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @JsonIgnore
     private Project project;

--- a/src/main/java/org/dependencytrack/model/ServiceComponent.java
+++ b/src/main/java/org/dependencytrack/model/ServiceComponent.java
@@ -31,6 +31,8 @@ import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -154,6 +156,7 @@ public class ServiceComponent implements Serializable {
     private List<ExternalReference> externalReferences;
 
     @Persistent
+    @ForeignKey(name = "SERVICECOMPONENT_SERVICECOMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PARENT_SERVICECOMPONENT_ID")
     private ServiceComponent parent;
 
@@ -162,12 +165,13 @@ public class ServiceComponent implements Serializable {
     private Collection<ServiceComponent> children;
 
     @Persistent(table = "SERVICECOMPONENTS_VULNERABILITIES")
-    @Join(column = "SERVICECOMPONENT_ID")
-    @Element(column = "VULNERABILITY_ID")
+    @Join(column = "SERVICECOMPONENT_ID", foreignKey = "SERVICECOMPONENTS_VULNERABILITIES_SERVICECOMPONENT_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "VULNERABILITY_ID", foreignKey = "SERVICECOMPONENTS_VULNERABILITIES_VULNERABILITY_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "id ASC"))
     private List<Vulnerability> vulnerabilities;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "SERVICECOMPONENT_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @NotNull
     private Project project;

--- a/src/main/java/org/dependencytrack/model/Vex.java
+++ b/src/main/java/org/dependencytrack/model/Vex.java
@@ -24,6 +24,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -93,6 +95,7 @@ public class Vex implements Serializable {
     private String serialNumber;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "VEX_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID", allowsNull = "false")
     @NotNull
     private Project project;

--- a/src/main/java/org/dependencytrack/model/ViolationAnalysis.java
+++ b/src/main/java/org/dependencytrack/model/ViolationAnalysis.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Order;
 import javax.jdo.annotations.PersistenceCapable;
@@ -51,16 +53,19 @@ public class ViolationAnalysis implements Serializable {
     private long id;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "VIOLATIONANALYSIS_PROJECT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PROJECT_ID")
     @JsonIgnore
     private Project project;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "VIOLATIONANALYSIS_COMPONENT_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "COMPONENT_ID")
     @JsonIgnore
     private Component component;
 
     @Persistent(defaultFetchGroup = "true")
+    @ForeignKey(name = "VIOLATIONANALYSIS_POLICYVIOLATION_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "POLICYVIOLATION_ID", allowsNull = "false")
     @NotNull
     @JsonIgnore

--- a/src/main/java/org/dependencytrack/model/ViolationAnalysisComment.java
+++ b/src/main/java/org/dependencytrack/model/ViolationAnalysisComment.java
@@ -26,6 +26,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -50,6 +52,7 @@ public class ViolationAnalysisComment implements Serializable {
     private long id;
 
     @Persistent(defaultFetchGroup = "true", dependent = "true")
+    @ForeignKey(name = "VIOLATIONANALYSISCOMMENT_VIOLATIONANALYSIS_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "VIOLATIONANALYSIS_ID", allowsNull = "false")
     @NotNull
     @JsonIgnore

--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -42,6 +42,7 @@ import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -321,8 +322,8 @@ public class Vulnerability implements Serializable {
     private UUID uuid;
 
     @Persistent(table = "VULNERABILITIES_TAGS", defaultFetchGroup = "true", mappedBy = "vulnerabilities")
-    @Join(column = "VULNERABILITY_ID")
-    @Element(column = "TAG_ID")
+    @Join(column = "VULNERABILITY_ID", foreignKey = "VULNERABILITIES_TAGS_VULNERABILITY_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "TAG_ID", foreignKey = "VULNERABILITIES_TAGS_TAG_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Tag> tags;
 

--- a/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;
@@ -163,8 +164,8 @@ public class VulnerableSoftware implements ICpe, Serializable {
     private boolean vulnerable;
 
     @Persistent(table = "VULNERABLESOFTWARE_VULNERABILITIES", mappedBy = "vulnerableSoftware")
-    @Join(column = "VULNERABLESOFTWARE_ID")
-    @Element(column = "VULNERABILITY_ID", dependent = "false")
+    @Join(column = "VULNERABLESOFTWARE_ID", foreignKey = "VULNERABLESOFTWARE_VULNERABILITIES_VULNERABLESOFTWARE_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "VULNERABILITY_ID", foreignKey = "VULNERABLESOFTWARE_VULNERABILITIES_VULNERABILITY_FK", deleteAction = ForeignKeyAction.CASCADE, dependent = "false")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "id ASC"))
     private List<Vulnerability> vulnerabilities;
 

--- a/src/main/java/org/dependencytrack/model/WorkflowState.java
+++ b/src/main/java/org/dependencytrack/model/WorkflowState.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKey;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
@@ -45,6 +47,7 @@ public class WorkflowState implements Serializable {
 
     // null allowed because first step will have no parent and will be the first step of recursion
     @Persistent
+    @ForeignKey(name = "WORKFLOW_STATE_WORKFLOW_STATE_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE, deferred = "true")
     @Column(name = "PARENT_STEP_ID" , allowsNull = "true")
     private WorkflowState parent;
 

--- a/src/main/resources/META-INF/package.jdo
+++ b/src/main/resources/META-INF/package.jdo
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<jdo xmlns="https://db.apache.org/jdo/xmlns/jdo"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="https://db.apache.org/jdo/xmlns/jdo https://db.apache.org/jdo/xmlns/jdo_3_2.xsd" version="3.2">
+    <!--
+      Enrich Alpine model classes with Foreign Key metadata.
+        * https://github.com/DependencyTrack/hyades/issues/1716
+        * https://www.datanucleus.org/products/accessplatform_6_0/jdo/metadata_xml.html
+      TODO: Remove once the model class annotations have been updated.
+    -->
+    <package name="alpine.model">
+        <class name="ApiKey">
+            <field name="teams" table="APIKEYS_TEAMS" default-fetch-group="true">
+                <element>
+                    <column name="TEAM_ID"/>
+                    <foreign-key name="APIKEYS_TEAMS_TEAM_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="APIKEY_ID"/>
+                    <foreign-key name="APIKEYS_TEAMS_APIKEY_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+        </class>
+        <class name="LdapUser">
+            <field name="permissions" table="LDAPUSERS_PERMISSIONS" default-fetch-group="true">
+                <element>
+                    <column name="PERMISSION_ID"/>
+                    <foreign-key name="LDAPUSERS_PERMISSIONS_PERMISSION_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="LDAPUSER_ID"/>
+                    <foreign-key name="LDAPUSERS_PERMISSIONS_LDAPUSER_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+            <field name="teams" table="LDAPUSERS_TEAMS" default-fetch-group="true">
+                <element>
+                    <column name="TEAM_ID"/>
+                    <foreign-key name="LDAPUSERS_TEAMS_TEAM_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="LDAPUSER_ID"/>
+                    <foreign-key name="LDAPUSERS_TEAMS_LDAPUSER_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+        </class>
+        <class name="ManagedUser">
+            <field name="permissions" table="MANAGEDUSERS_PERMISSIONS" default-fetch-group="true">
+                <element>
+                    <column name="PERMISSION_ID"/>
+                    <foreign-key name="MANAGEDUSERS_PERMISSIONS_PERMISSION_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="MANAGEDUSER_ID"/>
+                    <foreign-key name="MANAGEDUSERS_PERMISSIONS_MANAGEDUSER_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+            <field name="teams" table="MANAGEDUSERS_TEAMS" default-fetch-group="true">
+                <element>
+                    <column name="TEAM_ID"/>
+                    <foreign-key name="MANAGEDUSERS_TEAMS_TEAM_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="MANAGEDUSER_ID"/>
+                    <foreign-key name="MANAGEDUSERS_TEAMS_MANAGEDUSER_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+        </class>
+        <class name="MappedLdapGroup">
+            <field name="team" default-fetch-group="true">
+                <foreign-key name="MAPPEDLDAPGROUP_TEAM_FK" update-action="none" delete-action="cascade" deferred="true"/>
+            </field>
+        </class>
+        <class name="MappedOidcGroup">
+            <field name="group" default-fetch-group="true">
+                <foreign-key name="MAPPEDOIDCGROUP_OIDCGROUP_FK" update-action="none" delete-action="cascade"/>
+            </field>
+            <field name="team" default-fetch-group="true">
+                <foreign-key name="MAPPEDOIDCGROUP_TEAM_FK" update-action="none" delete-action="cascade" deferred="true"/>
+            </field>
+        </class>
+        <class name="OidcUser">
+            <field name="permissions" table="OIDCUSERS_PERMISSIONS" default-fetch-group="true">
+                <element>
+                    <column name="PERMISSION_ID"/>
+                    <foreign-key name="OIDCUSERS_PERMISSIONS_PERMISSION_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="OIDCUSER_ID"/>
+                    <foreign-key name="OIDCUSERS_PERMISSIONS_OIDCUSER_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+            <field name="teams" table="OIDCUSERS_TEAMS" default-fetch-group="true">
+                <element>
+                    <column name="TEAM_ID"/>
+                    <foreign-key name="OIDCUSERS_TEAMS_TEAM_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="OIDCUSERS_ID"/>
+                    <foreign-key name="OIDCUSERS_TEAMS_OIDCUSER_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+        </class>
+        <class name="Team">
+            <field name="permissions" table="TEAMS_PERMISSIONS" default-fetch-group="true">
+                <element>
+                    <column name="PERMISSION_ID"/>
+                    <foreign-key name="TEAMS_PERMISSIONS_PERMISSION_FK" delete-action="cascade"/>
+                </element>
+                <join>
+                    <column name="TEAM_ID"/>
+                    <foreign-key name="TEAMS_PERMISSIONS_TEAM_FK" delete-action="cascade"/>
+                </join>
+                <order>
+                    <extension vendor-name="datanucleus" key="list-ordering" value="name ASC"/>
+                </order>
+            </field>
+        </class>
+    </package>
+</jdo>
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -211,6 +211,16 @@ alpine.datanucleus.cache.level2.type=none
 # @hidden
 alpine.datanucleus.executioncontext.maxidle=0
 
+# Controls the deletion policy utilized by DataNucleus.
+# The default `JDO2` does not consider FK constraints for cascading deletes, only `DataNucleus` does.
+# Refer to https://www.datanucleus.org/products/accessplatform/jdo/persistence.html#_deleting_an_object for details.
+#
+# @category:     Database
+# @type:         string
+# @valid-values: [JDO2, DataNucleus]
+# @hidden
+alpine.datanucleus.deletionpolicy=DataNucleus
+
 # Defines whether database migrations should be executed on startup.
 # <br/><br/>
 # From v5.6.0 onwards, migrations are considered part of the initialization tasks.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes deletions performed via DataNucleus not honouring FK constraints.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/1716

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Classes from Alpine are enriched using [JDO XML Metadata](https://www.datanucleus.org/products/accessplatform_6_0/jdo/metadata_xml.html).

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
