### PR TITLE
Consolidate user tables

### DIFF
--- a/alpine/alpine-model/src/main/java/alpine/model/ApiKey.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/ApiKey.java
@@ -158,7 +158,7 @@ public class ApiKey implements Serializable, Principal {
      * Do not use - only here to satisfy Principal implementation requirement.
      *
      * @return a String presentation of the username
-     * @deprecated use {@link UserPrincipal#getUsername()}
+     * @deprecated use {@link #getMaskedKey()}
      */
     @Deprecated
     @JsonIgnore

--- a/alpine/alpine-model/src/main/java/alpine/model/LdapUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/LdapUser.java
@@ -19,6 +19,7 @@
 package alpine.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -41,6 +42,7 @@ import javax.jdo.annotations.Persistent;
 @Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
 @Discriminator(value = "LDAP")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = { "username", "dn", "email", "teams", "permissions" })
 public class LdapUser extends UserPrincipal {
 
     private static final long serialVersionUID = 261924579887470488L;

--- a/alpine/alpine-model/src/main/java/alpine/model/LdapUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/LdapUser.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Discriminator;
 import javax.jdo.annotations.Inheritance;
@@ -43,7 +42,7 @@ import javax.jdo.annotations.Persistent;
 @Discriminator(value = "LDAP")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder(value = { "username", "dn", "email", "teams", "permissions" })
-public class LdapUser extends UserPrincipal {
+public class LdapUser extends User {
 
     private static final long serialVersionUID = 261924579887470488L;
 

--- a/alpine/alpine-model/src/main/java/alpine/model/LdapUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/LdapUser.java
@@ -18,26 +18,18 @@
  */
 package alpine.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import javax.jdo.annotations.Column;
-import javax.jdo.annotations.Element;
-import javax.jdo.annotations.Extension;
-import javax.jdo.annotations.ForeignKeyAction;
-import javax.jdo.annotations.IdGeneratorStrategy;
-import javax.jdo.annotations.Join;
-import javax.jdo.annotations.Order;
+import javax.jdo.annotations.Discriminator;
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
-import javax.jdo.annotations.PrimaryKey;
-import javax.jdo.annotations.Unique;
-import java.io.Serializable;
-import java.security.Principal;
-import java.util.List;
 
 /**
  * Persistable object representing an LdapUser.
@@ -46,23 +38,12 @@ import java.util.List;
  * @since 1.0.0
  */
 @PersistenceCapable
+@Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
+@Discriminator(value = "LDAP")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class LdapUser implements Serializable, Principal, UserPrincipal {
+public class LdapUser extends UserPrincipal {
 
     private static final long serialVersionUID = 261924579887470488L;
-
-    @PrimaryKey
-    @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
-    private long id;
-
-    @Persistent
-    @Unique(name = "LDAPUSER_USERNAME_IDX")
-    @Column(name = "USERNAME")
-    @NotBlank
-    @Size(min = 1, max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The username must not contain control characters")
-    private String username;
 
     @Persistent
     @Column(name = "DN", allowsNull = "false")
@@ -71,81 +52,12 @@ public class LdapUser implements Serializable, Principal, UserPrincipal {
     @Pattern(regexp = "[\\P{Cc}]+", message = "The distinguished name must not contain control characters")
     private String dn;
 
-    @Persistent(table = "LDAPUSERS_TEAMS", defaultFetchGroup = "true")
-    @Join(column = "LDAPUSER_ID", primaryKey = "LDAPUSERS_TEAMS_PK", foreignKey = "LDAPUSERS_TEAMS_LDAPUSER_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Element(column = "TEAM_ID", foreignKey = "LDAPUSERS_TEAMS_TEAM_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Team> teams;
-
-    @Persistent
-    @Column(name = "EMAIL", allowsNull = "true")
-    @Size(max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The email address must not contain control characters")
-    private String email;
-
-    @Persistent(table = "LDAPUSERS_PERMISSIONS", defaultFetchGroup = "true")
-    @Join(column = "LDAPUSER_ID", primaryKey = "LDAPUSERS_PERMISSIONS_PK", foreignKey = "LDAPUSERS_PERMISSIONS_LDAPUSER_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Element(column = "PERMISSION_ID", foreignKey = "LDAPUSERS_PERMISSIONS_PERMISSION_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Permission> permissions;
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
     public String getDN() {
         return dn;
     }
 
     public void setDN(String dn) {
         this.dn = dn;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
-
-    public List<Team> getTeams() {
-        return teams;
-    }
-
-    public void setTeams(List<Team> teams) {
-        this.teams = teams;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public List<Permission> getPermissions() {
-        return permissions;
-    }
-
-    public void setPermissions(List<Permission> permissions) {
-        this.permissions = permissions;
-    }
-
-    /**
-     * Do not use - only here to satisfy Principal implementation requirement.
-     * @deprecated use {@link LdapUser#getUsername()}
-     * @return the value of {@link #getUsername()}
-     */
-    @Deprecated
-    @JsonIgnore
-    public String getName() {
-        return getUsername();
     }
 
 }

--- a/alpine/alpine-model/src/main/java/alpine/model/ManagedUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/ManagedUser.java
@@ -26,14 +26,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Discriminator;
 import javax.jdo.annotations.Inheritance;
 import javax.jdo.annotations.InheritanceStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
-
 import java.util.Date;
 
 /**
@@ -56,7 +54,7 @@ import java.util.Date;
         "nonExpiryPassword",
         "teams",
         "permissions" })
-public class ManagedUser extends UserPrincipal {
+public class ManagedUser extends User {
 
     private static final long serialVersionUID = 7944779964068911025L;
 

--- a/alpine/alpine-model/src/main/java/alpine/model/ManagedUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/ManagedUser.java
@@ -20,6 +20,7 @@ package alpine.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -45,6 +46,16 @@ import java.util.Date;
 @Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
 @Discriminator(value = "MANAGED")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = {
+        "username",
+        "lastPasswordChange",
+        "fullname",
+        "email",
+        "suspended",
+        "forcePasswordChange",
+        "nonExpiryPassword",
+        "teams",
+        "permissions" })
 public class ManagedUser extends UserPrincipal {
 
     private static final long serialVersionUID = 7944779964068911025L;

--- a/alpine/alpine-model/src/main/java/alpine/model/ManagedUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/ManagedUser.java
@@ -25,21 +25,15 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import javax.jdo.annotations.Column;
-import javax.jdo.annotations.Element;
-import javax.jdo.annotations.Extension;
-import javax.jdo.annotations.ForeignKeyAction;
-import javax.jdo.annotations.IdGeneratorStrategy;
-import javax.jdo.annotations.Join;
-import javax.jdo.annotations.Order;
+import javax.jdo.annotations.Discriminator;
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
-import javax.jdo.annotations.PrimaryKey;
-import javax.jdo.annotations.Unique;
-import java.io.Serializable;
-import java.security.Principal;
+
 import java.util.Date;
-import java.util.List;
 
 /**
  * Persistable object representing an ManagedUser.
@@ -48,23 +42,12 @@ import java.util.List;
  * @since 1.0.0
  */
 @PersistenceCapable
+@Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
+@Discriminator(value = "MANAGED")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class ManagedUser implements Serializable, Principal, UserPrincipal {
+public class ManagedUser extends UserPrincipal {
 
     private static final long serialVersionUID = 7944779964068911025L;
-
-    @PrimaryKey
-    @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
-    private long id;
-
-    @Persistent
-    @Unique(name = "MANAGEDUSER_USERNAME_IDX")
-    @Column(name = "USERNAME")
-    @NotBlank
-    @Size(min = 1, max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The username must not contain control characters")
-    private String username;
 
     @Persistent
     @Column(name = "PASSWORD", allowsNull = "false")
@@ -94,12 +77,6 @@ public class ManagedUser implements Serializable, Principal, UserPrincipal {
     private String fullname;
 
     @Persistent
-    @Column(name = "EMAIL")
-    @Size(max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The email address must not contain control characters")
-    private String email;
-
-    @Persistent
     @Column(name = "SUSPENDED")
     private boolean suspended;
 
@@ -110,34 +87,6 @@ public class ManagedUser implements Serializable, Principal, UserPrincipal {
     @Persistent
     @Column(name = "NON_EXPIRY_PASSWORD")
     private boolean nonExpiryPassword;
-
-    @Persistent(table = "MANAGEDUSERS_TEAMS", defaultFetchGroup = "true")
-    @Join(column = "MANAGEDUSER_ID", primaryKey = "MANAGEDUSERS_TEAMS_PK", foreignKey = "MANAGEDUSERS_TEAMS_MANAGEDUSER_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Element(column = "TEAM_ID", foreignKey = "MANAGEDUSERS_TEAMS_TEAM_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Team> teams;
-
-    @Persistent(table = "MANAGEDUSERS_PERMISSIONS", defaultFetchGroup = "true")
-    @Join(column = "MANAGEDUSER_ID", primaryKey = "MANAGEDUSERS_PERMISSIONS_PK", foreignKey = "MANAGEDUSERS_PERMISSIONS_MANAGEDUSER_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Element(column = "PERMISSION_ID", foreignKey = "MANAGEDUSERS_PERMISSIONS_PERMISSION_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Permission> permissions;
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
-    }
-
-    public String getUsername() {
-        return username;
-    }
-
-    public void setUsername(String username) {
-        this.username = username;
-    }
 
     public String getPassword() {
         return password;
@@ -179,14 +128,6 @@ public class ManagedUser implements Serializable, Principal, UserPrincipal {
         this.fullname = fullname;
     }
 
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
     public boolean isSuspended() {
         return suspended;
     }
@@ -209,33 +150,6 @@ public class ManagedUser implements Serializable, Principal, UserPrincipal {
 
     public void setNonExpiryPassword(boolean nonExpiryPassword) {
         this.nonExpiryPassword = nonExpiryPassword;
-    }
-
-    public List<Team> getTeams() {
-        return teams;
-    }
-
-    public void setTeams(List<Team> teams) {
-        this.teams = teams;
-    }
-
-    public List<Permission> getPermissions() {
-        return permissions;
-    }
-
-    public void setPermissions(List<Permission> permissions) {
-        this.permissions = permissions;
-    }
-
-    /**
-     * Do not use - only here to satisfy Principal implementation requirement.
-     * @deprecated use {@link ManagedUser#getUsername()}
-     * @return the value of {@link #getUsername()}
-     */
-    @Deprecated
-    @JsonIgnore
-    public String getName() {
-        return getUsername();
     }
 
 }

--- a/alpine/alpine-model/src/main/java/alpine/model/OidcUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/OidcUser.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Discriminator;
 import javax.jdo.annotations.Inheritance;
@@ -42,7 +41,7 @@ import javax.jdo.annotations.Persistent;
 @Discriminator(value = "OIDC")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder(value = { "username", "subjectIdentifier", "email", "teams", "permissions" })
-public class OidcUser extends UserPrincipal {
+public class OidcUser extends User {
 
     private static final long serialVersionUID = -6852825148699565269L;
 

--- a/alpine/alpine-model/src/main/java/alpine/model/OidcUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/OidcUser.java
@@ -19,26 +19,17 @@
 
 package alpine.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
 import javax.jdo.annotations.Column;
-import javax.jdo.annotations.Element;
-import javax.jdo.annotations.Extension;
-import javax.jdo.annotations.ForeignKeyAction;
-import javax.jdo.annotations.IdGeneratorStrategy;
-import javax.jdo.annotations.Join;
-import javax.jdo.annotations.Order;
+import javax.jdo.annotations.Discriminator;
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
 import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
-import javax.jdo.annotations.PrimaryKey;
-import javax.jdo.annotations.Unique;
-import java.io.Serializable;
-import java.security.Principal;
-import java.util.List;
 
 /**
  * Persistable object representing an OpenID Connect user.
@@ -46,21 +37,12 @@ import java.util.List;
  * @since 1.8.0
  */
 @PersistenceCapable
+@Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
+@Discriminator(value = "OIDC")
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class OidcUser implements Serializable, Principal, UserPrincipal {
+public class OidcUser extends UserPrincipal {
 
-    @PrimaryKey
-    @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
-    private long id;
-
-    @Persistent
-    @Unique(name = "OIDCUSER_USERNAME_IDX")
-    @Column(name = "USERNAME", allowsNull = "false")
-    @NotBlank
-    @Size(min = 1, max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The username must not contain control characters")
-    private String username;
+    private static final long serialVersionUID = -6852825148699565269L;
 
     @Persistent
     @Column(name = "SUBJECT_IDENTIFIER")
@@ -68,93 +50,12 @@ public class OidcUser implements Serializable, Principal, UserPrincipal {
     @Pattern(regexp = "[\\P{Cc}]+", message = "The subject identifier must not contain control characters")
     private String subjectIdentifier;
 
-    @Persistent
-    @Column(name = "EMAIL", allowsNull = "true")
-    @Size(max = 255)
-    @Pattern(regexp = "[\\P{Cc}]+", message = "The email address must not contain control characters")
-    private String email;
-
-    @Persistent(table = "OIDCUSERS_TEAMS", defaultFetchGroup = "true")
-    @Join(column = "OIDCUSERS_ID", primaryKey = "OIDCUSERS_TEAMS_PK", foreignKey = "OIDCUSERS_TEAMS_OIDCUSER_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Element(column = "TEAM_ID", foreignKey = "OIDCUSERS_TEAMS_TEAM_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Team> teams;
-
-    @Persistent(table = "OIDCUSERS_PERMISSIONS", defaultFetchGroup = "true")
-    @Join(column = "OIDCUSER_ID", primaryKey = "OIDCUSERS_PERMISSIONS_PK", foreignKey = "OIDCUSERS_PERMISSIONS_OIDCUSER_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Element(column = "PERMISSION_ID", foreignKey = "OIDCUSERS_PERMISSIONS_PERMISSION_FK", deleteAction = ForeignKeyAction.CASCADE)
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
-    private List<Permission> permissions;
-
-    @Override
-    public long getId() {
-        return id;
-    }
-
-    @Override
-    public void setId(final long id) {
-        this.id = id;
-    }
-
-    @Override
-    public String getUsername() {
-        return username;
-    }
-
-    @Override
-    public void setUsername(final String username) {
-        this.username = username;
-    }
-
     public String getSubjectIdentifier() {
         return subjectIdentifier;
     }
 
     public void setSubjectIdentifier(final String subjectIdentifier) {
         this.subjectIdentifier = subjectIdentifier;
-    }
-
-    @Override
-    public String getEmail() {
-        return email;
-    }
-
-    @Override
-    public void setEmail(final String email) {
-        this.email = email;
-    }
-
-    @Override
-    public List<Team> getTeams() {
-        return teams;
-    }
-
-    @Override
-    public void setTeams(final List<Team> teams) {
-        this.teams = teams;
-    }
-
-    @Override
-    public List<Permission> getPermissions() {
-        return permissions;
-    }
-
-    @Override
-    public void setPermissions(final List<Permission> permissions) {
-        this.permissions = permissions;
-    }
-
-    /**
-     * Do not use - only here to satisfy Principal implementation requirement.
-     *
-     * @return the value of {@link #getUsername()}
-     * @deprecated use {@link OidcUser#getUsername()}
-     */
-    @Deprecated
-    @JsonIgnore
-    @Override
-    public String getName() {
-        return getUsername();
     }
 
 }

--- a/alpine/alpine-model/src/main/java/alpine/model/OidcUser.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/OidcUser.java
@@ -20,6 +20,7 @@
 package alpine.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -40,6 +41,7 @@ import javax.jdo.annotations.Persistent;
 @Inheritance(strategy = InheritanceStrategy.SUPERCLASS_TABLE)
 @Discriminator(value = "OIDC")
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = { "username", "subjectIdentifier", "email", "teams", "permissions" })
 public class OidcUser extends UserPrincipal {
 
     private static final long serialVersionUID = -6852825148699565269L;

--- a/alpine/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Permission.java
@@ -35,6 +35,7 @@ import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -110,7 +111,7 @@ public class Permission implements Serializable {
     }
 
     public List<OidcUser> getOidcUsers() {
-        return users.stream()
+        return (users != null ? users : Collections.emptyList()).stream()
                 .filter(user -> user instanceof OidcUser)
                 .map(user -> (OidcUser) user)
                 .toList();
@@ -122,7 +123,7 @@ public class Permission implements Serializable {
     }
 
     public List<LdapUser> getLdapUsers() {
-        return users.stream()
+        return (users != null ? users : Collections.emptyList()).stream()
                 .filter(user -> user instanceof LdapUser)
                 .map(user -> (LdapUser) user)
                 .toList();
@@ -134,7 +135,7 @@ public class Permission implements Serializable {
     }
 
     public List<ManagedUser> getManagedUsers() {
-        return users.stream()
+        return (users != null ? users : Collections.emptyList()).stream()
                 .filter(user -> user instanceof ManagedUser)
                 .map(user -> (ManagedUser) user)
                 .toList();

--- a/alpine/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Permission.java
@@ -34,7 +34,9 @@ import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Persistable object representing a Permission.
@@ -73,17 +75,7 @@ public class Permission implements Serializable {
     @Persistent(mappedBy = "permissions")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
     @JsonIgnore
-    private List<OidcUser> oidcUsers;
-
-    @Persistent(mappedBy = "permissions")
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
-    @JsonIgnore
-    private List<LdapUser> ldapUsers;
-
-    @Persistent(mappedBy = "permissions")
-    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
-    @JsonIgnore
-    private List<ManagedUser> managedUsers;
+    private List<UserPrincipal> users;
 
     public long getId() {
         return id;
@@ -118,27 +110,46 @@ public class Permission implements Serializable {
     }
 
     public List<OidcUser> getOidcUsers() {
-        return oidcUsers;
+        return users.stream()
+                .filter(user -> user instanceof OidcUser)
+                .map(user -> (OidcUser) user)
+                .toList();
     }
 
     public void setOidcUsers(List<OidcUser> oidcUsers) {
-        this.oidcUsers = oidcUsers;
+        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users.addAll(oidcUsers);
     }
 
     public List<LdapUser> getLdapUsers() {
-        return ldapUsers;
+        return users.stream()
+                .filter(user -> user instanceof LdapUser)
+                .map(user -> (LdapUser) user)
+                .toList();
     }
 
     public void setLdapUsers(List<LdapUser> ldapUsers) {
-        this.ldapUsers = ldapUsers;
+        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users.addAll(ldapUsers);
     }
 
     public List<ManagedUser> getManagedUsers() {
-        return managedUsers;
+        return users.stream()
+                .filter(user -> user instanceof ManagedUser)
+                .map(user -> (ManagedUser) user)
+                .toList();
     }
 
     public void setManagedUsers(List<ManagedUser> managedUsers) {
-        this.managedUsers = managedUsers;
+        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users.addAll(managedUsers);
+    }
+
+    public List<UserPrincipal> getUsers() {
+        return users;
+    }
+
+    public void setUsers(List<UserPrincipal> users) {
+        this.users = users;
     }
 }
-

--- a/alpine/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Permission.java
@@ -35,7 +35,6 @@ import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -111,7 +110,10 @@ public class Permission implements Serializable {
     }
 
     public List<OidcUser> getOidcUsers() {
-        return (users != null ? users : Collections.emptyList()).stream()
+        if (users == null || users.isEmpty())
+            return null;
+
+        return users.stream()
                 .filter(user -> user instanceof OidcUser)
                 .map(user -> (OidcUser) user)
                 .toList();
@@ -123,7 +125,10 @@ public class Permission implements Serializable {
     }
 
     public List<LdapUser> getLdapUsers() {
-        return (users != null ? users : Collections.emptyList()).stream()
+        if (users == null || users.isEmpty())
+            return null;
+
+        return users.stream()
                 .filter(user -> user instanceof LdapUser)
                 .map(user -> (LdapUser) user)
                 .toList();
@@ -135,7 +140,10 @@ public class Permission implements Serializable {
     }
 
     public List<ManagedUser> getManagedUsers() {
-        return (users != null ? users : Collections.emptyList()).stream()
+        if (users == null || users.isEmpty())
+            return null;
+
+        return users.stream()
                 .filter(user -> user instanceof ManagedUser)
                 .map(user -> (ManagedUser) user)
                 .toList();

--- a/alpine/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Permission.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * @since 1.0.0
  */
 @PersistenceCapable
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Permission implements Serializable {
 
     private static final long serialVersionUID = 1420020753285692448L;
@@ -110,8 +110,9 @@ public class Permission implements Serializable {
     }
 
     public List<OidcUser> getOidcUsers() {
-        if (users == null || users.isEmpty())
+        if (users == null) {
             return null;
+        }
 
         return users.stream()
                 .filter(user -> user instanceof OidcUser)
@@ -120,13 +121,14 @@ public class Permission implements Serializable {
     }
 
     public void setOidcUsers(List<OidcUser> oidcUsers) {
-        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users = Objects.requireNonNullElseGet(this.users, ArrayList::new);
         this.users.addAll(oidcUsers);
     }
 
     public List<LdapUser> getLdapUsers() {
-        if (users == null || users.isEmpty())
+        if (users == null) {
             return null;
+        }
 
         return users.stream()
                 .filter(user -> user instanceof LdapUser)
@@ -135,13 +137,14 @@ public class Permission implements Serializable {
     }
 
     public void setLdapUsers(List<LdapUser> ldapUsers) {
-        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users = Objects.requireNonNullElseGet(this.users, ArrayList::new);
         this.users.addAll(ldapUsers);
     }
 
     public List<ManagedUser> getManagedUsers() {
-        if (users == null || users.isEmpty())
+        if (users == null) {
             return null;
+        }
 
         return users.stream()
                 .filter(user -> user instanceof ManagedUser)
@@ -150,7 +153,7 @@ public class Permission implements Serializable {
     }
 
     public void setManagedUsers(List<ManagedUser> managedUsers) {
-        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users = Objects.requireNonNullElseGet(this.users, ArrayList::new);
         this.users.addAll(managedUsers);
     }
 

--- a/alpine/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Permission.java
@@ -75,7 +75,7 @@ public class Permission implements Serializable {
     @Persistent(mappedBy = "permissions")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
     @JsonIgnore
-    private List<UserPrincipal> users;
+    private List<User> users;
 
     public long getId() {
         return id;
@@ -154,11 +154,11 @@ public class Permission implements Serializable {
         this.users.addAll(managedUsers);
     }
 
-    public List<UserPrincipal> getUsers() {
+    public List<User> getUsers() {
         return users;
     }
 
-    public void setUsers(List<UserPrincipal> users) {
+    public void setUsers(List<User> users) {
         this.users = users;
     }
 }

--- a/alpine/alpine-model/src/main/java/alpine/model/Team.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Team.java
@@ -97,7 +97,7 @@ public class Team implements Serializable {
 
     @Persistent(mappedBy = "teams")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
-    private List<UserPrincipal> users;
+    private List<User> users;
 
     @Persistent(mappedBy = "team")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "dn ASC"))
@@ -190,11 +190,11 @@ public class Team implements Serializable {
         this.users.addAll(oidcUsers);
     }
 
-    public List<UserPrincipal> getUsers() {
+    public List<User> getUsers() {
         return users;
     }
 
-    public void setUsers(List<UserPrincipal> users) {
+    public void setUsers(List<User> users) {
         this.users = users;
     }
 

--- a/alpine/alpine-model/src/main/java/alpine/model/Team.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Team.java
@@ -40,7 +40,6 @@ import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -147,7 +146,10 @@ public class Team implements Serializable {
     }
 
     public List<LdapUser> getLdapUsers() {
-        return (users != null ? users : Collections.emptyList()).stream()
+        if (users == null || users.isEmpty())
+            return null;
+
+        return users.stream()
                 .filter(user -> user instanceof LdapUser)
                 .map(user -> (LdapUser) user)
                 .toList();
@@ -159,7 +161,10 @@ public class Team implements Serializable {
     }
 
     public List<ManagedUser> getManagedUsers() {
-        return (users != null ? users : Collections.emptyList()).stream()
+        if (users == null || users.isEmpty())
+            return null;
+
+        return users.stream()
                 .filter(user -> user instanceof ManagedUser)
                 .map(user -> (ManagedUser) user)
                 .toList();
@@ -171,7 +176,10 @@ public class Team implements Serializable {
     }
 
     public List<OidcUser> getOidcUsers() {
-        return (users != null ? users : Collections.emptyList()).stream()
+        if (users == null || users.isEmpty())
+            return null;
+
+        return users.stream()
                 .filter(user -> user instanceof OidcUser)
                 .map(user -> (OidcUser) user)
                 .toList();

--- a/alpine/alpine-model/src/main/java/alpine/model/Team.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Team.java
@@ -29,6 +29,7 @@ import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
 import javax.jdo.annotations.FetchGroup;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Index;
 import javax.jdo.annotations.Join;

--- a/alpine/alpine-model/src/main/java/alpine/model/Team.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Team.java
@@ -40,6 +40,7 @@ import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -146,7 +147,7 @@ public class Team implements Serializable {
     }
 
     public List<LdapUser> getLdapUsers() {
-        return users.stream()
+        return (users != null ? users : Collections.emptyList()).stream()
                 .filter(user -> user instanceof LdapUser)
                 .map(user -> (LdapUser) user)
                 .toList();
@@ -158,7 +159,7 @@ public class Team implements Serializable {
     }
 
     public List<ManagedUser> getManagedUsers() {
-        return users.stream()
+        return (users != null ? users : Collections.emptyList()).stream()
                 .filter(user -> user instanceof ManagedUser)
                 .map(user -> (ManagedUser) user)
                 .toList();
@@ -170,7 +171,7 @@ public class Team implements Serializable {
     }
 
     public List<OidcUser> getOidcUsers() {
-        return users.stream()
+        return (users != null ? users : Collections.emptyList()).stream()
                 .filter(user -> user instanceof OidcUser)
                 .map(user -> (OidcUser) user)
                 .toList();

--- a/alpine/alpine-model/src/main/java/alpine/model/Team.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Team.java
@@ -60,7 +60,7 @@ import java.util.UUID;
         @Persistent(name = "mappedOidcGroups"),
         @Persistent(name = "permissions")
 })
-@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class Team implements Serializable {
 
     private static final long serialVersionUID = 6938424919898277944L;
@@ -146,8 +146,9 @@ public class Team implements Serializable {
     }
 
     public List<LdapUser> getLdapUsers() {
-        if (users == null || users.isEmpty())
+        if (users == null) {
             return null;
+        }
 
         return users.stream()
                 .filter(user -> user instanceof LdapUser)
@@ -156,13 +157,14 @@ public class Team implements Serializable {
     }
 
     public void setLdapUsers(List<LdapUser> ldapUsers) {
-        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users = Objects.requireNonNullElseGet(this.users, ArrayList::new);
         this.users.addAll(ldapUsers);
     }
 
     public List<ManagedUser> getManagedUsers() {
-        if (users == null || users.isEmpty())
+        if (users == null) {
             return null;
+        }
 
         return users.stream()
                 .filter(user -> user instanceof ManagedUser)
@@ -171,13 +173,14 @@ public class Team implements Serializable {
     }
 
     public void setManagedUsers(List<ManagedUser> managedUsers) {
-        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users = Objects.requireNonNullElseGet(this.users, ArrayList::new);
         this.users.addAll(managedUsers);
     }
 
     public List<OidcUser> getOidcUsers() {
-        if (users == null || users.isEmpty())
+        if (users == null) {
             return null;
+        }
 
         return users.stream()
                 .filter(user -> user instanceof OidcUser)
@@ -186,7 +189,7 @@ public class Team implements Serializable {
     }
 
     public void setOidcUsers(List<OidcUser> oidcUsers) {
-        this.users = Objects.requireNonNullElse(this.users, new ArrayList<>());
+        this.users = Objects.requireNonNullElseGet(this.users, ArrayList::new);
         this.users.addAll(oidcUsers);
     }
 

--- a/alpine/alpine-model/src/main/java/alpine/model/User.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/User.java
@@ -18,15 +18,17 @@
  */
 package alpine.model;
 
-import java.io.Serializable;
-import java.security.Principal;
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Discriminator;
 import javax.jdo.annotations.DiscriminatorStrategy;
 import javax.jdo.annotations.Element;
 import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.ForeignKeyAction;
 import javax.jdo.annotations.IdGeneratorStrategy;
 import javax.jdo.annotations.Inheritance;
 import javax.jdo.annotations.InheritanceStrategy;
@@ -36,36 +38,34 @@ import javax.jdo.annotations.PersistenceCapable;
 import javax.jdo.annotations.Persistent;
 import javax.jdo.annotations.PrimaryKey;
 import javax.jdo.annotations.Unique;
+import java.io.Serializable;
+import java.security.Principal;
+import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
-
-@PersistenceCapable
+@PersistenceCapable(table = "USER")
 @Discriminator(column = "TYPE", strategy = DiscriminatorStrategy.VALUE_MAP)
 @Inheritance(strategy = InheritanceStrategy.NEW_TABLE)
-public abstract class UserPrincipal implements Serializable, Principal {
+public abstract class User implements Serializable, Principal {
 
     @PrimaryKey
     @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
     @JsonIgnore
     private long id;
 
-    @Persistent(table = "USERPRINCIPALS_TEAMS", defaultFetchGroup = "true")
-    @Join(column = "USERPRINCIPAL_ID")
-    @Element(column = "TEAM_ID")
+    @Persistent(table = "USERS_TEAMS", defaultFetchGroup = "true")
+    @Join(column = "USER_ID", primaryKey = "USERS_TEAMS_PK", foreignKey = "USERS_TEAMS_USER_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "TEAM_ID", foreignKey = "USERS_TEAMS_TEAM_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Team> teams;
 
-    @Persistent(table = "USERPRINCIPALS_PERMISSIONS", defaultFetchGroup = "true")
-    @Join(column = "USERPRINCIPAL_ID")
-    @Element(column = "PERMISSION_ID")
+    @Persistent(table = "USERS_PERMISSIONS", defaultFetchGroup = "true")
+    @Join(column = "USER_ID", primaryKey = "USERS_PERMISSIONS_PK", foreignKey = "USERS_PERMISSIONS_USER_FK", deleteAction = ForeignKeyAction.CASCADE)
+    @Element(column = "PERMISSION_ID", foreignKey = "USERS_PERMISSIONS_PERMISSION_FK", updateAction = ForeignKeyAction.NONE, deleteAction = ForeignKeyAction.CASCADE)
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
     private List<Permission> permissions;
 
     @Persistent
-    @Unique(name = "USERPRINCIPAL_USERNAME_IDX")
+    @Unique(name = "USER_USERNAME_IDX")
     @Column(name = "USERNAME")
     @NotBlank
     @Size(min = 1, max = 255)

--- a/alpine/alpine-model/src/main/java/alpine/model/UserPrincipal.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/UserPrincipal.java
@@ -18,81 +18,155 @@
  */
 package alpine.model;
 
+import java.io.Serializable;
+import java.security.Principal;
 import java.util.List;
 
-/**
- * Defines Alpine UserPrincipal.
- *
- * @author Steve Springett
- * @since 1.0.0
- */
-public interface UserPrincipal {
+import javax.jdo.annotations.Column;
+import javax.jdo.annotations.Discriminator;
+import javax.jdo.annotations.DiscriminatorStrategy;
+import javax.jdo.annotations.Element;
+import javax.jdo.annotations.Extension;
+import javax.jdo.annotations.IdGeneratorStrategy;
+import javax.jdo.annotations.Inheritance;
+import javax.jdo.annotations.InheritanceStrategy;
+import javax.jdo.annotations.Join;
+import javax.jdo.annotations.Order;
+import javax.jdo.annotations.PersistenceCapable;
+import javax.jdo.annotations.Persistent;
+import javax.jdo.annotations.PrimaryKey;
+import javax.jdo.annotations.Unique;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@PersistenceCapable
+@Discriminator(column = "TYPE", strategy = DiscriminatorStrategy.VALUE_MAP, value = "USER")
+@Inheritance(strategy = InheritanceStrategy.NEW_TABLE)
+public abstract class UserPrincipal implements Serializable, Principal {
+
+    @PrimaryKey
+    @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
+    @JsonIgnore
+    private long id;
+
+    @Persistent(table = "USERPRINCIPALS_TEAMS", defaultFetchGroup = "true")
+    @Join(column = "USERPRINCIPAL_ID")
+    @Element(column = "TEAM_ID")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
+    private List<Team> teams;
+
+    @Persistent(table = "USERPRINCIPALS_PERMISSIONS", defaultFetchGroup = "true")
+    @Join(column = "USERPRINCIPAL_ID")
+    @Element(column = "PERMISSION_ID")
+    @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "name ASC"))
+    private List<Permission> permissions;
+
+    @Persistent
+    @Unique(name = "USERPRINCIPAL_USERNAME_IDX")
+    @Column(name = "USERNAME")
+    @NotBlank
+    @Size(min = 1, max = 255)
+    @Pattern(regexp = "[\\P{Cc}]+", message = "The username must not contain control characters")
+    private String username;
+
+    @Persistent
+    @Column(name = "EMAIL", allowsNull = "true")
+    @Size(max = 255)
+    @Pattern(regexp = "[\\P{Cc}]+", message = "The email address must not contain control characters")
+    private String email;
 
     /**
      * The database id of the principal.
      * @return a long of the unique id
      */
-    long getId();
+    public long getId() {
+        return id;
+    }
 
     /**
      * Specifies the database id of the principal.
      * @param id a long of the unique id
      */
-    void setId(long id);
+    public void setId(long id) {
+        this.id = id;
+    }
 
     /**
      * The username of the principal.
      * @return a String of the username
      */
-    String getUsername();
+    public String getUsername() {
+        return username;
+    }
 
     /**
      * Specifies the username of the principal.
      * @param username the username of the principal
      */
-    void setUsername(String username);
+    public void setUsername(String username) {
+        this.username = username;
+    }
 
     /**
      * The email address of the principal.
      * @return a String of the email address
      */
-    String getEmail();
+    public String getEmail() {
+        return email;
+    }
 
     /**
      * Specifies the email address of the principal.
      * @param email the email address of the principal
      */
-    void setEmail(String email);
+    public void setEmail(String email) {
+        this.email = email;
+    }
 
     /**
      * A list of teams the principal is a member of.
      * @return a List of Team objects
      */
-    List<Team> getTeams();
+    public List<Team> getTeams() {
+        return teams;
+    }
 
     /**
      * Specifies the teams the principal is a member of.
      * @param teams a List of Team objects
      */
-    void setTeams(List<Team> teams);
+    public void setTeams(List<Team> teams) {
+        this.teams = teams;
+    }
 
     /**
      * A list of permissions the principal has.
      * @return a List of Permissions objects
      */
-    List<Permission> getPermissions();
+    public List<Permission> getPermissions() {
+        return permissions;
+    }
 
     /**
      * Specifies the permissions the principal should have.
      * @param permissions a List of Permission objects
      */
-    void setPermissions(List<Permission> permissions);
+    public void setPermissions(List<Permission> permissions) {
+        this.permissions = permissions;
+    }
 
     /**
-     * Use of this method may be necessary to satisfy {@link java.security.Principal}
-     * requirements, but the implementation should not be used and should return
-     * the same value as {@link #getUsername}.
-     * @return a String of the username
+     * Do not use - only here to satisfy Principal implementation requirement.
+     * @deprecated use {@link #getUsername()}
+     * @return the value of {@link #getUsername()}
      */
-    String getName();
+    @Deprecated
+    @JsonIgnore
+    public String getName() {
+        return getUsername();
+    }
+
 }

--- a/alpine/alpine-model/src/main/java/alpine/model/UserPrincipal.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/UserPrincipal.java
@@ -43,7 +43,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 @PersistenceCapable
-@Discriminator(column = "TYPE", strategy = DiscriminatorStrategy.VALUE_MAP, value = "USER")
+@Discriminator(column = "TYPE", strategy = DiscriminatorStrategy.VALUE_MAP)
 @Inheritance(strategy = InheritanceStrategy.NEW_TABLE)
 public abstract class UserPrincipal implements Serializable, Principal {
 

--- a/alpine/alpine-model/src/main/resources/META-INF/persistence.xml
+++ b/alpine/alpine-model/src/main/resources/META-INF/persistence.xml
@@ -32,6 +32,7 @@
         <class>alpine.model.MappedOidcGroup</class>
         <class>alpine.model.Permission</class>
         <class>alpine.model.Team</class>
+        <class>alpine.model.UserPrincipal</class>
 
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
     </persistence-unit>

--- a/alpine/alpine-model/src/main/resources/META-INF/persistence.xml
+++ b/alpine/alpine-model/src/main/resources/META-INF/persistence.xml
@@ -32,7 +32,7 @@
         <class>alpine.model.MappedOidcGroup</class>
         <class>alpine.model.Permission</class>
         <class>alpine.model.Team</class>
-        <class>alpine.model.UserPrincipal</class>
+        <class>alpine.model.User</class>
 
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
     </persistence-unit>

--- a/alpine/alpine-server/src/main/java/alpine/server/filters/AuthorizationFilter.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/filters/AuthorizationFilter.java
@@ -20,7 +20,7 @@ package alpine.server.filters;
 
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.auth.PermissionRequired;
 import org.glassfish.jersey.server.ContainerRequest;
@@ -83,7 +83,7 @@ public class AuthorizationFilter implements ContainerRequestFilter {
                             SecurityMarkers.SECURITY_FAILURE,
                             "Unauthorized access attempt made by API Key %s to %s".formatted(
                                     apiKey.getMaskedKey(), requestUri));
-                } else if (principal instanceof final UserPrincipal user) {
+                } else if (principal instanceof final User user) {
                     LOGGER.info(
                             SecurityMarkers.SECURITY_FAILURE,
                             "Unauthorized access attempt made by %s to %s".formatted(user.getUsername(), requestUri));

--- a/alpine/alpine-server/src/main/java/alpine/server/resources/AlpineResource.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/resources/AlpineResource.java
@@ -25,7 +25,7 @@ import alpine.model.ApiKey;
 import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.persistence.AlpineQueryManager;
 import alpine.resources.AlpineRequest;
 import alpine.server.filters.AuthorizationFilter;
@@ -332,8 +332,8 @@ public abstract class AlpineResource {
             boolean hasPermission = false;
             if (getPrincipal() instanceof ApiKey) {
                 hasPermission = qm.hasPermission((ApiKey)getPrincipal(), permission);
-            } else if (getPrincipal() instanceof UserPrincipal) {
-                hasPermission = qm.hasPermission((UserPrincipal)getPrincipal(), permission, true);
+            } else if (getPrincipal() instanceof User) {
+                hasPermission = qm.hasPermission((User)getPrincipal(), permission, true);
             }
             return hasPermission;
         }

--- a/alpine/alpine-server/src/test/java/alpine/server/auth/JwtAuthenticationServiceTest.java
+++ b/alpine/alpine-server/src/test/java/alpine/server/auth/JwtAuthenticationServiceTest.java
@@ -174,19 +174,11 @@ public class JwtAuthenticationServiceTest {
 
     @Test
     public void authenticateShouldReturnOidcUserWhenIdentityProviderIsLocal() throws AuthenticationException {
-        try (final AlpineQueryManager qm = new AlpineQueryManager()) {
-            qm.createManagedUser("username", "passwordHash");
-            qm.createLdapUser("username");
-
-            final OidcUser oidcUser = new OidcUser();
-            oidcUser.setUsername("username");
-            oidcUser.setSubjectIdentifier("subjectIdentifier");
-            qm.persist(oidcUser);
-        }
+        createTestUsers();
 
         final Principal principalMock = Mockito.mock(Principal.class);
         Mockito.when(principalMock.getName())
-                .thenReturn("username");
+                .thenReturn("mgd-user");
 
         final String token = new JsonWebToken().createToken(principalMock, null, IdentityProvider.LOCAL);
 
@@ -203,19 +195,11 @@ public class JwtAuthenticationServiceTest {
 
     @Test
     public void authenticateShouldReturnLdapUserWhenIdentityProviderIsLdap() throws AuthenticationException {
-        try (final AlpineQueryManager qm = new AlpineQueryManager()) {
-            qm.createManagedUser("username", "passwordHash");
-            qm.createLdapUser("username");
-
-            final OidcUser oidcUser = new OidcUser();
-            oidcUser.setUsername("username");
-            oidcUser.setSubjectIdentifier("subjectIdentifier");
-            qm.persist(oidcUser);
-        }
+        createTestUsers();
 
         final Principal principalMock = Mockito.mock(Principal.class);
         Mockito.when(principalMock.getName())
-                .thenReturn("username");
+                .thenReturn("ldap-user");
 
         final String token = new JsonWebToken().createToken(principalMock, null, IdentityProvider.LDAP);
 
@@ -232,19 +216,11 @@ public class JwtAuthenticationServiceTest {
 
     @Test
     public void authenticateShouldReturnOidcUserWhenIdentityProviderIsOpenIdConnect() throws AuthenticationException {
-        try (final AlpineQueryManager qm = new AlpineQueryManager()) {
-            qm.createManagedUser("username", "passwordHash");
-            qm.createLdapUser("username");
-
-            final OidcUser oidcUser = new OidcUser();
-            oidcUser.setUsername("username");
-            oidcUser.setSubjectIdentifier("subjectIdentifier");
-            qm.persist(oidcUser);
-        }
+        createTestUsers();
 
         final Principal principalMock = Mockito.mock(Principal.class);
         Mockito.when(principalMock.getName())
-                .thenReturn("username");
+                .thenReturn("oidc-user");
 
         final String token = new JsonWebToken().createToken(principalMock, null, IdentityProvider.OPENID_CONNECT);
 
@@ -257,6 +233,18 @@ public class JwtAuthenticationServiceTest {
         final UserPrincipal authenticatedUser = (UserPrincipal) authService.authenticate();
         Assertions.assertThat(authenticatedUser).isNotNull();
         Assertions.assertThat(authenticatedUser).isInstanceOf(OidcUser.class);
+    }
+
+    private void createTestUsers() {
+        try (final AlpineQueryManager qm = new AlpineQueryManager()) {
+            qm.createManagedUser("mgd-user", "passwordHash");
+            qm.createLdapUser("ldap-user");
+
+            final OidcUser oidcUser = new OidcUser();
+            oidcUser.setUsername("oidc-user");
+            oidcUser.setSubjectIdentifier("subjectIdentifier");
+            qm.persist(oidcUser);
+        }
     }
 
 }

--- a/alpine/alpine-server/src/test/java/alpine/server/auth/JwtAuthenticationServiceTest.java
+++ b/alpine/alpine-server/src/test/java/alpine/server/auth/JwtAuthenticationServiceTest.java
@@ -23,7 +23,7 @@ import alpine.Config;
 import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.persistence.PersistenceManagerFactory;
 import org.assertj.core.api.Assertions;
@@ -188,7 +188,7 @@ public class JwtAuthenticationServiceTest {
 
         final JwtAuthenticationService authService = new JwtAuthenticationService(containerRequestMock);
 
-        final UserPrincipal authenticatedUser = (UserPrincipal) authService.authenticate();
+        final User authenticatedUser = (User) authService.authenticate();
         Assertions.assertThat(authenticatedUser).isNotNull();
         Assertions.assertThat(authenticatedUser).isInstanceOf(ManagedUser.class);
     }
@@ -209,7 +209,7 @@ public class JwtAuthenticationServiceTest {
 
         final JwtAuthenticationService authService = new JwtAuthenticationService(containerRequestMock);
 
-        final UserPrincipal authenticatedUser = (UserPrincipal) authService.authenticate();
+        final User authenticatedUser = (User) authService.authenticate();
         Assertions.assertThat(authenticatedUser).isNotNull();
         Assertions.assertThat(authenticatedUser).isInstanceOf(LdapUser.class);
     }
@@ -230,7 +230,7 @@ public class JwtAuthenticationServiceTest {
 
         final JwtAuthenticationService authService = new JwtAuthenticationService(containerRequestMock);
 
-        final UserPrincipal authenticatedUser = (UserPrincipal) authService.authenticate();
+        final User authenticatedUser = (User) authService.authenticate();
         Assertions.assertThat(authenticatedUser).isNotNull();
         Assertions.assertThat(authenticatedUser).isInstanceOf(OidcUser.class);
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -21,7 +21,7 @@ package org.dependencytrack.persistence;
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.notification.Notification;
 import alpine.notification.NotificationLevel;
 import alpine.persistence.PaginatedResult;
@@ -1100,7 +1100,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     /**
      * Updates a Project ACL to add the principals Team to the AccessTeams
      * This only happens if Portfolio Access Control is enabled and the @param principal is an ApyKey
-     * For a UserPrincipal we don't know which Team(s) to add to the ACL,
+     * For a User we don't know which Team(s) to add to the ACL,
      * See https://github.com/DependencyTrack/dependency-track/issues/1435
      *
      * @param project
@@ -1125,8 +1125,8 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
     }
 
     @Override
-    public boolean hasAccessManagementPermission(final UserPrincipal userPrincipal) {
-        return hasPermission(userPrincipal, Permissions.Constants.ACCESS_MANAGEMENT, true);
+    public boolean hasAccessManagementPermission(final User user) {
+        return hasPermission(user, Permissions.Constants.ACCESS_MANAGEMENT, true);
     }
 
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -20,7 +20,6 @@ package org.dependencytrack.persistence;
 
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
-import alpine.model.Permission;
 import alpine.model.Team;
 import alpine.model.UserPrincipal;
 import alpine.notification.Notification;
@@ -1127,12 +1126,7 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
     @Override
     public boolean hasAccessManagementPermission(final UserPrincipal userPrincipal) {
-        for (Permission permission : getEffectivePermissions(userPrincipal)) {
-            if (Permissions.ACCESS_MANAGEMENT.name().equals(permission.getName())) {
-                return true;
-            }
-        }
-        return false;
+        return hasPermission(userPrincipal, Permissions.Constants.ACCESS_MANAGEMENT, true);
     }
 
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -1219,7 +1219,7 @@ public class QueryManager extends AlpineQueryManager {
 
     public List<Permission> getEffectivePermissions(UserPrincipal userPrincipal, Project project) {
         return JdbiFactory.withJdbiHandle(request, handle -> handle.attach(EffectivePermissionDao.class)
-                .getEffectivePermissions(userPrincipal.getClass(), userPrincipal.getId(), project.getId()));
+                .getEffectivePermissions(userPrincipal.getId(), project.getId()));
     }
 
     public boolean hasAccessManagementPermission(final Object principal) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -26,7 +26,7 @@ import alpine.model.ConfigProperty;
 import alpine.model.IConfigProperty.PropertyType;
 import alpine.model.Permission;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.notification.NotificationLevel;
 import alpine.persistence.AbstractAlpineQueryManager;
 import alpine.persistence.AlpineQueryManager;
@@ -488,9 +488,9 @@ public class QueryManager extends AlpineQueryManager {
      */
     protected Set<Long> getTeamIds(final Principal principal) {
         final var principalTeamIds = new HashSet<Long>();
-        if (principal instanceof final UserPrincipal userPrincipal
-                && userPrincipal.getTeams() != null) {
-            for (final Team userInTeam : userPrincipal.getTeams()) {
+        if (principal instanceof final User user
+            && user.getTeams() != null) {
+            for (final Team userInTeam : user.getTeams()) {
                 principalTeamIds.add(userInTeam.getId());
             }
         } else if (principal instanceof final ApiKey apiKey
@@ -1217,14 +1217,14 @@ public class QueryManager extends AlpineQueryManager {
         return getNotificationQueryManager().bind(notificationRule, tags);
     }
 
-    public List<Permission> getEffectivePermissions(UserPrincipal userPrincipal, Project project) {
+    public List<Permission> getEffectivePermissions(User user, Project project) {
         return JdbiFactory.withJdbiHandle(request, handle -> handle.attach(EffectivePermissionDao.class)
-                .getEffectivePermissions(userPrincipal.getId(), project.getId()));
+                .getEffectivePermissions(user.getId(), project.getId()));
     }
 
     public boolean hasAccessManagementPermission(final Object principal) {
-        if (principal instanceof final UserPrincipal userPrincipal) {
-            return hasAccessManagementPermission(userPrincipal);
+        if (principal instanceof final User user) {
+            return hasAccessManagementPermission(user);
         } else if (principal instanceof final ApiKey apiKey) {
             return hasAccessManagementPermission(apiKey);
         }
@@ -1232,8 +1232,8 @@ public class QueryManager extends AlpineQueryManager {
         throw new IllegalArgumentException("Provided principal is of invalid type " + ClassUtils.getName(principal));
     }
 
-    public boolean hasAccessManagementPermission(final UserPrincipal userPrincipal) {
-        return getProjectQueryManager().hasAccessManagementPermission(userPrincipal);
+    public boolean hasAccessManagementPermission(final User user) {
+        return getProjectQueryManager().hasAccessManagementPermission(user);
     }
 
     public boolean hasAccessManagementPermission(final ApiKey apiKey) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -20,7 +20,7 @@ package org.dependencytrack.persistence;
 
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.persistence.NotSortableException;
 import alpine.persistence.OrderDirection;
 import alpine.persistence.PaginatedResult;
@@ -251,7 +251,7 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
                                                              || hasPermission(apiKey, Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE);
                     hasvulnerabilityManagementUpdatePermission = hasPermission(apiKey, Permissions.Constants.VULNERABILITY_MANAGEMENT)
                             || hasPermission(apiKey, Permissions.Constants.VULNERABILITY_MANAGEMENT_UPDATE);
-                } else if (principal instanceof final UserPrincipal user) {
+                } else if (principal instanceof final User user) {
                     hasPortfolioManagementUpdatePermission = hasPermission(user, Permissions.Constants.PORTFOLIO_MANAGEMENT, /* includeTeams */ true)
                                                              || hasPermission(user, Permissions.Constants.PORTFOLIO_MANAGEMENT_UPDATE, /* includeTeams */ true);
                     hasPolicyManagementUpdatePermission = hasPermission(user, Permissions.Constants.POLICY_MANAGEMENT, /* includeTeams */ true)

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/EffectivePermissionDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/EffectivePermissionDao.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import org.jdbi.v3.sqlobject.config.RegisterFieldMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
-import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
@@ -35,8 +34,6 @@ import alpine.model.UserPrincipal;
 public interface EffectivePermissionDao {
 
     @SqlQuery(/* language=sql */ """
-            <#-- @ftlvariable name="userClass" type="java.lang.Class<? extends alpine.model.UserPrincipal>" -->
-            <#assign prefix = userClass.getSimpleName()?upper_case>
             SELECT
                 p."ID",
                 p."NAME",
@@ -44,14 +41,11 @@ public interface EffectivePermissionDao {
               FROM "USER_PROJECT_EFFECTIVE_PERMISSIONS" upep
              INNER JOIN "PERMISSION" p
                 ON upep."PERMISSION_ID" = p."ID"
-             WHERE upep."${prefix}_ID" = :userId
+             WHERE upep."USERPRINCIPAL_ID" = :userId
                AND upep."PROJECT_ID" = :projectId
             """)
     @DefineNamedBindings
     @RegisterFieldMapper(Permission.class)
-    <T extends UserPrincipal> List<Permission> getEffectivePermissions(
-            @Define Class<T> userClass,
-            @Bind Long userId,
-            @Bind Long projectId);
+    <T extends UserPrincipal> List<Permission> getEffectivePermissions(@Bind Long userId, @Bind Long projectId);
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/EffectivePermissionDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/EffectivePermissionDao.java
@@ -18,15 +18,13 @@
  */
 package org.dependencytrack.persistence.jdbi;
 
-import java.util.List;
-
+import alpine.model.Permission;
 import org.jdbi.v3.sqlobject.config.RegisterFieldMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 
-import alpine.model.Permission;
-import alpine.model.UserPrincipal;
+import java.util.List;
 
 /**
  * @since 5.6.0
@@ -41,11 +39,11 @@ public interface EffectivePermissionDao {
               FROM "USER_PROJECT_EFFECTIVE_PERMISSIONS" upep
              INNER JOIN "PERMISSION" p
                 ON upep."PERMISSION_ID" = p."ID"
-             WHERE upep."USERPRINCIPAL_ID" = :userId
+             WHERE upep."USER_ID" = :userId
                AND upep."PROJECT_ID" = :projectId
             """)
     @DefineNamedBindings
     @RegisterFieldMapper(Permission.class)
-    <T extends UserPrincipal> List<Permission> getEffectivePermissions(@Bind Long userId, @Bind Long projectId);
+    List<Permission> getEffectivePermissions(@Bind Long userId, @Bind Long projectId);
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/AnalysisResource.java
@@ -22,7 +22,7 @@ import alpine.common.validation.RegexSequence;
 import alpine.common.validation.ValidationTask;
 import alpine.model.ApiKey;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.server.auth.PermissionRequired;
 import com.google.protobuf.Any;
 import com.google.protobuf.util.Timestamps;
@@ -35,15 +35,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Validator;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.event.kafka.KafkaEventDispatcher;
@@ -63,6 +54,15 @@ import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.AnalysisRequest;
 import org.dependencytrack.util.AnalysisCommentFormatter.AnalysisCommentField;
 
+import jakarta.validation.Validator;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -195,7 +195,7 @@ public class AnalysisResource extends AbstractApiResource {
             }
 
             final String commenter;
-            if (getPrincipal() instanceof UserPrincipal principal) {
+            if (getPrincipal() instanceof User principal) {
                 commenter = principal.getUsername();
             } else if (getPrincipal() instanceof ApiKey apiKey) {
                 List<Team> teams = apiKey.getTeams();

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/BadgeResource.java
@@ -23,7 +23,7 @@ import alpine.model.ApiKey;
 import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.server.auth.ApiKeyAuthenticationService;
 import alpine.server.auth.AuthenticationNotRequired;
 import alpine.server.auth.JwtAuthenticationService;
@@ -137,7 +137,7 @@ public class BadgeResource extends AbstractApiResource {
             LOGGER.info(SecurityMarkers.SECURITY_FAILURE, "Unauthorized access attempt made by API Key "
                     + apiKey.getMaskedKey() + " to " + ((ContainerRequest) super.getRequestContext()).getRequestUri().toString());
         } else {
-            UserPrincipal user = null;
+            User user = null;
             if (principal instanceof ManagedUser) {
                 user = qm.getManagedUser(((ManagedUser) principal).getUsername());
             } else if (principal instanceof LdapUser) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/PermissionResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/PermissionResource.java
@@ -21,7 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.common.logging.Logger;
 import alpine.model.Permission;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.server.auth.PermissionRequired;
 import alpine.server.resources.AlpineResource;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,6 +33,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.validation.ValidUuid;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.resources.v1.vo.TeamPermissionsSetRequest;
+import org.dependencytrack.resources.v1.vo.UserPermissionsSetRequest;
+import org.owasp.security.logging.SecurityMarkers;
+
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -44,15 +51,8 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.model.validation.ValidUuid;
-import org.dependencytrack.persistence.QueryManager;
-import org.dependencytrack.resources.v1.vo.TeamPermissionsSetRequest;
-import org.dependencytrack.resources.v1.vo.UserPermissionsSetRequest;
-import org.owasp.security.logging.SecurityMarkers;
-
-import java.util.List;
 import javax.jdo.Query;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -105,7 +105,7 @@ public class PermissionResource extends AlpineResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated user",
-                    content = @Content(schema = @Schema(implementation = UserPrincipal.class))
+                    content = @Content(schema = @Schema(implementation = User.class))
             ),
             @ApiResponse(responseCode = "304", description = "The user already has the specified permission assigned"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -118,7 +118,7 @@ public class PermissionResource extends AlpineResource {
             @Parameter(description = "A valid permission", required = true)
             @PathParam("permission") String permissionName) {
         try (QueryManager qm = new QueryManager()) {
-            UserPrincipal principal = qm.getUserPrincipal(username);
+            User principal = qm.getUser(username);
             if (principal == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The user could not be found.").build();
             }
@@ -150,7 +150,7 @@ public class PermissionResource extends AlpineResource {
             @ApiResponse(
                     responseCode = "200",
                     description = "The updated user",
-                    content = @Content(schema = @Schema(implementation = UserPrincipal.class))
+                    content = @Content(schema = @Schema(implementation = User.class))
             ),
             @ApiResponse(responseCode = "304", description = "The user already has the specified permission assigned"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -163,7 +163,7 @@ public class PermissionResource extends AlpineResource {
             @Parameter(description = "A valid permission", required = true)
             @PathParam("permission") String permissionName) {
         try (QueryManager qm = new QueryManager()) {
-            UserPrincipal principal = qm.getUserPrincipal(username);
+            User principal = qm.getUser(username);
             if (principal == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The user could not be found.").build();
             }
@@ -277,7 +277,7 @@ public class PermissionResource extends AlpineResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "<p>Requires permission <strong>ACCESS_MANAGEMENT</strong> or <strong>ACCESS_MANAGEMENT_UPDATE</strong></p>")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "The updated user", content = @Content(schema = @Schema(implementation = UserPrincipal.class))),
+            @ApiResponse(responseCode = "200", description = "The updated user", content = @Content(schema = @Schema(implementation = User.class))),
             @ApiResponse(responseCode = "304", description = "The user is already has the specified permission(s)"),
             @ApiResponse(responseCode = "400", description = "Bad request"),
             @ApiResponse(responseCode = "401", description = "Unauthorized"),
@@ -286,7 +286,7 @@ public class PermissionResource extends AlpineResource {
     @PermissionRequired({ Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_UPDATE })
     public Response setUserPermissions(@Parameter(description = "A username and valid list permission") @Valid UserPermissionsSetRequest request) {
         try (QueryManager qm = new QueryManager()) {
-            UserPrincipal user = qm.getUserPrincipal(request.username());
+            User user = qm.getUser(request.username());
             if (user == null)
                 return Response.status(Response.Status.NOT_FOUND).entity("The user could not be found.").build();
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -22,7 +22,7 @@ import alpine.common.logging.Logger;
 import alpine.event.framework.Event;
 import alpine.model.ApiKey;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.persistence.PaginatedResult;
 import alpine.server.auth.PermissionRequired;
 import io.jsonwebtoken.lang.Collections;
@@ -494,8 +494,8 @@ public class ProjectResource extends AbstractApiResource {
 
                 if (!chosenTeams.isEmpty()) {
                     List<Team> userTeams;
-                    if (principal instanceof final UserPrincipal userPrincipal) {
-                        userTeams = userPrincipal.getTeams();
+                    if (principal instanceof final User user) {
+                        userTeams = user.getTeams();
                     } else if (principal instanceof final ApiKey apiKey) {
                         userTeams = apiKey.getTeams();
                     } else {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -22,7 +22,7 @@ import alpine.Config;
 import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.security.ApiKeyDecoder;
 import alpine.security.InvalidApiKeyFormatException;
 import alpine.server.auth.PermissionRequired;
@@ -58,7 +58,6 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -242,15 +241,14 @@ public class TeamResource extends AlpineResource {
     })
     public Response availableTeams() {
         try (QueryManager qm = new QueryManager()) {
-            Principal user = getPrincipal();
-            boolean isAllTeams = qm.hasAccessManagementPermission(user);
+            boolean isAllTeams = qm.hasAccessManagementPermission(getPrincipal());
             List<Team> teams = new ArrayList<>();
             if (isAllTeams) {
                 teams = qm.getTeams();
             } else {
-                if (user instanceof final UserPrincipal userPrincipal) {
-                    teams = userPrincipal.getTeams();
-                } else if (user instanceof final ApiKey apiKey) {
+                if (getPrincipal() instanceof final User user) {
+                    teams = user.getTeams();
+                } else if (getPrincipal() instanceof final ApiKey apiKey) {
                     teams = apiKey.getTeams();
                 }
             }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/UserResource.java
@@ -79,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import javax.jdo.Query;
@@ -123,7 +124,8 @@ public class UserResource extends AlpineResource {
         try (QueryManager qm = new QueryManager()) {
             final Principal principal = auth.authenticate();
             super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_SUCCESS, "Successful user login / username: " + username);
-            final List<Permission> permissions = qm.getEffectivePermissions((UserPrincipal) principal);
+            final Set<String> permissionNames = qm.getEffectivePermissions(principal);
+            final List<Permission> permissions = qm.getPermissionsByName(permissionNames);
             final KeyManager km = KeyManager.getInstance();
             final JsonWebToken jwt = new JsonWebToken(km.getSecretKey());
             final String token = jwt.createToken(principal, permissions);
@@ -173,7 +175,8 @@ public class UserResource extends AlpineResource {
         try (final QueryManager qm = new QueryManager()) {
             final Principal principal = authService.authenticate();
             super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_SUCCESS, "Successful OpenID Connect login / username: " + principal.getName());
-            final List<Permission> permissions = qm.getEffectivePermissions((UserPrincipal) principal);
+            final Set<String> permissionNames = qm.getEffectivePermissions(principal);
+            final List<Permission> permissions = qm.getPermissionsByName(permissionNames);
             final KeyManager km = KeyManager.getInstance();
             final JsonWebToken jwt = new JsonWebToken(km.getSecretKey());
             final String token = jwt.createToken(principal, permissions);

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ViolationAnalysisResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ViolationAnalysisResource.java
@@ -20,10 +20,7 @@ package org.dependencytrack.resources.v1;
 
 import alpine.common.validation.RegexSequence;
 import alpine.common.validation.ValidationTask;
-import alpine.model.LdapUser;
-import alpine.model.ManagedUser;
-import alpine.model.OidcUser;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.server.auth.PermissionRequired;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -154,8 +151,8 @@ public class ViolationAnalysisResource extends AbstractApiResource {
             }
 
             String commenter = null;
-            if (getPrincipal() instanceof LdapUser || getPrincipal() instanceof ManagedUser || getPrincipal() instanceof OidcUser) {
-                commenter = ((UserPrincipal) getPrincipal()).getUsername();
+            if (getPrincipal() instanceof final User user) {
+                commenter = user.getUsername();
             }
 
             boolean analysisStateChange = false;

--- a/apiserver/src/main/java/org/dependencytrack/util/PrincipalUtil.java
+++ b/apiserver/src/main/java/org/dependencytrack/util/PrincipalUtil.java
@@ -20,7 +20,7 @@ package org.dependencytrack.util;
 
 import alpine.model.ApiKey;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 
 import java.security.Principal;
 import java.util.HashSet;
@@ -37,9 +37,9 @@ public final class PrincipalUtil {
     public static Set<Long> getPrincipalTeamIds(final Principal principal) {
         final Set<Long> principalTeamIds = new HashSet<>();
 
-        if (principal instanceof final UserPrincipal userPrincipal
-                && userPrincipal.getTeams() != null) {
-            for (final Team userInTeam : userPrincipal.getTeams()) {
+        if (principal instanceof final User user
+            && user.getTeams() != null) {
+            for (final Team userInTeam : user.getTeams()) {
                 principalTeamIds.add(userInTeam.getId());
             }
         } else if (principal instanceof final ApiKey apiKey

--- a/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1673,20 +1673,6 @@
         <dropTable tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS" cascadeConstraints="true" />
 
         <createTable ifNotExists="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS">
-            <column name="USER_ID" type="BIGINT">
-                <constraints
-                        nullable="false"
-                        primaryKey="true"
-                        primaryKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PK"
-                        foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USER_FK"
-                        referencedTableName="USER"
-                        referencedColumnNames="ID"
-                        deferrable="true"
-                        initiallyDeferred="true"
-                        deleteCascade="true"
-                        validateForeignKey="true"/>
-            </column>
-
             <column name="PROJECT_ID" type="BIGINT">
                 <constraints
                         nullable="false"
@@ -1694,6 +1680,20 @@
                         primaryKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PK"
                         foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PROJECT_FK"
                         referencedTableName="PROJECT"
+                        referencedColumnNames="ID"
+                        deferrable="true"
+                        initiallyDeferred="true"
+                        deleteCascade="true"
+                        validateForeignKey="true"/>
+            </column>
+
+            <column name="USER_ID" type="BIGINT">
+                <constraints
+                        nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PK"
+                        foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USER_FK"
+                        referencedTableName="USER"
                         referencedColumnNames="ID"
                         deferrable="true"
                         initiallyDeferred="true"

--- a/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1430,4 +1430,327 @@
         <dropTable tableName="INSTALLEDUPGRADES"/>
         <dropTable tableName="SCHEMAVERSION"/>
     </changeSet>
+
+    <changeSet id="v5.6.0-23" author="jhoward-lm">
+        <createTable ifNotExists="true" tableName="USERPRINCIPAL">
+            <column autoIncrement="true" name="ID" type="BIGINT">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="USERPRINCIPAL_PK" />
+            </column>
+
+            <column name="USERNAME" type="TEXT">
+                <constraints nullable="false" validateNullable="true" />
+            </column>
+
+            <column name="EMAIL" type="TEXT" />
+
+            <column name="TYPE" type="TEXT">
+                <constraints nullable="false" validateNullable="true" />
+            </column>
+
+            <!-- Colunns specific to LDAP users -->
+            <column name="DN" type="TEXT" />
+
+            <!-- Colunns specific to managed users -->
+            <column name="FULLNAME" type="TEXT" />
+            <column name="FORCE_PASSWORD_CHANGE" type="BOOLEAN" />
+            <column name="SUSPENDED" type="BOOLEAN" />
+            <column name="NON_EXPIRY_PASSWORD" type="BOOLEAN" />
+            <column name="LAST_PASSWORD_CHANGE" type="TIMESTAMP WITH TIME ZONE" />
+            <column name="PASSWORD" type="TEXT" />
+
+            <!-- Colunns specific to OIDC users -->
+            <column name="SUBJECT_IDENTIFIER" type="TEXT" />
+        </createTable>
+
+        <createIndex unique="true" tableName="USERPRINCIPAL" indexName="USERPRINCIPAL_USERNAME_IDX">
+            <column name="USERNAME" />
+        </createIndex>
+
+        <createTable tableName="USERPRINCIPALS_PERMISSIONS">
+            <column name="USERPRINCIPAL_ID" type="BIGINT">
+                <constraints nullable="false"
+                    foreignKeyName="USERPRINCIPALS_PERMISSIONS_USERPRINCIPAL_FK"
+                    referencedTableName="USERPRINCIPAL"
+                    referencedColumnNames="ID"
+                    validateNullable="true" validateForeignKey="true" />
+            </column>
+
+            <column name="PERMISSION_ID" type="BIGINT">
+                <constraints nullable="false"
+                    foreignKeyName="USERPRINCIPALS_PERMISSIONS_PERMISSION_FK"
+                    referencedTableName="PERMISSION"
+                    referencedColumnNames="ID"
+                    validateNullable="true" validateForeignKey="true" />
+            </column>
+        </createTable>
+
+        <createTable tableName="USERPRINCIPALS_TEAMS">
+            <column name="USERPRINCIPAL_ID" type="BIGINT">
+                <constraints nullable="false"
+                    foreignKeyName="USERPRINCIPALS_TEAMS_USERPRINCIPAL_FK"
+                    referencedTableName="USERPRINCIPAL"
+                    referencedColumnNames="ID"
+                    validateNullable="true" validateForeignKey="true" />
+            </column>
+
+            <column name="TEAM_ID" type="BIGINT">
+                <constraints nullable="false"
+                    foreignKeyName="USERPRINCIPALS_TEAMS_TEAM_FK"
+                    referencedTableName="TEAM"
+                    referencedColumnNames="ID"
+                    validateNullable="true" validateForeignKey="true" />
+            </column>
+        </createTable>
+
+        <dropTable tableName="LDAPUSERS_TEAMS" cascadeConstraints="true" />
+        <dropTable tableName="LDAPUSERS_PERMISSIONS" cascadeConstraints="true" />
+        <dropTable tableName="LDAPUSER" cascadeConstraints="true" />
+        <dropTable tableName="MANAGEDUSERS_TEAMS" cascadeConstraints="true" />
+        <dropTable tableName="MANAGEDUSERS_PERMISSIONS" cascadeConstraints="true" />
+        <dropTable tableName="MANAGEDUSER" cascadeConstraints="true" />
+        <dropTable tableName="OIDCUSERS_TEAMS" cascadeConstraints="true" />
+        <dropTable tableName="OIDCUSERS_PERMISSIONS" cascadeConstraints="true" />
+        <dropTable tableName="OIDCUSER" cascadeConstraints="true" />
+
+        <sql splitStatements="true">
+            ALTER TABLE "USERPRINCIPAL"
+              ADD CONSTRAINT check_user_type
+            CHECK ("TYPE" IN ('MANAGED', 'LDAP', 'OIDC'));
+
+            ALTER TABLE "USERPRINCIPAL"
+              ADD CONSTRAINT check_managed_columns
+            CHECK (
+                ("TYPE" = 'MANAGED'
+                    AND "FORCE_PASSWORD_CHANGE" IS NOT NULL
+                    AND "LAST_PASSWORD_CHANGE" IS NOT NULL
+                    AND "NON_EXPIRY_PASSWORD" IS NOT NULL
+                    AND "PASSWORD" IS NOT NULL
+                    AND "SUSPENDED" IS NOT NULL)
+                OR
+                ("TYPE" != 'MANAGED'
+                    AND "FORCE_PASSWORD_CHANGE" IS NULL
+                    AND "FULLNAME" IS NULL
+                    AND "LAST_PASSWORD_CHANGE" IS NULL
+                    AND "NON_EXPIRY_PASSWORD" IS NULL
+                    AND "PASSWORD" IS NULL
+                    AND "SUSPENDED" IS NULL)
+            );
+
+            ALTER TABLE "USERPRINCIPAL"
+              ADD CONSTRAINT check_ldap_columns
+            CHECK (
+                ("TYPE" = 'LDAP' AND "DN" IS NOT NULL)
+                OR ("TYPE" != 'LDAP' AND "DN" IS NULL)
+            );
+
+            ALTER TABLE "USERPRINCIPAL"
+              ADD CONSTRAINT check_oidc_columns
+            CHECK ("TYPE" = 'OIDC' OR "SUBJECT_IDENTIFIER" IS NULL);
+        </sql>
+    </changeSet>
+
+    <changeSet id="v5.6.0-24" author="jhoward-lm">
+        <dropTable tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS" cascadeConstraints="true" />
+
+        <createTable ifNotExists="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS">
+            <column name="USERPRINCIPAL_ID" type="BIGINT">
+                <constraints nullable="true"
+                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USERPRINCIPAL_FK"
+                    referencedTableName="USERPRINCIPAL" referencedColumnNames="ID"
+                    deferrable="true" initiallyDeferred="true" deleteCascade="false"
+                    validateForeignKey="true" />
+            </column>
+
+            <column name="PROJECT_ID" type="BIGINT">
+                <constraints nullable="false"
+                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PROJECT_FK"
+                    referencedTableName="PROJECT" referencedColumnNames="ID"
+                    deferrable="true" initiallyDeferred="true" deleteCascade="true"
+                    validateForeignKey="true" />
+            </column>
+
+            <column name="PERMISSION_ID" type="BIGINT">
+                <constraints nullable="false"
+                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PERMISSION_ID_FK"
+                    referencedTableName="PERMISSION" referencedColumnNames="ID"
+                    deferrable="true" initiallyDeferred="true" deleteCascade="true"
+                    validateForeignKey="true" />
+            </column>
+
+            <column name="PERMISSION_NAME" type="VARCHAR(255)">
+                <constraints nullable="false"
+                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PERMISSION_NAME_FK"
+                    referencedTableName="PERMISSION" referencedColumnNames="NAME"
+                    deferrable="true" initiallyDeferred="true" deleteCascade="true"
+                    validateForeignKey="true" />
+            </column>
+        </createTable>
+
+        <createIndex unique="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS" indexName="USER_PROJECT_EFFECTIVE_PERMISSIONS_COMPOSITE_IDX">
+            <column name="USERPRINCIPAL_ID" />
+            <column name="PROJECT_ID" />
+            <column name="PERMISSION_ID" />
+        </createIndex>
+
+        <sql splitStatements="false">
+            -- Helper function to recalculate all user permissions for a project.
+            -- Called by trigger functions to update the values in the USER_PROJECT_EFFECTIVE_PERMISSIONS table.
+            CREATE OR REPLACE FUNCTION recalc_user_project_effective_permissions(project_ids BIGINT[])
+            RETURNS void AS $$
+            BEGIN
+              -- Remove any existing effective permissions for this project.
+              DELETE FROM "USER_PROJECT_EFFECTIVE_PERMISSIONS"
+              WHERE "PROJECT_ID" = ANY(project_ids);
+
+              -- Rebuild effective permissions for users
+              INSERT INTO "USER_PROJECT_EFFECTIVE_PERMISSIONS"
+                ("USERPRINCIPAL_ID", "PROJECT_ID", "PERMISSION_ID", "PERMISSION_NAME")
+              SELECT DISTINCT ut."USERPRINCIPAL_ID", pat."PROJECT_ID", tp."PERMISSION_ID", p."NAME"
+                FROM "PROJECT_ACCESS_TEAMS" pat
+               INNER JOIN "TEAMS_PERMISSIONS" tp
+                  ON tp."TEAM_ID" = pat."TEAM_ID"
+               INNER JOIN "PERMISSION" p
+                  ON p."ID" = tp."PERMISSION_ID"
+               INNER JOIN "USERPRINCIPALS_TEAMS" ut
+                  ON ut."TEAM_ID" = pat."TEAM_ID"
+               WHERE pat."PROJECT_ID" = ANY(project_ids);
+            END;
+            $$ LANGUAGE plpgsql;
+        </sql>
+
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION effective_permissions_mx_on_delete()
+            RETURNS TRIGGER AS $$
+            DECLARE
+              project_ids BIGINT[];
+            BEGIN
+              IF TG_TABLE_NAME = 'PROJECT_ACCESS_TEAMS' THEN
+                PERFORM recalc_user_project_effective_permissions(
+                  (SELECT ARRAY_AGG(DISTINCT "PROJECT_ID") FROM old_table)
+                );
+              ELSIF TG_TABLE_NAME IN ('USERPRINCIPALS_TEAMS', 'TEAMS_PERMISSIONS') THEN
+                PERFORM recalc_user_project_effective_permissions((
+                  SELECT ARRAY_AGG(DISTINCT pat."PROJECT_ID")
+                    FROM "PROJECT_ACCESS_TEAMS" AS pat
+                   INNER JOIN old_table
+                      ON old_table."TEAM_ID" = pat."TEAM_ID"
+                ));
+              END IF;
+              RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+        </sql>
+
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION effective_permissions_mx_on_insert()
+            RETURNS TRIGGER AS $$
+            DECLARE
+              project_ids BIGINT[];
+            BEGIN
+              IF TG_TABLE_NAME = 'PROJECT_ACCESS_TEAMS' THEN
+                PERFORM recalc_user_project_effective_permissions(
+                  (SELECT ARRAY_AGG(DISTINCT "PROJECT_ID") FROM new_table)
+                );
+              ELSIF TG_TABLE_NAME IN ('USERPRINCIPALS_TEAMS', 'TEAMS_PERMISSIONS') THEN
+                PERFORM recalc_user_project_effective_permissions((
+                  SELECT ARRAY_AGG(DISTINCT pat."PROJECT_ID")
+                    FROM "PROJECT_ACCESS_TEAMS" AS pat
+                   INNER JOIN new_table
+                      ON new_table."TEAM_ID" = pat."TEAM_ID"
+                ));
+              END IF;
+              RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+        </sql>
+
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION effective_permissions_mx_on_update()
+            RETURNS TRIGGER AS $$
+            DECLARE
+              project_ids BIGINT[];
+            BEGIN
+              IF TG_TABLE_NAME = 'PROJECT_ACCESS_TEAMS' THEN
+                PERFORM recalc_user_project_effective_permissions((
+                  SELECT ARRAY_AGG("PROJECT_ID")
+                    FROM (
+                      SELECT "PROJECT_ID" FROM old_table
+                      UNION
+                      SELECT "PROJECT_ID" FROM new_table
+                    ) AS combined_projects
+                ));
+              ELSIF TG_TABLE_NAME IN ('USERPRINCIPALS_TEAMS', 'TEAMS_PERMISSIONS') THEN
+                PERFORM recalc_user_project_effective_permissions((
+                  SELECT ARRAY_AGG(DISTINCT pat."PROJECT_ID")
+                    FROM "PROJECT_ACCESS_TEAMS" pat
+                    JOIN (
+                      SELECT "TEAM_ID" FROM old_table
+                      UNION
+                      SELECT "TEAM_ID" FROM new_table
+                    ) AS teams
+                      ON pat."TEAM_ID" = teams."TEAM_ID"
+                ));
+              END IF;
+              RETURN NULL;
+            END;
+            $$ LANGUAGE plpgsql;
+        </sql>
+
+        <sql splitStatements="false">
+            CREATE OR REPLACE FUNCTION prevent_direct_effective_permissions_writes()
+            RETURNS TRIGGER AS $$
+            BEGIN
+              -- Depth of 1 means this trigger was fired by an attempted direct
+              -- insert, update, or delete on USER_PROJECT_EFFECTIVE_PERMISSIONS.
+              -- Depth should be 2, meaning this trigger was fired from another trigger.
+              IF pg_trigger_depth() &lt; 2 THEN
+                RAISE EXCEPTION 'Direct modifications to USER_PROJECT_EFFECTIVE_PERMISSIONS are not allowed.';
+              END IF;
+              RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+        </sql>
+
+        <sql splitStatements="true">
+            -- INSERT trigger for USERPRINCIPALS_TEAMS
+            CREATE TRIGGER trigger_effective_permissions_mx_on_userprincipals_teams_insert
+            AFTER INSERT ON "USERPRINCIPALS_TEAMS"
+            REFERENCING NEW TABLE AS new_table
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION effective_permissions_mx_on_insert();
+
+            -- DELETE trigger for USERPRINCIPALS_TEAMS
+            CREATE TRIGGER trigger_effective_permissions_mx_on_userprincipals_teams_delete
+            AFTER DELETE ON "USERPRINCIPALS_TEAMS"
+            REFERENCING OLD TABLE AS old_table
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION effective_permissions_mx_on_delete();
+
+            -- UPDATE trigger for USERPRINCIPALS_TEAMS
+            CREATE TRIGGER trigger_effective_permissions_mx_on_userprincipals_teams_update
+            AFTER UPDATE ON "USERPRINCIPALS_TEAMS"
+            REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION effective_permissions_mx_on_update();
+        </sql>
+
+        <sql splitStatements="false">
+            -- Backfill the USER_PROJECT_EFFECTIVE_PERMISSIONS table for existing PROJECT_ACCESS_TEAMS entries
+            DO $$
+            BEGIN
+              PERFORM recalc_user_project_effective_permissions(
+                (SELECT ARRAY_AGG(DISTINCT "PROJECT_ID") FROM "PROJECT_ACCESS_TEAMS")
+              );
+            END;
+            $$;
+        </sql>
+
+        <sql splitStatements="true">
+            -- Prevent direct inserts/updates/writes to USER_PROJECT_EFFECTIVE_PERMISSIONS
+            CREATE TRIGGER trigger_prevent_direct_effective_permissions_writes
+            BEFORE DELETE OR INSERT OR UPDATE ON "USER_PROJECT_EFFECTIVE_PERMISSIONS"
+            FOR EACH STATEMENT
+            EXECUTE FUNCTION prevent_direct_effective_permissions_writes();
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1522,38 +1522,38 @@
 
         <sql splitStatements="true">
             ALTER TABLE "USER"
-                ADD CONSTRAINT check_user_type
-                    CHECK ("TYPE" IN ('MANAGED', 'LDAP', 'OIDC'));
+              ADD CONSTRAINT user_type_check
+            CHECK ("TYPE" IN ('MANAGED', 'LDAP', 'OIDC'));
 
             ALTER TABLE "USER"
-                ADD CONSTRAINT check_managed_columns
-                    CHECK (
-                        ("TYPE" = 'MANAGED'
-                            AND "FORCE_PASSWORD_CHANGE" IS NOT NULL
-                            AND "LAST_PASSWORD_CHANGE" IS NOT NULL
-                            AND "NON_EXPIRY_PASSWORD" IS NOT NULL
-                            AND "PASSWORD" IS NOT NULL
-                            AND "SUSPENDED" IS NOT NULL)
-                            OR
-                        ("TYPE" != 'MANAGED'
+              ADD CONSTRAINT user_managed_check
+            CHECK (
+                ("TYPE" = 'MANAGED'
+                    AND "FORCE_PASSWORD_CHANGE" IS NOT NULL
+                    AND "LAST_PASSWORD_CHANGE" IS NOT NULL
+                    AND "NON_EXPIRY_PASSWORD" IS NOT NULL
+                    AND "PASSWORD" IS NOT NULL
+                    AND "SUSPENDED" IS NOT NULL)
+                OR
+                ("TYPE" != 'MANAGED'
                     AND "FORCE_PASSWORD_CHANGE" IS NULL
                     AND "FULLNAME" IS NULL
                     AND "LAST_PASSWORD_CHANGE" IS NULL
                     AND "NON_EXPIRY_PASSWORD" IS NULL
                     AND "PASSWORD" IS NULL
                     AND "SUSPENDED" IS NULL)
-                        );
+            );
 
             ALTER TABLE "USER"
-                ADD CONSTRAINT check_ldap_columns
-                    CHECK (
-                        ("TYPE" = 'LDAP' AND "DN" IS NOT NULL)
-                            OR ("TYPE" != 'LDAP' AND "DN" IS NULL)
-                        );
+              ADD CONSTRAINT user_ldap_check
+            CHECK (
+                ("TYPE" = 'LDAP' AND "DN" IS NOT NULL)
+                OR ("TYPE" != 'LDAP' AND "DN" IS NULL)
+            );
 
             ALTER TABLE "USER"
-                ADD CONSTRAINT check_oidc_columns
-                    CHECK ("TYPE" = 'OIDC' OR "SUBJECT_IDENTIFIER" IS NULL);
+              ADD CONSTRAINT user_oidc_check
+            CHECK ("TYPE" = 'OIDC' OR "SUBJECT_IDENTIFIER" IS NULL);
         </sql>
 
         <!-- Migrate existing managed users. -->

--- a/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1467,6 +1467,8 @@
             <column name="USER_ID" type="BIGINT">
                 <constraints
                         nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USERS_PERMISSIONS_PK"
                         foreignKeyName="USERS_PERMISSIONS_USER_FK"
                         referencedTableName="USER"
                         referencedColumnNames="ID"
@@ -1478,6 +1480,8 @@
             <column name="PERMISSION_ID" type="BIGINT">
                 <constraints
                         nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USERS_PERMISSIONS_PK"
                         foreignKeyName="USERS_PERMISSIONS_PERMISSION_FK"
                         referencedTableName="PERMISSION"
                         referencedColumnNames="ID"
@@ -1491,6 +1495,8 @@
             <column name="USER_ID" type="BIGINT">
                 <constraints
                         nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USERS_TEAMS_PK"
                         foreignKeyName="USERS_TEAMS_USER_FK"
                         referencedTableName="USER"
                         referencedColumnNames="ID"
@@ -1502,6 +1508,8 @@
             <column name="TEAM_ID" type="BIGINT">
                 <constraints
                         nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USERS_TEAMS_PK"
                         foreignKeyName="USERS_TEAMS_TEAM_FK"
                         referencedTableName="TEAM"
                         referencedColumnNames="ID"
@@ -1510,15 +1518,6 @@
                         deleteCascade="true"/>
             </column>
         </createTable>
-
-        <addPrimaryKey
-                tableName="USERS_PERMISSIONS"
-                columnNames="USER_ID, PERMISSION_ID"
-                constraintName="USERS_PERMISSIONS_PK"/>
-        <addPrimaryKey
-                tableName="USERS_TEAMS"
-                columnNames="USER_ID, TEAM_ID"
-                constraintName="USERS_TEAMS_PK"/>
 
         <sql splitStatements="true">
             ALTER TABLE "USER"
@@ -1675,43 +1674,59 @@
 
         <createTable ifNotExists="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS">
             <column name="USER_ID" type="BIGINT">
-                <constraints nullable="true"
-                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USER_FK"
-                    referencedTableName="USER" referencedColumnNames="ID"
-                    deferrable="true" initiallyDeferred="true" deleteCascade="false"
-                    validateForeignKey="true" />
+                <constraints
+                        nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PK"
+                        foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USER_FK"
+                        referencedTableName="USER"
+                        referencedColumnNames="ID"
+                        deferrable="true"
+                        initiallyDeferred="true"
+                        deleteCascade="true"
+                        validateForeignKey="true"/>
             </column>
 
             <column name="PROJECT_ID" type="BIGINT">
-                <constraints nullable="false"
-                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PROJECT_FK"
-                    referencedTableName="PROJECT" referencedColumnNames="ID"
-                    deferrable="true" initiallyDeferred="true" deleteCascade="true"
-                    validateForeignKey="true" />
+                <constraints
+                        nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PK"
+                        foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PROJECT_FK"
+                        referencedTableName="PROJECT"
+                        referencedColumnNames="ID"
+                        deferrable="true"
+                        initiallyDeferred="true"
+                        deleteCascade="true"
+                        validateForeignKey="true"/>
             </column>
 
             <column name="PERMISSION_ID" type="BIGINT">
-                <constraints nullable="false"
-                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PERMISSION_ID_FK"
-                    referencedTableName="PERMISSION" referencedColumnNames="ID"
-                    deferrable="true" initiallyDeferred="true" deleteCascade="true"
-                    validateForeignKey="true" />
+                <constraints
+                        nullable="false"
+                        primaryKey="true"
+                        primaryKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PK"
+                        foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PERMISSION_ID_FK"
+                        referencedTableName="PERMISSION"
+                        referencedColumnNames="ID"
+                        deferrable="true"
+                        initiallyDeferred="true"
+                        deleteCascade="true"
+                        validateForeignKey="true"/>
             </column>
 
             <column name="PERMISSION_NAME" type="VARCHAR(255)">
-                <constraints nullable="false"
-                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PERMISSION_NAME_FK"
-                    referencedTableName="PERMISSION" referencedColumnNames="NAME"
-                    deferrable="true" initiallyDeferred="true" deleteCascade="true"
-                    validateForeignKey="true" />
+                <constraints
+                        nullable="false"
+                        foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_PERMISSION_NAME_FK"
+                        referencedTableName="PERMISSION"
+                        referencedColumnNames="NAME"
+                        deferrable="true"
+                        initiallyDeferred="true"
+                        deleteCascade="true"
+                        validateForeignKey="true"/>
             </column>
         </createTable>
-
-        <createIndex unique="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS" indexName="USER_PROJECT_EFFECTIVE_PERMISSIONS_COMPOSITE_IDX">
-            <column name="USER_ID" />
-            <column name="PROJECT_ID" />
-            <column name="PERMISSION_ID" />
-        </createIndex>
 
         <sql splitStatements="false">
             -- Helper function to recalculate all user permissions for a project.

--- a/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1644,7 +1644,7 @@
                 ON "OIDCUSER"."ID" = "OIDCUSERS_PERMISSIONS"."OIDCUSER_ID"
              INNER JOIN "USER"
                 ON "USER"."USERNAME" = "OIDCUSER"."USERNAME"
-               AND "USER"."TYPE" = 'LDAP'
+               AND "USER"."TYPE" = 'OIDC'
             ON CONFLICT ("PERMISSION_ID", "USER_ID") DO NOTHING;
 
             INSERT INTO "USERS_TEAMS" ("TEAM_ID", "USER_ID")
@@ -1655,7 +1655,7 @@
                 ON "OIDCUSER"."ID" = "OIDCUSERS_TEAMS"."OIDCUSERS_ID"
              INNER JOIN "USER"
                 ON "USER"."USERNAME" = "OIDCUSER"."USERNAME"
-               AND "USER"."TYPE" = 'LDAP'
+               AND "USER"."TYPE" = 'OIDC'
             ON CONFLICT ("TEAM_ID", "USER_ID") DO NOTHING;
         </sql>
 

--- a/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/apiserver/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1432,25 +1432,22 @@
     </changeSet>
 
     <changeSet id="v5.6.0-23" author="jhoward-lm">
-        <createTable ifNotExists="true" tableName="USERPRINCIPAL">
+        <createTable ifNotExists="true" tableName="USER">
             <column autoIncrement="true" name="ID" type="BIGINT">
-                <constraints nullable="false" primaryKey="true" primaryKeyName="USERPRINCIPAL_PK" />
+                <constraints nullable="false" primaryKey="true" primaryKeyName="USER_PK" />
             </column>
-
             <column name="USERNAME" type="TEXT">
                 <constraints nullable="false" validateNullable="true" />
             </column>
-
             <column name="EMAIL" type="TEXT" />
-
             <column name="TYPE" type="TEXT">
                 <constraints nullable="false" validateNullable="true" />
             </column>
 
-            <!-- Colunns specific to LDAP users -->
+            <!-- Columns specific to LDAP users -->
             <column name="DN" type="TEXT" />
 
-            <!-- Colunns specific to managed users -->
+            <!-- Columns specific to managed users -->
             <column name="FULLNAME" type="TEXT" />
             <column name="FORCE_PASSWORD_CHANGE" type="BOOLEAN" />
             <column name="SUSPENDED" type="BOOLEAN" />
@@ -1458,49 +1455,209 @@
             <column name="LAST_PASSWORD_CHANGE" type="TIMESTAMP WITH TIME ZONE" />
             <column name="PASSWORD" type="TEXT" />
 
-            <!-- Colunns specific to OIDC users -->
+            <!-- Columns specific to OIDC users -->
             <column name="SUBJECT_IDENTIFIER" type="TEXT" />
         </createTable>
 
-        <createIndex unique="true" tableName="USERPRINCIPAL" indexName="USERPRINCIPAL_USERNAME_IDX">
+        <createIndex unique="true" tableName="USER" indexName="USER_USERNAME_IDX">
             <column name="USERNAME" />
         </createIndex>
 
-        <createTable tableName="USERPRINCIPALS_PERMISSIONS">
-            <column name="USERPRINCIPAL_ID" type="BIGINT">
-                <constraints nullable="false"
-                    foreignKeyName="USERPRINCIPALS_PERMISSIONS_USERPRINCIPAL_FK"
-                    referencedTableName="USERPRINCIPAL"
-                    referencedColumnNames="ID"
-                    validateNullable="true" validateForeignKey="true" />
+        <createTable tableName="USERS_PERMISSIONS">
+            <column name="USER_ID" type="BIGINT">
+                <constraints
+                        nullable="false"
+                        foreignKeyName="USERS_PERMISSIONS_USER_FK"
+                        referencedTableName="USER"
+                        referencedColumnNames="ID"
+                        validateNullable="true"
+                        validateForeignKey="true"
+                        deleteCascade="true"/>
             </column>
 
             <column name="PERMISSION_ID" type="BIGINT">
-                <constraints nullable="false"
-                    foreignKeyName="USERPRINCIPALS_PERMISSIONS_PERMISSION_FK"
-                    referencedTableName="PERMISSION"
-                    referencedColumnNames="ID"
-                    validateNullable="true" validateForeignKey="true" />
+                <constraints
+                        nullable="false"
+                        foreignKeyName="USERS_PERMISSIONS_PERMISSION_FK"
+                        referencedTableName="PERMISSION"
+                        referencedColumnNames="ID"
+                        validateNullable="true"
+                        validateForeignKey="true"
+                        deleteCascade="true"/>
             </column>
         </createTable>
 
-        <createTable tableName="USERPRINCIPALS_TEAMS">
-            <column name="USERPRINCIPAL_ID" type="BIGINT">
-                <constraints nullable="false"
-                    foreignKeyName="USERPRINCIPALS_TEAMS_USERPRINCIPAL_FK"
-                    referencedTableName="USERPRINCIPAL"
-                    referencedColumnNames="ID"
-                    validateNullable="true" validateForeignKey="true" />
+        <createTable tableName="USERS_TEAMS">
+            <column name="USER_ID" type="BIGINT">
+                <constraints
+                        nullable="false"
+                        foreignKeyName="USERS_TEAMS_USER_FK"
+                        referencedTableName="USER"
+                        referencedColumnNames="ID"
+                        validateNullable="true"
+                        validateForeignKey="true"
+                        deleteCascade="true"/>
             </column>
 
             <column name="TEAM_ID" type="BIGINT">
-                <constraints nullable="false"
-                    foreignKeyName="USERPRINCIPALS_TEAMS_TEAM_FK"
-                    referencedTableName="TEAM"
-                    referencedColumnNames="ID"
-                    validateNullable="true" validateForeignKey="true" />
+                <constraints
+                        nullable="false"
+                        foreignKeyName="USERS_TEAMS_TEAM_FK"
+                        referencedTableName="TEAM"
+                        referencedColumnNames="ID"
+                        validateNullable="true"
+                        validateForeignKey="true"
+                        deleteCascade="true"/>
             </column>
         </createTable>
+
+        <addPrimaryKey
+                tableName="USERS_PERMISSIONS"
+                columnNames="USER_ID, PERMISSION_ID"
+                constraintName="USERS_PERMISSIONS_PK"/>
+        <addPrimaryKey
+                tableName="USERS_TEAMS"
+                columnNames="USER_ID, TEAM_ID"
+                constraintName="USERS_TEAMS_PK"/>
+
+        <sql splitStatements="true">
+            ALTER TABLE "USER"
+                ADD CONSTRAINT check_user_type
+                    CHECK ("TYPE" IN ('MANAGED', 'LDAP', 'OIDC'));
+
+            ALTER TABLE "USER"
+                ADD CONSTRAINT check_managed_columns
+                    CHECK (
+                        ("TYPE" = 'MANAGED'
+                            AND "FORCE_PASSWORD_CHANGE" IS NOT NULL
+                            AND "LAST_PASSWORD_CHANGE" IS NOT NULL
+                            AND "NON_EXPIRY_PASSWORD" IS NOT NULL
+                            AND "PASSWORD" IS NOT NULL
+                            AND "SUSPENDED" IS NOT NULL)
+                            OR
+                        ("TYPE" != 'MANAGED'
+                    AND "FORCE_PASSWORD_CHANGE" IS NULL
+                    AND "FULLNAME" IS NULL
+                    AND "LAST_PASSWORD_CHANGE" IS NULL
+                    AND "NON_EXPIRY_PASSWORD" IS NULL
+                    AND "PASSWORD" IS NULL
+                    AND "SUSPENDED" IS NULL)
+                        );
+
+            ALTER TABLE "USER"
+                ADD CONSTRAINT check_ldap_columns
+                    CHECK (
+                        ("TYPE" = 'LDAP' AND "DN" IS NOT NULL)
+                            OR ("TYPE" != 'LDAP' AND "DN" IS NULL)
+                        );
+
+            ALTER TABLE "USER"
+                ADD CONSTRAINT check_oidc_columns
+                    CHECK ("TYPE" = 'OIDC' OR "SUBJECT_IDENTIFIER" IS NULL);
+        </sql>
+
+        <!-- Migrate existing managed users. -->
+        <sql splitStatements="true">
+            INSERT INTO "USER" (
+              "TYPE"
+            , "USERNAME"
+            , "EMAIL"
+            , "PASSWORD"
+            , "LAST_PASSWORD_CHANGE"
+            , "FULLNAME"
+            , "SUSPENDED"
+            , "FORCE_PASSWORD_CHANGE"
+            , "NON_EXPIRY_PASSWORD"
+            )
+            SELECT 'MANAGED'
+                 , "USERNAME"
+                 , "EMAIL"
+                 , "PASSWORD"
+                 , "LAST_PASSWORD_CHANGE"
+                 , "FULLNAME"
+                 , "SUSPENDED"
+                 , "FORCE_PASSWORD_CHANGE"
+                 , "NON_EXPIRY_PASSWORD"
+              FROM "MANAGEDUSER";
+
+            INSERT INTO "USERS_PERMISSIONS" ("PERMISSION_ID", "USER_ID")
+            SELECT "MANAGEDUSERS_PERMISSIONS"."PERMISSION_ID"
+                 , "USER"."ID"
+              FROM "MANAGEDUSERS_PERMISSIONS"
+             INNER JOIN "MANAGEDUSER"
+                ON "MANAGEDUSER"."ID" = "MANAGEDUSERS_PERMISSIONS"."MANAGEDUSER_ID"
+             INNER JOIN "USER"
+                ON "USER"."USERNAME" = "MANAGEDUSER"."USERNAME"
+               AND "USER"."TYPE" = 'MANAGED'
+            ON CONFLICT ("PERMISSION_ID", "USER_ID") DO NOTHING;
+
+            INSERT INTO "USERS_TEAMS" ("TEAM_ID", "USER_ID")
+            SELECT "MANAGEDUSERS_TEAMS"."TEAM_ID"
+                 , "USER"."ID"
+              FROM "MANAGEDUSERS_TEAMS"
+             INNER JOIN "MANAGEDUSER"
+                ON "MANAGEDUSER"."ID" = "MANAGEDUSERS_TEAMS"."MANAGEDUSER_ID"
+             INNER JOIN "USER"
+                ON "USER"."USERNAME" = "MANAGEDUSER"."USERNAME"
+               AND "USER"."TYPE" = 'MANAGED'
+            ON CONFLICT ("TEAM_ID", "USER_ID") DO NOTHING;
+        </sql>
+
+        <!-- Migrate existing LDAP users. -->
+        <sql splitStatements="true">
+            INSERT INTO "USER" ("TYPE", "USERNAME", "EMAIL", "DN")
+            SELECT 'LDAP', "USERNAME", "EMAIL", "DN" FROM "LDAPUSER";
+
+            INSERT INTO "USERS_PERMISSIONS" ("PERMISSION_ID", "USER_ID")
+            SELECT "LDAPUSERS_PERMISSIONS"."PERMISSION_ID"
+                 , "USER"."ID"
+              FROM "LDAPUSERS_PERMISSIONS"
+             INNER JOIN "LDAPUSER"
+                ON "LDAPUSER"."ID" = "LDAPUSERS_PERMISSIONS"."LDAPUSER_ID"
+             INNER JOIN "USER"
+                ON "USER"."USERNAME" = "LDAPUSER"."USERNAME"
+               AND "USER"."TYPE" = 'LDAP'
+            ON CONFLICT ("PERMISSION_ID", "USER_ID") DO NOTHING;
+
+            INSERT INTO "USERS_TEAMS" ("TEAM_ID", "USER_ID")
+            SELECT "LDAPUSERS_TEAMS"."TEAM_ID"
+                 , "USER"."ID"
+              FROM "LDAPUSERS_TEAMS"
+             INNER JOIN "LDAPUSER"
+                ON "LDAPUSER"."ID" = "LDAPUSERS_TEAMS"."LDAPUSER_ID"
+             INNER JOIN "USER"
+                ON "USER"."USERNAME" = "LDAPUSER"."USERNAME"
+               AND "USER"."TYPE" = 'LDAP'
+            ON CONFLICT ("TEAM_ID", "USER_ID") DO NOTHING;
+        </sql>
+
+        <!-- Migrate existing OIDC users. -->
+        <sql splitStatements="true">
+            INSERT INTO "USER" ("TYPE", "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER")
+            SELECT 'OIDC', "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER" FROM "OIDCUSER";
+
+            INSERT INTO "USERS_PERMISSIONS" ("PERMISSION_ID", "USER_ID")
+            SELECT "OIDCUSERS_PERMISSIONS"."PERMISSION_ID"
+                 , "USER"."ID"
+              FROM "OIDCUSERS_PERMISSIONS"
+             INNER JOIN "OIDCUSER"
+                ON "OIDCUSER"."ID" = "OIDCUSERS_PERMISSIONS"."OIDCUSER_ID"
+             INNER JOIN "USER"
+                ON "USER"."USERNAME" = "OIDCUSER"."USERNAME"
+               AND "USER"."TYPE" = 'LDAP'
+            ON CONFLICT ("PERMISSION_ID", "USER_ID") DO NOTHING;
+
+            INSERT INTO "USERS_TEAMS" ("TEAM_ID", "USER_ID")
+            SELECT "OIDCUSERS_TEAMS"."TEAM_ID"
+                 , "USER"."ID"
+              FROM "OIDCUSERS_TEAMS"
+             INNER JOIN "OIDCUSER"
+                ON "OIDCUSER"."ID" = "OIDCUSERS_TEAMS"."OIDCUSERS_ID"
+             INNER JOIN "USER"
+                ON "USER"."USERNAME" = "OIDCUSER"."USERNAME"
+               AND "USER"."TYPE" = 'LDAP'
+            ON CONFLICT ("TEAM_ID", "USER_ID") DO NOTHING;
+        </sql>
 
         <dropTable tableName="LDAPUSERS_TEAMS" cascadeConstraints="true" />
         <dropTable tableName="LDAPUSERS_PERMISSIONS" cascadeConstraints="true" />
@@ -1511,52 +1668,16 @@
         <dropTable tableName="OIDCUSERS_TEAMS" cascadeConstraints="true" />
         <dropTable tableName="OIDCUSERS_PERMISSIONS" cascadeConstraints="true" />
         <dropTable tableName="OIDCUSER" cascadeConstraints="true" />
-
-        <sql splitStatements="true">
-            ALTER TABLE "USERPRINCIPAL"
-              ADD CONSTRAINT check_user_type
-            CHECK ("TYPE" IN ('MANAGED', 'LDAP', 'OIDC'));
-
-            ALTER TABLE "USERPRINCIPAL"
-              ADD CONSTRAINT check_managed_columns
-            CHECK (
-                ("TYPE" = 'MANAGED'
-                    AND "FORCE_PASSWORD_CHANGE" IS NOT NULL
-                    AND "LAST_PASSWORD_CHANGE" IS NOT NULL
-                    AND "NON_EXPIRY_PASSWORD" IS NOT NULL
-                    AND "PASSWORD" IS NOT NULL
-                    AND "SUSPENDED" IS NOT NULL)
-                OR
-                ("TYPE" != 'MANAGED'
-                    AND "FORCE_PASSWORD_CHANGE" IS NULL
-                    AND "FULLNAME" IS NULL
-                    AND "LAST_PASSWORD_CHANGE" IS NULL
-                    AND "NON_EXPIRY_PASSWORD" IS NULL
-                    AND "PASSWORD" IS NULL
-                    AND "SUSPENDED" IS NULL)
-            );
-
-            ALTER TABLE "USERPRINCIPAL"
-              ADD CONSTRAINT check_ldap_columns
-            CHECK (
-                ("TYPE" = 'LDAP' AND "DN" IS NOT NULL)
-                OR ("TYPE" != 'LDAP' AND "DN" IS NULL)
-            );
-
-            ALTER TABLE "USERPRINCIPAL"
-              ADD CONSTRAINT check_oidc_columns
-            CHECK ("TYPE" = 'OIDC' OR "SUBJECT_IDENTIFIER" IS NULL);
-        </sql>
     </changeSet>
 
     <changeSet id="v5.6.0-24" author="jhoward-lm">
         <dropTable tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS" cascadeConstraints="true" />
 
         <createTable ifNotExists="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS">
-            <column name="USERPRINCIPAL_ID" type="BIGINT">
+            <column name="USER_ID" type="BIGINT">
                 <constraints nullable="true"
-                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USERPRINCIPAL_FK"
-                    referencedTableName="USERPRINCIPAL" referencedColumnNames="ID"
+                    foreignKeyName="USER_PROJECT_EFFECTIVE_PERMISSIONS_USER_FK"
+                    referencedTableName="USER" referencedColumnNames="ID"
                     deferrable="true" initiallyDeferred="true" deleteCascade="false"
                     validateForeignKey="true" />
             </column>
@@ -1587,7 +1708,7 @@
         </createTable>
 
         <createIndex unique="true" tableName="USER_PROJECT_EFFECTIVE_PERMISSIONS" indexName="USER_PROJECT_EFFECTIVE_PERMISSIONS_COMPOSITE_IDX">
-            <column name="USERPRINCIPAL_ID" />
+            <column name="USER_ID" />
             <column name="PROJECT_ID" />
             <column name="PERMISSION_ID" />
         </createIndex>
@@ -1604,14 +1725,14 @@
 
               -- Rebuild effective permissions for users
               INSERT INTO "USER_PROJECT_EFFECTIVE_PERMISSIONS"
-                ("USERPRINCIPAL_ID", "PROJECT_ID", "PERMISSION_ID", "PERMISSION_NAME")
-              SELECT DISTINCT ut."USERPRINCIPAL_ID", pat."PROJECT_ID", tp."PERMISSION_ID", p."NAME"
+                ("USER_ID", "PROJECT_ID", "PERMISSION_ID", "PERMISSION_NAME")
+              SELECT DISTINCT ut."USER_ID", pat."PROJECT_ID", tp."PERMISSION_ID", p."NAME"
                 FROM "PROJECT_ACCESS_TEAMS" pat
                INNER JOIN "TEAMS_PERMISSIONS" tp
                   ON tp."TEAM_ID" = pat."TEAM_ID"
                INNER JOIN "PERMISSION" p
                   ON p."ID" = tp."PERMISSION_ID"
-               INNER JOIN "USERPRINCIPALS_TEAMS" ut
+               INNER JOIN "USERS_TEAMS" ut
                   ON ut."TEAM_ID" = pat."TEAM_ID"
                WHERE pat."PROJECT_ID" = ANY(project_ids);
             END;
@@ -1628,7 +1749,7 @@
                 PERFORM recalc_user_project_effective_permissions(
                   (SELECT ARRAY_AGG(DISTINCT "PROJECT_ID") FROM old_table)
                 );
-              ELSIF TG_TABLE_NAME IN ('USERPRINCIPALS_TEAMS', 'TEAMS_PERMISSIONS') THEN
+              ELSIF TG_TABLE_NAME IN ('USERS_TEAMS', 'TEAMS_PERMISSIONS') THEN
                 PERFORM recalc_user_project_effective_permissions((
                   SELECT ARRAY_AGG(DISTINCT pat."PROJECT_ID")
                     FROM "PROJECT_ACCESS_TEAMS" AS pat
@@ -1651,7 +1772,7 @@
                 PERFORM recalc_user_project_effective_permissions(
                   (SELECT ARRAY_AGG(DISTINCT "PROJECT_ID") FROM new_table)
                 );
-              ELSIF TG_TABLE_NAME IN ('USERPRINCIPALS_TEAMS', 'TEAMS_PERMISSIONS') THEN
+              ELSIF TG_TABLE_NAME IN ('USERS_TEAMS', 'TEAMS_PERMISSIONS') THEN
                 PERFORM recalc_user_project_effective_permissions((
                   SELECT ARRAY_AGG(DISTINCT pat."PROJECT_ID")
                     FROM "PROJECT_ACCESS_TEAMS" AS pat
@@ -1679,7 +1800,7 @@
                       SELECT "PROJECT_ID" FROM new_table
                     ) AS combined_projects
                 ));
-              ELSIF TG_TABLE_NAME IN ('USERPRINCIPALS_TEAMS', 'TEAMS_PERMISSIONS') THEN
+              ELSIF TG_TABLE_NAME IN ('USERS_TEAMS', 'TEAMS_PERMISSIONS') THEN
                 PERFORM recalc_user_project_effective_permissions((
                   SELECT ARRAY_AGG(DISTINCT pat."PROJECT_ID")
                     FROM "PROJECT_ACCESS_TEAMS" pat
@@ -1712,23 +1833,23 @@
         </sql>
 
         <sql splitStatements="true">
-            -- INSERT trigger for USERPRINCIPALS_TEAMS
-            CREATE TRIGGER trigger_effective_permissions_mx_on_userprincipals_teams_insert
-            AFTER INSERT ON "USERPRINCIPALS_TEAMS"
+            -- INSERT trigger for USERS_TEAMS
+            CREATE TRIGGER trigger_effective_permissions_mx_on_users_teams_insert
+            AFTER INSERT ON "USERS_TEAMS"
             REFERENCING NEW TABLE AS new_table
             FOR EACH STATEMENT
             EXECUTE FUNCTION effective_permissions_mx_on_insert();
 
-            -- DELETE trigger for USERPRINCIPALS_TEAMS
-            CREATE TRIGGER trigger_effective_permissions_mx_on_userprincipals_teams_delete
-            AFTER DELETE ON "USERPRINCIPALS_TEAMS"
+            -- DELETE trigger for USERS_TEAMS
+            CREATE TRIGGER trigger_effective_permissions_mx_on_users_teams_delete
+            AFTER DELETE ON "USERS_TEAMS"
             REFERENCING OLD TABLE AS old_table
             FOR EACH STATEMENT
             EXECUTE FUNCTION effective_permissions_mx_on_delete();
 
-            -- UPDATE trigger for USERPRINCIPALS_TEAMS
-            CREATE TRIGGER trigger_effective_permissions_mx_on_userprincipals_teams_update
-            AFTER UPDATE ON "USERPRINCIPALS_TEAMS"
+            -- UPDATE trigger for USERS_TEAMS
+            CREATE TRIGGER trigger_effective_permissions_mx_on_users_teams_update
+            AFTER UPDATE ON "USERS_TEAMS"
             REFERENCING OLD TABLE AS old_table NEW TABLE AS new_table
             FOR EACH STATEMENT
             EXECUTE FUNCTION effective_permissions_mx_on_update();

--- a/apiserver/src/test/java/org/dependencytrack/persistence/QueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/QueryManagerTest.java
@@ -18,6 +18,10 @@
  */
 package org.dependencytrack.persistence;
 
+import alpine.model.Permission;
+import alpine.model.Team;
+import alpine.model.User;
+import alpine.server.auth.PasswordService;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.Component;
@@ -27,13 +31,7 @@ import org.dependencytrack.model.IntegrityAnalysis;
 import org.dependencytrack.model.IntegrityMatchStatus;
 import org.dependencytrack.model.IntegrityMetaComponent;
 import org.dependencytrack.model.Project;
-
 import org.junit.Test;
-
-import alpine.model.Permission;
-import alpine.model.Team;
-import alpine.model.UserPrincipal;
-import alpine.server.auth.PasswordService;
 
 import java.util.Date;
 import java.util.List;
@@ -275,7 +273,7 @@ public class QueryManagerTest extends PersistenceCapableTest {
                 .map(Permission::getName)
                 .toArray(String[]::new);
 
-        record TestMatrixEntry(UserPrincipal user, Project project, Team team, List<Project> noAccessProjects) {
+        record TestMatrixEntry(User user, Project project, Team team, List<Project> noAccessProjects) {
             String[] getPermissionNames(List<Permission> permissions) {
                 return permissions
                         .stream()

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -501,8 +501,7 @@ public class NotificationRuleResourceTest extends ResourceTest {
                           "teams": [
                             {
                               "uuid": "${json-unit.matches:teamUuid}",
-                              "name": "Team Example",
-                              "permissions": []
+                              "name": "Team Example"
                             }
                           ],
                           "notifyOn": [],

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -253,7 +253,7 @@ public class PermissionResourceTest extends ResourceTest {
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
         Assert.assertEquals("team1", json.getString("name"));
-        Assert.assertEquals(0, json.getJsonArray("permissions").size());
+        Assert.assertFalse(json.containsKey("permissions"));
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -156,7 +156,7 @@ public class TeamResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals("My Team", json.getString("name"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-        Assert.assertTrue(json.getJsonArray("apiKeys").isEmpty());
+        Assert.assertFalse(json.containsKey("apiKeys"));
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/UserResourceAuthenticatedTest.java
@@ -22,7 +22,7 @@ import alpine.model.LdapUser;
 import alpine.model.ManagedUser;
 import alpine.model.OidcUser;
 import alpine.model.Team;
-import alpine.model.UserPrincipal;
+import alpine.model.User;
 import alpine.server.auth.JsonWebToken;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFilter;
@@ -698,7 +698,7 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
 
         Assert.assertEquals(200, response.getStatus());
 
-        UserPrincipal user = qm.getManagedUser("blackbeard");
+        User user = qm.getManagedUser("blackbeard");
         List<Team> userTeams = user.getTeams();
 
         Assert.assertEquals(userTeams.size(), teamSet1.size());
@@ -709,7 +709,7 @@ public class UserResourceAuthenticatedTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
                 .put(Entity.entity(teamRequest2.toString(), MediaType.APPLICATION_JSON));
 
-        user = qm.getUserPrincipal("blackbeard");
+        user = qm.getUser("blackbeard");
         userTeams = user.getTeams();
 
         Assert.assertEquals(200, response.getStatus());


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Consolidates user tables.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Implements [ADR-006](https://github.com/DependencyTrack/hyades/blob/bc5ac65943f63a6af84eb35d92fc13a62c10bc27/docs/architecture/decisions/006-consolidate-user-tables.md)
Closes https://github.com/DependencyTrack/hyades/issues/1760
Continues https://github.com/DependencyTrack/hyades-apiserver/pull/1158

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Migration tested using [`docker-compose.yml`](https://github.com/DependencyTrack/hyades/blob/main/docker-compose.yml) as follows:

1. [Build container image](https://github.com/DependencyTrack/hyades-apiserver/blob/main/DEVELOPING.md#building-container-images) for this PR
2. `docker compose --profile demo up -d --pull always`
3. Wait for all services to start and become healthy
4. `docker exec -i dt-postgres psql -Udtrack < test.sql` (see `test.sql` below)
5. `sed -i '' -e 's/apiserver:snapshot/apiserver:local/g' docker-compose.yml`
6. `docker compose --profile demo up -d`
7. Observe DB contents (see Results below)

<details>
<summary>test.sql</summary>

(Script generated with AI, hence the cheesy team names)

```sql
-- Test data population script for PostgreSQL schema
-- This script will insert at least 10 records into each table

-- Clear existing data (if any)
DELETE FROM public."PROJECT_ACCESS_TEAMS";
DELETE FROM public."TEAMS_PERMISSIONS";
DELETE FROM public."OIDCUSERS_TEAMS";
DELETE FROM public."OIDCUSERS_PERMISSIONS";
DELETE FROM public."MANAGEDUSERS_TEAMS";
DELETE FROM public."MANAGEDUSERS_PERMISSIONS";
DELETE FROM public."LDAPUSERS_TEAMS";
DELETE FROM public."LDAPUSERS_PERMISSIONS";
DELETE FROM public."PROJECT";
DELETE FROM public."OIDCUSER";
DELETE FROM public."MANAGEDUSER";
DELETE FROM public."LDAPUSER";
DELETE FROM public."TEAM";
DELETE FROM public."PERMISSION";

-- Reset all sequences to ensure IDs start at 1
ALTER SEQUENCE public."LDAPUSER_ID_seq" RESTART WITH 1;
ALTER SEQUENCE public."MANAGEDUSER_ID_seq" RESTART WITH 1;
ALTER SEQUENCE public."OIDCUSER_ID_seq" RESTART WITH 1;
ALTER SEQUENCE public."PERMISSION_ID_seq" RESTART WITH 1;
ALTER SEQUENCE public."TEAM_ID_seq" RESTART WITH 1;
ALTER SEQUENCE public."PROJECT_ID_seq" RESTART WITH 1;

-- Insert PERMISSION records
INSERT INTO public."PERMISSION" ("NAME", "DESCRIPTION") VALUES
  ('BOM_UPLOAD', 'Allows the ability to upload CycloneDX Software Bill of Materials (SBOM)'),
  ('VIEW_PORTFOLIO', 'Provides the ability to view the portfolio of projects, components, and licenses'),
  ('PORTFOLIO_MANAGEMENT', 'Allows the creation, modification, and deletion of data in the portfolio'),
  ('PORTFOLIO_MANAGEMENT_CREATE', 'Allows the creation of data in the portfolio'),
  ('PORTFOLIO_MANAGEMENT_READ', 'Allows the reading of data in the portfolio'),
  ('PORTFOLIO_MANAGEMENT_UPDATE', 'Allows the updating of data in the portfolio'),
  ('PORTFOLIO_MANAGEMENT_DELETE', 'Allows the deletion of data in the portfolio'),
  ('VIEW_VULNERABILITY', 'Provides the ability to view the vulnerabilities projects are affected by'),
  ('VULNERABILITY_ANALYSIS', 'Provides all abilities to make analysis decisions on vulnerabilities'),
  ('VULNERABILITY_ANALYSIS_CREATE', 'Provides the ability to upload supported VEX documents to a project'),
  ('VULNERABILITY_ANALYSIS_READ', 'Provides the ability read the VEX document for a project'),
  ('VULNERABILITY_ANALYSIS_UPDATE', 'Provides the ability to make analysis decisions on vulnerabilities and upload supported VEX documents for a project'),
  ('VIEW_POLICY_VIOLATION', 'Provides the ability to view policy violations'),
  ('VULNERABILITY_MANAGEMENT', 'Allows all management permissions of internally-defined vulnerabilities'),
  ('VULNERABILITY_MANAGEMENT_CREATE', 'Allows creation of internally-defined vulnerabilities'),
  ('VULNERABILITY_MANAGEMENT_READ', 'Allows reading internally-defined vulnerabilities'),
  ('VULNERABILITY_MANAGEMENT_UPDATE', 'Allows updating internally-defined vulnerabilities and vulnerability tags'),
  ('VULNERABILITY_MANAGEMENT_DELETE', 'Allows management of internally-defined vulnerabilities'),
  ('POLICY_VIOLATION_ANALYSIS', 'Provides the ability to make analysis decisions on policy violations'),
  ('ACCESS_MANAGEMENT', 'Allows the management of users, teams, and API keys'),
  ('ACCESS_MANAGEMENT_CREATE', 'Allows create permissions of users, teams, and API keys'),
  ('ACCESS_MANAGEMENT_READ', 'Allows read permissions of users, teams, and API keys'),
  ('ACCESS_MANAGEMENT_UPDATE', 'Allows update permissions of users, teams, and API keys'),
  ('ACCESS_MANAGEMENT_DELETE', 'Allows delete permissions of users, teams, and API keys'),
  ('SYSTEM_CONFIGURATION', 'Allows all access to configuration of the system including notifications, repositories, and email settings'),
  ('SYSTEM_CONFIGURATION_CREATE', 'Allows creating configuration of the system including notifications, repositories, and email settings'),
  ('SYSTEM_CONFIGURATION_READ', 'Allows reading the configuration of the system including notifications, repositories, and email settings'),
  ('SYSTEM_CONFIGURATION_UPDATE', 'Allows updating the configuration of the system including notifications, repositories, and email settings'),
  ('SYSTEM_CONFIGURATION_DELETE', 'Allows deleting the configuration of the system including notifications, repositories, and email settings'),
  ('PROJECT_CREATION_UPLOAD', 'Provides the ability to optionally create project (if non-existent) on BOM or scan upload'),
  ('POLICY_MANAGEMENT', 'Allows the creation, modification, and deletion of policy'),
  ('POLICY_MANAGEMENT_CREATE', 'Allows the creation of a policy'),
  ('POLICY_MANAGEMENT_READ', 'Allows reading of policies'),
  ('POLICY_MANAGEMENT_UPDATE', 'Allows the modification of a policy'),
  ('POLICY_MANAGEMENT_DELETE', 'Allows the deletion of a policy'),
  ('TAG_MANAGEMENT', 'Allows the modification and deletion of tags'),
  ('TAG_MANAGEMENT_DELETE', 'Allows the deletion of a tag'),
  ('VIEW_BADGES', 'Provides the ability to view badges');

-- Insert TEAM records
INSERT INTO public."TEAM" ("NAME", "UUID") VALUES
  ('Engineering', '550e8400-e29b-41d4-a716-446655440000'),
  ('Marketing', '550e8400-e29b-41d4-a716-446655440001'),
  ('Sales', '550e8400-e29b-41d4-a716-446655440002'),
  ('Support', '550e8400-e29b-41d4-a716-446655440003'),
  ('Operations', '550e8400-e29b-41d4-a716-446655440004'),
  ('Finance', '550e8400-e29b-41d4-a716-446655440005'),
  ('Legal', '550e8400-e29b-41d4-a716-446655440006'),
  ('HR', '550e8400-e29b-41d4-a716-446655440007'),
  ('Research', '550e8400-e29b-41d4-a716-446655440008'),
  ('Executive', '550e8400-e29b-41d4-a716-446655440009');

-- Insert LDAPUSER records
INSERT INTO public."LDAPUSER" ("DN", "EMAIL", "USERNAME") VALUES
  ('cn=john.doe,ou=users,dc=example,dc=com', 'john.doe@example.com', 'john.doe'),
  ('cn=jane.smith,ou=users,dc=example,dc=com', 'jane.smith@example.com', 'jane.smith'),
  ('cn=bob.johnson,ou=users,dc=example,dc=com', 'bob.johnson@example.com', 'bob.johnson'),
  ('cn=alice.williams,ou=users,dc=example,dc=com', 'alice.williams@example.com', 'alice.williams'),
  ('cn=david.brown,ou=users,dc=example,dc=com', 'david.brown@example.com', 'david.brown'),
  ('cn=susan.miller,ou=users,dc=example,dc=com', 'susan.miller@example.com', 'susan.miller'),
  ('cn=michael.davis,ou=users,dc=example,dc=com', 'michael.davis@example.com', 'michael.davis'),
  ('cn=patricia.garcia,ou=users,dc=example,dc=com', 'patricia.garcia@example.com', 'patricia.garcia'),
  ('cn=james.wilson,ou=users,dc=example,dc=com', 'james.wilson@example.com', 'james.wilson'),
  ('cn=linda.martinez,ou=users,dc=example,dc=com', 'linda.martinez@example.com', 'linda.martinez');

-- Insert MANAGEDUSER records
INSERT INTO public."MANAGEDUSER" ("EMAIL", "FORCE_PASSWORD_CHANGE", "FULLNAME", "LAST_PASSWORD_CHANGE", "NON_EXPIRY_PASSWORD", "PASSWORD", "SUSPENDED", "USERNAME") VALUES
  ('sarah.thompson@example.com', false, 'Sarah Thompson', '2025-01-15T14:30:00Z', true, '$2a$10$abcdefghijklmnopqrstuv', false, 'sarah.thompson'),
  ('robert.anderson@example.com', false, 'Robert Anderson', '2025-02-20T09:45:00Z', true, '$2a$10$bcdefghijklmnopqrstuvw', false, 'robert.anderson'),
  ('jennifer.thomas@example.com', true, 'Jennifer Thomas', '2024-11-10T16:20:00Z', false, '$2a$10$cdefghijklmnopqrstuvwx', false, 'jennifer.thomas'),
  ('william.jackson@example.com', false, 'William Jackson', '2025-03-05T11:15:00Z', true, '$2a$10$defghijklmnopqrstuvwxy', false, 'william.jackson'),
  ('elizabeth.white@example.com', false, 'Elizabeth White', '2025-04-12T08:30:00Z', true, '$2a$10$efghijklmnopqrstuvwxyz', false, 'elizabeth.white'),
  ('richard.harris@example.com', true, 'Richard Harris', '2024-10-25T13:45:00Z', false, '$2a$10$fghijklmnopqrstuvwxyza', true, 'richard.harris'),
  ('barbara.clark@example.com', false, 'Barbara Clark', '2025-01-30T10:20:00Z', true, '$2a$10$ghijklmnopqrstuvwxyzab', false, 'barbara.clark'),
  ('thomas.lewis@example.com', false, 'Thomas Lewis', '2025-02-28T15:10:00Z', true, '$2a$10$hijklmnopqrstuvwxyzabc', false, 'thomas.lewis'),
  ('margaret.lee@example.com', true, 'Margaret Lee', '2024-12-05T09:30:00Z', false, '$2a$10$ijklmnopqrstuvwxyzabcd', false, 'margaret.lee'),
  ('joseph.walker@example.com', false, 'Joseph Walker', '2025-03-20T14:45:00Z', true, '$2a$10$jklmnopqrstuvwxyzabcde', false, 'joseph.walker');

-- Insert OIDCUSER records
INSERT INTO public."OIDCUSER" ("EMAIL", "SUBJECT_IDENTIFIER", "USERNAME") VALUES
  ('charles.young@example.com', 'sub_charles_young_123', 'charles.young'),
  ('karen.allen@example.com', 'sub_karen_allen_456', 'karen.allen'),
  ('steven.king@example.com', 'sub_steven_king_789', 'steven.king'),
  ('donna.wright@example.com', 'sub_donna_wright_012', 'donna.wright'),
  ('daniel.scott@example.com', 'sub_daniel_scott_345', 'daniel.scott'),
  ('nancy.green@example.com', 'sub_nancy_green_678', 'nancy.green'),
  ('paul.adams@example.com', 'sub_paul_adams_901', 'paul.adams'),
  ('sandra.baker@example.com', 'sub_sandra_baker_234', 'sandra.baker'),
  ('mark.hill@example.com', 'sub_mark_hill_567', 'mark.hill'),
  ('carol.carter@example.com', 'sub_carol_carter_890', 'carol.carter');

-- Insert PROJECT records
INSERT INTO public."PROJECT" ("NAME", "UUID", "VERSION") VALUES
  ('AcmeCRM', '123e4567-e89b-12d3-a456-426614174000', '1.0.0'),
  ('TechStack API', '123e4567-e89b-12d3-a456-426614174001', '2.1.0'),
  ('MegaSuite Pro', '123e4567-e89b-12d3-a456-426614174002', '3.5.2'),
  ('PayWave System', '123e4567-e89b-12d3-a456-426614174003', '1.2.0'),
  ('CloudDB Manager', '123e4567-e89b-12d3-a456-426614174004', '2.0.0'),
  ('DataIntegrator', '123e4567-e89b-12d3-a456-426614174005', '1.0.0'),
  ('SecureDocs Portal', '123e4567-e89b-12d3-a456-426614174006', '1.1.0'),
  ('HR-Portal 2025', '123e4567-e89b-12d3-a456-426614174007', '3.0.0'),
  ('AI-Analytics', '123e4567-e89b-12d3-a456-426614174008', '1.0.0'),
  ('ExecDashboard', '123e4567-e89b-12d3-a456-426614174009', '2.5.0');

-- Now that all base tables are populated, we can add the relationships

-- Insert TEAMS_PERMISSIONS records (assign permissions to teams)
INSERT INTO public."TEAMS_PERMISSIONS" ("TEAM_ID", "PERMISSION_ID") VALUES
  -- Engineering team gets BOM and vulnerability management permissions
  (1, 1), (1, 8), (1, 9), (1, 14), -- BOM_UPLOAD, VIEW_VULNERABILITY, VULNERABILITY_ANALYSIS, VULNERABILITY_MANAGEMENT

  -- Marketing team gets viewing permissions
  (2, 2), (2, 8), (2, 13), (2, 38), -- VIEW_PORTFOLIO, VIEW_VULNERABILITY, VIEW_POLICY_VIOLATION, VIEW_BADGES

  -- Sales team gets viewing permissions
  (3, 2), (3, 38), -- VIEW_PORTFOLIO, VIEW_BADGES

  -- Support team gets analytical permissions
  (4, 2), (4, 8), (4, 13), (4, 19), -- VIEW_PORTFOLIO, VIEW_VULNERABILITY, VIEW_POLICY_VIOLATION, POLICY_VIOLATION_ANALYSIS

  -- Operations team gets system configuration
  (5, 25), (5, 26), (5, 27), (5, 28), (5, 29), -- SYSTEM_CONFIGURATION and all sub-permissions

  -- Finance team gets policy management
  (6, 13), (6, 31), (6, 32), (6, 33), (6, 34), (6, 35), -- VIEW_POLICY_VIOLATION, POLICY_MANAGEMENT and sub-permissions

  -- Legal team gets policy analysis
  (7, 13), (7, 19), (7, 33), -- VIEW_POLICY_VIOLATION, POLICY_VIOLATION_ANALYSIS, POLICY_MANAGEMENT_READ

  -- HR team gets access management
  (8, 20), (8, 21), (8, 22), (8, 23), (8, 24), -- ACCESS_MANAGEMENT and all sub-permissions

  -- Research team gets portfolio and vulnerability management
  (9, 2), (9, 3), (9, 8), (9, 14), -- VIEW_PORTFOLIO, PORTFOLIO_MANAGEMENT, VIEW_VULNERABILITY, VULNERABILITY_MANAGEMENT

  -- Executive team gets broad access
  (10, 2), (10, 3), (10, 8), (10, 13), (10, 20), (10, 25), (10, 31), (10, 36), (10, 38); -- VIEW_PORTFOLIO, PORTFOLIO_MANAGEMENT, VIEW_VULNERABILITY, VIEW_POLICY_VIOLATION, ACCESS_MANAGEMENT, SYSTEM_CONFIGURATION, POLICY_MANAGEMENT, TAG_MANAGEMENT, VIEW_BADGES

-- Insert LDAPUSERS_PERMISSIONS records (assign direct permissions to LDAP users)
INSERT INTO public."LDAPUSERS_PERMISSIONS" ("LDAPUSER_ID", "PERMISSION_ID") VALUES
  (1, 20), -- john.doe has ACCESS_MANAGEMENT
  (2, 1), -- jane.smith has BOM_UPLOAD
  (3, 30), -- bob.johnson has PROJECT_CREATION_UPLOAD
  (4, 38), -- alice.williams has VIEW_BADGES
  (5, 9), -- david.brown has VULNERABILITY_ANALYSIS
  (6, 2), -- susan.miller has VIEW_PORTFOLIO
  (7, 14), -- michael.davis has VULNERABILITY_MANAGEMENT
  (8, 37), -- patricia.garcia has TAG_MANAGEMENT_DELETE
  (9, 31), -- james.wilson has POLICY_MANAGEMENT
  (10, 25); -- linda.martinez has SYSTEM_CONFIGURATION

-- Insert MANAGEDUSERS_PERMISSIONS records (assign direct permissions to managed users)
INSERT INTO public."MANAGEDUSERS_PERMISSIONS" ("MANAGEDUSER_ID", "PERMISSION_ID") VALUES
  (1, 3), (1, 4), -- sarah.thompson has PORTFOLIO_MANAGEMENT, PORTFOLIO_MANAGEMENT_CREATE
  (2, 8), (2, 9), -- robert.anderson has VIEW_VULNERABILITY, VULNERABILITY_ANALYSIS
  (3, 2), (3, 38), -- jennifer.thomas has VIEW_PORTFOLIO, VIEW_BADGES
  (4, 3), (4, 7), -- william.jackson has PORTFOLIO_MANAGEMENT, PORTFOLIO_MANAGEMENT_DELETE
  (5, 21), (5, 23), -- elizabeth.white has ACCESS_MANAGEMENT_CREATE, ACCESS_MANAGEMENT_UPDATE
  (6, 13), (6, 19), -- richard.harris has VIEW_POLICY_VIOLATION, POLICY_VIOLATION_ANALYSIS
  (7, 5), (7, 6), -- barbara.clark has PORTFOLIO_MANAGEMENT_READ, PORTFOLIO_MANAGEMENT_UPDATE
  (8, 25), (8, 27), -- thomas.lewis has SYSTEM_CONFIGURATION, SYSTEM_CONFIGURATION_READ
  (9, 2), (9, 8), -- margaret.lee has VIEW_PORTFOLIO, VIEW_VULNERABILITY
  (10, 14), (10, 15), (10, 16), (10, 17); -- joseph.walker has VULNERABILITY_MANAGEMENT and sub-permissions

-- Insert OIDCUSERS_PERMISSIONS records (assign direct permissions to OIDC users)
INSERT INTO public."OIDCUSERS_PERMISSIONS" ("OIDCUSER_ID", "PERMISSION_ID") VALUES
  (1, 1), (1, 30), -- charles.young has BOM_UPLOAD, PROJECT_CREATION_UPLOAD
  (2, 2), (2, 38), -- karen.allen has VIEW_PORTFOLIO, VIEW_BADGES
  (3, 10), -- steven.king has VULNERABILITY_ANALYSIS_CREATE
  (4, 8), (4, 11), (4, 12), -- donna.wright has VIEW_VULNERABILITY, VULNERABILITY_ANALYSIS_READ, VULNERABILITY_ANALYSIS_UPDATE
  (5, 20), -- daniel.scott has ACCESS_MANAGEMENT
  (6, 2), (6, 13), -- nancy.green has VIEW_PORTFOLIO, VIEW_POLICY_VIOLATION
  (7, 31), (7, 35), -- paul.adams has POLICY_MANAGEMENT, POLICY_MANAGEMENT_DELETE
  (8, 2), (8, 5), -- sandra.baker has VIEW_PORTFOLIO, PORTFOLIO_MANAGEMENT_READ
  (9, 8), (9, 14), -- mark.hill has VIEW_VULNERABILITY, VULNERABILITY_MANAGEMENT
  (10, 36), (10, 37), (10, 25); -- carol.carter has TAG_MANAGEMENT, TAG_MANAGEMENT_DELETE, SYSTEM_CONFIGURATION

-- Insert LDAPUSERS_TEAMS records (assign LDAP users to teams)
INSERT INTO public."LDAPUSERS_TEAMS" ("TEAM_ID", "LDAPUSER_ID") VALUES
  (1, 1), -- john.doe in Engineering
  (2, 2), -- jane.smith in Marketing
  (3, 3), -- bob.johnson in Sales
  (4, 4), -- alice.williams in Support
  (5, 5), -- david.brown in Operations
  (6, 6), -- susan.miller in Finance
  (7, 7), -- michael.davis in Legal
  (8, 8), -- patricia.garcia in HR
  (9, 9), -- james.wilson in Research
  (10, 10); -- linda.martinez in Executive

-- Insert MANAGEDUSERS_TEAMS records (assign managed users to teams)
INSERT INTO public."MANAGEDUSERS_TEAMS" ("TEAM_ID", "MANAGEDUSER_ID") VALUES
  (1, 1), -- sarah.thompson in Engineering
  (1, 2), -- robert.anderson in Engineering
  (2, 3), -- jennifer.thomas in Marketing
  (3, 4), -- william.jackson in Sales
  (4, 5), -- elizabeth.white in Support
  (5, 6), -- richard.harris in Operations
  (6, 7), -- barbara.clark in Finance
  (7, 8), -- thomas.lewis in Legal
  (8, 9), -- margaret.lee in HR
  (9, 10); -- joseph.walker in Research

-- Insert OIDCUSERS_TEAMS records (assign OIDC users to teams)
INSERT INTO public."OIDCUSERS_TEAMS" ("TEAM_ID", "OIDCUSERS_ID") VALUES
  (1, 1), -- charles.young in Engineering
  (2, 2), -- karen.allen in Marketing
  (3, 3), -- steven.king in Sales
  (4, 4), -- donna.wright in Support
  (5, 5), -- daniel.scott in Operations
  (6, 6), -- nancy.green in Finance
  (7, 7), -- paul.adams in Legal
  (8, 8), -- sandra.baker in HR
  (9, 9), -- mark.hill in Research
  (10, 10); -- carol.carter in Executive

-- Insert PROJECT_ACCESS_TEAMS records (assign teams to projects)
INSERT INTO public."PROJECT_ACCESS_TEAMS" ("PROJECT_ID", "TEAM_ID") VALUES
  -- Engineering team has access to technical projects
  (1, 1), (1, 3), -- AcmeCRM can be accessed by Engineering and Sales
  (2, 1), (2, 4), -- TechStack API can be accessed by Engineering and Support
  (3, 1), (3, 2), (3, 10), -- MegaSuite Pro can be accessed by Engineering, Marketing, and Executive
  (4, 1), (4, 6), -- PayWave System can be accessed by Engineering and Finance
  (5, 1), (5, 9), -- CloudDB Manager can be accessed by Engineering and Research

  -- All teams have access to general purpose projects
  (6, 1), (6, 5), (6, 8), -- DataIntegrator can be accessed by Engineering, Operations, and HR
  (7, 7), (7, 8), (7, 5), -- SecureDocs Portal can be accessed by Legal, HR, and Operations
  (8, 8), (8, 9), (8, 10), -- HR-Portal 2025 can be accessed by HR, Research, and Executive
  (9, 9), (9, 1), (9, 10), -- AI-Analytics can be accessed by Research, Engineering, and Executive
  (10, 10), (10, 1), (10, 2), (10, 6), (10, 7); -- ExecDashboard can be accessed by Executive and many other teams
```

</details>

<details>
<summary>Results: User Teams</summary>

```sql
select "USER"."TYPE" as "USER_TYPE", "USER"."USERNAME", "TEAM"."NAME" as "TEAM_NAME"
from "USER"
left join "USERS_TEAMS" on "USERS_TEAMS"."USER_ID" = "USER"."ID"
left join "TEAM" on "TEAM"."ID" = "USERS_TEAMS"."TEAM_ID"
order by "USER_TYPE", "USERNAME", "TEAM_NAME"
```

| USER\_TYPE | USERNAME | TEAM\_NAME |
| :--- | :--- | :--- |
| LDAP | alice.williams | Support |
| LDAP | bob.johnson | Sales |
| LDAP | david.brown | Operations |
| LDAP | james.wilson | Research |
| LDAP | jane.smith | Marketing |
| LDAP | john.doe | Engineering |
| LDAP | linda.martinez | Executive |
| LDAP | michael.davis | Legal |
| LDAP | patricia.garcia | HR |
| LDAP | susan.miller | Finance |
| MANAGED | barbara.clark | Finance |
| MANAGED | elizabeth.white | Support |
| MANAGED | jennifer.thomas | Marketing |
| MANAGED | joseph.walker | Research |
| MANAGED | margaret.lee | HR |
| MANAGED | richard.harris | Operations |
| MANAGED | robert.anderson | Engineering |
| MANAGED | sarah.thompson | Engineering |
| MANAGED | thomas.lewis | Legal |
| MANAGED | william.jackson | Sales |
| OIDC | carol.carter | Executive |
| OIDC | charles.young | Engineering |
| OIDC | daniel.scott | Operations |
| OIDC | donna.wright | Support |
| OIDC | karen.allen | Marketing |
| OIDC | mark.hill | Research |
| OIDC | nancy.green | Finance |
| OIDC | paul.adams | Legal |
| OIDC | sandra.baker | HR |
| OIDC | steven.king | Sales |

</details>

<details>
<summary>Results: User Permissions</summary>

```sql
select "USER"."TYPE" as "USER_TYPE", "USER"."USERNAME", "TEAM"."NAME" as "TEAM_NAME"
from "USER"
left join "USERS_TEAMS" on "USERS_TEAMS"."USER_ID" = "USER"."ID"
left join "TEAM" on "TEAM"."ID" = "USERS_TEAMS"."TEAM_ID"
order by "USER_TYPE", "USERNAME", "TEAM_NAME"
```

| USER\_TYPE | USERNAME | PERMISSION\_NAME |
| :--- | :--- | :--- |
| LDAP | alice.williams | VIEW\_BADGES |
| LDAP | bob.johnson | PROJECT\_CREATION\_UPLOAD |
| LDAP | david.brown | VULNERABILITY\_ANALYSIS |
| LDAP | james.wilson | POLICY\_MANAGEMENT |
| LDAP | jane.smith | BOM\_UPLOAD |
| LDAP | john.doe | ACCESS\_MANAGEMENT |
| LDAP | linda.martinez | SYSTEM\_CONFIGURATION |
| LDAP | michael.davis | VULNERABILITY\_MANAGEMENT |
| LDAP | patricia.garcia | TAG\_MANAGEMENT\_DELETE |
| LDAP | susan.miller | VIEW\_PORTFOLIO |
| MANAGED | barbara.clark | PORTFOLIO\_MANAGEMENT\_READ |
| MANAGED | barbara.clark | PORTFOLIO\_MANAGEMENT\_UPDATE |
| MANAGED | elizabeth.white | ACCESS\_MANAGEMENT\_CREATE |
| MANAGED | elizabeth.white | ACCESS\_MANAGEMENT\_UPDATE |
| MANAGED | jennifer.thomas | VIEW\_BADGES |
| MANAGED | jennifer.thomas | VIEW\_PORTFOLIO |
| MANAGED | joseph.walker | VULNERABILITY\_MANAGEMENT |
| MANAGED | joseph.walker | VULNERABILITY\_MANAGEMENT\_CREATE |
| MANAGED | joseph.walker | VULNERABILITY\_MANAGEMENT\_READ |
| MANAGED | joseph.walker | VULNERABILITY\_MANAGEMENT\_UPDATE |
| MANAGED | margaret.lee | VIEW\_PORTFOLIO |
| MANAGED | margaret.lee | VIEW\_VULNERABILITY |
| MANAGED | richard.harris | POLICY\_VIOLATION\_ANALYSIS |
| MANAGED | richard.harris | VIEW\_POLICY\_VIOLATION |
| MANAGED | robert.anderson | VIEW\_VULNERABILITY |
| MANAGED | robert.anderson | VULNERABILITY\_ANALYSIS |
| MANAGED | sarah.thompson | PORTFOLIO\_MANAGEMENT |
| MANAGED | sarah.thompson | PORTFOLIO\_MANAGEMENT\_CREATE |
| MANAGED | thomas.lewis | SYSTEM\_CONFIGURATION |
| MANAGED | thomas.lewis | SYSTEM\_CONFIGURATION\_READ |
| MANAGED | william.jackson | PORTFOLIO\_MANAGEMENT |
| MANAGED | william.jackson | PORTFOLIO\_MANAGEMENT\_DELETE |
| OIDC | carol.carter | SYSTEM\_CONFIGURATION |
| OIDC | carol.carter | TAG\_MANAGEMENT |
| OIDC | carol.carter | TAG\_MANAGEMENT\_DELETE |
| OIDC | charles.young | BOM\_UPLOAD |
| OIDC | charles.young | PROJECT\_CREATION\_UPLOAD |
| OIDC | daniel.scott | ACCESS\_MANAGEMENT |
| OIDC | donna.wright | VIEW\_VULNERABILITY |
| OIDC | donna.wright | VULNERABILITY\_ANALYSIS\_READ |
| OIDC | donna.wright | VULNERABILITY\_ANALYSIS\_UPDATE |
| OIDC | karen.allen | VIEW\_BADGES |
| OIDC | karen.allen | VIEW\_PORTFOLIO |
| OIDC | mark.hill | VIEW\_VULNERABILITY |
| OIDC | mark.hill | VULNERABILITY\_MANAGEMENT |
| OIDC | nancy.green | VIEW\_POLICY\_VIOLATION |
| OIDC | nancy.green | VIEW\_PORTFOLIO |
| OIDC | paul.adams | POLICY\_MANAGEMENT |
| OIDC | paul.adams | POLICY\_MANAGEMENT\_DELETE |
| OIDC | sandra.baker | PORTFOLIO\_MANAGEMENT\_READ |
| OIDC | sandra.baker | VIEW\_PORTFOLIO |
| OIDC | steven.king | VULNERABILITY\_ANALYSIS\_CREATE |

</details>

<details>
<summary>Results: Team Permissions</summary>

```sql
select "TEAM"."NAME" as "TEAM_NAME", "PERMISSION"."NAME" as "PERMISSION_NAME"
from "TEAM"
left join "TEAMS_PERMISSIONS" on "TEAMS_PERMISSIONS"."TEAM_ID" = "TEAM"."ID"
left join "PERMISSION" on "PERMISSION"."ID" = "TEAMS_PERMISSIONS"."PERMISSION_ID"
order by "TEAM_NAME", "PERMISSION_NAME";
```

| TEAM\_NAME | PERMISSION\_NAME |
| :--- | :--- |
| Engineering | BOM\_UPLOAD |
| Engineering | VIEW\_VULNERABILITY |
| Engineering | VULNERABILITY\_ANALYSIS |
| Engineering | VULNERABILITY\_MANAGEMENT |
| Executive | ACCESS\_MANAGEMENT |
| Executive | POLICY\_MANAGEMENT |
| Executive | PORTFOLIO\_MANAGEMENT |
| Executive | SYSTEM\_CONFIGURATION |
| Executive | TAG\_MANAGEMENT |
| Executive | VIEW\_BADGES |
| Executive | VIEW\_POLICY\_VIOLATION |
| Executive | VIEW\_PORTFOLIO |
| Executive | VIEW\_VULNERABILITY |
| Finance | POLICY\_MANAGEMENT |
| Finance | POLICY\_MANAGEMENT\_CREATE |
| Finance | POLICY\_MANAGEMENT\_DELETE |
| Finance | POLICY\_MANAGEMENT\_READ |
| Finance | POLICY\_MANAGEMENT\_UPDATE |
| Finance | VIEW\_POLICY\_VIOLATION |
| HR | ACCESS\_MANAGEMENT |
| HR | ACCESS\_MANAGEMENT\_CREATE |
| HR | ACCESS\_MANAGEMENT\_DELETE |
| HR | ACCESS\_MANAGEMENT\_READ |
| HR | ACCESS\_MANAGEMENT\_UPDATE |
| Legal | POLICY\_MANAGEMENT\_READ |
| Legal | POLICY\_VIOLATION\_ANALYSIS |
| Legal | VIEW\_POLICY\_VIOLATION |
| Marketing | VIEW\_BADGES |
| Marketing | VIEW\_POLICY\_VIOLATION |
| Marketing | VIEW\_PORTFOLIO |
| Marketing | VIEW\_VULNERABILITY |
| Operations | SYSTEM\_CONFIGURATION |
| Operations | SYSTEM\_CONFIGURATION\_CREATE |
| Operations | SYSTEM\_CONFIGURATION\_DELETE |
| Operations | SYSTEM\_CONFIGURATION\_READ |
| Operations | SYSTEM\_CONFIGURATION\_UPDATE |
| Research | PORTFOLIO\_MANAGEMENT |
| Research | VIEW\_PORTFOLIO |
| Research | VIEW\_VULNERABILITY |
| Research | VULNERABILITY\_MANAGEMENT |
| Sales | VIEW\_BADGES |
| Sales | VIEW\_PORTFOLIO |
| Support | POLICY\_VIOLATION\_ANALYSIS |
| Support | VIEW\_POLICY\_VIOLATION |
| Support | VIEW\_PORTFOLIO |
| Support | VIEW\_VULNERABILITY |

</details>

<details>
<summary>Results: Effective User Project Permissions</summary>

```sql
select "USER"."USERNAME", "PROJECT"."NAME" as "PROJECT_NAME", "PERMISSION_NAME"
from "USER_PROJECT_EFFECTIVE_PERMISSIONS"
inner join "USER" on "USER"."ID" = "USER_PROJECT_EFFECTIVE_PERMISSIONS"."USER_ID"
inner join "PROJECT" on "PROJECT"."ID" = "USER_PROJECT_EFFECTIVE_PERMISSIONS"."PROJECT_ID"
order by "USERNAME", "PROJECT_NAME", "PERMISSION_NAME";
```

| USERNAME | PROJECT\_NAME | PERMISSION\_NAME |
| :--- | :--- | :--- |
| alice.williams | TechStack API | POLICY\_VIOLATION\_ANALYSIS |
| alice.williams | TechStack API | VIEW\_POLICY\_VIOLATION |
| alice.williams | TechStack API | VIEW\_PORTFOLIO |
| alice.williams | TechStack API | VIEW\_VULNERABILITY |
| barbara.clark | ExecDashboard | POLICY\_MANAGEMENT |
| barbara.clark | ExecDashboard | POLICY\_MANAGEMENT\_CREATE |
| barbara.clark | ExecDashboard | POLICY\_MANAGEMENT\_DELETE |
| barbara.clark | ExecDashboard | POLICY\_MANAGEMENT\_READ |
| barbara.clark | ExecDashboard | POLICY\_MANAGEMENT\_UPDATE |
| barbara.clark | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| barbara.clark | PayWave System | POLICY\_MANAGEMENT |
| barbara.clark | PayWave System | POLICY\_MANAGEMENT\_CREATE |
| barbara.clark | PayWave System | POLICY\_MANAGEMENT\_DELETE |
| barbara.clark | PayWave System | POLICY\_MANAGEMENT\_READ |
| barbara.clark | PayWave System | POLICY\_MANAGEMENT\_UPDATE |
| barbara.clark | PayWave System | VIEW\_POLICY\_VIOLATION |
| bob.johnson | AcmeCRM | VIEW\_BADGES |
| bob.johnson | AcmeCRM | VIEW\_PORTFOLIO |
| carol.carter | AI-Analytics | ACCESS\_MANAGEMENT |
| carol.carter | AI-Analytics | POLICY\_MANAGEMENT |
| carol.carter | AI-Analytics | PORTFOLIO\_MANAGEMENT |
| carol.carter | AI-Analytics | SYSTEM\_CONFIGURATION |
| carol.carter | AI-Analytics | TAG\_MANAGEMENT |
| carol.carter | AI-Analytics | VIEW\_BADGES |
| carol.carter | AI-Analytics | VIEW\_POLICY\_VIOLATION |
| carol.carter | AI-Analytics | VIEW\_PORTFOLIO |
| carol.carter | AI-Analytics | VIEW\_VULNERABILITY |
| carol.carter | ExecDashboard | ACCESS\_MANAGEMENT |
| carol.carter | ExecDashboard | POLICY\_MANAGEMENT |
| carol.carter | ExecDashboard | PORTFOLIO\_MANAGEMENT |
| carol.carter | ExecDashboard | SYSTEM\_CONFIGURATION |
| carol.carter | ExecDashboard | TAG\_MANAGEMENT |
| carol.carter | ExecDashboard | VIEW\_BADGES |
| carol.carter | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| carol.carter | ExecDashboard | VIEW\_PORTFOLIO |
| carol.carter | ExecDashboard | VIEW\_VULNERABILITY |
| carol.carter | HR-Portal 2025 | ACCESS\_MANAGEMENT |
| carol.carter | HR-Portal 2025 | POLICY\_MANAGEMENT |
| carol.carter | HR-Portal 2025 | PORTFOLIO\_MANAGEMENT |
| carol.carter | HR-Portal 2025 | SYSTEM\_CONFIGURATION |
| carol.carter | HR-Portal 2025 | TAG\_MANAGEMENT |
| carol.carter | HR-Portal 2025 | VIEW\_BADGES |
| carol.carter | HR-Portal 2025 | VIEW\_POLICY\_VIOLATION |
| carol.carter | HR-Portal 2025 | VIEW\_PORTFOLIO |
| carol.carter | HR-Portal 2025 | VIEW\_VULNERABILITY |
| carol.carter | MegaSuite Pro | ACCESS\_MANAGEMENT |
| carol.carter | MegaSuite Pro | POLICY\_MANAGEMENT |
| carol.carter | MegaSuite Pro | PORTFOLIO\_MANAGEMENT |
| carol.carter | MegaSuite Pro | SYSTEM\_CONFIGURATION |
| carol.carter | MegaSuite Pro | TAG\_MANAGEMENT |
| carol.carter | MegaSuite Pro | VIEW\_BADGES |
| carol.carter | MegaSuite Pro | VIEW\_POLICY\_VIOLATION |
| carol.carter | MegaSuite Pro | VIEW\_PORTFOLIO |
| carol.carter | MegaSuite Pro | VIEW\_VULNERABILITY |
| charles.young | AI-Analytics | BOM\_UPLOAD |
| charles.young | AI-Analytics | VIEW\_VULNERABILITY |
| charles.young | AI-Analytics | VULNERABILITY\_ANALYSIS |
| charles.young | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| charles.young | AcmeCRM | BOM\_UPLOAD |
| charles.young | AcmeCRM | VIEW\_VULNERABILITY |
| charles.young | AcmeCRM | VULNERABILITY\_ANALYSIS |
| charles.young | AcmeCRM | VULNERABILITY\_MANAGEMENT |
| charles.young | CloudDB Manager | BOM\_UPLOAD |
| charles.young | CloudDB Manager | VIEW\_VULNERABILITY |
| charles.young | CloudDB Manager | VULNERABILITY\_ANALYSIS |
| charles.young | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| charles.young | DataIntegrator | BOM\_UPLOAD |
| charles.young | DataIntegrator | VIEW\_VULNERABILITY |
| charles.young | DataIntegrator | VULNERABILITY\_ANALYSIS |
| charles.young | DataIntegrator | VULNERABILITY\_MANAGEMENT |
| charles.young | ExecDashboard | BOM\_UPLOAD |
| charles.young | ExecDashboard | VIEW\_VULNERABILITY |
| charles.young | ExecDashboard | VULNERABILITY\_ANALYSIS |
| charles.young | ExecDashboard | VULNERABILITY\_MANAGEMENT |
| charles.young | MegaSuite Pro | BOM\_UPLOAD |
| charles.young | MegaSuite Pro | VIEW\_VULNERABILITY |
| charles.young | MegaSuite Pro | VULNERABILITY\_ANALYSIS |
| charles.young | MegaSuite Pro | VULNERABILITY\_MANAGEMENT |
| charles.young | PayWave System | BOM\_UPLOAD |
| charles.young | PayWave System | VIEW\_VULNERABILITY |
| charles.young | PayWave System | VULNERABILITY\_ANALYSIS |
| charles.young | PayWave System | VULNERABILITY\_MANAGEMENT |
| charles.young | TechStack API | BOM\_UPLOAD |
| charles.young | TechStack API | VIEW\_VULNERABILITY |
| charles.young | TechStack API | VULNERABILITY\_ANALYSIS |
| charles.young | TechStack API | VULNERABILITY\_MANAGEMENT |
| daniel.scott | DataIntegrator | SYSTEM\_CONFIGURATION |
| daniel.scott | DataIntegrator | SYSTEM\_CONFIGURATION\_CREATE |
| daniel.scott | DataIntegrator | SYSTEM\_CONFIGURATION\_DELETE |
| daniel.scott | DataIntegrator | SYSTEM\_CONFIGURATION\_READ |
| daniel.scott | DataIntegrator | SYSTEM\_CONFIGURATION\_UPDATE |
| daniel.scott | SecureDocs Portal | SYSTEM\_CONFIGURATION |
| daniel.scott | SecureDocs Portal | SYSTEM\_CONFIGURATION\_CREATE |
| daniel.scott | SecureDocs Portal | SYSTEM\_CONFIGURATION\_DELETE |
| daniel.scott | SecureDocs Portal | SYSTEM\_CONFIGURATION\_READ |
| daniel.scott | SecureDocs Portal | SYSTEM\_CONFIGURATION\_UPDATE |
| david.brown | DataIntegrator | SYSTEM\_CONFIGURATION |
| david.brown | DataIntegrator | SYSTEM\_CONFIGURATION\_CREATE |
| david.brown | DataIntegrator | SYSTEM\_CONFIGURATION\_DELETE |
| david.brown | DataIntegrator | SYSTEM\_CONFIGURATION\_READ |
| david.brown | DataIntegrator | SYSTEM\_CONFIGURATION\_UPDATE |
| david.brown | SecureDocs Portal | SYSTEM\_CONFIGURATION |
| david.brown | SecureDocs Portal | SYSTEM\_CONFIGURATION\_CREATE |
| david.brown | SecureDocs Portal | SYSTEM\_CONFIGURATION\_DELETE |
| david.brown | SecureDocs Portal | SYSTEM\_CONFIGURATION\_READ |
| david.brown | SecureDocs Portal | SYSTEM\_CONFIGURATION\_UPDATE |
| donna.wright | TechStack API | POLICY\_VIOLATION\_ANALYSIS |
| donna.wright | TechStack API | VIEW\_POLICY\_VIOLATION |
| donna.wright | TechStack API | VIEW\_PORTFOLIO |
| donna.wright | TechStack API | VIEW\_VULNERABILITY |
| elizabeth.white | TechStack API | POLICY\_VIOLATION\_ANALYSIS |
| elizabeth.white | TechStack API | VIEW\_POLICY\_VIOLATION |
| elizabeth.white | TechStack API | VIEW\_PORTFOLIO |
| elizabeth.white | TechStack API | VIEW\_VULNERABILITY |
| james.wilson | AI-Analytics | PORTFOLIO\_MANAGEMENT |
| james.wilson | AI-Analytics | VIEW\_PORTFOLIO |
| james.wilson | AI-Analytics | VIEW\_VULNERABILITY |
| james.wilson | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| james.wilson | CloudDB Manager | PORTFOLIO\_MANAGEMENT |
| james.wilson | CloudDB Manager | VIEW\_PORTFOLIO |
| james.wilson | CloudDB Manager | VIEW\_VULNERABILITY |
| james.wilson | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| james.wilson | HR-Portal 2025 | PORTFOLIO\_MANAGEMENT |
| james.wilson | HR-Portal 2025 | VIEW\_PORTFOLIO |
| james.wilson | HR-Portal 2025 | VIEW\_VULNERABILITY |
| james.wilson | HR-Portal 2025 | VULNERABILITY\_MANAGEMENT |
| jane.smith | ExecDashboard | VIEW\_BADGES |
| jane.smith | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| jane.smith | ExecDashboard | VIEW\_PORTFOLIO |
| jane.smith | ExecDashboard | VIEW\_VULNERABILITY |
| jane.smith | MegaSuite Pro | VIEW\_BADGES |
| jane.smith | MegaSuite Pro | VIEW\_POLICY\_VIOLATION |
| jane.smith | MegaSuite Pro | VIEW\_PORTFOLIO |
| jane.smith | MegaSuite Pro | VIEW\_VULNERABILITY |
| jennifer.thomas | ExecDashboard | VIEW\_BADGES |
| jennifer.thomas | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| jennifer.thomas | ExecDashboard | VIEW\_PORTFOLIO |
| jennifer.thomas | ExecDashboard | VIEW\_VULNERABILITY |
| jennifer.thomas | MegaSuite Pro | VIEW\_BADGES |
| jennifer.thomas | MegaSuite Pro | VIEW\_POLICY\_VIOLATION |
| jennifer.thomas | MegaSuite Pro | VIEW\_PORTFOLIO |
| jennifer.thomas | MegaSuite Pro | VIEW\_VULNERABILITY |
| john.doe | AI-Analytics | BOM\_UPLOAD |
| john.doe | AI-Analytics | VIEW\_VULNERABILITY |
| john.doe | AI-Analytics | VULNERABILITY\_ANALYSIS |
| john.doe | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| john.doe | AcmeCRM | BOM\_UPLOAD |
| john.doe | AcmeCRM | VIEW\_VULNERABILITY |
| john.doe | AcmeCRM | VULNERABILITY\_ANALYSIS |
| john.doe | AcmeCRM | VULNERABILITY\_MANAGEMENT |
| john.doe | CloudDB Manager | BOM\_UPLOAD |
| john.doe | CloudDB Manager | VIEW\_VULNERABILITY |
| john.doe | CloudDB Manager | VULNERABILITY\_ANALYSIS |
| john.doe | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| john.doe | DataIntegrator | BOM\_UPLOAD |
| john.doe | DataIntegrator | VIEW\_VULNERABILITY |
| john.doe | DataIntegrator | VULNERABILITY\_ANALYSIS |
| john.doe | DataIntegrator | VULNERABILITY\_MANAGEMENT |
| john.doe | ExecDashboard | BOM\_UPLOAD |
| john.doe | ExecDashboard | VIEW\_VULNERABILITY |
| john.doe | ExecDashboard | VULNERABILITY\_ANALYSIS |
| john.doe | ExecDashboard | VULNERABILITY\_MANAGEMENT |
| john.doe | MegaSuite Pro | BOM\_UPLOAD |
| john.doe | MegaSuite Pro | VIEW\_VULNERABILITY |
| john.doe | MegaSuite Pro | VULNERABILITY\_ANALYSIS |
| john.doe | MegaSuite Pro | VULNERABILITY\_MANAGEMENT |
| john.doe | PayWave System | BOM\_UPLOAD |
| john.doe | PayWave System | VIEW\_VULNERABILITY |
| john.doe | PayWave System | VULNERABILITY\_ANALYSIS |
| john.doe | PayWave System | VULNERABILITY\_MANAGEMENT |
| john.doe | TechStack API | BOM\_UPLOAD |
| john.doe | TechStack API | VIEW\_VULNERABILITY |
| john.doe | TechStack API | VULNERABILITY\_ANALYSIS |
| john.doe | TechStack API | VULNERABILITY\_MANAGEMENT |
| joseph.walker | AI-Analytics | PORTFOLIO\_MANAGEMENT |
| joseph.walker | AI-Analytics | VIEW\_PORTFOLIO |
| joseph.walker | AI-Analytics | VIEW\_VULNERABILITY |
| joseph.walker | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| joseph.walker | CloudDB Manager | PORTFOLIO\_MANAGEMENT |
| joseph.walker | CloudDB Manager | VIEW\_PORTFOLIO |
| joseph.walker | CloudDB Manager | VIEW\_VULNERABILITY |
| joseph.walker | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| joseph.walker | HR-Portal 2025 | PORTFOLIO\_MANAGEMENT |
| joseph.walker | HR-Portal 2025 | VIEW\_PORTFOLIO |
| joseph.walker | HR-Portal 2025 | VIEW\_VULNERABILITY |
| joseph.walker | HR-Portal 2025 | VULNERABILITY\_MANAGEMENT |
| karen.allen | ExecDashboard | VIEW\_BADGES |
| karen.allen | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| karen.allen | ExecDashboard | VIEW\_PORTFOLIO |
| karen.allen | ExecDashboard | VIEW\_VULNERABILITY |
| karen.allen | MegaSuite Pro | VIEW\_BADGES |
| karen.allen | MegaSuite Pro | VIEW\_POLICY\_VIOLATION |
| karen.allen | MegaSuite Pro | VIEW\_PORTFOLIO |
| karen.allen | MegaSuite Pro | VIEW\_VULNERABILITY |
| linda.martinez | AI-Analytics | ACCESS\_MANAGEMENT |
| linda.martinez | AI-Analytics | POLICY\_MANAGEMENT |
| linda.martinez | AI-Analytics | PORTFOLIO\_MANAGEMENT |
| linda.martinez | AI-Analytics | SYSTEM\_CONFIGURATION |
| linda.martinez | AI-Analytics | TAG\_MANAGEMENT |
| linda.martinez | AI-Analytics | VIEW\_BADGES |
| linda.martinez | AI-Analytics | VIEW\_POLICY\_VIOLATION |
| linda.martinez | AI-Analytics | VIEW\_PORTFOLIO |
| linda.martinez | AI-Analytics | VIEW\_VULNERABILITY |
| linda.martinez | ExecDashboard | ACCESS\_MANAGEMENT |
| linda.martinez | ExecDashboard | POLICY\_MANAGEMENT |
| linda.martinez | ExecDashboard | PORTFOLIO\_MANAGEMENT |
| linda.martinez | ExecDashboard | SYSTEM\_CONFIGURATION |
| linda.martinez | ExecDashboard | TAG\_MANAGEMENT |
| linda.martinez | ExecDashboard | VIEW\_BADGES |
| linda.martinez | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| linda.martinez | ExecDashboard | VIEW\_PORTFOLIO |
| linda.martinez | ExecDashboard | VIEW\_VULNERABILITY |
| linda.martinez | HR-Portal 2025 | ACCESS\_MANAGEMENT |
| linda.martinez | HR-Portal 2025 | POLICY\_MANAGEMENT |
| linda.martinez | HR-Portal 2025 | PORTFOLIO\_MANAGEMENT |
| linda.martinez | HR-Portal 2025 | SYSTEM\_CONFIGURATION |
| linda.martinez | HR-Portal 2025 | TAG\_MANAGEMENT |
| linda.martinez | HR-Portal 2025 | VIEW\_BADGES |
| linda.martinez | HR-Portal 2025 | VIEW\_POLICY\_VIOLATION |
| linda.martinez | HR-Portal 2025 | VIEW\_PORTFOLIO |
| linda.martinez | HR-Portal 2025 | VIEW\_VULNERABILITY |
| linda.martinez | MegaSuite Pro | ACCESS\_MANAGEMENT |
| linda.martinez | MegaSuite Pro | POLICY\_MANAGEMENT |
| linda.martinez | MegaSuite Pro | PORTFOLIO\_MANAGEMENT |
| linda.martinez | MegaSuite Pro | SYSTEM\_CONFIGURATION |
| linda.martinez | MegaSuite Pro | TAG\_MANAGEMENT |
| linda.martinez | MegaSuite Pro | VIEW\_BADGES |
| linda.martinez | MegaSuite Pro | VIEW\_POLICY\_VIOLATION |
| linda.martinez | MegaSuite Pro | VIEW\_PORTFOLIO |
| linda.martinez | MegaSuite Pro | VIEW\_VULNERABILITY |
| margaret.lee | DataIntegrator | ACCESS\_MANAGEMENT |
| margaret.lee | DataIntegrator | ACCESS\_MANAGEMENT\_CREATE |
| margaret.lee | DataIntegrator | ACCESS\_MANAGEMENT\_DELETE |
| margaret.lee | DataIntegrator | ACCESS\_MANAGEMENT\_READ |
| margaret.lee | DataIntegrator | ACCESS\_MANAGEMENT\_UPDATE |
| margaret.lee | HR-Portal 2025 | ACCESS\_MANAGEMENT |
| margaret.lee | HR-Portal 2025 | ACCESS\_MANAGEMENT\_CREATE |
| margaret.lee | HR-Portal 2025 | ACCESS\_MANAGEMENT\_DELETE |
| margaret.lee | HR-Portal 2025 | ACCESS\_MANAGEMENT\_READ |
| margaret.lee | HR-Portal 2025 | ACCESS\_MANAGEMENT\_UPDATE |
| margaret.lee | SecureDocs Portal | ACCESS\_MANAGEMENT |
| margaret.lee | SecureDocs Portal | ACCESS\_MANAGEMENT\_CREATE |
| margaret.lee | SecureDocs Portal | ACCESS\_MANAGEMENT\_DELETE |
| margaret.lee | SecureDocs Portal | ACCESS\_MANAGEMENT\_READ |
| margaret.lee | SecureDocs Portal | ACCESS\_MANAGEMENT\_UPDATE |
| mark.hill | AI-Analytics | PORTFOLIO\_MANAGEMENT |
| mark.hill | AI-Analytics | VIEW\_PORTFOLIO |
| mark.hill | AI-Analytics | VIEW\_VULNERABILITY |
| mark.hill | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| mark.hill | CloudDB Manager | PORTFOLIO\_MANAGEMENT |
| mark.hill | CloudDB Manager | VIEW\_PORTFOLIO |
| mark.hill | CloudDB Manager | VIEW\_VULNERABILITY |
| mark.hill | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| mark.hill | HR-Portal 2025 | PORTFOLIO\_MANAGEMENT |
| mark.hill | HR-Portal 2025 | VIEW\_PORTFOLIO |
| mark.hill | HR-Portal 2025 | VIEW\_VULNERABILITY |
| mark.hill | HR-Portal 2025 | VULNERABILITY\_MANAGEMENT |
| michael.davis | ExecDashboard | POLICY\_MANAGEMENT\_READ |
| michael.davis | ExecDashboard | POLICY\_VIOLATION\_ANALYSIS |
| michael.davis | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| michael.davis | SecureDocs Portal | POLICY\_MANAGEMENT\_READ |
| michael.davis | SecureDocs Portal | POLICY\_VIOLATION\_ANALYSIS |
| michael.davis | SecureDocs Portal | VIEW\_POLICY\_VIOLATION |
| nancy.green | ExecDashboard | POLICY\_MANAGEMENT |
| nancy.green | ExecDashboard | POLICY\_MANAGEMENT\_CREATE |
| nancy.green | ExecDashboard | POLICY\_MANAGEMENT\_DELETE |
| nancy.green | ExecDashboard | POLICY\_MANAGEMENT\_READ |
| nancy.green | ExecDashboard | POLICY\_MANAGEMENT\_UPDATE |
| nancy.green | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| nancy.green | PayWave System | POLICY\_MANAGEMENT |
| nancy.green | PayWave System | POLICY\_MANAGEMENT\_CREATE |
| nancy.green | PayWave System | POLICY\_MANAGEMENT\_DELETE |
| nancy.green | PayWave System | POLICY\_MANAGEMENT\_READ |
| nancy.green | PayWave System | POLICY\_MANAGEMENT\_UPDATE |
| nancy.green | PayWave System | VIEW\_POLICY\_VIOLATION |
| patricia.garcia | DataIntegrator | ACCESS\_MANAGEMENT |
| patricia.garcia | DataIntegrator | ACCESS\_MANAGEMENT\_CREATE |
| patricia.garcia | DataIntegrator | ACCESS\_MANAGEMENT\_DELETE |
| patricia.garcia | DataIntegrator | ACCESS\_MANAGEMENT\_READ |
| patricia.garcia | DataIntegrator | ACCESS\_MANAGEMENT\_UPDATE |
| patricia.garcia | HR-Portal 2025 | ACCESS\_MANAGEMENT |
| patricia.garcia | HR-Portal 2025 | ACCESS\_MANAGEMENT\_CREATE |
| patricia.garcia | HR-Portal 2025 | ACCESS\_MANAGEMENT\_DELETE |
| patricia.garcia | HR-Portal 2025 | ACCESS\_MANAGEMENT\_READ |
| patricia.garcia | HR-Portal 2025 | ACCESS\_MANAGEMENT\_UPDATE |
| patricia.garcia | SecureDocs Portal | ACCESS\_MANAGEMENT |
| patricia.garcia | SecureDocs Portal | ACCESS\_MANAGEMENT\_CREATE |
| patricia.garcia | SecureDocs Portal | ACCESS\_MANAGEMENT\_DELETE |
| patricia.garcia | SecureDocs Portal | ACCESS\_MANAGEMENT\_READ |
| patricia.garcia | SecureDocs Portal | ACCESS\_MANAGEMENT\_UPDATE |
| paul.adams | ExecDashboard | POLICY\_MANAGEMENT\_READ |
| paul.adams | ExecDashboard | POLICY\_VIOLATION\_ANALYSIS |
| paul.adams | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| paul.adams | SecureDocs Portal | POLICY\_MANAGEMENT\_READ |
| paul.adams | SecureDocs Portal | POLICY\_VIOLATION\_ANALYSIS |
| paul.adams | SecureDocs Portal | VIEW\_POLICY\_VIOLATION |
| richard.harris | DataIntegrator | SYSTEM\_CONFIGURATION |
| richard.harris | DataIntegrator | SYSTEM\_CONFIGURATION\_CREATE |
| richard.harris | DataIntegrator | SYSTEM\_CONFIGURATION\_DELETE |
| richard.harris | DataIntegrator | SYSTEM\_CONFIGURATION\_READ |
| richard.harris | DataIntegrator | SYSTEM\_CONFIGURATION\_UPDATE |
| richard.harris | SecureDocs Portal | SYSTEM\_CONFIGURATION |
| richard.harris | SecureDocs Portal | SYSTEM\_CONFIGURATION\_CREATE |
| richard.harris | SecureDocs Portal | SYSTEM\_CONFIGURATION\_DELETE |
| richard.harris | SecureDocs Portal | SYSTEM\_CONFIGURATION\_READ |
| richard.harris | SecureDocs Portal | SYSTEM\_CONFIGURATION\_UPDATE |
| robert.anderson | AI-Analytics | BOM\_UPLOAD |
| robert.anderson | AI-Analytics | VIEW\_VULNERABILITY |
| robert.anderson | AI-Analytics | VULNERABILITY\_ANALYSIS |
| robert.anderson | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| robert.anderson | AcmeCRM | BOM\_UPLOAD |
| robert.anderson | AcmeCRM | VIEW\_VULNERABILITY |
| robert.anderson | AcmeCRM | VULNERABILITY\_ANALYSIS |
| robert.anderson | AcmeCRM | VULNERABILITY\_MANAGEMENT |
| robert.anderson | CloudDB Manager | BOM\_UPLOAD |
| robert.anderson | CloudDB Manager | VIEW\_VULNERABILITY |
| robert.anderson | CloudDB Manager | VULNERABILITY\_ANALYSIS |
| robert.anderson | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| robert.anderson | DataIntegrator | BOM\_UPLOAD |
| robert.anderson | DataIntegrator | VIEW\_VULNERABILITY |
| robert.anderson | DataIntegrator | VULNERABILITY\_ANALYSIS |
| robert.anderson | DataIntegrator | VULNERABILITY\_MANAGEMENT |
| robert.anderson | ExecDashboard | BOM\_UPLOAD |
| robert.anderson | ExecDashboard | VIEW\_VULNERABILITY |
| robert.anderson | ExecDashboard | VULNERABILITY\_ANALYSIS |
| robert.anderson | ExecDashboard | VULNERABILITY\_MANAGEMENT |
| robert.anderson | MegaSuite Pro | BOM\_UPLOAD |
| robert.anderson | MegaSuite Pro | VIEW\_VULNERABILITY |
| robert.anderson | MegaSuite Pro | VULNERABILITY\_ANALYSIS |
| robert.anderson | MegaSuite Pro | VULNERABILITY\_MANAGEMENT |
| robert.anderson | PayWave System | BOM\_UPLOAD |
| robert.anderson | PayWave System | VIEW\_VULNERABILITY |
| robert.anderson | PayWave System | VULNERABILITY\_ANALYSIS |
| robert.anderson | PayWave System | VULNERABILITY\_MANAGEMENT |
| robert.anderson | TechStack API | BOM\_UPLOAD |
| robert.anderson | TechStack API | VIEW\_VULNERABILITY |
| robert.anderson | TechStack API | VULNERABILITY\_ANALYSIS |
| robert.anderson | TechStack API | VULNERABILITY\_MANAGEMENT |
| sandra.baker | DataIntegrator | ACCESS\_MANAGEMENT |
| sandra.baker | DataIntegrator | ACCESS\_MANAGEMENT\_CREATE |
| sandra.baker | DataIntegrator | ACCESS\_MANAGEMENT\_DELETE |
| sandra.baker | DataIntegrator | ACCESS\_MANAGEMENT\_READ |
| sandra.baker | DataIntegrator | ACCESS\_MANAGEMENT\_UPDATE |
| sandra.baker | HR-Portal 2025 | ACCESS\_MANAGEMENT |
| sandra.baker | HR-Portal 2025 | ACCESS\_MANAGEMENT\_CREATE |
| sandra.baker | HR-Portal 2025 | ACCESS\_MANAGEMENT\_DELETE |
| sandra.baker | HR-Portal 2025 | ACCESS\_MANAGEMENT\_READ |
| sandra.baker | HR-Portal 2025 | ACCESS\_MANAGEMENT\_UPDATE |
| sandra.baker | SecureDocs Portal | ACCESS\_MANAGEMENT |
| sandra.baker | SecureDocs Portal | ACCESS\_MANAGEMENT\_CREATE |
| sandra.baker | SecureDocs Portal | ACCESS\_MANAGEMENT\_DELETE |
| sandra.baker | SecureDocs Portal | ACCESS\_MANAGEMENT\_READ |
| sandra.baker | SecureDocs Portal | ACCESS\_MANAGEMENT\_UPDATE |
| sarah.thompson | AI-Analytics | BOM\_UPLOAD |
| sarah.thompson | AI-Analytics | VIEW\_VULNERABILITY |
| sarah.thompson | AI-Analytics | VULNERABILITY\_ANALYSIS |
| sarah.thompson | AI-Analytics | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | AcmeCRM | BOM\_UPLOAD |
| sarah.thompson | AcmeCRM | VIEW\_VULNERABILITY |
| sarah.thompson | AcmeCRM | VULNERABILITY\_ANALYSIS |
| sarah.thompson | AcmeCRM | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | CloudDB Manager | BOM\_UPLOAD |
| sarah.thompson | CloudDB Manager | VIEW\_VULNERABILITY |
| sarah.thompson | CloudDB Manager | VULNERABILITY\_ANALYSIS |
| sarah.thompson | CloudDB Manager | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | DataIntegrator | BOM\_UPLOAD |
| sarah.thompson | DataIntegrator | VIEW\_VULNERABILITY |
| sarah.thompson | DataIntegrator | VULNERABILITY\_ANALYSIS |
| sarah.thompson | DataIntegrator | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | ExecDashboard | BOM\_UPLOAD |
| sarah.thompson | ExecDashboard | VIEW\_VULNERABILITY |
| sarah.thompson | ExecDashboard | VULNERABILITY\_ANALYSIS |
| sarah.thompson | ExecDashboard | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | MegaSuite Pro | BOM\_UPLOAD |
| sarah.thompson | MegaSuite Pro | VIEW\_VULNERABILITY |
| sarah.thompson | MegaSuite Pro | VULNERABILITY\_ANALYSIS |
| sarah.thompson | MegaSuite Pro | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | PayWave System | BOM\_UPLOAD |
| sarah.thompson | PayWave System | VIEW\_VULNERABILITY |
| sarah.thompson | PayWave System | VULNERABILITY\_ANALYSIS |
| sarah.thompson | PayWave System | VULNERABILITY\_MANAGEMENT |
| sarah.thompson | TechStack API | BOM\_UPLOAD |
| sarah.thompson | TechStack API | VIEW\_VULNERABILITY |
| sarah.thompson | TechStack API | VULNERABILITY\_ANALYSIS |
| sarah.thompson | TechStack API | VULNERABILITY\_MANAGEMENT |
| steven.king | AcmeCRM | VIEW\_BADGES |
| steven.king | AcmeCRM | VIEW\_PORTFOLIO |
| susan.miller | ExecDashboard | POLICY\_MANAGEMENT |
| susan.miller | ExecDashboard | POLICY\_MANAGEMENT\_CREATE |
| susan.miller | ExecDashboard | POLICY\_MANAGEMENT\_DELETE |
| susan.miller | ExecDashboard | POLICY\_MANAGEMENT\_READ |
| susan.miller | ExecDashboard | POLICY\_MANAGEMENT\_UPDATE |
| susan.miller | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| susan.miller | PayWave System | POLICY\_MANAGEMENT |
| susan.miller | PayWave System | POLICY\_MANAGEMENT\_CREATE |
| susan.miller | PayWave System | POLICY\_MANAGEMENT\_DELETE |
| susan.miller | PayWave System | POLICY\_MANAGEMENT\_READ |
| susan.miller | PayWave System | POLICY\_MANAGEMENT\_UPDATE |
| susan.miller | PayWave System | VIEW\_POLICY\_VIOLATION |
| thomas.lewis | ExecDashboard | POLICY\_MANAGEMENT\_READ |
| thomas.lewis | ExecDashboard | POLICY\_VIOLATION\_ANALYSIS |
| thomas.lewis | ExecDashboard | VIEW\_POLICY\_VIOLATION |
| thomas.lewis | SecureDocs Portal | POLICY\_MANAGEMENT\_READ |
| thomas.lewis | SecureDocs Portal | POLICY\_VIOLATION\_ANALYSIS |
| thomas.lewis | SecureDocs Portal | VIEW\_POLICY\_VIOLATION |
| william.jackson | AcmeCRM | VIEW\_BADGES |
| william.jackson | AcmeCRM | VIEW\_PORTFOLIO |

</details>

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
