### PR TITLE
Prevent duplicate OIDC groups

### DIFF
--- a/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1349,4 +1349,53 @@
             ALTER TABLE "VULNERABILITY" ALTER COLUMN "SEVERITY" TYPE severity USING "SEVERITY"::severity;
         </sql>
     </changeSet>
+
+    <changeSet id="v5.6.0-19" author="nscuro">
+        <sql>
+            -- Identify OIDC groups with duplicate names.
+            WITH cte_duplicate_group AS (
+              SELECT "NAME" AS name
+                   , MIN("ID") AS canonical_id
+                FROM "OIDCGROUP"
+               GROUP BY "NAME"
+              HAVING COUNT(*) &gt; 1
+            ),
+            -- Delete mappings of duplicate OIDC groups.
+            cte_deleted_mapping AS (
+              DELETE FROM "MAPPEDOIDCGROUP"
+               USING cte_duplicate_group
+                   , "OIDCGROUP"
+               WHERE "MAPPEDOIDCGROUP"."GROUP_ID" = "OIDCGROUP"."ID"
+                 AND "OIDCGROUP"."NAME" = cte_duplicate_group.name
+                 AND "OIDCGROUP"."ID" != cte_duplicate_group.canonical_id
+              RETURNING "OIDCGROUP"."NAME" AS group_name
+                      , "MAPPEDOIDCGROUP"."TEAM_ID" AS team_id
+                      , "MAPPEDOIDCGROUP"."UUID" AS uuid
+            ),
+            -- Delete duplicate OIDC groups.
+            cte_deleted_group AS (
+              DELETE FROM "OIDCGROUP"
+               USING cte_duplicate_group
+               WHERE "OIDCGROUP"."NAME" = cte_duplicate_group.name
+                 AND "OIDCGROUP"."ID" != cte_duplicate_group.canonical_id
+              RETURNING "OIDCGROUP"."ID" AS id
+            )
+            -- Re-create deleted mappings, but using the canonical group ID.
+            INSERT INTO "MAPPEDOIDCGROUP" ("GROUP_ID", "TEAM_ID", "UUID")
+            SELECT "OIDCGROUP"."ID"
+                 , cte_deleted_mapping.team_id
+                 , cte_deleted_mapping.uuid
+              FROM cte_deleted_mapping
+             INNER JOIN "OIDCGROUP"
+                ON "OIDCGROUP"."NAME" = cte_deleted_mapping.group_name
+             -- This condition mostly just forces evaluation of cte_deleted_group.
+             WHERE "OIDCGROUP"."ID" NOT IN (SELECT id FROM cte_deleted_group)
+            -- If the duplicate groups had overlapping mappings, we'll get conflicts here.
+            ON CONFLICT ("TEAM_ID", "GROUP_ID") DO NOTHING
+        </sql>
+
+        <createIndex tableName="OIDCGROUP" indexName="OIDCGROUP_NAME_IDX" unique="true">
+            <column name="NAME"/>
+        </createIndex>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prevents duplicate OIDC groups.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/1756

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Migration query tested with the following script:

```sql
begin;

-- Create two duplicate and one unique group.
INSERT INTO "OIDCGROUP" ("NAME", "UUID")
VALUES ('foo', gen_random_uuid())
     , ('foo', gen_random_uuid())
     , ('bar', gen_random_uuid());

-- Create two teams.
INSERT INTO "TEAM" ("NAME", "UUID") VALUES ('a', gen_random_uuid());
INSERT INTO "TEAM" ("NAME", "UUID") VALUES ('b', gen_random_uuid());

-- Map groups to teams such that duplicate groups overlap.
INSERT INTO "MAPPEDOIDCGROUP" ("GROUP_ID", "TEAM_ID", "UUID")
VALUES ((SELECT "ID" FROM "OIDCGROUP" WHERE "NAME" = 'foo' ORDER BY "ID" LIMIT 1), (SELECT "ID" FROM "TEAM" WHERE "NAME" = 'a'), gen_random_uuid())
     , ((SELECT "ID" FROM "OIDCGROUP" WHERE "NAME" = 'foo' ORDER BY "ID" OFFSET 1 LIMIT 1), (SELECT "ID" FROM "TEAM" WHERE "NAME" = 'a'), gen_random_uuid())
     , ((SELECT "ID" FROM "OIDCGROUP" WHERE "NAME" = 'foo' ORDER BY "ID" OFFSET 1 LIMIT 1), (SELECT "ID" FROM "TEAM" WHERE "NAME" = 'b'), gen_random_uuid())
     , ((SELECT "ID" FROM "OIDCGROUP" WHERE "NAME" = 'bar' LIMIT 1), (SELECT "ID" FROM "TEAM" WHERE "NAME" = 'a'), gen_random_uuid());

-- Identify OIDC groups with duplicate names.
WITH cte_duplicate_group AS (
  SELECT "NAME" AS name
       , MIN("ID") AS canonical_id
    FROM "OIDCGROUP"
   GROUP BY "NAME"
  HAVING COUNT(*) > 1
),
-- Delete mappings of duplicate OIDC groups.
cte_deleted_mapping AS (
  DELETE FROM "MAPPEDOIDCGROUP"
   USING cte_duplicate_group
       , "OIDCGROUP"
   WHERE "MAPPEDOIDCGROUP"."GROUP_ID" = "OIDCGROUP"."ID"
     AND "OIDCGROUP"."NAME" = cte_duplicate_group.name
     AND "OIDCGROUP"."ID" != cte_duplicate_group.canonical_id
  RETURNING "OIDCGROUP"."NAME" AS group_name
          , "MAPPEDOIDCGROUP"."TEAM_ID" AS team_id
          , "MAPPEDOIDCGROUP"."UUID" AS uuid
),
-- Delete duplicate OIDC groups.
cte_deleted_group AS (
  DELETE FROM "OIDCGROUP"
   USING cte_duplicate_group
   WHERE "OIDCGROUP"."NAME" = cte_duplicate_group.name
     AND "OIDCGROUP"."ID" != cte_duplicate_group.canonical_id
  RETURNING "OIDCGROUP"."ID" AS id
)
-- Re-create deleted mappings, but using the canonical group ID.
INSERT INTO "MAPPEDOIDCGROUP" ("GROUP_ID", "TEAM_ID", "UUID")
SELECT "OIDCGROUP"."ID"
     , cte_deleted_mapping.team_id
     , cte_deleted_mapping.uuid
  FROM cte_deleted_mapping
 INNER JOIN "OIDCGROUP"
    ON "OIDCGROUP"."NAME" = cte_deleted_mapping.group_name
 -- This condition mostly just forces evaluation of cte_deleted_group.
 WHERE "OIDCGROUP"."ID" NOT IN (SELECT id FROM cte_deleted_group)
-- If the duplicate groups had overlapping mappings, we'll get conflicts here.
ON CONFLICT ("TEAM_ID", "GROUP_ID") DO NOTHING;

SELECT * FROM "OIDCGROUP";
SELECT * FROM "MAPPEDOIDCGROUP";

rollback;
```

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
