### PR TITLE
Use HikariCP for DB connection pooling in tests

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
@@ -101,6 +101,7 @@ public abstract class PersistenceCapableTest {
         dnProps.put(PropertyNames.PROPERTY_CONNECTION_DRIVER_NAME, postgresContainer.getDriverClassName());
         dnProps.put(PropertyNames.PROPERTY_CONNECTION_USER_NAME, postgresContainer.getUsername());
         dnProps.put(PropertyNames.PROPERTY_CONNECTION_PASSWORD, postgresContainer.getPassword());
+        dnProps.put(PropertyNames.PROPERTY_CONNECTION_POOLINGTYPE, "HikariCP");
         dnProps.putAll(Config.getInstance().getPassThroughProperties("datanucleus"));
 
         final var pmf = (JDOPersistenceManagerFactory) JDOHelper.getPersistenceManagerFactory(dnProps, "Alpine");

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/JdbiFactoryTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/JdbiFactoryTest.java
@@ -22,6 +22,7 @@ import alpine.server.persistence.PersistenceManagerFactory;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
+import org.jdbi.v3.core.ConnectionException;
 import org.jdbi.v3.core.Jdbi;
 import org.junit.Test;
 
@@ -70,10 +71,9 @@ public class JdbiFactoryTest extends PersistenceCapableTest {
 
         // Close the PMF and ensure that the JDBI instance is no longer usable.
         PersistenceManagerFactory.tearDown();
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatExceptionOfType(ConnectionException.class)
                 .isThrownBy(() -> jdbi.withHandle(handle ->
-                        handle.createQuery("SELECT 666").mapTo(Integer.class).one()))
-                .withMessage("Pool not open");
+                        handle.createQuery("SELECT 666").mapTo(Integer.class).one()));
 
         // Create a new QueryManager.
         configurePmf(postgresContainer);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Uses HikariCP for DB connection pooling in tests.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->


DataNucleus per default uses a forked variant of Apache DBCP (https://github.com/datanucleus/datanucleus-rdbms/blob/98fe4db812cc35157dcdb96f7f78f347706d9113/src/main/java/org/datanucleus/store/rdbms/datasource/dbcp2/package.html).

It appears like this connection pool can have deadlock issues which were triggered by `ProjectResourceTest#createProjectDuplicateRaceConditionTest`. The deadlock prevented the `PersistenceManagerFactory` from being closed after tests, which then impacted all tests executed afterward, causing them to fail.

We use HikariCP at runtime. Switching to HikariCP for tests resolves the deadlock issue.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
