### PR TITLE
Refactor metrics queries to use JDBI

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/DependencyMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/DependencyMetrics.java
@@ -262,7 +262,7 @@ public class DependencyMetrics implements Serializable {
         this.unassigned = unassigned;
     }
 
-    public long getVulnerabilities() {
+    public int getVulnerabilities() {
         return vulnerabilities;
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/model/ProjectMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ProjectMetrics.java
@@ -255,7 +255,7 @@ public class ProjectMetrics implements Serializable {
         this.unassigned = unassigned;
     }
 
-    public long getVulnerabilities() {
+    public int getVulnerabilities() {
         return vulnerabilities;
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/persistence/MetricsQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/MetricsQueryManager.java
@@ -29,7 +29,6 @@ import org.dependencytrack.model.VulnerabilityMetrics;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-import java.util.Date;
 import java.util.List;
 
 public class MetricsQueryManager extends QueryManager implements IQueryManager {
@@ -88,18 +87,6 @@ public class MetricsQueryManager extends QueryManager implements IQueryManager {
     }
 
     /**
-     * Retrieves PortfolioMetrics in ascending order starting with the oldest since the date specified.
-     *
-     * @return a List of metrics
-     */
-    @SuppressWarnings("unchecked")
-    public List<PortfolioMetrics> getPortfolioMetricsSince(Date since) {
-        final Query<PortfolioMetrics> query = pm.newQuery(PortfolioMetrics.class, "lastOccurrence >= :since");
-        query.setOrdering("lastOccurrence asc");
-        return (List<PortfolioMetrics>) query.execute(since);
-    }
-
-    /**
      * Retrieves the most recent ProjectMetrics.
      *
      * @param project the Project to retrieve metrics for
@@ -122,18 +109,6 @@ public class MetricsQueryManager extends QueryManager implements IQueryManager {
         final Query<ProjectMetrics> query = pm.newQuery(ProjectMetrics.class, "project == :project");
         query.setOrdering("lastOccurrence desc");
         return execute(query, project);
-    }
-
-    /**
-     * Retrieves ProjectMetrics in ascending order starting with the oldest since the date specified.
-     *
-     * @return a List of metrics
-     */
-    @SuppressWarnings("unchecked")
-    public List<ProjectMetrics> getProjectMetricsSince(Project project, Date since) {
-        final Query<ProjectMetrics> query = pm.newQuery(ProjectMetrics.class, "project == :project && lastOccurrence >= :since");
-        query.setOrdering("lastOccurrence asc");
-        return (List<ProjectMetrics>) query.execute(project, since);
     }
 
     /**
@@ -174,18 +149,6 @@ public class MetricsQueryManager extends QueryManager implements IQueryManager {
         final Query<DependencyMetrics> query = pm.newQuery(DependencyMetrics.class, "component == :component");
         query.setOrdering("lastOccurrence desc");
         return execute(query, component);
-    }
-
-    /**
-     * Retrieves DependencyMetrics in ascending order starting with the oldest since the date specified.
-     *
-     * @return a List of metrics
-     */
-    @SuppressWarnings("unchecked")
-    public List<DependencyMetrics> getDependencyMetricsSince(Component component, Date since) {
-        final Query<DependencyMetrics> query = pm.newQuery(DependencyMetrics.class, "component == :component && lastOccurrence >= :since");
-        query.setOrdering("lastOccurrence asc");
-        return (List<DependencyMetrics>) query.execute(component, since);
     }
 
     /**

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -23,8 +23,8 @@ import alpine.common.util.BooleanUtil;
 import alpine.common.validation.RegexSequence;
 import alpine.model.ApiKey;
 import alpine.model.ConfigProperty;
-import alpine.model.Permission;
 import alpine.model.IConfigProperty.PropertyType;
+import alpine.model.Permission;
 import alpine.model.Team;
 import alpine.model.UserPrincipal;
 import alpine.notification.NotificationLevel;
@@ -1059,20 +1059,12 @@ public class QueryManager extends AlpineQueryManager {
         return getMetricsQueryManager().getPortfolioMetrics();
     }
 
-    public List<PortfolioMetrics> getPortfolioMetricsSince(Date since) {
-        return getMetricsQueryManager().getPortfolioMetricsSince(since);
-    }
-
     public ProjectMetrics getMostRecentProjectMetrics(Project project) {
         return getMetricsQueryManager().getMostRecentProjectMetrics(project);
     }
 
     public PaginatedResult getProjectMetrics(Project project) {
         return getMetricsQueryManager().getProjectMetrics(project);
-    }
-
-    public List<ProjectMetrics> getProjectMetricsSince(Project project, Date since) {
-        return getMetricsQueryManager().getProjectMetricsSince(project, since);
     }
 
     public DependencyMetrics getMostRecentDependencyMetrics(Component component) {
@@ -1085,10 +1077,6 @@ public class QueryManager extends AlpineQueryManager {
 
     public PaginatedResult getDependencyMetrics(Component component) {
         return getMetricsQueryManager().getDependencyMetrics(component);
-    }
-
-    public List<DependencyMetrics> getDependencyMetricsSince(Component component, Date since) {
-        return getMetricsQueryManager().getDependencyMetricsSince(component, since);
     }
 
     public void synchronizeVulnerabilityMetrics(List<VulnerabilityMetrics> metrics) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -18,10 +18,17 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
+import org.dependencytrack.model.DependencyMetrics;
+import org.dependencytrack.model.PortfolioMetrics;
+import org.dependencytrack.model.ProjectMetrics;
+import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
 
 /**
  * @since 5.6.0
@@ -55,4 +62,29 @@ public interface MetricsDao {
             """)
     int deletePortfolioMetricsForRetentionDuration(@Bind Duration duration);
 
+    @SqlQuery("""
+            SELECT * FROM "PORTFOLIOMETRICS"
+            WHERE "LAST_OCCURRENCE" >= :since
+            ORDER BY "LAST_OCCURRENCE" ASC
+            """)
+    @RegisterBeanMapper(PortfolioMetrics.class)
+    List<PortfolioMetrics> getPortfolioMetricsSince(@Bind Instant since);
+
+    @SqlQuery("""
+            SELECT * FROM "PROJECTMETRICS"
+            WHERE "PROJECT_ID" = :projectId
+            AND "LAST_OCCURRENCE" >= :since
+            ORDER BY "LAST_OCCURRENCE" ASC
+            """)
+    @RegisterBeanMapper(ProjectMetrics.class)
+    List<ProjectMetrics> getProjectMetricsSince(@Bind Long projectId, @Bind Instant since);
+
+    @SqlQuery("""
+            SELECT * FROM "DEPENDENCYMETRICS"
+            WHERE "COMPONENT_ID" = :componentId
+            AND "LAST_OCCURRENCE" >= :since
+            ORDER BY "LAST_OCCURRENCE" ASC
+            """)
+    @RegisterBeanMapper(DependencyMetrics.class)
+    List<DependencyMetrics> getDependencyMetricsSince(@Bind Long componentId,@Bind Instant since);
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -283,4 +283,12 @@ public interface ProjectDao {
             SELECT "ID" FROM "PROJECT" WHERE "UUID" = :projectUuid
             """)
     Long getProjectId(@Bind UUID projectUuid);
+
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
+            SELECT ${apiProjectAclCondition}
+              FROM "PROJECT"
+             WHERE "UUID" = :projectUuid
+            """)
+    Boolean isAccessible(@Bind UUID projectUuid);
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
@@ -156,7 +156,7 @@ public class MetricsResource extends AbstractApiResource {
     @Path("/portfolio/{days}/days")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Returns X (30 by default) days of historical metrics for the entire portfolio",
+            summary = "Returns X days of historical metrics for the entire portfolio",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
     @ApiResponses(value = {
@@ -266,7 +266,7 @@ public class MetricsResource extends AbstractApiResource {
     @Path("/project/{uuid}/days/{days}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Returns X (30 by default) days of historical metrics for a specific project",
+            summary = "Returns X days of historical metrics for a specific project",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
     @ApiResponses(value = {
@@ -399,7 +399,7 @@ public class MetricsResource extends AbstractApiResource {
     @Path("/component/{uuid}/days/{days}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Returns X (30 by default) days of historical metrics for a specific component",
+            summary = "Returns X days of historical metrics for a specific component",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
     @ApiResponses(value = {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/MetricsResource.java
@@ -30,6 +30,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.time.DateUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.ComponentMetricsUpdateEvent;
@@ -43,17 +49,18 @@ import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.ComponentDao;
+import org.dependencytrack.persistence.jdbi.MetricsDao;
+import org.dependencytrack.persistence.jdbi.ProjectDao;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.util.DateUtil;
 
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.PathParam;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 /**
  * JAX-RS resources for processing metrics.
@@ -140,17 +147,16 @@ public class MetricsResource extends AbstractApiResource {
         if (since == null) {
             return Response.status(Response.Status.BAD_REQUEST).entity("The specified date format is incorrect.").build();
         }
-        try (QueryManager qm = new QueryManager()) {
-            final List<PortfolioMetrics> metrics = qm.getPortfolioMetricsSince(since);
-            return Response.ok(metrics).build();
-        }
+        List<PortfolioMetrics> metrics = withJdbiHandle(handle ->
+                handle.attach(MetricsDao.class).getPortfolioMetricsSince(since.toInstant()));
+        return Response.ok(metrics).build();
     }
 
     @GET
     @Path("/portfolio/{days}/days")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Returns X days of historical metrics for the entire portfolio",
+            summary = "Returns X (30 by default) days of historical metrics for the entire portfolio",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
     @ApiResponses(value = {
@@ -165,12 +171,10 @@ public class MetricsResource extends AbstractApiResource {
     public Response getPortfolioMetricsXDays(
             @Parameter(description = "The number of days back to retrieve metrics for", required = true)
             @PathParam("days") int days) {
-
         final Date since = DateUtils.addDays(new Date(), -days);
-        try (QueryManager qm = new QueryManager()) {
-            final List<PortfolioMetrics> metrics = qm.getPortfolioMetricsSince(since);
-            return Response.ok(metrics).build();
-        }
+        List<PortfolioMetrics> metrics = withJdbiHandle(handle ->
+                handle.attach(MetricsDao.class).getPortfolioMetricsSince(since.toInstant()));
+        return Response.ok(metrics).build();
     }
 
     @GET
@@ -254,7 +258,6 @@ public class MetricsResource extends AbstractApiResource {
             @PathParam("uuid") @ValidUuid String uuid,
             @Parameter(description = "The start date to retrieve metrics for", required = true)
             @PathParam("date") String date) {
-
         final Date since = DateUtil.parseShortDate(date);
         return getProjectMetrics(uuid, since);
     }
@@ -263,7 +266,7 @@ public class MetricsResource extends AbstractApiResource {
     @Path("/project/{uuid}/days/{days}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Returns X days of historical metrics for a specific project",
+            summary = "Returns X (30 by default) days of historical metrics for a specific project",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
     @ApiResponses(value = {
@@ -285,7 +288,6 @@ public class MetricsResource extends AbstractApiResource {
             @PathParam("uuid") @ValidUuid String uuid,
             @Parameter(description = "The number of days back to retrieve metrics for", required = true)
             @PathParam("days") int days) {
-
         final Date since = DateUtils.addDays(new Date(), -days);
         return getProjectMetrics(uuid, since);
     }
@@ -386,7 +388,6 @@ public class MetricsResource extends AbstractApiResource {
             @PathParam("uuid") @ValidUuid String uuid,
             @Parameter(description = "The start date to retrieve metrics for", required = true)
             @PathParam("date") String date) {
-
         final Date since = DateUtil.parseShortDate(date);
         if (since == null) {
             return Response.status(Response.Status.BAD_REQUEST).entity("The specified date format is incorrect.").build();
@@ -398,7 +399,7 @@ public class MetricsResource extends AbstractApiResource {
     @Path("/component/{uuid}/days/{days}")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
-            summary = "Returns X days of historical metrics for a specific component",
+            summary = "Returns X (30 by default) days of historical metrics for a specific component",
             description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
     )
     @ApiResponses(value = {
@@ -420,7 +421,6 @@ public class MetricsResource extends AbstractApiResource {
             @PathParam("uuid") @ValidUuid String uuid,
             @Parameter(description = "The number of days back to retrieve metrics for", required = true)
             @PathParam("days") int days) {
-
         final Date since = DateUtils.addDays(new Date(), -days);
         return getComponentMetrics(uuid, since);
     }
@@ -465,16 +465,15 @@ public class MetricsResource extends AbstractApiResource {
      * @return a Response object
      */
     private Response getProjectMetrics(String uuid, Date since) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final Project project = qm.getObjectByUuid(Project.class, uuid);
-            if (project != null) {
-                requireAccess(qm, project);
-                final List<ProjectMetrics> metrics = qm.getProjectMetricsSince(project, since);
-                return Response.ok(metrics).build();
-            } else {
+        return inJdbiTransaction(getAlpineRequest(), handle -> {
+            var projectId = handle.attach(ProjectDao.class).getProjectId(UUID.fromString(uuid));
+            if (projectId == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
             }
-        }
+            requireProjectAccess(handle, UUID.fromString(uuid));
+            final List<ProjectMetrics> metrics = handle.attach(MetricsDao.class).getProjectMetricsSince(projectId, since.toInstant());
+            return Response.ok(metrics).build();
+        });
     }
 
     /**
@@ -485,16 +484,14 @@ public class MetricsResource extends AbstractApiResource {
      * @return a Response object
      */
     private Response getComponentMetrics(String uuid, Date since) {
-        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final Component component = qm.getObjectByUuid(Component.class, uuid);
-            if (component != null) {
-                requireAccess(qm, component.getProject());
-                final List<DependencyMetrics> metrics = qm.getDependencyMetricsSince(component, since);
-                return Response.ok(metrics).build();
-            } else {
+        return inJdbiTransaction(getAlpineRequest(), handle -> {
+            var componentId = handle.attach(ComponentDao.class).getComponentId(UUID.fromString(uuid));
+            if (componentId == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The component could not be found.").build();
             }
-        }
+            requireComponentAccess(handle, UUID.fromString(uuid));
+            final List<DependencyMetrics> metrics = handle.attach(MetricsDao.class).getDependencyMetricsSince(componentId, since.toInstant());
+            return Response.ok(metrics).build();
+        });
     }
-
 }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.model.Component;
+import org.dependencytrack.model.DependencyMetrics;
+import org.dependencytrack.model.PortfolioMetrics;
+import org.dependencytrack.model.ProjectMetrics;
+import org.jdbi.v3.core.Handle;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+
+public class MetricsDaoTest extends PersistenceCapableTest {
+
+    private Handle jdbiHandle;
+    private MetricsDao metricsDao;
+
+    @Before
+    public void before() throws Exception {
+        super.before();
+        jdbiHandle = openJdbiHandle();
+        metricsDao = jdbiHandle.attach(MetricsDao.class);
+    }
+
+    @After
+    public void after() {
+        if (jdbiHandle != null) {
+            jdbiHandle.close();
+        }
+        super.after();
+    }
+
+    @Test
+    public void testGetPortfolioMetricsForXDays() {
+        var metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new PortfolioMetrics();
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        var portfolioMetrics = metricsDao.getPortfolioMetricsSince(Instant.now().minus(Duration.ofDays(35)));
+        assertThat(portfolioMetrics.size()).isEqualTo(2);
+        assertThat(portfolioMetrics.get(0).getVulnerabilities()).isEqualTo(3);
+        assertThat(portfolioMetrics.get(1).getVulnerabilities()).isEqualTo(2);
+    }
+
+    @Test
+    public void testGetProjectMetricsForXDays() {
+        final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+
+        var metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new ProjectMetrics();
+        metrics.setProject(project);
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        var projectMetrics = withJdbiHandle(handle ->
+                handle.attach(MetricsDao.class).getProjectMetricsSince(project.getId(), Instant.now().minus(Duration.ofDays(35))));
+        assertThat(projectMetrics.size()).isEqualTo(2);
+        assertThat(projectMetrics.get(0).getVulnerabilities()).isEqualTo(3);
+        assertThat(projectMetrics.get(1).getVulnerabilities()).isEqualTo(2);
+    }
+
+    @Test
+    public void testGetDependencyMetricsForXDays() {
+        final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        qm.createComponent(component, false);
+
+        var metrics = new DependencyMetrics();
+        metrics.setProject(project);
+        metrics.setComponent(component);
+        metrics.setVulnerabilities(4);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(40))));
+        qm.persist(metrics);
+
+        metrics = new DependencyMetrics();
+        metrics.setProject(project);
+        metrics.setComponent(component);
+        metrics.setVulnerabilities(3);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(30))));
+        qm.persist(metrics);
+
+        metrics = new DependencyMetrics();
+        metrics.setProject(project);
+        metrics.setComponent(component);
+        metrics.setVulnerabilities(2);
+        metrics.setFirstOccurrence(new Date());
+        metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
+        qm.persist(metrics);
+
+        var dependencyMetrics = metricsDao.getDependencyMetricsSince(component.getId(), Instant.now().minus(Duration.ofDays(35)));
+        assertThat(dependencyMetrics.size()).isEqualTo(2);
+        assertThat(dependencyMetrics.get(0).getVulnerabilities()).isEqualTo(3);
+        assertThat(dependencyMetrics.get(1).getVulnerabilities()).isEqualTo(2);
+    }
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -1413,7 +1413,6 @@ public class ProjectResourceTest extends ResourceTest {
 
     @Test
     public void getProjectByInvalidUuidTest() {
-        qm.createProject("ABC", null, "1.0", null, null, null, null, false);
         Response response = jersey.target(V1_PROJECT + "/" + UUID.randomUUID())
                 .request()
                 .header(X_API_KEY, apiKey)


### PR DESCRIPTION
### Description

Make the duration for which metrics are being fetched selectable by users.
Refactor DN queries to JDBI for dashboard metrics.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1697
Frontend: https://github.com/DependencyTrack/hyades-frontend/pull/272

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
