### PR TITLE
Allow reuse of project name and version when different parent project

### DIFF
--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1349,4 +1349,38 @@
             ALTER TABLE "VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
         </sql>
     </changeSet>
+
+    <changeSet id="v5.6.0-19" author="jhoward-lm">
+        <dropIndex tableName="PROJECT" indexName="PROJECT_NAME_VERSION_IDX" />
+        <dropIndex tableName="PROJECT" indexName="PROJECT_NAME_VERSION_NULL_IDX" />
+
+        <sql splitStatements="true">
+            -- Remove all duplicate projects that would violate the unique indices before creating
+            DELETE FROM "PROJECT"
+             WHERE "ID" NOT IN (
+               SELECT MIN("ID")
+                 FROM "PROJECT"
+                GROUP BY 
+                    "NAME", 
+                    COALESCE("PARENT_PROJECT_ID", -1), 
+                    COALESCE("VERSION", 'NULL_PLACEHOLDER')
+            );
+
+            -- Unique index that excludes rows where PARENT_PROJECT_ID or VERSION is NULL
+            CREATE UNIQUE INDEX "PROJECT_NAME_VERSION_PARENT_IDX"
+                ON "PROJECT" ("NAME", "PARENT_PROJECT_ID", "VERSION")
+             WHERE "PARENT_PROJECT_ID" IS NOT NULL
+               AND "VERSION" IS NOT NULL;
+
+            -- Unique index to handle cases where PARENT_PROJECT_ID is NULL
+            CREATE UNIQUE INDEX "PROJECT_NAME_VERSION_NULL_PARENT_IDX"
+                ON "PROJECT" ("NAME", "VERSION")
+             WHERE "PARENT_PROJECT_ID" IS NULL;
+
+            -- Unique index to handle cases where VERSION is NULL
+            CREATE UNIQUE INDEX "PROJECT_NAME_PARENT_NULL_VERSION_IDX"
+                ON "PROJECT" ("NAME", "PARENT_PROJECT_ID")
+             WHERE "VERSION" IS NULL;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

This PR modifies the existing unique constraint on a project's combined name and version columns to include the parent project ID as an additional factor defining uniqueness.

The goal is to allow reuse of a project name, or project name and version, when the child projects have different parent projects.

```mermaid
---
title: New Behavior
---
erDiagram
    p1["parent project"] {
        NAME parent-project
        VERSION v1
    }

    p2["parent project"] {
        NAME parent-project
        VERSION v2
    }

    c1["child project"] {
        NAME child-project
        VERSION v1
    }

    c2["child project"] {
        NAME child-project
        VERSION v2
    }

    c3["child project"] {
        NAME child-project
        VERSION v1
    }

    c4["child project"] {
        NAME child-project
        VERSION v2
    }

    p1 |o--o{ c1 : "parent of"
    p1 |o--o{ c2 : "parent of"
    p2 |o--o{ c3 : "parent of"
    p2 |o--o{ c4 : "parent of"
```

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [X] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [X] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
