### PR TITLE
Fix failing `v5.6.0-23` migration for deployments with duplicate usernames

### DIFF
--- a/persistence-migration/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/persistence-migration/src/main/resources/migration/changelog-v5.6.0.xml
@@ -1432,6 +1432,15 @@
     </changeSet>
 
     <changeSet id="v5.6.0-23" author="jhoward-lm">
+        <!--
+          A previous version of this changeset did not cater to duplicate usernames existing
+          across the MANAGEDUSER, LDAPUSER, and OIDCUSER tables.
+          Deployments that did not have duplicate usernames across user tables at the time
+          of the execution were able to successfully complete this changeset and do not have
+          to repeat it.
+        -->
+        <validCheckSum>9:aa6e0cecae0b4f050a56eb1bbcb686be</validCheckSum>
+
         <createTable ifNotExists="true" tableName="USER">
             <column autoIncrement="true" name="ID" type="BIGINT">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="USER_PK" />
@@ -1604,8 +1613,17 @@
 
         <!-- Migrate existing LDAP users. -->
         <sql splitStatements="true">
+            WITH cte_created_user AS (
+              INSERT INTO "USER" ("TYPE", "USERNAME", "EMAIL", "DN")
+              SELECT 'LDAP', "USERNAME", "EMAIL", "DN"
+                FROM "LDAPUSER"
+              ON CONFLICT ("USERNAME") DO NOTHING
+              RETURNING "USERNAME"
+            )
             INSERT INTO "USER" ("TYPE", "USERNAME", "EMAIL", "DN")
-            SELECT 'LDAP', "USERNAME", "EMAIL", "DN" FROM "LDAPUSER";
+            SELECT 'LDAP', ("USERNAME" || '-CONFLICT-LDAP') AS "USERNAME", "EMAIL", "DN"
+              FROM "LDAPUSER"
+             WHERE "USERNAME" NOT IN (SELECT "USERNAME" FROM cte_created_user);
 
             INSERT INTO "USERS_PERMISSIONS" ("PERMISSION_ID", "USER_ID")
             SELECT "LDAPUSERS_PERMISSIONS"."PERMISSION_ID"
@@ -1614,7 +1632,8 @@
              INNER JOIN "LDAPUSER"
                 ON "LDAPUSER"."ID" = "LDAPUSERS_PERMISSIONS"."LDAPUSER_ID"
              INNER JOIN "USER"
-                ON "USER"."USERNAME" = "LDAPUSER"."USERNAME"
+                ON ("USER"."USERNAME" = "LDAPUSER"."USERNAME"
+                    OR "USER"."USERNAME" = ("LDAPUSER"."USERNAME" || '-CONFLICT-LDAP'))
                AND "USER"."TYPE" = 'LDAP'
             ON CONFLICT ("PERMISSION_ID", "USER_ID") DO NOTHING;
 
@@ -1625,15 +1644,25 @@
              INNER JOIN "LDAPUSER"
                 ON "LDAPUSER"."ID" = "LDAPUSERS_TEAMS"."LDAPUSER_ID"
              INNER JOIN "USER"
-                ON "USER"."USERNAME" = "LDAPUSER"."USERNAME"
+                ON ("USER"."USERNAME" = "LDAPUSER"."USERNAME"
+                    OR "USER"."USERNAME" = ("LDAPUSER"."USERNAME" || '-CONFLICT-LDAP'))
                AND "USER"."TYPE" = 'LDAP'
             ON CONFLICT ("TEAM_ID", "USER_ID") DO NOTHING;
         </sql>
 
         <!-- Migrate existing OIDC users. -->
         <sql splitStatements="true">
+            WITH cte_created_user AS (
+              INSERT INTO "USER" ("TYPE", "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER")
+              SELECT 'OIDC', "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER"
+                FROM "OIDCUSER"
+              ON CONFLICT ("USERNAME") DO NOTHING
+              RETURNING "USERNAME"
+            )
             INSERT INTO "USER" ("TYPE", "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER")
-            SELECT 'OIDC', "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER" FROM "OIDCUSER";
+            SELECT 'OIDC', ("USERNAME" || '-CONFLICT-OIDC') AS "USERNAME", "EMAIL", "SUBJECT_IDENTIFIER"
+              FROM "OIDCUSER"
+            WHERE "USERNAME" NOT IN (SELECT "USERNAME" FROM cte_created_user);
 
             INSERT INTO "USERS_PERMISSIONS" ("PERMISSION_ID", "USER_ID")
             SELECT "OIDCUSERS_PERMISSIONS"."PERMISSION_ID"
@@ -1642,7 +1671,8 @@
              INNER JOIN "OIDCUSER"
                 ON "OIDCUSER"."ID" = "OIDCUSERS_PERMISSIONS"."OIDCUSER_ID"
              INNER JOIN "USER"
-                ON "USER"."USERNAME" = "OIDCUSER"."USERNAME"
+                ON ("USER"."USERNAME" = "OIDCUSER"."USERNAME"
+                    OR "USER"."USERNAME" = ("OIDCUSER"."USERNAME" || '-CONFLICT-OIDC'))
                AND "USER"."TYPE" = 'OIDC'
             ON CONFLICT ("PERMISSION_ID", "USER_ID") DO NOTHING;
 
@@ -1653,7 +1683,8 @@
              INNER JOIN "OIDCUSER"
                 ON "OIDCUSER"."ID" = "OIDCUSERS_TEAMS"."OIDCUSERS_ID"
              INNER JOIN "USER"
-                ON "USER"."USERNAME" = "OIDCUSER"."USERNAME"
+                ON ("USER"."USERNAME" = "OIDCUSER"."USERNAME"
+                    OR "USER"."USERNAME" = ("OIDCUSER"."USERNAME" || '-CONFLICT-OIDC'))
                AND "USER"."TYPE" = 'OIDC'
             ON CONFLICT ("TEAM_ID", "USER_ID") DO NOTHING;
         </sql>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes failing `v5.6.0-23` migration for deployments with duplicate usernames.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1169 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Upgrade notes have been updated to reflect the consequence of this migration: https://github.com/DependencyTrack/hyades/pull/1788

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
