### PR TITLE
Include Alpine JDO classes in `persistence.xml` of API Server

### DIFF
--- a/apiserver/src/main/resources/META-INF/persistence.xml
+++ b/apiserver/src/main/resources/META-INF/persistence.xml
@@ -21,6 +21,18 @@
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd" version="3.0">
   <persistence-unit name="Alpine">
+    <class>alpine.model.ApiKey</class>
+    <class>alpine.model.ConfigProperty</class>
+    <class>alpine.model.EventServiceLog</class>
+    <class>alpine.model.LdapUser</class>
+    <class>alpine.model.ManagedUser</class>
+    <class>alpine.model.OidcUser</class>
+    <class>alpine.model.OidcGroup</class>
+    <class>alpine.model.MappedLdapGroup</class>
+    <class>alpine.model.MappedOidcGroup</class>
+    <class>alpine.model.Permission</class>
+    <class>alpine.model.Team</class>
+    <class>alpine.model.User</class>
     <class>org.dependencytrack.model.AffectedVersionAttribution</class>
     <class>org.dependencytrack.model.Analysis</class>
     <class>org.dependencytrack.model.AnalysisComment</class>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Includes Alpine JDO classes in `persistence.xml` of API Server.

This fixes an issue where DataNucleus would not get to know about subclasses of `User`, until those subclasses are explicitly being used.

It turns out that classes defined in `alpine-model`'s `persistence.xml` are not implicitly included in `apiserver`'s `persistence.xml`.

For reference, this behavior is pointed out in the DN docs:

* https://www.datanucleus.org/products/accessplatform_6_0/jdo/mapping.html#inheritance
* https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#autostart
* https://www.datanucleus.org/products/accessplatform_6_0/jdo/persistence.html#persistenceunit

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
