### PR TITLE
Disable DataNucleus bulk-fetching for list operations on `Project`

### DIFF
--- a/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -73,6 +73,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.util.Objects.requireNonNullElse;
+import static org.datanucleus.store.rdbms.RDBMSPropertyNames.PROPERTY_RDBMS_QUERY_MULTIVALUED_FETCH;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistentAll;
 
@@ -139,8 +140,19 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final String queryFilter = filterBuilder.buildFilter();
         final Map<String, Object> params = filterBuilder.getParams();
 
+        // Disable bulk-fetch due to performance concerns.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        query.addExtension(PROPERTY_RDBMS_QUERY_MULTIVALUED_FETCH, "none");
+
         preprocessACLs(query, queryFilter, params, false);
         result = execute(query, params);
+
+        // Compensate for disabled bulk-fetch. Rest assured this hurt to commit.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        for (final Project project : result.getList(Project.class)) {
+            var ignored = project.getTags();
+        }
+
         if (includeMetrics) {
             // Populate each Project object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
@@ -227,8 +239,20 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final String queryFilter = filterBuilder.buildFilter();
         final Map<String, Object> params = filterBuilder.getParams();
 
+        // Disable bulk-fetch due to performance concerns.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        query.addExtension(PROPERTY_RDBMS_QUERY_MULTIVALUED_FETCH, "none");
+
         preprocessACLs(query, queryFilter, params, false);
-        return execute(query, params);
+        final PaginatedResult result = execute(query, params);
+
+        // Compensate for disabled bulk-fetch. Rest assured this hurt to commit.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        for (final Project project : result.getList(Project.class)) {
+            var ignored = project.getTags();
+        }
+
+        return result;
     }
 
     /**
@@ -335,8 +359,20 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final String queryFilter = filterBuilder.buildFilter();
         final Map<String, Object> params = filterBuilder.getParams();
 
+        // Disable bulk-fetch due to performance concerns.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        query.addExtension(PROPERTY_RDBMS_QUERY_MULTIVALUED_FETCH, "none");
+
         preprocessACLs(query, queryFilter, params, bypass);
-        return execute(query, params);
+        final PaginatedResult result = execute(query, params);
+
+        // Compensate for disabled bulk-fetch. Rest assured this hurt to commit.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        for (final Project project : result.getList(Project.class)) {
+            var ignored = project.getTags();
+        }
+
+        return result;
     }
 
     /**
@@ -370,8 +406,19 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final String queryFilter = filterBuilder.buildFilter();
         final Map<String, Object> params = filterBuilder.getParams();
 
+        // Disable bulk-fetch due to performance concerns.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        query.addExtension(PROPERTY_RDBMS_QUERY_MULTIVALUED_FETCH, "none");
+
         preprocessACLs(query, queryFilter, params, false);
         result = execute(query, params);
+
+        // Compensate for disabled bulk-fetch. Rest assured this hurt to commit.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        for (final Project project : result.getList(Project.class)) {
+            var ignored = project.getTags();
+        }
+
         if (includeMetrics) {
             // Populate each Project object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
@@ -379,6 +426,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 project.setMetrics(getMostRecentProjectMetrics(project));
             }
         }
+
         return result;
     }
 
@@ -408,8 +456,19 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
         final String queryFilter = filterBuilder.buildFilter();
         final Map<String, Object> params = filterBuilder.getParams();
 
+        // Disable bulk-fetch due to performance concerns.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        query.addExtension(PROPERTY_RDBMS_QUERY_MULTIVALUED_FETCH, "none");
+
         preprocessACLs(query, queryFilter, params, false);
         result = execute(query, params);
+
+        // Compensate for disabled bulk-fetch. Rest assured this hurt to commit.
+        // https://github.com/DependencyTrack/hyades/issues/1754
+        for (final Project project : result.getList(Project.class)) {
+            var ignored = project.getTags();
+        }
+
         if (includeMetrics) {
             // Populate each Project object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
@@ -417,6 +476,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                 project.setMetrics(getMostRecentProjectMetrics(project));
             }
         }
+
         return result;
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Disables DataNucleus bulk-fetching for list operations on `Project` due to performance concerns.

To ensure that tags are still present in REST API responses, forces tags to be loaded for project endpoints, unfortunately re-introducing the N+1 problem.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/1754

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
