### PR TITLE
Ensure no duplicate entries in join tables

### DIFF
--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -125,9 +125,8 @@ public class NotificationRule implements Serializable {
     private List<Tag> tags;
 
     @Persistent(table = "NOTIFICATIONRULE_TEAMS", defaultFetchGroup = "true")
-    @Join(column = "NOTIFICATIONRULE_ID", foreignKey = "NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Join(column = "NOTIFICATIONRULE_ID", primaryKey = "NOTIFICATIONRULE_TEAMS_PK", foreignKey = "NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Element(column = "TEAM_ID", foreignKey = "NOTIFICATIONRULE_TEAMS_TEAM_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private Set<Team> teams;
 
     @Persistent

--- a/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -128,7 +128,7 @@ public class NotificationRule implements Serializable {
     @Join(column = "NOTIFICATIONRULE_ID", foreignKey = "NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Element(column = "TEAM_ID", foreignKey = "NOTIFICATIONRULE_TEAMS_TEAM_FK", deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Team> teams;
+    private Set<Team> teams;
 
     @Persistent
     @Column(name = "NOTIFY_ON", length = 1024)
@@ -232,11 +232,11 @@ public class NotificationRule implements Serializable {
         this.tags = tags;
     }
 
-    public List<Team> getTeams() {
+    public Set<Team> getTeams() {
         return teams;
     }
 
-    public void setTeams(List<Team> teams) {
+    public void setTeams(Set<Team> teams) {
         this.teams = teams;
     }
 

--- a/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -55,6 +55,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.Set;
 
 import static org.dependencytrack.notification.publisher.PublisherClass.SendMailPublisher;
 
@@ -329,7 +330,7 @@ public class NotificationRuleResource extends AbstractApiResource {
             if (team == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
             }
-            final List<Team> teams = rule.getTeams();
+            final Set<Team> teams = rule.getTeams();
             if (teams != null && !teams.contains(team)) {
                 rule.getTeams().add(team);
                 qm.persist(rule);
@@ -374,7 +375,7 @@ public class NotificationRuleResource extends AbstractApiResource {
             if (team == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
             }
-            final List<Team> teams = rule.getTeams();
+            final Set<Team> teams = rule.getTeams();
             if (teams != null && teams.contains(team)) {
                 rule.getTeams().remove(team);
                 qm.persist(rule);

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1234,35 +1234,9 @@
               PERFORM remove_duplicate_rows('TEAMS_PERMISSIONS', 'TEAM_ID', 'PERMISSION_ID');
             END
             $$;
-        </sql>
 
-        <addPrimaryKey tableName="APIKEYS_TEAMS"
-            columnNames="TEAM_ID, APIKEY_ID"
-            constraintName="APIKEYS_TEAMS_PK" />
-        <addPrimaryKey tableName="LDAPUSERS_PERMISSIONS"
-            columnNames="LDAPUSER_ID, PERMISSION_ID"
-            constraintName="LDAPUSERS_PERMISSIONS_PK" />
-        <addPrimaryKey tableName="LDAPUSERS_TEAMS"
-            columnNames="TEAM_ID, LDAPUSER_ID"
-            constraintName="LDAPUSERS_TEAMS_PK" />
-        <addPrimaryKey tableName="MANAGEDUSERS_PERMISSIONS"
-            columnNames="MANAGEDUSER_ID, PERMISSION_ID"
-            constraintName="MANAGEDUSERS_PERMISSIONS_PK" />
-        <addPrimaryKey tableName="MANAGEDUSERS_TEAMS"
-            columnNames="TEAM_ID, MANAGEDUSER_ID"
-            constraintName="MANAGEDUSERS_TEAMS_PK" />
-        <addPrimaryKey tableName="OIDCUSERS_PERMISSIONS"
-            columnNames="OIDCUSER_ID, PERMISSION_ID"
-            constraintName="OIDCUSERS_PERMISSIONS_PK" />
-        <addPrimaryKey tableName="OIDCUSERS_TEAMS"
-            columnNames="TEAM_ID, OIDCUSERS_ID"
-            constraintName="OIDCUSERS_TEAMS_PK" />
-        <addPrimaryKey tableName="NOTIFICATIONRULE_TEAMS"
-            columnNames="NOTIFICATIONRULE_ID, TEAM_ID"
-            constraintName="NOTIFICATIONRULE_TEAMS_PK" />
-        <addPrimaryKey tableName="TEAMS_PERMISSIONS"
-            columnNames="TEAM_ID, PERMISSION_ID"
-            constraintName="TEAMS_PERMISSIONS_PK" />
+            DROP FUNCTION remove_duplicate_rows;
+        </sql>
 
         <sql splitStatements="false">
             -- Remove all duplicates from TEAM table, updating foreign
@@ -1303,20 +1277,53 @@
 
                   FOREACH tbl_name IN ARRAY referencing_tables
                   LOOP
-                    EXECUTE format(
-                      'UPDATE %I SET "TEAM_ID" = %s WHERE "TEAM_ID" = %s',
-                      tbl_name, rec.canonical_id, dup_id
-                    );
+                    EXECUTE format($update$
+                      UPDATE %I
+                         SET "TEAM_ID" = %s
+                       WHERE "TEAM_ID" = %s
+                      $update$, tbl_name, rec.canonical_id, dup_id);
                   END LOOP;
 
                   -- After reassigning foreign keys, delete the duplicate row from TEAM
                   RAISE NOTICE 'Deleting duplicate TEAM row with ID % for team "%" ', dup_id, rec.name;
-                  EXECUTE format('DELETE FROM "TEAM" WHERE "ID" = %s', dup_id);
+                  EXECUTE format($delete$
+                    DELETE FROM "TEAM"
+                     WHERE "ID" = %s
+                    $delete$, dup_id);
                 END LOOP;
               END LOOP;
             END $$;
         </sql>
 
-        <addUniqueConstraint tableName="TEAM" columnNames="NAME" constraintName="TEAM_NAME_IDX" />
+        <addPrimaryKey tableName="APIKEYS_TEAMS"
+            columnNames="TEAM_ID, APIKEY_ID"
+            constraintName="APIKEYS_TEAMS_PK" />
+        <addPrimaryKey tableName="LDAPUSERS_PERMISSIONS"
+            columnNames="LDAPUSER_ID, PERMISSION_ID"
+            constraintName="LDAPUSERS_PERMISSIONS_PK" />
+        <addPrimaryKey tableName="LDAPUSERS_TEAMS"
+            columnNames="TEAM_ID, LDAPUSER_ID"
+            constraintName="LDAPUSERS_TEAMS_PK" />
+        <addPrimaryKey tableName="MANAGEDUSERS_PERMISSIONS"
+            columnNames="MANAGEDUSER_ID, PERMISSION_ID"
+            constraintName="MANAGEDUSERS_PERMISSIONS_PK" />
+        <addPrimaryKey tableName="MANAGEDUSERS_TEAMS"
+            columnNames="TEAM_ID, MANAGEDUSER_ID"
+            constraintName="MANAGEDUSERS_TEAMS_PK" />
+        <addPrimaryKey tableName="OIDCUSERS_PERMISSIONS"
+            columnNames="OIDCUSER_ID, PERMISSION_ID"
+            constraintName="OIDCUSERS_PERMISSIONS_PK" />
+        <addPrimaryKey tableName="OIDCUSERS_TEAMS"
+            columnNames="TEAM_ID, OIDCUSERS_ID"
+            constraintName="OIDCUSERS_TEAMS_PK" />
+        <addPrimaryKey tableName="NOTIFICATIONRULE_TEAMS"
+            columnNames="NOTIFICATIONRULE_ID, TEAM_ID"
+            constraintName="NOTIFICATIONRULE_TEAMS_PK" />
+        <addPrimaryKey tableName="TEAMS_PERMISSIONS"
+            columnNames="TEAM_ID, PERMISSION_ID"
+            constraintName="TEAMS_PERMISSIONS_PK" />
+        <addUniqueConstraint tableName="TEAM"
+            columnNames="NAME"
+            constraintName="TEAM_NAME_IDX" />
     </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1179,4 +1179,144 @@
             EXECUTE FUNCTION prevent_direct_effective_permissions_writes();
         </sql>
     </changeSet>
+
+    <changeSet id="v5.6.0-17" author="jhoward-lm">
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION remove_duplicate_rows(
+              table_name TEXT,
+              column_1   TEXT,
+              column_2   TEXT
+            )
+            RETURNS void AS $$
+            BEGIN
+              EXECUTE format($q$
+                DELETE FROM %I a
+                 USING %I b
+                 WHERE a.%I = b.%I
+                   AND a.%I = b.%I
+                   AND a.ctid &lt; b.ctid
+                $q$, table_name, table_name, column_1, column_1, column_2, column_2
+              );
+            END;
+            $$ LANGUAGE plpgsql;    
+        </sql>
+
+        <dropIndex tableName="APIKEYS_TEAMS" indexName="APIKEYS_TEAMS_TEAM_ID_IDX" />
+        <dropIndex tableName="APIKEYS_TEAMS" indexName="APIKEYS_TEAMS_APIKEY_ID_IDX" />
+        <dropIndex tableName="LDAPUSERS_PERMISSIONS" indexName="LDAPUSERS_PERMISSIONS_PERMISSION_ID_IDX" />
+        <dropIndex tableName="LDAPUSERS_PERMISSIONS" indexName="LDAPUSERS_PERMISSIONS_LDAPUSER_ID_IDX" />
+        <dropIndex tableName="LDAPUSERS_TEAMS" indexName="LDAPUSERS_TEAMS_TEAM_ID_IDX" />
+        <dropIndex tableName="LDAPUSERS_TEAMS" indexName="LDAPUSERS_TEAMS_LDAPUSER_ID_IDX" />
+        <dropIndex tableName="MANAGEDUSERS_PERMISSIONS" indexName="MANAGEDUSERS_PERMISSIONS_PERMISSION_ID_IDX" />
+        <dropIndex tableName="MANAGEDUSERS_PERMISSIONS" indexName="MANAGEDUSERS_PERMISSIONS_MANAGEDUSER_ID_IDX" />
+        <dropIndex tableName="MANAGEDUSERS_TEAMS" indexName="MANAGEDUSERS_TEAMS_TEAM_ID_IDX" />
+        <dropIndex tableName="MANAGEDUSERS_TEAMS" indexName="MANAGEDUSERS_TEAMS_MANAGEDUSER_ID_IDX" />
+        <dropIndex tableName="OIDCUSERS_PERMISSIONS" indexName="OIDCUSERS_PERMISSIONS_PERMISSION_ID_IDX" />
+        <dropIndex tableName="OIDCUSERS_PERMISSIONS" indexName="OIDCUSERS_PERMISSIONS_OIDCUSER_ID_IDX" />
+        <dropIndex tableName="OIDCUSERS_TEAMS" indexName="OIDCUSERS_TEAMS_TEAM_ID_IDX" />
+        <dropIndex tableName="OIDCUSERS_TEAMS" indexName="OIDCUSERS_TEAMS_OIDCUSERS_ID_IDX" />
+        <dropIndex tableName="NOTIFICATIONRULE_TEAMS" indexName="NOTIFICATIONRULE_TEAMS_NOTIFICATIONRULE_ID_IDX" />
+        <dropIndex tableName="NOTIFICATIONRULE_TEAMS" indexName="NOTIFICATIONRULE_TEAMS_TEAM_ID_IDX" />
+        <dropIndex tableName="TEAMS_PERMISSIONS" indexName="TEAMS_PERMISSIONS_TEAM_ID_IDX" />
+        <dropIndex tableName="TEAMS_PERMISSIONS" indexName="TEAMS_PERMISSIONS_PERMISSION_ID_IDX" />
+
+        <sql splitStatements="false">
+            DO $$ 
+            BEGIN
+              PERFORM remove_duplicate_rows('APIKEYS_TEAMS', 'TEAM_ID', 'APIKEY_ID');
+              PERFORM remove_duplicate_rows('LDAPUSERS_PERMISSIONS', 'LDAPUSER_ID', 'PERMISSION_ID');
+              PERFORM remove_duplicate_rows('LDAPUSERS_TEAMS', 'TEAM_ID', 'LDAPUSER_ID');
+              PERFORM remove_duplicate_rows('MANAGEDUSERS_PERMISSIONS', 'MANAGEDUSER_ID', 'PERMISSION_ID');
+              PERFORM remove_duplicate_rows('MANAGEDUSERS_TEAMS', 'TEAM_ID', 'MANAGEDUSER_ID');
+              PERFORM remove_duplicate_rows('NOTIFICATIONRULE_TEAMS', 'NOTIFICATIONRULE_ID', 'TEAM_ID');
+              PERFORM remove_duplicate_rows('OIDCUSERS_PERMISSIONS', 'OIDCUSER_ID', 'PERMISSION_ID');
+              PERFORM remove_duplicate_rows('OIDCUSERS_TEAMS', 'TEAM_ID', 'OIDCUSERS_ID');
+              PERFORM remove_duplicate_rows('TEAMS_PERMISSIONS', 'TEAM_ID', 'PERMISSION_ID');
+            END
+            $$;
+        </sql>
+
+        <addPrimaryKey tableName="APIKEYS_TEAMS"
+            columnNames="TEAM_ID, APIKEY_ID"
+            constraintName="APIKEYS_TEAMS_PK" />
+        <addPrimaryKey tableName="LDAPUSERS_PERMISSIONS"
+            columnNames="LDAPUSER_ID, PERMISSION_ID"
+            constraintName="LDAPUSERS_PERMISSIONS_PK" />
+        <addPrimaryKey tableName="LDAPUSERS_TEAMS"
+            columnNames="TEAM_ID, LDAPUSER_ID"
+            constraintName="LDAPUSERS_TEAMS_PK" />
+        <addPrimaryKey tableName="MANAGEDUSERS_PERMISSIONS"
+            columnNames="MANAGEDUSER_ID, PERMISSION_ID"
+            constraintName="MANAGEDUSERS_PERMISSIONS_PK" />
+        <addPrimaryKey tableName="MANAGEDUSERS_TEAMS"
+            columnNames="TEAM_ID, MANAGEDUSER_ID"
+            constraintName="MANAGEDUSERS_TEAMS_PK" />
+        <addPrimaryKey tableName="OIDCUSERS_PERMISSIONS"
+            columnNames="OIDCUSER_ID, PERMISSION_ID"
+            constraintName="OIDCUSERS_PERMISSIONS_PK" />
+        <addPrimaryKey tableName="OIDCUSERS_TEAMS"
+            columnNames="TEAM_ID, OIDCUSERS_ID"
+            constraintName="OIDCUSERS_TEAMS_PK" />
+        <addPrimaryKey tableName="NOTIFICATIONRULE_TEAMS"
+            columnNames="NOTIFICATIONRULE_ID, TEAM_ID"
+            constraintName="NOTIFICATIONRULE_TEAMS_PK" />
+        <addPrimaryKey tableName="TEAMS_PERMISSIONS"
+            columnNames="TEAM_ID, PERMISSION_ID"
+            constraintName="TEAMS_PERMISSIONS_PK" />
+
+        <sql splitStatements="false">
+            -- Remove all duplicates from TEAM table, updating foreign
+            -- keys in other tables referencing the removed entries
+            DO $$
+            DECLARE
+              referencing_tables TEXT[] := ARRAY[
+                'APIKEYS_TEAMS',
+                'LDAPUSERS_TEAMS',
+                'MANAGEDUSERS_TEAMS',
+                'NOTIFICATIONRULE_TEAMS',
+                'OIDCUSERS_TEAMS',
+                'TEAMS_PERMISSIONS'
+              ];
+              tbl_name TEXT;
+              rec      RECORD;
+              dup_id   INTEGER;
+            BEGIN
+            -- Loop over each team name group that has duplicates.
+              FOR rec IN
+              SELECT
+                  "NAME",
+                  MIN("ID") AS canonical_id,
+                  ARRAY_AGG("ID") AS all_ids
+                FROM "TEAM"
+               GROUP BY "NAME"
+              HAVING COUNT(*) &gt; 1
+              LOOP
+                RAISE NOTICE 'Processing team "%" with canonical ID %', rec.name, rec.canonical_id;
+
+                -- For every duplicate row in the group, update references and delete the duplicate.
+                FOREACH dup_id IN ARRAY rec.all_ids
+                LOOP
+                  -- Skip the chosen canonical row
+                  CONTINUE WHEN dup_id = rec.canonical_id;
+
+                  RAISE NOTICE 'Updating foreign key references from duplicate ID % to canonical ID %', dup_id, rec.canonical_id;
+
+                  FOREACH tbl_name IN ARRAY referencing_tables
+                  LOOP
+                    EXECUTE format(
+                      'UPDATE %I SET "TEAM_ID" = %s WHERE "TEAM_ID" = %s',
+                      tbl_name, rec.canonical_id, dup_id
+                    );
+                  END LOOP;
+
+                  -- After reassigning foreign keys, delete the duplicate row from TEAM
+                  RAISE NOTICE 'Deleting duplicate TEAM row with ID % for team "%" ', dup_id, rec.name;
+                  EXECUTE format('DELETE FROM "TEAM" WHERE "ID" = %s', dup_id);
+                END LOOP;
+              END LOOP;
+            END $$;
+        </sql>
+
+        <addUniqueConstraint tableName="TEAM" columnNames="NAME" constraintName="TEAM_NAME_IDX" />
+    </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
+++ b/src/test/java/org/dependencytrack/model/NotificationRuleTest.java
@@ -123,19 +123,21 @@ public class NotificationRuleTest {
     }
 
     @Test
-    public void testTeams(){
-        List<Team> teams = new ArrayList<>();
+    public void testTeams() {
+        Set<Team> teams = new HashSet<>();
         Team team = new Team();
         teams.add(team);
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
         Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
+        var ruleTeam = rule.getTeams().stream().findFirst().orElse(null);
+        Assert.assertNotNull(ruleTeam);
+        Assert.assertEquals(team, ruleTeam);
     }
 
     @Test
-    public void testManagedUsers(){
-        List<Team> teams = new ArrayList<>();
+    public void testManagedUsers() {
+        Set<Team> teams = new HashSet<>();
         Team team = new Team();
         List<ManagedUser> managedUsers = new ArrayList<>();
         ManagedUser managedUser = new ManagedUser();
@@ -145,13 +147,15 @@ public class NotificationRuleTest {
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
         Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
-        Assert.assertEquals(managedUser, rule.getTeams().get(0).getManagedUsers().get(0));
+        var ruleTeam = rule.getTeams().stream().findFirst().orElse(null);
+        Assert.assertNotNull(ruleTeam);
+        Assert.assertEquals(team, ruleTeam);
+        Assert.assertEquals(managedUser, ruleTeam.getManagedUsers().get(0));
     }
 
     @Test
-    public void testLdapUsers(){
-        List<Team> teams = new ArrayList<>();
+    public void testLdapUsers() {
+        Set<Team> teams = new HashSet<>();
         Team team = new Team();
         List<LdapUser> ldapUsers = new ArrayList<>();
         LdapUser ldapUser = new LdapUser();
@@ -161,13 +165,15 @@ public class NotificationRuleTest {
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
         Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
-        Assert.assertEquals(ldapUser, rule.getTeams().get(0).getLdapUsers().get(0));
+        var ruleTeam = rule.getTeams().stream().findFirst().orElse(null);
+        Assert.assertNotNull(ruleTeam);
+        Assert.assertEquals(team, ruleTeam);
+        Assert.assertEquals(ldapUser, ruleTeam.getLdapUsers().get(0));
     }
 
     @Test
-    public void testOidcUsers(){
-        List<Team> teams = new ArrayList<>();
+    public void testOidcUsers() {
+        Set<Team> teams = new HashSet<>();
         Team team = new Team();
         List<OidcUser> oidcUsers = new ArrayList<>();
         OidcUser oidcUser = new OidcUser();
@@ -177,8 +183,10 @@ public class NotificationRuleTest {
         NotificationRule rule = new NotificationRule();
         rule.setTeams(teams);
         Assert.assertEquals(1, rule.getTeams().size());
-        Assert.assertEquals(team, rule.getTeams().get(0));
-        Assert.assertEquals(oidcUser, rule.getTeams().get(0).getOidcUsers().get(0));
+        var ruleTeam = rule.getTeams().stream().findFirst().orElse(null);
+        Assert.assertNotNull(ruleTeam);
+        Assert.assertEquals(team, ruleTeam);
+        Assert.assertEquals(oidcUser, ruleTeam.getOidcUsers().get(0));
     }
 
     @Test

--- a/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -46,7 +46,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -448,7 +450,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        List<Team> teams = new ArrayList<>();
+        Set<Team> teams = new HashSet<>();
         teams.add(team);
         rule.setTeams(teams);
         qm.persist(rule);
@@ -522,7 +524,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
         Team team = qm.createTeam("Team Example", false);
         NotificationPublisher publisher = qm.getNotificationPublisher(DefaultNotificationPublishers.EMAIL.getPublisherName());
         NotificationRule rule = qm.createNotificationRule("Example Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
-        List<Team> teams = new ArrayList<>();
+        Set<Team> teams = new HashSet<>();
         teams.add(team);
         rule.setTeams(teams);
         qm.persist(rule);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR adds primary key constraints on the following tables to prevent duplicate entities:

- `APIKEYS_TEAMS`
- `LDAPUSERS_PERMISSIONS`
- `LDAPUSERS_TEAMS`
- `MANAGEDUSERS_PERMISSIONS`
- `MANAGEDUSERS_TEAMS`
- `OIDCUSERS_PERMISSIONS`
- `OIDCUSERS_TEAMS`
- `NOTIFICATIONRULE_TEAMS`
- `TEAMS_PERMISSIONS`

Additionally, for the `TEAM` table:

- remove all rows with duplicate `NAME` values
- update foreign key references to the removed duplicates in other tables 
- add a unique constraint to the `NAME` column

The `NotificationRule` class' `teams` field type was changed to `Set`, but the other types are defined in Alpine, so uniqueness can't be enforced at the model level here; they should still be enforced at the database level, however.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines]
- [ ] ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [X] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
