### PR TITLE
Refactor default timespan of dashboard metrics to make it user-selectable

### DIFF
--- a/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
+++ b/src/main/java/org/dependencytrack/model/ConfigPropertyConstants.java
@@ -52,6 +52,10 @@ public enum ConfigPropertyConstants {
     MAINTENANCE_VULNERABILITY_SCAN_RETENTION_HOURS("maintenance", "vuln.scan.retention.hours", "24", PropertyType.INTEGER, "Number of hours to retain vulnerability scan records for", ConfigPropertyAccessMode.READ_WRITE),
     MAINTENANCE_WORKFLOW_RETENTION_HOURS("maintenance", "workflow.retention.hours", "72", PropertyType.INTEGER, "Number of hours to retain workflow records for", ConfigPropertyAccessMode.READ_WRITE),
     MAINTENANCE_WORKFLOW_STEP_TIMEOUT_MINUTES("maintenance", "workflow.step.timeout.minutes", "60", PropertyType.INTEGER, "Number of minutes after which workflow steps are timed out", ConfigPropertyAccessMode.READ_WRITE),
+    METRIC_DAYS_PORTFOLIO("metrics", "portfolio.days", "30", PropertyType.INTEGER, "Number of days of historical metrics for the entire portfolio", ConfigPropertyAccessMode.READ_WRITE),
+    METRIC_DAYS_PROJECT("metrics", "project.days", "30", PropertyType.INTEGER, "Number of days of historical metrics for a specific project", ConfigPropertyAccessMode.READ_WRITE),
+    METRIC_DAYS_COMPONENT("metrics", "component.days", "30", PropertyType.INTEGER, "Number of days of historical metrics for a specific component", ConfigPropertyAccessMode.READ_WRITE),
+
     SCANNER_INTERNAL_ENABLED("scanner", "internal.enabled", "true", PropertyType.BOOLEAN, "Flag to enable/disable the internal analyzer", ConfigPropertyAccessMode.READ_WRITE),
     SCANNER_INTERNAL_FUZZY_ENABLED("scanner", "internal.fuzzy.enabled", "false", PropertyType.BOOLEAN, "Flag to enable/disable non-exact fuzzy matching using the internal analyzer", ConfigPropertyAccessMode.READ_WRITE),
     SCANNER_INTERNAL_FUZZY_EXCLUDE_PURL("scanner", "internal.fuzzy.exclude.purl", "true", PropertyType.BOOLEAN, "Flag to enable/disable fuzzy matching on components that have a Package URL (PURL) defined", ConfigPropertyAccessMode.READ_WRITE),

--- a/src/main/java/org/dependencytrack/model/ProjectMetrics.java
+++ b/src/main/java/org/dependencytrack/model/ProjectMetrics.java
@@ -255,7 +255,7 @@ public class ProjectMetrics implements Serializable {
         this.unassigned = unassigned;
     }
 
-    public long getVulnerabilities() {
+    public int getVulnerabilities() {
         return vulnerabilities;
     }
 

--- a/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -283,4 +283,12 @@ public interface ProjectDao {
             SELECT "ID" FROM "PROJECT" WHERE "UUID" = :projectUuid
             """)
     Long getProjectId(@Bind UUID projectUuid);
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
+            SELECT ${apiProjectAclCondition}
+              FROM "PROJECT"
+             WHERE "UUID" = :projectUuid
+            """)
+    Boolean isAccessible(@Bind UUID projectUuid);
 }

--- a/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
+++ b/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import alpine.model.ManagedUser;
+import alpine.resources.AlpineRequest;
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.PortfolioMetrics;
+import org.dependencytrack.model.ProjectMetrics;
+import org.jdbi.v3.core.Handle;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+public class MetricsDaoTest extends PersistenceCapableTest {
+
+    private Handle jdbiHandle;
+    private MetricsDao metricsDao;
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+        jdbiHandle = openJdbiHandle();
+        metricsDao = jdbiHandle.attach(MetricsDao.class);
+    }
+
+    @After
+    public void after() {
+        if (jdbiHandle != null) {
+            jdbiHandle.close();
+        }
+        super.after();
+    }
+
+    @Test
+    public void testGetPortfolioMetricsForXDays() {
+        var metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        List<PortfolioMetrics> portfolioMetrics = metricsDao.getPortfolioMetricsXDays(Duration.ofDays(35));
+        assertThat(portfolioMetrics.size()).isEqualTo(2);
+        assertThat(portfolioMetrics.get(0).getVulnerabilities()).isEqualTo(3);
+        assertThat(portfolioMetrics.get(1).getVulnerabilities()).isEqualTo(2);
+    }
+
+    @Test
+    public void testGetProjectMetricsForXDays() {
+        final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+        final ManagedUser managedUser = qm.createManagedUser("username", "passwordHash");
+        final var request = new AlpineRequest(
+                /* principal */ managedUser,
+                /* pagination */ null,
+                /* filter */ null,
+                /* orderBy */ null,
+                /* orderDirection */ null
+        );
+
+        var metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        var projectMetrics = withJdbiHandle(request, handle ->
+                handle.attach(MetricsDao.class).getProjectMetricsXDays(project.getId(), Duration.ofDays(35)));
+        assertThat(projectMetrics.size()).isEqualTo(2);
+        assertThat(projectMetrics.get(0).getVulnerabilities()).isEqualTo(3);
+        assertThat(projectMetrics.get(1).getVulnerabilities()).isEqualTo(2);
+    }
+}

--- a/src/test/java/org/dependencytrack/resources/v1/MetricsResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/MetricsResourceTest.java
@@ -21,20 +21,30 @@ package org.dependencytrack.resources.v1;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
 import alpine.server.filters.AuthorizationFilter;
+import jakarta.json.JsonArray;
+import jakarta.ws.rs.core.Response;
+import org.apache.http.HttpStatus;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.PortfolioMetrics;
 import org.dependencytrack.model.Project;
+import org.dependencytrack.model.ProjectMetrics;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import jakarta.ws.rs.core.Response;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
 import java.util.function.Supplier;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.model.ConfigPropertyConstants.METRIC_DAYS_PORTFOLIO;
+import static org.dependencytrack.model.ConfigPropertyConstants.METRIC_DAYS_PROJECT;
 
 public class MetricsResourceTest extends ResourceTest {
 
@@ -87,37 +97,6 @@ public class MetricsResourceTest extends ResourceTest {
 
         final Supplier<Response> responseSupplier = () -> jersey
                 .target(V1_METRICS + "/project/" + project.getUuid() + "/since/20250101")
-                .request()
-                .header(X_API_KEY, apiKey)
-                .get();
-
-        Response response = responseSupplier.get();
-        assertThat(response.getStatus()).isEqualTo(403);
-        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
-                {
-                  "status": 403,
-                  "title": "Project access denied",
-                  "detail": "Access to the requested project is forbidden"
-                }
-                """);
-
-        project.addAccessTeam(super.team);
-
-        response = responseSupplier.get();
-        assertThat(response.getStatus()).isEqualTo(200);
-    }
-
-    @Test
-    public void getProjectMetricsXDaysAclTest() {
-        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
-        enablePortfolioAccessControl();
-
-        final var project = new Project();
-        project.setName("acme-app");
-        qm.persist(project);
-
-        final Supplier<Response> responseSupplier = () -> jersey
-                .target(V1_METRICS + "/project/" + project.getUuid() + "/days/666")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();
@@ -313,4 +292,132 @@ public class MetricsResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(200);
     }
 
+    @Test
+    public void getPortfolioMetricsXDaysAclTest() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+        qm.createConfigProperty(
+                METRIC_DAYS_PORTFOLIO.getGroupName(),
+                METRIC_DAYS_PORTFOLIO.getPropertyName(),
+                String.valueOf(35),
+                METRIC_DAYS_PORTFOLIO.getPropertyType(),
+                METRIC_DAYS_PORTFOLIO.getDescription()
+        );
+
+        var metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        final Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/portfolio/days")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        JsonArray json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(2);
+        assertThat(json.getJsonObject(0).getInt("vulnerabilities")).isEqualTo(3);
+        assertThat(json.getJsonObject(1).getInt("vulnerabilities")).isEqualTo(2);
+    }
+
+    @Test
+    public void getProjectMetricsXDaysAclTest() {
+        enablePortfolioAccessControl();
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        qm.createConfigProperty(
+                METRIC_DAYS_PROJECT.getGroupName(),
+                METRIC_DAYS_PROJECT.getPropertyName(),
+                String.valueOf(35),
+                METRIC_DAYS_PROJECT.getPropertyType(),
+                METRIC_DAYS_PROJECT.getDescription()
+        );
+
+        Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + project.getUuid() + "/days")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_FORBIDDEN);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 403,
+                  "title": "Project access denied",
+                  "detail": "Access to the requested project is forbidden"
+                }
+                """);
+
+        project.addAccessTeam(super.team);
+
+        var metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + project.getUuid() + "/days")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        JsonArray json = parseJsonArray(response);
+        assertThat(json.size()).isEqualTo(2);
+        assertThat(json.getJsonObject(0).getInt("vulnerabilities")).isEqualTo(3);
+        assertThat(json.getJsonObject(1).getInt("vulnerabilities")).isEqualTo(2);
+    }
+
+    @Test
+    public void getProjectMetricsXDays404Test() {
+        enablePortfolioAccessControl();
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        Supplier<Response> responseSupplier = () -> jersey
+                .target(V1_METRICS + "/project/" + UUID.randomUUID() + "/days")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        Response response = responseSupplier.get();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
+        assertThat(getPlainTextBody(response)).isEqualTo("The project could not be found.");
+    }
 }

--- a/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -1413,7 +1413,6 @@ public class ProjectResourceTest extends ResourceTest {
 
     @Test
     public void getProjectByInvalidUuidTest() {
-        qm.createProject("ABC", null, "1.0", null, null, null, null, false);
         Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)


### PR DESCRIPTION
### Description

Add global config properties to retain timespan of metrics for portfolio, project and component dashboards. Make the duration for which metrics are being fetched selectable by users.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1697

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
