### PR TITLE
Collect latency metrics of SQL queries executed via JDBI

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/jdbi/JdbiAttributes.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/JdbiAttributes.java
@@ -23,12 +23,13 @@ package org.dependencytrack.persistence.jdbi;
  *
  * @since 5.5.0
  */
-final class JdbiAttributes {
+public final class JdbiAttributes {
 
     static final String ATTRIBUTE_API_FILTER_PARAMETER = "apiFilterParameter";
     static final String ATTRIBUTE_API_OFFSET_LIMIT_CLAUSE = "apiOffsetLimitClause";
     static final String ATTRIBUTE_API_ORDER_BY_CLAUSE = "apiOrderByClause";
     static final String ATTRIBUTE_API_PROJECT_ACL_CONDITION = "apiProjectAclCondition";
+    public static final String ATTRIBUTE_QUERY_NAME = "queryName";
 
     private JdbiAttributes() {
     }

--- a/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
+import alpine.Config;
+import alpine.common.metrics.Metrics;
 import alpine.resources.AlpineRequest;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.json.JsonMapper;
@@ -192,6 +194,10 @@ public class JdbiFactory {
                 .installPlugin(new PostgresPlugin())
                 .installPlugin(new Jackson2Plugin())
                 .setTemplateEngine(FreemarkerEngine.instance());
+
+        if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
+            preparedJdbi.setSqlLogger(new QueryTimingSqlLogger(Metrics.getRegistry()));
+        }
 
         preparedJdbi.getConfig(Jackson2Config.class).setMapper(createJsonMapper());
         return preparedJdbi;

--- a/src/main/java/org/dependencytrack/persistence/jdbi/QueryTimingSqlLogger.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/QueryTimingSqlLogger.java
@@ -1,0 +1,98 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.jdbi.v3.core.extension.ExtensionMethod;
+import org.jdbi.v3.core.statement.SqlLogger;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.TimeUnit;
+
+import static org.dependencytrack.persistence.jdbi.JdbiAttributes.ATTRIBUTE_QUERY_NAME;
+
+/**
+ * @since 5.6.0
+ */
+final class QueryTimingSqlLogger implements SqlLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(QueryTimingSqlLogger.class);
+
+    private final MeterRegistry meterRegistry;
+
+    QueryTimingSqlLogger(final MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public void logException(final StatementContext context, final SQLException ex) {
+        recordQueryLatency(context, ex);
+    }
+
+    @Override
+    public void logAfterExecution(final StatementContext context) {
+        recordQueryLatency(context, null);
+    }
+
+    private void recordQueryLatency(final StatementContext context, final SQLException ex) {
+        if (meterRegistry == null) {
+            return;
+        }
+
+        final String queryName = getQueryName(context);
+        if (queryName == null) {
+            return;
+        }
+
+        final long latencyNanos = context.getElapsedTime(ChronoUnit.NANOS);
+        final String outcome = ex == null ? "success" : "failure";
+
+        Timer.builder("jdbi.query.latency")
+                .tag("query", queryName)
+                .tag("outcome", outcome)
+                .register(meterRegistry)
+                .record(latencyNanos, TimeUnit.NANOSECONDS);
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Query {} completed with outcome {} in {}", queryName, outcome, Duration.ofNanos(latencyNanos));
+        }
+    }
+
+    private String getQueryName(final StatementContext context) {
+        if (context.getAttribute(ATTRIBUTE_QUERY_NAME) instanceof final String queryNameAttribute) {
+            return queryNameAttribute;
+        }
+
+        final ExtensionMethod extensionMethod = context.getExtensionMethod();
+        if (extensionMethod != null) {
+            return "%s#%s".formatted(
+                    extensionMethod.getType().getSimpleName(),
+                    extensionMethod.getMethod().getName());
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -23,7 +23,6 @@ import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import io.github.nscuro.versatile.Vers;
 import io.github.nscuro.versatile.VersException;
-import jakarta.annotation.Nullable;
 import org.dependencytrack.model.RepositoryType;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.proto.policy.v1.Component;
@@ -45,6 +44,7 @@ import org.projectnessie.cel.common.types.Types;
 import org.projectnessie.cel.common.types.ref.Val;
 import org.projectnessie.cel.interpreter.functions.Overload;
 
+import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.Period;
@@ -63,6 +63,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.substringAfter;
+import static org.dependencytrack.persistence.jdbi.JdbiAttributes.ATTRIBUTE_QUERY_NAME;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMPONENT;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
@@ -416,6 +417,7 @@ public class CelCommonPolicyLibrary implements Library {
                           AND ${filters}
                         """);
                 return query
+                        .define(ATTRIBUTE_QUERY_NAME, "%s#dependsOn_withoutInMemoryFilters".formatted(CelCommonPolicyLibrary.class.getSimpleName()))
                         .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                         .bind("projectUuid", UUID.fromString(project.getUuid()))
                         .bindMap(compositeNodeFilter.sqlFilterParams())
@@ -438,6 +440,7 @@ public class CelCommonPolicyLibrary implements Library {
                       AND ${filters}
                     """);
             return query
+                    .define(ATTRIBUTE_QUERY_NAME, "%s#dependsOn_withInMemoryFilters".formatted(CelCommonPolicyLibrary.class.getSimpleName()))
                     .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                     .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
                     .bind("projectUuid", UUID.fromString(project.getUuid()))
@@ -534,6 +537,7 @@ public class CelCommonPolicyLibrary implements Library {
                         """);
 
                 return query
+                        .define(ATTRIBUTE_QUERY_NAME, "%s#isDependencyOf_withoutInMemoryFilters".formatted(CelCommonPolicyLibrary.class.getSimpleName()))
                         .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                         .bind("leafComponentUuid", UUID.fromString(leafComponent.getUuid()))
                         .bindMap(compositeNodeFilter.sqlFilterParams())
@@ -620,6 +624,7 @@ public class CelCommonPolicyLibrary implements Library {
                     """);
 
             return query
+                    .define(ATTRIBUTE_QUERY_NAME, "%s#isDependencyOf_withInMemoryFilters".formatted(CelCommonPolicyLibrary.class.getSimpleName()))
                     .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                     .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
                     .bind("leafComponentUuid", UUID.fromString(leafComponent.getUuid()))
@@ -736,6 +741,7 @@ public class CelCommonPolicyLibrary implements Library {
                     """);
 
             final List<DependencyNode> nodes = query
+                    .define(ATTRIBUTE_QUERY_NAME, "%s#isExclusiveDependencyOf".formatted(CelCommonPolicyLibrary.class.getSimpleName()))
                     .define("filters", compositeNodeFilter.sqlFiltersConjunctive())
                     .define("selectColumnNames", compositeNodeFilter.sqlSelectColumns())
                     .bind("leafComponentUuid", UUID.fromString(leafComponent.getUuid()))
@@ -976,6 +982,7 @@ public class CelCommonPolicyLibrary implements Library {
                 """);
 
         return query
+                .define(ATTRIBUTE_QUERY_NAME, "%s#isDirectDependency".formatted(CelCommonPolicyLibrary.class.getSimpleName()))
                 .bind("leafComponentUuid", UUID.fromString(component.getUuid()))
                 .mapTo(Boolean.class)
                 .findOne()

--- a/src/test/java/org/dependencytrack/persistence/jdbi/QueryTimingSqlLoggerTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/QueryTimingSqlLoggerTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.search.MeterNotFoundException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.dependencytrack.PersistenceCapableTest;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.JdbiException;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.junit.Before;
+import org.junit.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.dependencytrack.persistence.jdbi.JdbiAttributes.ATTRIBUTE_QUERY_NAME;
+
+public class QueryTimingSqlLoggerTest extends PersistenceCapableTest {
+
+    public interface TestDao {
+
+        @SqlQuery("""
+                SELECT COUNT(*) FROM "CONFIGPROPERTY"
+                """)
+        long getConfigPropertyCount();
+
+    }
+
+    private PGSimpleDataSource dataSource;
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+
+        dataSource = new PGSimpleDataSource();
+        dataSource.setUrl(postgresContainer.getJdbcUrl());
+        dataSource.setUser(postgresContainer.getUsername());
+        dataSource.setPassword(postgresContainer.getPassword());
+    }
+
+    @Test
+    public void shouldCaptureQueryNameForSqlObject() {
+        final var meterRegistry = new SimpleMeterRegistry();
+
+        final var jdbi = Jdbi
+                .create(dataSource)
+                .installPlugin(new SqlObjectPlugin())
+                .setSqlLogger(new QueryTimingSqlLogger(meterRegistry));
+
+        final long configPropertyCount = jdbi.withExtension(TestDao.class, TestDao::getConfigPropertyCount);
+        assertThat(configPropertyCount).isZero();
+
+        final Timer latencyTimer = meterRegistry.get("jdbi.query.latency").timer();
+        assertThat(latencyTimer).isNotNull();
+
+        final Meter.Id latencyTimerId = latencyTimer.getId();
+        assertThat(latencyTimerId.getTag("query")).isEqualTo("TestDao#getConfigPropertyCount");
+        assertThat(latencyTimerId.getTag("outcome")).isEqualTo("success");
+    }
+
+    @Test
+    public void shouldCaptureExplicitQueryName() {
+        final var meterRegistry = new SimpleMeterRegistry();
+
+        final var jdbi = Jdbi
+                .create(dataSource)
+                .installPlugin(new SqlObjectPlugin())
+                .setSqlLogger(new QueryTimingSqlLogger(meterRegistry));
+
+        final long configPropertyCount = jdbi.withHandle(handle -> handle.createQuery("""
+                        SELECT COUNT(*) FROM "CONFIGPROPERTY"
+                        """)
+                .define(ATTRIBUTE_QUERY_NAME, "someQueryName")
+                .mapTo(Long.class)
+                .one());
+        assertThat(configPropertyCount).isZero();
+
+        final Timer latencyTimer = meterRegistry.get("jdbi.query.latency").timer();
+        assertThat(latencyTimer).isNotNull();
+
+        final Meter.Id latencyTimerId = latencyTimer.getId();
+        assertThat(latencyTimerId.getTag("query")).isEqualTo("someQueryName");
+        assertThat(latencyTimerId.getTag("outcome")).isEqualTo("success");
+    }
+
+    @Test
+    public void shouldNotCaptureUnnamedQueries() {
+        final var meterRegistry = new SimpleMeterRegistry();
+
+        final var jdbi = Jdbi
+                .create(dataSource)
+                .installPlugin(new SqlObjectPlugin())
+                .setSqlLogger(new QueryTimingSqlLogger(meterRegistry));
+
+        final long configPropertyCount = jdbi.withHandle(handle -> handle.createQuery("""
+                        SELECT COUNT(*) FROM "CONFIGPROPERTY"
+                        """)
+                .mapTo(Long.class)
+                .one());
+        assertThat(configPropertyCount).isZero();
+
+        assertThatExceptionOfType(MeterNotFoundException.class)
+                .isThrownBy(() -> meterRegistry.get("jdbi.query.latency").timer());
+    }
+
+    @Test
+    public void shouldCaptureQueryNameForFailure() {
+        final var meterRegistry = new SimpleMeterRegistry();
+
+        final var jdbi = Jdbi
+                .create(dataSource)
+                .installPlugin(new SqlObjectPlugin())
+                .setSqlLogger(new QueryTimingSqlLogger(meterRegistry));
+
+        assertThatExceptionOfType(JdbiException.class)
+                .isThrownBy(() -> jdbi.withHandle(handle -> handle.createQuery("""
+                                SELECT COUNT(*) FROM does_not_exist
+                                """)
+                        .define(ATTRIBUTE_QUERY_NAME, "someQueryName")
+                        .mapTo(Long.class)
+                        .one()));
+
+        final Timer latencyTimer = meterRegistry.get("jdbi.query.latency").timer();
+        assertThat(latencyTimer).isNotNull();
+
+        final Meter.Id latencyTimerId = latencyTimer.getId();
+        assertThat(latencyTimerId.getTag("query")).isEqualTo("someQueryName");
+        assertThat(latencyTimerId.getTag("outcome")).isEqualTo("failure");
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Collects latency metrics of SQL queries executed via JDBI.

For DAO interfaces, the query name recorded is being constructed via `<simpleClassName>#<methodName>`.

Queries executed ad-hoc can define an attribute to influence the query name.

Queries executed outside of DAO classes, without explicit query name defined, will not be recorded.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1746

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
