### PR TITLE
Add `severity` as postgres enum `type`

### DIFF
--- a/src/main/java/org/dependencytrack/model/Analysis.java
+++ b/src/main/java/org/dependencytrack/model/Analysis.java
@@ -25,6 +25,7 @@ import jakarta.validation.constraints.NotNull;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.Extensions;
 import javax.jdo.annotations.ForeignKey;
 import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
@@ -104,6 +105,10 @@ public class Analysis implements Serializable {
 
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "SEVERITY")
+    @Extensions(value = {
+            @Extension(vendorName = "datanucleus", key = "insert-function", value = "CAST(? AS severity)"),
+            @Extension(vendorName = "datanucleus", key = "update-function", value = "CAST(? AS severity)")
+    })
     @JsonProperty(value = "severity")
     private Severity severity;
 

--- a/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -40,6 +40,7 @@ import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.Extensions;
 import javax.jdo.annotations.FetchGroup;
 import javax.jdo.annotations.FetchGroups;
 import javax.jdo.annotations.ForeignKeyAction;
@@ -287,6 +288,10 @@ public class Vulnerability implements Serializable {
 
     @Persistent
     @Column(name = "SEVERITY")
+    @Extensions(value = {
+            @Extension(vendorName = "datanucleus", key = "insert-function", value = "CAST(? AS severity)"),
+            @Extension(vendorName = "datanucleus", key = "update-function", value = "CAST(? AS severity)")
+    })
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The severity may only contain printable characters")
     private Severity severity;
 

--- a/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -249,23 +249,7 @@ public interface FindingDao {
     @AllowApiOrdering(alwaysBy = "attribution.id", by = {
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "\"VULNERABILITY\".\"TITLE\""),
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "\"VULNERABILITY\".\"VULNID\""),
-            @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = """ 
-                     CASE WHEN "VULNERABILITY"."SEVERITY" = 'UNASSIGNED' 
-                          THEN 0 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'LOW' 
-                          THEN 3 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'MEDIUM' 
-                          THEN 6 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'HIGH' 
-                          THEN 8 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'CRITICAL' 
-                          THEN 10 
-                          ELSE CASE WHEN "VULNERABILITY"."CVSSV3BASESCORE" IS NOT NULL 
-                                    THEN "VULNERABILITY"."CVSSV3BASESCORE" 
-                                    ELSE "VULNERABILITY"."CVSSV2BASESCORE" 
-                               END 
-                     END 
-                     """),
+            @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"VULNERABILITY\".\"SEVERITY\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV3BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV3BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV2BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.published", queryName = "\"VULNERABILITY\".\"PUBLISHED\""),
@@ -359,23 +343,7 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "vulnerability.id", queryName = "\"VULNERABILITY\".\"ID\""),
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "\"VULNERABILITY\".\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.title", queryName = "\"VULNERABILITY\".\"TITLE\""),
-            @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = """ 
-                     CASE WHEN "VULNERABILITY"."SEVERITY" = 'UNASSIGNED' 
-                          THEN 0 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'LOW' 
-                          THEN 3 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'MEDIUM' 
-                          THEN 6 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'HIGH' 
-                          THEN 8 
-                          WHEN "VULNERABILITY"."SEVERITY" = 'CRITICAL' 
-                          THEN 10 
-                          ELSE CASE WHEN "VULNERABILITY"."CVSSV3BASESCORE" IS NOT NULL 
-                                    THEN "VULNERABILITY"."CVSSV3BASESCORE" 
-                                    ELSE "VULNERABILITY"."CVSSV2BASESCORE" 
-                               END 
-                     END 
-                     """),
+            @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"VULNERABILITY\".\"SEVERITY\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV3BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV3BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"VULNERABILITY\".\"CVSSV2BASESCORE\""),
             @AllowApiOrdering.Column(name = "vulnerability.published", queryName = "\"VULNERABILITY\".\"PUBLISHED\""),

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1334,4 +1334,20 @@
             columnNames="NAME"
             constraintName="TEAM_NAME_IDX" />
     </changeSet>
+
+    <changeSet id="v5.6.0-18" author="sahibamittal">
+        <sql splitStatements="false">
+            CREATE TYPE severity AS ENUM (
+                'UNASSIGNED'
+                , 'INFO'
+                , 'LOW'
+                , 'MEDIUM'
+                , 'HIGH'
+                , 'CRITICAL'
+            );
+            CREATE CAST (varchar AS severity) WITH INOUT AS IMPLICIT;
+            ALTER TABLE public."ANALYSIS" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
+            ALTER TABLE public."VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1345,6 +1345,7 @@
                 , 'HIGH'
                 , 'CRITICAL'
             );
+            CREATE CAST (varchar AS severity) WITH INOUT AS IMPLICIT;
             ALTER TABLE public."ANALYSIS" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
             ALTER TABLE public."VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
         </sql>

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1345,7 +1345,6 @@
                 , 'HIGH'
                 , 'CRITICAL'
             );
-            CREATE CAST (varchar AS severity) WITH INOUT AS IMPLICIT;
             ALTER TABLE public."ANALYSIS" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
             ALTER TABLE public."VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
         </sql>

--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1345,8 +1345,8 @@
                 , 'HIGH'
                 , 'CRITICAL'
             );
-            ALTER TABLE public."ANALYSIS" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
-            ALTER TABLE public."VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
+            ALTER TABLE "ANALYSIS" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
+            ALTER TABLE "VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
         </sql>
     </changeSet>
 </databaseChangeLog>

--- a/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -561,6 +561,36 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getAllFindingsSortedBySeverity() {
+        Project p1 = qm.createProject("Acme Example 1", null, "1.0", null, null, null, null, false);
+        Component c1 = createComponent(p1, "Component A", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.MEDIUM);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.HIGH);
+        Date date = new Date();
+        v1.setPublished(date);
+        v2.setPublished(date);
+        v3.setPublished(date);
+        qm.addVulnerability(v1, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v2, c1, AnalyzerIdentity.NONE);
+        qm.addVulnerability(v3, c1, AnalyzerIdentity.NONE);
+        Response response = jersey.target(V1_FINDING)
+                .queryParam("sortName", "vulnerability.severity")
+                .queryParam("sortOrder", "desc")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertEquals(200, response.getStatus(), 0);
+        assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        assertNotNull(json);
+        assertEquals(3, json.size());
+        assertEquals(v1.getSeverity().name(), json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+        assertEquals(v3.getSeverity().name(), json.getJsonObject(1).getJsonObject("vulnerability").getString("severity"));
+        assertEquals(v2.getSeverity().name(), json.getJsonObject(2).getJsonObject("vulnerability").getString("severity"));
+    }
+
+    @Test
     public void getAllFindingsWithAclEnabled() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
         Project p1_child = qm.createProject("Acme Example Child", null, "1.0", null, p1, null, null, false);


### PR DESCRIPTION
### Description

Make `SEVERITY` a PostgreSQL enum.
This is present as column in tables `VULNERABILITY` and `ANALYSIS`.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1725

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
