### PR TITLE
Add pagination to `/api/v1/finding` endpoints

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -96,40 +96,43 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
     }
 
     private void defineOrdering(final StatementContext ctx) {
-        if (apiRequest == null || apiRequest.getOrderBy() == null) {
+        if (apiRequest == null) {
             return;
-        }
-
-        final var config = ctx.getConfig(ApiRequestConfig.class);
-        if (config.orderingAllowedColumns() == null) {
-            return;
-        }
-        if (config.orderingAllowedColumns().isEmpty()) {
-            throw new IllegalArgumentException("Ordering is not allowed");
         }
 
         final var ordering = new Ordering(apiRequest);
-        final OrderingColumn orderingColumn = config.orderingAllowedColumn(ordering.by())
-                .orElseThrow(() -> new IllegalArgumentException("Ordering by column %s is not allowed; Allowed columns are: %s"
-                        .formatted(ordering.by(), config.orderingAllowedColumns().stream().map(OrderingColumn::name).toList())));
+        final var orderingBuilder = new StringBuilder();
+        final var config = ctx.getConfig(ApiRequestConfig.class);
 
-        final var orderingBuilder = new StringBuilder("ORDER BY ");
-        if (orderingColumn.queryName() == null) {
-            orderingBuilder
-                    .append("\"")
-                    .append(ordering.by())
-                    .append("\"");
-        } else {
-            orderingBuilder.append(orderingColumn.queryName());
+        if (apiRequest.getOrderBy() != null) {
+            if (config.orderingAllowedColumns() == null) {
+                return;
+            }
+            if (config.orderingAllowedColumns().isEmpty()) {
+                throw new IllegalArgumentException("Ordering is not allowed");
+            }
+            final OrderingColumn orderingColumn = config.orderingAllowedColumn(ordering.by())
+                    .orElseThrow(() -> new IllegalArgumentException("Ordering by column %s is not allowed; Allowed columns are: %s"
+                            .formatted(ordering.by(), config.orderingAllowedColumns().stream().map(OrderingColumn::name).toList())));
+
+            orderingBuilder.append("ORDER BY ");
+            if (orderingColumn.queryName() == null) {
+                orderingBuilder
+                        .append("\"")
+                        .append(ordering.by())
+                        .append("\"");
+            } else {
+                orderingBuilder.append(orderingColumn.queryName());
+            }
+
+            if (ordering.direction() != null && ordering.direction() != OrderDirection.UNSPECIFIED) {
+                orderingBuilder
+                        .append(" ")
+                        .append(ordering.direction() == OrderDirection.ASCENDING ? "ASC" : "DESC");
+            }
         }
 
-        if (ordering.direction() != null && ordering.direction() != OrderDirection.UNSPECIFIED) {
-            orderingBuilder
-                    .append(" ")
-                    .append(ordering.direction() == OrderDirection.ASCENDING ? "ASC" : "DESC");
-        }
-
-        if (!config.orderingAlwaysBy().isBlank() && !ordering.by().equals(config.orderingAlwaysBy())) {
+        if (!config.orderingAlwaysBy().isBlank() && (ordering.by() == null || !ordering.by().equals(config.orderingAlwaysBy()))) {
             final String[] alwaysByParts = config.orderingAlwaysBy().split("\\s");
             if (alwaysByParts.length > 2) {
                 throw new IllegalArgumentException("alwaysBy must consist of no more than two parts");
@@ -138,13 +141,16 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
             final OrderingColumn orderingColumnAlwaysBy = config.orderingAllowedColumn(alwaysByParts[0])
                     .orElseThrow(() -> new IllegalArgumentException("Ordering by column %s is not allowed; Allowed columns are: %s"
                             .formatted(alwaysByParts[0], config.orderingAllowedColumns().stream().map(OrderingColumn::name).toList())));
+
             if (orderingColumnAlwaysBy.queryName() == null) {
                 orderingBuilder
-                        .append(", \"")
+                        .append(orderingBuilder.isEmpty() ? "ORDER BY \"" : ", \"")
                         .append(orderingColumnAlwaysBy.name())
                         .append("\"");
             } else {
-                orderingBuilder.append(", " + orderingColumnAlwaysBy.queryName());
+                orderingBuilder
+                        .append(orderingBuilder.isEmpty() ? "ORDER BY " : ", ")
+                        .append(orderingColumnAlwaysBy.queryName());
             }
 
             if (alwaysByParts.length == 2
@@ -155,7 +161,9 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
             }
         }
 
-        ctx.define(ATTRIBUTE_API_ORDER_BY_CLAUSE, orderingBuilder.toString());
+        if (!orderingBuilder.isEmpty()) {
+            ctx.define(ATTRIBUTE_API_ORDER_BY_CLAUSE, orderingBuilder.toString());
+        }
     }
 
     private void definePagination(final StatementContext ctx) {

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -144,7 +144,7 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
                         .append(orderingColumnAlwaysBy.name())
                         .append("\"");
             } else {
-                orderingBuilder.append(orderingColumnAlwaysBy.queryName());
+                orderingBuilder.append(", " + orderingColumnAlwaysBy.queryName());
             }
 
             if (alwaysByParts.length == 2

--- a/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -18,21 +18,13 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
-import alpine.persistence.PaginatedResult;
-import alpine.resources.AlpineRequest;
 import alpine.server.util.DbUtil;
-import com.github.packageurl.PackageURL;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.AnalyzerIdentity;
 import org.dependencytrack.model.Finding;
-import org.dependencytrack.model.GroupedFinding;
-import org.dependencytrack.model.RepositoryMetaComponent;
-import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
-import org.dependencytrack.persistence.RepositoryQueryManager.RepositoryMetaComponentSearch;
-import org.dependencytrack.util.PurlUtil;
 import org.jdbi.v3.json.Json;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
@@ -47,11 +39,9 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+import static org.dependencytrack.resources.v1.FindingResource.mapComponentLatestVersion;
 
 public interface FindingDao {
 
@@ -91,7 +81,8 @@ public interface FindingDao {
             String alt_id,
             String reference_url,
             AnalysisState analysisState,
-            boolean suppressed
+            boolean suppressed,
+            long totalCount
     ) {
     }
 
@@ -105,11 +96,13 @@ public interface FindingDao {
             Instant vulnPublished,
             List<Integer> cwes,
             AnalyzerIdentity analyzerIdentity,
-            int affectedProjectCount
+            int affectedProjectCount,
+            long totalCount
     ) {
     }
 
-    @SqlQuery("""
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             SELECT "PROJECT"."UUID" AS "projectUuid"
                  , "PROJECT"."NAME" AS "projectName"
                  , "PROJECT"."VERSION" AS "projectVersion"
@@ -146,6 +139,7 @@ public interface FindingDao {
                  , "FINDINGATTRIBUTION"."REFERENCE_URL"
                  , "ANALYSIS"."STATE" AS "analysisState"
                  , "ANALYSIS"."SUPPRESSED"
+                 , COUNT(*) OVER() AS "totalCount"
               FROM "COMPONENT"
              INNER JOIN "COMPONENTS_VULNERABILITIES"
                 ON "COMPONENT"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
@@ -164,13 +158,13 @@ public interface FindingDao {
                 ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
              WHERE "COMPONENT"."PROJECT_ID" = :projectId
                AND (:includeSuppressed OR "ANALYSIS"."SUPPRESSED" IS NULL OR NOT "ANALYSIS"."SUPPRESSED")
+             ${apiOffsetLimitClause!}
             """)
     @RegisterConstructorMapper(FindingRow.class)
     List<FindingRow> getFindingsByProject(@Bind long projectId, @Bind boolean includeSuppressed);
 
     default List<Finding> getFindings(final long projectId, final boolean includeSuppressed) {
-        List<FindingRow> findingRows = withJdbiHandle(handle ->
-                getFindingsByProject(projectId, includeSuppressed));
+        List<FindingRow> findingRows = getFindingsByProject(projectId, includeSuppressed);
         List<Finding> findings = findingRows.stream().map(Finding::new).toList();
         findings = mapComponentLatestVersion(findings);
         return findings;
@@ -182,6 +176,7 @@ public interface FindingDao {
             <#-- @ftlvariable name="queryFilter" type="String" -->
             <#-- @ftlvariable name="activeFilter" type="Boolean" -->
             <#-- @ftlvariable name="suppressedFilter" type="Boolean" -->
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             SELECT "PROJECT"."UUID" AS "projectUuid"
                  , "PROJECT"."NAME" AS "projectName"
                  , "PROJECT"."VERSION" AS "projectVersion"
@@ -218,6 +213,7 @@ public interface FindingDao {
                  , "FINDINGATTRIBUTION"."REFERENCE_URL"
                  , "ANALYSIS"."STATE" AS "analysisState"
                  , "ANALYSIS"."SUPPRESSED"
+                 , COUNT(*) OVER() AS "totalCount"
               FROM "COMPONENT"
              INNER JOIN "COMPONENTS_VULNERABILITIES"
                 ON "COMPONENT"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
@@ -247,6 +243,7 @@ public interface FindingDao {
              <#if apiOrderByClause??>
               ${apiOrderByClause}
              </#if>
+             ${apiOffsetLimitClause!}
             """)
     @AllowApiOrdering(by = {
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "\"VULNERABILITY\".\"TITLE\""),
@@ -294,26 +291,18 @@ public interface FindingDao {
      * @param showInactive   determines if inactive projects should be included or not
      * @return a List of Finding objects
      */
-    default PaginatedResult getAllFindings(final AlpineRequest alpineRequest, final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
+    default List<FindingRow> getAllFindings(final Map<String, String> filters, final boolean showSuppressed, final boolean showInactive) {
         StringBuilder queryFilter = new StringBuilder();
         Map<String, Object> params = new HashMap<>();
         processFilters(filters, queryFilter, params);
-        final List<FindingRow> findingRows = withJdbiHandle(handle ->
-                getAllFindings(String.valueOf(queryFilter), showInactive, showSuppressed, params));
-        List<Finding> findings = findingRows.stream().map(Finding::new).toList();
-        PaginatedResult result = new PaginatedResult();
-        result.setTotal(findings.size());
-        List<Finding> findingList = findings.subList(alpineRequest.getPagination().getOffset(),
-                Math.min(alpineRequest.getPagination().getOffset() + alpineRequest.getPagination().getLimit(), findings.size()));
-        findingList = mapComponentLatestVersion(findingList);
-        result.setObjects(findingList);
-        return result;
+        return getAllFindings(String.valueOf(queryFilter), showInactive, showSuppressed, params);
     }
 
     @SqlQuery("""
             <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="activeFilter" type="Boolean" -->
+            <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
             SELECT "VULNERABILITY"."SOURCE" AS "vulnSource"
                 , "VULNERABILITY"."VULNID"
                 , "VULNERABILITY"."TITLE" AS "vulnTitle"
@@ -324,6 +313,7 @@ public interface FindingDao {
                 , CAST(STRING_TO_ARRAY("VULNERABILITY"."CWES", ',') AS INT[]) AS "CWES"
                 , "FINDINGATTRIBUTION"."ANALYZERIDENTITY"
                 , COUNT(DISTINCT "PROJECT"."ID") AS "affectedProjectCount"
+                , COUNT(*) OVER() AS "totalCount"
             FROM "COMPONENT"
                 INNER JOIN "COMPONENTS_VULNERABILITIES"
                     ON ("COMPONENT"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID")
@@ -361,6 +351,7 @@ public interface FindingDao {
             <#if apiOrderByClause??>
               ${apiOrderByClause}
             </#if>
+            ${apiOffsetLimitClause!}
             """)
     @AllowApiOrdering(by = {
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "\"VULNERABILITY\".\"VULNID\""),
@@ -403,62 +394,14 @@ public interface FindingDao {
      * @param showInactive  determines if inactive projects should be included or not
      * @return a List of Finding objects
      */
-    default PaginatedResult getGroupedFindings(final AlpineRequest alpineRequest, final Map<String, String> filters, final boolean showInactive) {
+    default List<GroupedFindingRow> getGroupedFindings(final Map<String, String> filters, final boolean showInactive) {
         StringBuilder queryFilter = new StringBuilder();
         Map<String, Object> params = new HashMap<>();
         processFilters(filters, queryFilter, params);
         StringBuilder aggregateFilter = new StringBuilder();
         processAggregateFilters(filters, aggregateFilter, params);
-        final List<GroupedFindingRow> findingRows = withJdbiHandle(alpineRequest, handle ->
-                getGroupedFindings(String.valueOf(queryFilter), showInactive, String.valueOf(aggregateFilter), params));
-        List<GroupedFinding> findings = findingRows.stream().map(GroupedFinding::new).toList();
-        PaginatedResult result = new PaginatedResult();
-        result.setTotal(findings.size());
-        final List<GroupedFinding> findingsList = findings.subList(alpineRequest.getPagination().getOffset(),
-                Math.min(alpineRequest.getPagination().getOffset()
-                        + alpineRequest.getPagination().getLimit(), findings.size()));
-        result.setObjects(findingsList);
-        return result;
+        return getGroupedFindings(String.valueOf(queryFilter), showInactive, String.valueOf(aggregateFilter), params);
     }
-
-    private List<Finding> mapComponentLatestVersion(List<Finding> findingList){
-
-        final Map<RepositoryMetaComponentSearch, List<Finding>> findingsByMetaComponentSearch = findingList.stream()
-                .filter(finding -> finding.getComponent().get("purl") != null)
-                .map(finding -> {
-                    final PackageURL purl = PurlUtil.silentPurl((String) finding.getComponent().get("purl"));
-                    if (purl == null) {
-                        return null;
-                    }
-
-                    final var repositoryType = RepositoryType.resolve(purl);
-                    if (repositoryType == RepositoryType.UNSUPPORTED) {
-                        return null;
-                    }
-
-                    final var search = new RepositoryMetaComponentSearch(repositoryType, purl.getNamespace(), purl.getName());
-                    return Map.entry(search, finding);
-                })
-                .filter(Objects::nonNull)
-                .collect(Collectors.groupingBy(
-                        Map.Entry::getKey,
-                        Collectors.mapping(Map.Entry::getValue, Collectors.toList())
-                ));
-
-        final List<RepositoryMetaComponent> repositoryMetaComponents = withJdbiHandle(handle ->
-                handle.attach(RepositoryMetaDao.class).getRepositoryMetaComponents(findingsByMetaComponentSearch.keySet()));
-        repositoryMetaComponents.forEach(metaComponent -> {
-            final var search = new RepositoryMetaComponentSearch(metaComponent.getRepositoryType(), metaComponent.getNamespace(), metaComponent.getName());
-            final List<Finding> affectedFindings = findingsByMetaComponentSearch.get(search);
-            if (affectedFindings != null) {
-                for (final Finding finding : affectedFindings) {
-                    finding.getComponent().put("latestVersion", metaComponent.getLatestVersion());
-                }
-            }
-        });
-        return findingList;
-    }
-
 
     private void processFilters(Map<String, String> filters, StringBuilder queryFilter, Map<String, Object> params) {
         for (String filter : filters.keySet()) {

--- a/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -355,7 +355,8 @@ public interface FindingDao {
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(alwaysBy = "attribution.id", by = {
+    @AllowApiOrdering(alwaysBy = "vulnerability.id", by = {
+            @AllowApiOrdering.Column(name = "vulnerability.id", queryName = "\"VULNERABILITY\".\"ID\""),
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "\"VULNERABILITY\".\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "\"VULNERABILITY\".\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = """ 
@@ -378,7 +379,6 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "vulnerability.cvssV3BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV3BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV2BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.published", queryName = "\"VULNERABILITY\".\"PUBLISHED\""),
-            @AllowApiOrdering.Column(name = "attribution.id", queryName = "\"FINDINGATTRIBUTION\".\"ID\""),
             @AllowApiOrdering.Column(name = "attribution.analyzerIdentity", queryName = "\"FINDINGATTRIBUTION\".\"ANALYZERIDENTITY\""),
             @AllowApiOrdering.Column(name = "vulnerability.affectedProjectCount", queryName = "COUNT(DISTINCT \"PROJECT\".\"ID\")")
     })

--- a/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -158,6 +158,7 @@ public interface FindingDao {
                 ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
              WHERE "COMPONENT"."PROJECT_ID" = :projectId
                AND (:includeSuppressed OR "ANALYSIS"."SUPPRESSED" IS NULL OR NOT "ANALYSIS"."SUPPRESSED")
+             ORDER BY "FINDINGATTRIBUTION"."ID"
              ${apiOffsetLimitClause!}
             """)
     @RegisterConstructorMapper(FindingRow.class)
@@ -245,7 +246,7 @@ public interface FindingDao {
              </#if>
              ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(by = {
+    @AllowApiOrdering(alwaysBy = "attribution.id", by = {
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "\"VULNERABILITY\".\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "\"VULNERABILITY\".\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = """ 
@@ -274,6 +275,7 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "component.version", queryName = "\"COMPONENT\".\"VERSION\""),
             @AllowApiOrdering.Column(name = "analysis.state", queryName = "\"ANALYSIS\".\"STATE\""),
             @AllowApiOrdering.Column(name = "analysis.isSuppressed", queryName = "\"ANALYSIS\".\"SUPPRESSED\""),
+            @AllowApiOrdering.Column(name = "attribution.id", queryName = "\"FINDINGATTRIBUTION\".\"ID\""),
             @AllowApiOrdering.Column(name = "attribution.attributedOn", queryName = "\"FINDINGATTRIBUTION\".\"ATTRIBUTED_ON\"")
     })
     @DefineNamedBindings
@@ -353,7 +355,7 @@ public interface FindingDao {
             </#if>
             ${apiOffsetLimitClause!}
             """)
-    @AllowApiOrdering(by = {
+    @AllowApiOrdering(alwaysBy = "attribution.id", by = {
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "\"VULNERABILITY\".\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "\"VULNERABILITY\".\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = """ 
@@ -376,6 +378,7 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "vulnerability.cvssV3BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV3BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV2BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.published", queryName = "\"VULNERABILITY\".\"PUBLISHED\""),
+            @AllowApiOrdering.Column(name = "attribution.id", queryName = "\"FINDINGATTRIBUTION\".\"ID\""),
             @AllowApiOrdering.Column(name = "attribution.analyzerIdentity", queryName = "\"FINDINGATTRIBUTION\".\"ANALYZERIDENTITY\""),
             @AllowApiOrdering.Column(name = "vulnerability.affectedProjectCount", queryName = "COUNT(DISTINCT \"PROJECT\".\"ID\")")
     })

--- a/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -79,7 +79,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                 "vuln-recommendation", Instant.now(), Severity.CRITICAL, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", null, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
-                AnalyzerIdentity.OSSINDEX_ANALYZER, Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true);
+                AnalyzerIdentity.OSSINDEX_ANALYZER, Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true, 1);
         Finding findingWithoutAlias = new Finding(findingRow);
 
         var alias = new VulnerabilityAlias();
@@ -108,7 +108,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                 "vuln-recommendation", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", List.of(alias, other), BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
-                AnalyzerIdentity.INTERNAL_ANALYZER, Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true);
+                AnalyzerIdentity.INTERNAL_ANALYZER, Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true, 1);
         Finding findingWithAlias = new Finding(findingRow);
 
         FindingPackagingFormat fpf = new FindingPackagingFormat(

--- a/src/test/java/org/dependencytrack/model/FindingTest.java
+++ b/src/test/java/org/dependencytrack/model/FindingTest.java
@@ -117,7 +117,7 @@ public class FindingTest extends PersistenceCapableTest {
                 "vuln-recommendation", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", null, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
-                AnalyzerIdentity.INTERNAL_ANALYZER, Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true);
+                AnalyzerIdentity.INTERNAL_ANALYZER, Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true, 1);
 
         return new Finding(findingRow);
     }

--- a/src/test/java/org/dependencytrack/model/GroupedFindingTest.java
+++ b/src/test/java/org/dependencytrack/model/GroupedFindingTest.java
@@ -60,7 +60,7 @@ public class GroupedFindingTest extends PersistenceCapableTest {
     private GroupedFinding createTestFinding() {
         FindingDao.GroupedFindingRow findingRow = new FindingDao.GroupedFindingRow(Vulnerability.Source.GITHUB,
                 "vuln-vulnId", "vuln-title", Severity.HIGH, BigDecimal.valueOf(8.5), BigDecimal.valueOf(8.4),
-                Instant.now(), null, AnalyzerIdentity.INTERNAL_ANALYZER, 3);
+                Instant.now(), null, AnalyzerIdentity.INTERNAL_ANALYZER, 3, 1);
         return new GroupedFinding(findingRow);
     }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -952,6 +952,123 @@ public class FindingResourceTest extends ResourceTest {
         );
     }
 
+    @Test
+    public void getFindingsByProjectWithPaginationTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+
+        for (int i = 0; i < 5; i++) {
+            Component component = createComponent(p1, "Component "+i, "1.0."+i);
+            Vulnerability vulnerability = createVulnerability("Vuln-"+i, Severity.LOW);
+            qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
+        }
+
+        Response response = jersey.target(V1_FINDING  + "/project/" + p1.getUuid())
+                .queryParam("pageNumber", "1")
+                .queryParam("pageSize", "3")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        JsonArray json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(3);
+        assertThat(json.get(0).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-0");
+        assertThat(json.get(1).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-1");
+        assertThat(json.get(2).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-2");
+
+        response = jersey.target(V1_FINDING)
+                .queryParam("pageNumber", "2")
+                .queryParam("pageSize", "3")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(2);
+        assertThat(json.get(0).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-3");
+        assertThat(json.get(1).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-4");
+
+    }
+
+    @Test
+    public void getAllFindingsWithPaginationTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+
+        for (int i = 0; i < 5; i++) {
+            Component component = createComponent(p1, "Component "+i, "1.0."+i);
+            Vulnerability vulnerability = createVulnerability("Vuln-"+i, Severity.LOW);
+            qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
+        }
+
+        Response response = jersey.target(V1_FINDING)
+                .queryParam("pageNumber", "1")
+                .queryParam("pageSize", "3")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        JsonArray json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(3);
+        assertThat(json.get(0).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-0");
+        assertThat(json.get(1).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-1");
+        assertThat(json.get(2).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-2");
+
+        response = jersey.target(V1_FINDING)
+                .queryParam("pageNumber", "2")
+                .queryParam("pageSize", "3")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(2);
+        assertThat(json.get(0).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-3");
+        assertThat(json.get(1).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-4");
+
+    }
+
+    @Test
+    public void getAllGroupedFindingsWithPaginationTest() {
+        Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+
+        for (int i = 0; i < 5; i++) {
+            Component component = createComponent(p1, "Component "+i, "1.0."+i);
+            Vulnerability vulnerability = createVulnerability("Vuln-"+i, Severity.LOW);
+            qm.addVulnerability(vulnerability, component, AnalyzerIdentity.NONE);
+        }
+
+        Response response = jersey.target(V1_FINDING + "/grouped")
+                .queryParam("pageNumber", "1")
+                .queryParam("pageSize", "3")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        JsonArray json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(3);
+        assertThat(json.get(0).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-0");
+        assertThat(json.get(1).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-1");
+        assertThat(json.get(2).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-2");
+
+        response = jersey.target(V1_FINDING)
+                .queryParam("pageNumber", "2")
+                .queryParam("pageSize", "3")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("5");
+        json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(2);
+        assertThat(json.get(0).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-3");
+        assertThat(json.get(1).asJsonObject().getJsonObject("vulnerability").getString("vulnId")).isEqualTo("Vuln-4");
+
+    }
+
     private Component createComponent(Project project, String name, String version) {
         Component component = new Component();
         component.setProject(project);

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -610,16 +610,16 @@ public class FindingResourceTest extends ResourceTest {
         assertEquals(p1.getName() ,json.getJsonObject(1).getJsonObject("component").getString("projectName"));
         assertEquals(p1.getVersion() ,json.getJsonObject(1).getJsonObject("component").getString("projectVersion"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject(1).getJsonObject("component").getString("project"));
-        assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1.getName() ,json.getJsonObject(2).getJsonObject("component").getString("projectName"));
-        assertEquals(p1.getVersion() ,json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
-        assertEquals(p1.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
+        assertEquals(date.getTime(), json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        assertEquals(p1.getName() ,json.getJsonObject(3).getJsonObject("component").getString("projectName"));
+        assertEquals(p1.getVersion() ,json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1.getUuid().toString(), json.getJsonObject(3).getJsonObject("component").getString("project"));
 
         // Findings of p1_child are returned because team was given access to its parent project p1.
-        assertEquals(date.getTime(), json.getJsonObject(3).getJsonObject("vulnerability").getJsonNumber("published").longValue());
-        assertEquals(p1_child.getName(), json.getJsonObject(3).getJsonObject("component").getString("projectName"));
-        assertEquals(p1_child.getVersion(), json.getJsonObject(3).getJsonObject("component").getString("projectVersion"));
-        assertEquals(p1_child.getUuid().toString(), json.getJsonObject(3).getJsonObject("component").getString("project"));
+        assertEquals(date.getTime(), json.getJsonObject(2).getJsonObject("vulnerability").getJsonNumber("published").longValue());
+        assertEquals(p1_child.getName(), json.getJsonObject(2).getJsonObject("component").getString("projectName"));
+        assertEquals(p1_child.getVersion(), json.getJsonObject(2).getJsonObject("component").getString("projectVersion"));
+        assertEquals(p1_child.getUuid().toString(), json.getJsonObject(2).getJsonObject("component").getString("project"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Refactor the findings endpoints to support JDBI pagination.
1. `/v1/finding/project/{uuid}`
2. `/v1/finding`
3. `/v1/finding/grouped`

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1708

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
