### PR TITLE
Improve performance of metrics queries

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/DependencyMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/DependencyMetrics.java
@@ -21,8 +21,9 @@ package org.dependencytrack.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
 
+import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -217,6 +218,7 @@ public class DependencyMetrics implements Serializable {
         this.findingsUnaudited = findingsUnaudited;
     }
 
+    @ColumnName("RISKSCORE")
     public double getInheritedRiskScore() {
         return inheritedRiskScore;
     }

--- a/apiserver/src/main/java/org/dependencytrack/model/ProjectMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ProjectMetrics.java
@@ -21,8 +21,9 @@ package org.dependencytrack.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
+import org.jdbi.v3.core.mapper.reflect.ColumnName;
 
+import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -225,6 +226,7 @@ public class ProjectMetrics implements Serializable {
         this.findingsUnaudited = findingsUnaudited;
     }
 
+    @ColumnName("RISKSCORE")
     public double getInheritedRiskScore() {
         return inheritedRiskScore;
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -24,9 +24,6 @@ import alpine.persistence.PaginatedResult;
 import alpine.resources.AlpineRequest;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonValue;
 import org.apache.commons.lang3.tuple.Pair;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.ComponentIdentity;
@@ -41,6 +38,9 @@ import org.dependencytrack.persistence.jdbi.MetricsDao;
 import org.dependencytrack.resources.v1.vo.DependencyGraphResponse;
 import org.dependencytrack.tasks.IntegrityMetaInitializerTask;
 
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonValue;
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.io.StringReader;
@@ -290,7 +290,8 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             if (includeMetrics) {
 //             Populate each Component object in the paginated result with transitive related
 //             data to minimize the number of round trips a client needs to make, process, and render.
-                component.setMetrics(withJdbiHandle(handle -> handle.attach(MetricsDao.class).getMostRecentDependencyMetrics(component.getId())));
+                component.setMetrics(withJdbiHandle(handle -> handle.attach(MetricsDao.class)
+                        .getMostRecentDependencyMetrics(project.getId(), component.getId())));
                 final PackageURL purl = component.getPurl();
                 if (purl != null) {
                     final RepositoryType type = RepositoryType.resolve(purl);
@@ -407,7 +408,8 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
             // Populate each Component object in the paginated result with transitive related
             // data to minimize the number of round trips a client needs to make, process, and render.
             for (Component component : result.getList(Component.class)) {
-                final DependencyMetrics metrics = withJdbiHandle(handle -> handle.attach(MetricsDao.class).getMostRecentDependencyMetrics(component.getId()));
+                final DependencyMetrics metrics = withJdbiHandle(handle -> handle.attach(MetricsDao.class)
+                        .getMostRecentDependencyMetrics(component.getProject().getId(), component.getId()));
                 component.setMetrics(metrics);
                 final PackageURL purl = component.getPurl();
                 if (purl != null) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
@@ -20,6 +20,7 @@ package org.dependencytrack.persistence.jdbi;
 
 import org.dependencytrack.model.ComponentOccurrence;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
+import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -72,4 +73,17 @@ public interface ComponentDao {
             SELECT "ID" FROM "COMPONENT" WHERE "UUID" = :componentUuid
             """)
     Long getComponentId(@Bind UUID componentUuid);
+
+    record ComponentAndProjectId(long componentId, long projectId) {
+    }
+
+    @SqlQuery("""
+            SELECT "ID" AS component_id
+                 , "PROJECT_ID"
+              FROM "COMPONENT"
+             WHERE "UUID" = :componentUuid
+            """)
+    @RegisterConstructorMapper(ComponentAndProjectId.class)
+    ComponentAndProjectId getComponentAndProjectId(@Bind UUID componentUuid);
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/MetricsDao.java
@@ -54,16 +54,17 @@ public interface MetricsDao extends SqlObject {
             ORDER BY "LAST_OCCURRENCE" ASC
             """)
     @RegisterBeanMapper(ProjectMetrics.class)
-    List<ProjectMetrics> getProjectMetricsSince(@Bind Long projectId, @Bind Instant since);
+    List<ProjectMetrics> getProjectMetricsSince(@Bind long projectId, @Bind Instant since);
 
     @SqlQuery("""
             SELECT * FROM "DEPENDENCYMETRICS"
-            WHERE "COMPONENT_ID" = :componentId
+            WHERE "PROJECT_ID" = :projectId
+            AND "COMPONENT_ID" = :componentId
             AND "LAST_OCCURRENCE" >= :since
             ORDER BY "LAST_OCCURRENCE" ASC
             """)
     @RegisterBeanMapper(DependencyMetrics.class)
-    List<DependencyMetrics> getDependencyMetricsSince(@Bind Long componentId,@Bind Instant since);
+    List<DependencyMetrics> getDependencyMetricsSince(@Bind long projectId, @Bind long componentId, @Bind Instant since);
 
     @SqlQuery("""
             SELECT *
@@ -75,7 +76,7 @@ public interface MetricsDao extends SqlObject {
     PortfolioMetrics getMostRecentPortfolioMetrics();
 
     @SqlQuery("""
-            SELECT *, "RISKSCORE" AS "inheritedRiskScore"
+            SELECT *
             FROM "PROJECTMETRICS"
             WHERE "PROJECT_ID" = :projectId
             ORDER BY "LAST_OCCURRENCE" DESC
@@ -85,14 +86,14 @@ public interface MetricsDao extends SqlObject {
     ProjectMetrics getMostRecentProjectMetrics(@Bind final long projectId);
 
     @SqlQuery("""
-            SELECT *, "RISKSCORE" AS "inheritedRiskScore"
+            SELECT *
             FROM "DEPENDENCYMETRICS"
             WHERE "COMPONENT_ID" = :componentId
             ORDER BY "LAST_OCCURRENCE" DESC
             LIMIT 1
             """)
     @RegisterBeanMapper(DependencyMetrics.class)
-    DependencyMetrics getMostRecentDependencyMetrics(@Bind final long componentId);
+    DependencyMetrics getMostRecentDependencyMetrics(@Bind long projectId, @Bind long componentId);
 
     @SqlQuery("""
             SELECT inhrelid::regclass AS partition_name
@@ -116,41 +117,41 @@ public interface MetricsDao extends SqlObject {
     List<String> getDependencyMetricsPartitions();
 
     @SqlUpdate("""
-        DO $$
-        DECLARE
-            today DATE := DATE '${targetDate}';
-            tomorrow DATE := DATE '${nextDate}';
-            partition_suffix TEXT := to_char(today, 'YYYYMMDD');
-            partition_name TEXT;
-            partition_exists BOOLEAN;
-            table_name TEXT;
-            metric_tables TEXT[] := ARRAY['PORTFOLIOMETRICS', 'PROJECTMETRICS', 'DEPENDENCYMETRICS'];
-        BEGIN
-            FOREACH table_name IN ARRAY metric_tables
-            LOOP
-                partition_name := format('%s_%s', table_name, partition_suffix);
-                SELECT EXISTS (
-                    SELECT 1 FROM pg_class WHERE relname = partition_name
-                ) INTO partition_exists;
-
-                IF NOT partition_exists THEN
-                    EXECUTE format(
-                        'CREATE TABLE IF NOT EXISTS %I (LIKE %I INCLUDING ALL);',
-                        partition_name,
-                        table_name
-                    );
-                    EXECUTE format(
-                        'ALTER TABLE %I ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L);',
-                        table_name,
-                        partition_name,
-                        today,
-                        tomorrow
-                    );
-                END IF;
-            END LOOP;
-        END;
-        $$;
-    """)
+                DO $$
+                DECLARE
+                    today DATE := DATE '${targetDate}';
+                    tomorrow DATE := DATE '${nextDate}';
+                    partition_suffix TEXT := to_char(today, 'YYYYMMDD');
+                    partition_name TEXT;
+                    partition_exists BOOLEAN;
+                    table_name TEXT;
+                    metric_tables TEXT[] := ARRAY['PORTFOLIOMETRICS', 'PROJECTMETRICS', 'DEPENDENCYMETRICS'];
+                BEGIN
+                    FOREACH table_name IN ARRAY metric_tables
+                    LOOP
+                        partition_name := format('%s_%s', table_name, partition_suffix);
+                        SELECT EXISTS (
+                            SELECT 1 FROM pg_class WHERE relname = partition_name
+                        ) INTO partition_exists;
+            
+                        IF NOT partition_exists THEN
+                            EXECUTE format(
+                                'CREATE TABLE IF NOT EXISTS %I (LIKE %I INCLUDING ALL);',
+                                partition_name,
+                                table_name
+                            );
+                            EXECUTE format(
+                                'ALTER TABLE %I ATTACH PARTITION %I FOR VALUES FROM (%L) TO (%L);',
+                                table_name,
+                                partition_name,
+                                today,
+                                tomorrow
+                            );
+                        END IF;
+                    END LOOP;
+                END;
+                $$;
+            """)
     void createMetricsPartitionsForDate(@Define("targetDate") String targetDate, @Define("nextDate") String nextDate);
 
     default int deletePortfolioMetricsForRetentionDuration(Duration retentionDuration) {
@@ -178,7 +179,7 @@ public interface MetricsDao extends SqlObject {
             if (partitionDate.isBefore(cutoffDate) || partitionDate.isEqual(cutoffDate)) {
                 String sql = String.format("DROP TABLE IF EXISTS %s CASCADE;", partition);
                 getHandle().execute(sql);
-                deletedCount ++;
+                deletedCount++;
             }
         }
         return deletedCount;

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/MetricsDaoTest.java
@@ -162,7 +162,7 @@ public class MetricsDaoTest extends PersistenceCapableTest {
         metrics.setLastOccurrence(Date.from(Instant.now().minus(Duration.ofDays(20))));
         metricsTestDao.createDependencyMetrics(metrics);
 
-        var dependencyMetrics = metricsDao.getDependencyMetricsSince(component.getId(), Instant.now().minus(Duration.ofDays(35)));
+        var dependencyMetrics = metricsDao.getDependencyMetricsSince(project.getId(), component.getId(), Instant.now().minus(Duration.ofDays(35)));
         assertThat(dependencyMetrics.size()).isEqualTo(2);
         assertThat(dependencyMetrics.get(0).getVulnerabilities()).isEqualTo(3);
         assertThat(dependencyMetrics.get(1).getVulnerabilities()).isEqualTo(2);

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
@@ -240,7 +240,7 @@ public class ProjectDaoTest extends PersistenceCapableTest {
         // Ensure that metrics have been deleted.
         MetricsDao dao = jdbiHandle.attach(MetricsDao.class);
         assertThat(dao.getProjectMetricsSince(project.getId(), DateUtil.parseShortDate("20250101").toInstant())).isEmpty();
-        assertThat(dao.getDependencyMetricsSince(component.getId(), DateUtil.parseShortDate("20250101").toInstant())).isEmpty();
+        assertThat(dao.getDependencyMetricsSince(project.getId(), component.getId(), DateUtil.parseShortDate("20250101").toInstant())).isEmpty();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/MetricsMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/MetricsMaintenanceTaskTest.java
@@ -144,7 +144,7 @@ public class MetricsMaintenanceTaskTest extends PersistenceCapableTest {
         final var task = new MetricsMaintenanceTask();
         assertThatNoException().isThrownBy(() -> task.inform(new MetricsMaintenanceEvent()));
 
-        assertThat(metricsDao.getDependencyMetricsSince(component.getId(), now.minus(91, ChronoUnit.DAYS))).satisfiesExactly(
+        assertThat(metricsDao.getDependencyMetricsSince(project.getId(), component.getId(), now.minus(91, ChronoUnit.DAYS))).satisfiesExactly(
                 metrics -> assertThat(metrics.getVulnerabilities()).isEqualTo(89));
 
         assertThat(metricsDao.getProjectMetricsSince(project.getId(), now.minus(91, ChronoUnit.DAYS))).satisfiesExactly(


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Always queries component metrics by component *and* project ID.

This allows Postgres to make better usage of the primary key index. Extending the query is desirable over adding more indexes because the project ID is always known anyway within the context of a component.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1141 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
