### PR TITLE
Use fixed ports for dev services containers

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/common/ConfigKey.java
+++ b/apiserver/src/main/java/org/dependencytrack/common/ConfigKey.java
@@ -63,7 +63,10 @@ public enum ConfigKey implements Config.Key {
     DEV_SERVICES_ENABLED("dev.services.enabled", false),
     DEV_SERVICES_IMAGE_FRONTEND("dev.services.image.frontend", "ghcr.io/dependencytrack/hyades-frontend:snapshot"),
     DEV_SERVICES_IMAGE_KAFKA("dev.services.image.kafka", "apache/kafka-native:3.9.0"),
-    DEV_SERVICES_IMAGE_POSTGRES("dev.services.image.postgres", "postgres:13-alpine");
+    DEV_SERVICES_IMAGE_POSTGRES("dev.services.image.postgres", "postgres:13-alpine"),
+    DEV_SERVICES_PORT_FRONTEND("dev.services.port.frontend", 8081),
+    DEV_SERVICES_PORT_KAFKA("dev.services.port.kafka", 9092),
+    DEV_SERVICES_PORT_POSTGRES("dev.services.port.postgres", 5432);
 
     private final String propertyName;
     private final Object defaultValue;

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1309,6 +1309,24 @@ dev.services.image.kafka=apache/kafka-native:3.9.0
 # @type:     string
 dev.services.image.postgres=postgres:13-alpine
 
+# The port on which the frontend dev services container shall be exposed on the host.
+#
+# @category: Development
+# @type:     integer
+dev.services.port.frontend=8081
+
+# The port on which the Kafka dev services container shall be exposed on the host.
+#
+# @category: Development
+# @type:     integer
+dev.services.port.kafka=9092
+
+# The port on which the PostgreSQL dev services container shall be exposed on the host.
+#
+# @category: Development
+# @type:     integer
+dev.services.port.postgres=5432
+
 # Cron expression of the component metadata maintenance task.
 # <br/><br/>
 # The task deletes orphaned records from the `INTEGRITY_META_COMPONENT` and

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -69,6 +69,9 @@
                             <goal>report-aggregate</goal>
                         </goals>
                         <configuration>
+                            <excludes>
+                                <exclude>org/dependencytrack/dev/**/*</exclude>
+                            </excludes>
                             <formats>
                                 <format>HTML</format>
                                 <format>XML</format>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Uses fixed ports for dev services containers.

This makes it easier to interact with containers across restarts, e.g. to inspect database state.

Also update PostgreSQL connection details to match what we use in our Docker Compose setup.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
