### PR TITLE
Fix various Maven build cache issues

### DIFF
--- a/.idea/runConfigurations/Jetty_w__Dev_Services.xml
+++ b/.idea/runConfigurations/Jetty_w__Dev_Services.xml
@@ -14,7 +14,7 @@
               <option value="-pl" />
               <option value="apiserver" />
               <option value="-am" />
-              <option value="test" />
+              <option value="verify" />
             </list>
           </option>
           <option name="multimoduleDir" />

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -22,6 +22,12 @@
     <configuration>
         <enabled>true</enabled>
         <hashAlgorithm>XX</hashAlgorithm>
+        <attachedOutputs>
+            <dirNames>
+                <!-- Required by Jetty plugin. -->
+                <dirName>classes</dirName>
+            </dirNames>
+        </attachedOutputs>
     </configuration>
     <input>
         <global>
@@ -31,15 +37,19 @@
             </includes>
         </global>
     </input>
-    <output>
-        <exclude>
-            <patterns>
-                <pattern>.*\.war</pattern>
-            </patterns>
-        </exclude>
-    </output>
     <executionControl>
         <runAlways>
+            <executions>
+                <execution artifactId="maven-antrun-plugin">
+                    <execIds>
+                        <!--
+                          The build cache only restores the API server WAR file,
+                          but the JAR file is required for container image builds.
+                        -->
+                        <execId>rename-war-file</execId>
+                    </execIds>
+                </execution>
+            </executions>
             <goalsLists>
                 <!--
                   https://github.com/ascopes/protobuf-maven-plugin/issues/472

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -114,7 +114,7 @@ Now visit `http://127.0.0.1:8081` in your browser and use Dependency-Track as us
 To launch the API server with Dev Services, execute the following command:
 
 ```shell
-mvn -pl apiserver -am -Pquick -Pdev-services test
+mvn -pl apiserver -am -Pquick -Pdev-services verify
 ```
 
 In this mode, the application will automatically launch containers for:

--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -765,6 +765,8 @@
                 <checkstyle.skip>true</checkstyle.skip>
                 <jacoco.skip>true</jacoco.skip>
                 <maven.test.skip>true</maven.test.skip>
+                <maven.war.skip>true</maven.war.skip>
+                <cyclonedx.skip>true</cyclonedx.skip>
             </properties>
             <dependencies>
                 <dependency>
@@ -797,7 +799,7 @@
                         <artifactId>jetty-ee10-maven-plugin</artifactId>
                         <executions>
                             <execution>
-                                <phase>test</phase>
+                                <phase>verify</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes various Maven build cache issues.

* Run dev mode in `verify` phase, since the build cache is only fully populated after the `package` phase. Running in `test` phase caused the cache to not contain JAR files.
* Attach classes to cache output, since the Jetty plugin may require those for classpath scanning.
* Always run the `rename-war-file` plugin execution to ensure that the API server JAR is present when trying to build container images.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
