### PR TITLE
Fix v5.6.0 migration failing when projects without parent exist

### DIFF
--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -704,6 +704,13 @@
     </changeSet>
 
     <changeSet id="v5.6.0-15" author="nscuro">
+        <!--
+          Previous version of this changeset failed if projects without parent existed.
+          Deployments that successfully executed this changeset are in a valid state though.
+          https://github.com/DependencyTrack/hyades/issues/1737
+        -->
+        <validCheckSum>9:e7ba3d0bcd5751d57ada707ec0ffc449</validCheckSum>
+
         <createTable tableName="PROJECT_HIERARCHY">
             <column name="PARENT_PROJECT_ID" type="BIGINT"/>
             <column name="CHILD_PROJECT_ID" type="BIGINT"/>
@@ -810,6 +817,7 @@
                    , "PARENT_PROJECT_ID" AS parent_id
                    , 1 AS depth
                 FROM "PROJECT"
+               WHERE "PARENT_PROJECT_ID" IS NOT NULL
                UNION ALL
               SELECT child_id
                    , "PARENT_PROJECT_ID" AS parent_id


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes v5.6.0 migration failing when projects without parent exist.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/1737

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
