### PR TITLE
Fix breaking changes in user API responses

### DIFF
--- a/alpine/alpine-model/src/main/java/alpine/model/Permission.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Permission.java
@@ -45,7 +45,7 @@ import java.util.Objects;
  * @since 1.0.0
  */
 @PersistenceCapable
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Permission implements Serializable {
 
     private static final long serialVersionUID = 1420020753285692448L;

--- a/alpine/alpine-model/src/main/java/alpine/model/Team.java
+++ b/alpine/alpine-model/src/main/java/alpine/model/Team.java
@@ -60,7 +60,7 @@ import java.util.UUID;
         @Persistent(name = "mappedOidcGroups"),
         @Persistent(name = "permissions")
 })
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Team implements Serializable {
 
     private static final long serialVersionUID = 6938424919898277944L;
@@ -97,6 +97,7 @@ public class Team implements Serializable {
 
     @Persistent(mappedBy = "teams")
     @Order(extensions = @Extension(vendorName = "datanucleus", key = "list-ordering", value = "username ASC"))
+    @JsonIgnore
     private List<User> users;
 
     @Persistent(mappedBy = "team")

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -502,7 +502,8 @@ public class NotificationRuleResourceTest extends ResourceTest {
                           "teams": [
                             {
                               "uuid": "${json-unit.matches:teamUuid}",
-                              "name": "Team Example"
+                              "name": "Team Example",
+                              "permissions": []
                             }
                           ],
                           "notifyOn": [],

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -253,7 +253,7 @@ public class PermissionResourceTest extends ResourceTest {
         JsonObject json = parseJsonObject(response);
         Assert.assertNotNull(json);
         Assert.assertEquals("team1", json.getString("name"));
-        Assert.assertFalse(json.containsKey("permissions"));
+        Assert.assertEquals(0, json.getJsonArray("permissions").size());
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -156,7 +156,7 @@ public class TeamResourceTest extends ResourceTest {
         Assert.assertNotNull(json);
         Assert.assertEquals("My Team", json.getString("name"));
         Assert.assertTrue(UuidUtil.isValidUUID(json.getString("uuid")));
-        Assert.assertFalse(json.containsKey("apiKeys"));
+        Assert.assertEquals(0, json.getJsonArray("apiKeys").size());
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Revert changes in response behavior introduced in #1169 that the frontend (and possibly other clients) rely on.

Also emits redundant `users` field from `Team` when serialized to JSON.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
