### PR TITLE
Add `hasOccurrences` in `/api/v1/finding` responses

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Finding.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Finding.java
@@ -61,6 +61,7 @@ public class Finding implements Serializable {
         }
         optValue(component, "cpe", findingRow.componentCpe());
         optValue(component, "project", findingRow.projectUuid());
+        optValue(component, "hasOccurrences", findingRow.componentHasOccurrences(), false);
 
         optValue(vulnerability, "uuid", findingRow.vulnUuid());
         optValue(vulnerability, "source", findingRow.vulnSource());

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -55,6 +55,7 @@ public interface FindingDao {
             String componentVersion,
             String componentPurl,
             String componentCpe,
+            boolean componentHasOccurrences,
             UUID vulnUuid,
             Vulnerability.Source vulnSource,
             String vulnId,
@@ -112,6 +113,10 @@ public interface FindingDao {
                  , "COMPONENT"."VERSION" AS "componentVersion"
                  , "COMPONENT"."PURL" AS "componentPurl"
                  , "COMPONENT"."CPE" AS "componentCpe"
+                 , CASE
+                    WHEN co."COMPONENT_ID" IS NOT NULL THEN true
+                    ELSE false
+                    END AS "componentHasOccurrences"
                  , "V"."UUID" AS "vulnUuid"
                  , "V"."SOURCE" AS "vulnSource"
                  , "V"."VULNID"
@@ -182,6 +187,8 @@ public interface FindingDao {
                AND "COMPONENT"."PROJECT_ID" = "A"."PROJECT_ID"
               INNER JOIN "PROJECT"
                 ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
+              LEFT JOIN "COMPONENT_OCCURRENCE" co
+                ON "COMPONENT"."ID" = "co"."COMPONENT_ID"
              WHERE "COMPONENT"."PROJECT_ID" = :projectId
                AND (:includeSuppressed OR "A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
              ORDER BY "FINDINGATTRIBUTION"."ID"
@@ -213,6 +220,10 @@ public interface FindingDao {
                  , "COMPONENT"."VERSION" AS "componentVersion"
                  , "COMPONENT"."PURL" AS "componentPurl"
                  , "COMPONENT"."CPE" AS "componentCpe"
+                 , CASE
+                    WHEN co."COMPONENT_ID" IS NOT NULL THEN true
+                    ELSE false
+                    END AS "componentHasOccurrences"
                  , "V"."UUID" AS "vulnUuid"
                  , "V"."SOURCE" AS "vulnSource"
                  , "V"."VULNID"
@@ -283,6 +294,8 @@ public interface FindingDao {
                AND "COMPONENT"."PROJECT_ID" = "A"."PROJECT_ID"
              INNER JOIN "PROJECT"
                 ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
+             LEFT JOIN "COMPONENT_OCCURRENCE" co
+                ON "COMPONENT"."ID" = "co"."COMPONENT_ID"
              WHERE ${apiProjectAclCondition}
              <#if !activeFilter>
                 AND "PROJECT"."INACTIVE_SINCE" IS NULL

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -113,10 +113,7 @@ public interface FindingDao {
                  , "COMPONENT"."VERSION" AS "componentVersion"
                  , "COMPONENT"."PURL" AS "componentPurl"
                  , "COMPONENT"."CPE" AS "componentCpe"
-                 , CASE
-                    WHEN co."COMPONENT_ID" IS NOT NULL THEN true
-                    ELSE false
-                    END AS "componentHasOccurrences"
+                 , EXISTS(SELECT 1 FROM "COMPONENT_OCCURRENCE" WHERE "COMPONENT_ID" = "COMPONENT"."ID") AS "componentHasOccurrences"
                  , "V"."UUID" AS "vulnUuid"
                  , "V"."SOURCE" AS "vulnSource"
                  , "V"."VULNID"
@@ -187,8 +184,6 @@ public interface FindingDao {
                AND "COMPONENT"."PROJECT_ID" = "A"."PROJECT_ID"
               INNER JOIN "PROJECT"
                 ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
-              LEFT JOIN "COMPONENT_OCCURRENCE" co
-                ON "COMPONENT"."ID" = "co"."COMPONENT_ID"
              WHERE "COMPONENT"."PROJECT_ID" = :projectId
                AND (:includeSuppressed OR "A"."SUPPRESSED" IS NULL OR NOT "A"."SUPPRESSED")
              ORDER BY "FINDINGATTRIBUTION"."ID"
@@ -220,10 +215,7 @@ public interface FindingDao {
                  , "COMPONENT"."VERSION" AS "componentVersion"
                  , "COMPONENT"."PURL" AS "componentPurl"
                  , "COMPONENT"."CPE" AS "componentCpe"
-                 , CASE
-                    WHEN co."COMPONENT_ID" IS NOT NULL THEN true
-                    ELSE false
-                    END AS "componentHasOccurrences"
+                 , EXISTS(SELECT 1 FROM "COMPONENT_OCCURRENCE" WHERE "COMPONENT_ID" = "COMPONENT"."ID") AS "componentHasOccurrences"
                  , "V"."UUID" AS "vulnUuid"
                  , "V"."SOURCE" AS "vulnSource"
                  , "V"."VULNID"
@@ -294,8 +286,6 @@ public interface FindingDao {
                AND "COMPONENT"."PROJECT_ID" = "A"."PROJECT_ID"
              INNER JOIN "PROJECT"
                 ON "COMPONENT"."PROJECT_ID" = "PROJECT"."ID"
-             LEFT JOIN "COMPONENT_OCCURRENCE" co
-                ON "COMPONENT"."ID" = "co"."COMPONENT_ID"
              WHERE ${apiProjectAclCondition}
              <#if !activeFilter>
                 AND "PROJECT"."INACTIVE_SINCE" IS NULL

--- a/apiserver/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -74,8 +74,8 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                 "Test", "Sample project", "1.0", null, null, null, null, false);
 
         FindingDao.FindingRow findingRow = new FindingDao.FindingRow(project.getUuid(), UUID.randomUUID(), project.getName(), project.getVersion(),
-                "component-name-1", null, "component-version", null, null, UUID.randomUUID(),
-                Vulnerability.Source.GITHUB, "vuln-vulnId-1", "vuln-title", "vuln-subtitle", "vuln-description",
+                "component-name-1", null, "component-version", null, null, true,
+                UUID.randomUUID(), Vulnerability.Source.GITHUB, "vuln-vulnId-1", "vuln-title", "vuln-subtitle", "vuln-description",
                 "vuln-recommendation", Instant.now(), Severity.CRITICAL, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", null, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
@@ -103,8 +103,8 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
         other.setVulnDbId(null);
 
         findingRow = new FindingDao.FindingRow(project.getUuid(), UUID.randomUUID(), project.getName(), project.getVersion(),
-                "component-name-2", null, "component-version", null, null, UUID.randomUUID(),
-                Vulnerability.Source.NVD, "vuln-vulnId-2", "vuln-title", "vuln-subtitle", "vuln-description",
+                "component-name-2", null, "component-version", null, null, true,
+                UUID.randomUUID(), Vulnerability.Source.NVD, "vuln-vulnId-2", "vuln-title", "vuln-subtitle", "vuln-description",
                 "vuln-recommendation", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", List.of(alias, other), BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),

--- a/apiserver/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/integrations/defectdojo/DefectDojoUploaderTest.java
@@ -212,6 +212,7 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
                                         "name": "acme-lib",
                                         "version": "1.2.3",
                                         "project": "${json-unit.any-string}",
+                                        "hasOccurrences": false,
                                         "projectName" : "acme-app",
                                         "projectVersion" : "1.0.0"
                                       },
@@ -468,6 +469,7 @@ public class DefectDojoUploaderTest extends PersistenceCapableTest {
                                         "name": "acme-lib",
                                         "version": "1.2.3",
                                         "project": "${json-unit.any-string}",
+                                        "hasOccurrences": false,
                                         "projectName" : "acme-app",
                                         "projectVersion" : "1.0.0"
                                       },

--- a/apiserver/src/test/java/org/dependencytrack/model/FindingTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/FindingTest.java
@@ -113,7 +113,7 @@ public class FindingTest extends PersistenceCapableTest {
 
         FindingDao.FindingRow findingRow = new FindingDao.FindingRow(project.getUuid(), UUID.randomUUID(), project.getName(), project.getVersion(),
                 "component-name", "component-group", "component-version", "pkg:maven/foo/bar@1.2.3", "component-cpe",
-                UUID.randomUUID(), Vulnerability.Source.GITHUB, "vuln-vulnId", "vuln-title", "vuln-subtitle", "vuln-description",
+                true, UUID.randomUUID(), Vulnerability.Source.GITHUB, "vuln-vulnId", "vuln-title", "vuln-subtitle", "vuln-description",
                 "vuln-recommendation", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", null, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),


### PR DESCRIPTION
### Description

Add `hasOccurrences` boolean field in responses for two endpoints below : 

1. Get finding by project: `/api/v1/finding/project/{projectId}`
2. Get all findings: `/api/v1/finding/`

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1696

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
