### PR TITLE
Improve efficiency of `is_dependency_of` and `is_exclusive_dependency_of` CEL functions

### DIFF
--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -509,6 +509,7 @@ public class CelCommonPolicyLibrary implements Library {
                           WHERE
                             -- Short-circuit the recursive query if we don't have any matches at all.
                             EXISTS(SELECT 1 FROM "CTE_MATCHES")
+                            AND "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
                             -- Otherwise, find components of which the given leaf component is a direct dependency.
                             AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                           UNION ALL
@@ -585,6 +586,7 @@ public class CelCommonPolicyLibrary implements Library {
                       WHERE
                         -- Short-circuit the recursive query if we don't have any matches at all.
                         EXISTS(SELECT 1 FROM "CTE_MATCHES")
+                        AND "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
                         -- Otherwise, find components of which the given leaf component is a direct dependency.
                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                       UNION ALL
@@ -699,6 +701,7 @@ public class CelCommonPolicyLibrary implements Library {
                       WHERE
                         -- Short-circuit the recursive query if we don't have any matches at all.
                         EXISTS(SELECT 1 FROM "CTE_MATCHES")
+                        AND "C"."PROJECT_ID" = (SELECT "ID" FROM "CTE_PROJECT")
                         -- Otherwise, find components of which the given leaf component is a direct dependency.
                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', :leafComponentUuid))
                       UNION ALL
@@ -730,7 +733,7 @@ public class CelCommonPolicyLibrary implements Library {
                         AND "C"."DIRECT_DEPENDENCIES" @> JSONB_BUILD_ARRAY(JSONB_BUILD_OBJECT('uuid', "PREVIOUS"."UUID"))
                     )
                     SELECT "ID", ${selectColumnNames?join(", ", "", ", ")} "FOUND", "PATH" FROM "CTE_DEPENDENCIES";
-                     """);
+                    """);
 
             final List<DependencyNode> nodes = query
                     .define("filters", compositeNodeFilter.sqlFiltersConjunctive())


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves efficiency of `is_dependency_of` and `is_exclusive_dependency_of` CEL functions.

By not limiting the initial query of the recursive CTEs to a specific project, the queries were scanning over all components across all projects. This could cause major inefficiencies for larger portfolios with >100k projects.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
