### PR TITLE
Add explicit permission to bypass project access checks

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/auth/Permissions.java
+++ b/apiserver/src/main/java/org/dependencytrack/auth/Permissions.java
@@ -28,6 +28,7 @@ public enum Permissions {
 
     BOM_UPLOAD("Allows the ability to upload CycloneDX Software Bill of Materials (SBOM)"),
     VIEW_PORTFOLIO("Provides the ability to view the portfolio of projects, components, and licenses"),
+    PORTFOLIO_ACCESS_CONTROL_BYPASS("Provides the ability to bypass portfolio access control, granting access to all projects"),
     PORTFOLIO_MANAGEMENT("Allows the creation, modification, and deletion of data in the portfolio"),
     PORTFOLIO_MANAGEMENT_CREATE("Allows the creation of data in the portfolio"),
     PORTFOLIO_MANAGEMENT_READ("Allows the reading of data in the portfolio"),
@@ -78,6 +79,7 @@ public enum Permissions {
     public static class Constants {
         public static final String BOM_UPLOAD = "BOM_UPLOAD";
         public static final String VIEW_PORTFOLIO = "VIEW_PORTFOLIO";
+        public static final String PORTFOLIO_ACCESS_CONTROL_BYPASS = Permissions.PORTFOLIO_ACCESS_CONTROL_BYPASS.name();
         public static final String PORTFOLIO_MANAGEMENT = "PORTFOLIO_MANAGEMENT";
         public static final String PORTFOLIO_MANAGEMENT_CREATE = "PORTFOLIO_MANAGEMENT_CREATE";
         public static final String PORTFOLIO_MANAGEMENT_READ = "PORTFOLIO_MANAGEMENT_READ";

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -30,7 +30,6 @@ import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.core.statement.StatementCustomizer;
 
 import javax.jdo.Query;
-
 import java.security.Principal;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -180,7 +179,7 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
         if (apiRequest == null
                 || apiRequest.getPrincipal() == null
                 || !isAclEnabled(ctx)
-                || apiRequest.getEffectivePermissions().contains(Permissions.ACCESS_MANAGEMENT.name())) {
+                || apiRequest.getEffectivePermissions().contains(Permissions.Constants.PORTFOLIO_ACCESS_CONTROL_BYPASS)) {
             ctx.define(ATTRIBUTE_API_PROJECT_ACL_CONDITION, "TRUE");
             return;
         }

--- a/apiserver/src/test/java/org/dependencytrack/auth/PermissionsTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/auth/PermissionsTest.java
@@ -33,6 +33,7 @@ import static org.dependencytrack.auth.Permissions.Constants.POLICY_MANAGEMENT_D
 import static org.dependencytrack.auth.Permissions.Constants.POLICY_MANAGEMENT_READ;
 import static org.dependencytrack.auth.Permissions.Constants.POLICY_MANAGEMENT_UPDATE;
 import static org.dependencytrack.auth.Permissions.Constants.POLICY_VIOLATION_ANALYSIS;
+import static org.dependencytrack.auth.Permissions.Constants.PORTFOLIO_ACCESS_CONTROL_BYPASS;
 import static org.dependencytrack.auth.Permissions.Constants.PORTFOLIO_MANAGEMENT;
 import static org.dependencytrack.auth.Permissions.Constants.PORTFOLIO_MANAGEMENT_CREATE;
 import static org.dependencytrack.auth.Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE;
@@ -46,6 +47,7 @@ import static org.dependencytrack.auth.Permissions.Constants.SYSTEM_CONFIGURATIO
 import static org.dependencytrack.auth.Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE;
 import static org.dependencytrack.auth.Permissions.Constants.TAG_MANAGEMENT;
 import static org.dependencytrack.auth.Permissions.Constants.TAG_MANAGEMENT_DELETE;
+import static org.dependencytrack.auth.Permissions.Constants.VIEW_BADGES;
 import static org.dependencytrack.auth.Permissions.Constants.VIEW_POLICY_VIOLATION;
 import static org.dependencytrack.auth.Permissions.Constants.VIEW_PORTFOLIO;
 import static org.dependencytrack.auth.Permissions.Constants.VIEW_VULNERABILITY;
@@ -58,15 +60,15 @@ import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_MANAG
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_MANAGEMENT_DELETE;
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_MANAGEMENT_READ;
 import static org.dependencytrack.auth.Permissions.Constants.VULNERABILITY_MANAGEMENT_UPDATE;
-import static org.dependencytrack.auth.Permissions.Constants.VIEW_BADGES;
 
 public class PermissionsTest {
 
     @Test
     public void testPermissionEnums() {
-        Assert.assertEquals(38, Permissions.values().length);
+        Assert.assertEquals(39, Permissions.values().length);
         Assert.assertEquals("BOM_UPLOAD", Permissions.BOM_UPLOAD.name());
         Assert.assertEquals("VIEW_PORTFOLIO", Permissions.VIEW_PORTFOLIO.name());
+        Assert.assertEquals("PORTFOLIO_ACCESS_CONTROL_BYPASS", Permissions.PORTFOLIO_ACCESS_CONTROL_BYPASS.name());
         Assert.assertEquals("PORTFOLIO_MANAGEMENT", Permissions.PORTFOLIO_MANAGEMENT.name());
         Assert.assertEquals("PORTFOLIO_MANAGEMENT_CREATE", Permissions.PORTFOLIO_MANAGEMENT_CREATE.name());
         Assert.assertEquals("PORTFOLIO_MANAGEMENT_READ", Permissions.PORTFOLIO_MANAGEMENT_READ.name());
@@ -109,6 +111,7 @@ public class PermissionsTest {
     public void testPermissionConstants() {
         Assert.assertEquals("BOM_UPLOAD", BOM_UPLOAD);
         Assert.assertEquals("VIEW_PORTFOLIO", VIEW_PORTFOLIO);
+        Assert.assertEquals("PORTFOLIO_ACCESS_CONTROL_BYPASS", PORTFOLIO_ACCESS_CONTROL_BYPASS);
         Assert.assertEquals("PORTFOLIO_MANAGEMENT", PORTFOLIO_MANAGEMENT);
         Assert.assertEquals("PORTFOLIO_MANAGEMENT_CREATE", PORTFOLIO_MANAGEMENT_CREATE);
         Assert.assertEquals("PORTFOLIO_MANAGEMENT_READ", PORTFOLIO_MANAGEMENT_READ);

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizerTest.java
@@ -436,7 +436,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithPortfolioAclEnabledWithApiKeyHavingAccessManagementPermission() {
+    public void testWithPortfolioAclEnabledWithApiKeyHavingPortfolioAccessControlBypassPermission() {
         qm.createConfigProperty(
                 ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -454,7 +454,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 /* filter */ null,
                 /* orderBy */ null,
                 /* orderDirection */ null,
-                /* effectivePermissions */ Set.of(Permissions.ACCESS_MANAGEMENT.name())
+                /* effectivePermissions */ Set.of(Permissions.Constants.PORTFOLIO_ACCESS_CONTROL_BYPASS)
         );
 
         useJdbiHandle(request, handle -> handle
@@ -471,7 +471,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithPortfolioAclEnabledWithManagedUserHavingAccessManagementPermission() {
+    public void testWithPortfolioAclEnabledWithManagedUserHavingPortfolioAccessControlBypassPermission() {
         qm.createConfigProperty(
                 ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -488,7 +488,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 /* filter */ null,
                 /* orderBy */ null,
                 /* orderDirection */ null,
-                /* effectivePermissions */ Set.of(Permissions.ACCESS_MANAGEMENT.name())
+                /* effectivePermissions */ Set.of(Permissions.Constants.PORTFOLIO_ACCESS_CONTROL_BYPASS)
         );
 
         useJdbiHandle(request, handle -> handle
@@ -505,7 +505,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithPortfolioAclEnabledWithLdapUserHavingAccessManagementPermission() {
+    public void testWithPortfolioAclEnabledWithLdapUserHavingPortfolioAccessControlBypassPermission() {
         qm.createConfigProperty(
                 ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -522,7 +522,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 /* filter */ null,
                 /* orderBy */ null,
                 /* orderDirection */ null,
-                /* effectivePermissions */ Set.of(Permissions.ACCESS_MANAGEMENT.name())
+                /* effectivePermissions */ Set.of(Permissions.Constants.PORTFOLIO_ACCESS_CONTROL_BYPASS)
         );
 
         useJdbiHandle(request, handle -> handle
@@ -539,7 +539,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithPortfolioAclEnabledWithOidcUserHavingAccessManagementPermission() {
+    public void testWithPortfolioAclEnabledWithOidcUserHavingPortfolioAccessControlBypassPermission() {
         qm.createConfigProperty(
                 ACCESS_MANAGEMENT_ACL_ENABLED.getGroupName(),
                 ACCESS_MANAGEMENT_ACL_ENABLED.getPropertyName(),
@@ -556,7 +556,7 @@ public class ApiRequestStatementCustomizerTest extends PersistenceCapableTest {
                 /* filter */ null,
                 /* orderBy */ null,
                 /* orderDirection */ null,
-                /* effectivePermissions */ Set.of(Permissions.ACCESS_MANAGEMENT.name())
+                /* effectivePermissions */ Set.of(Permissions.Constants.PORTFOLIO_ACCESS_CONTROL_BYPASS)
         );
 
         useJdbiHandle(request, handle -> handle

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/PermissionResourceTest.java
@@ -70,7 +70,7 @@ public class PermissionResourceTest extends ResourceTest {
         Assert.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(38, json.size());
+        Assert.assertEquals(39, json.size());
         Assert.assertEquals("ACCESS_MANAGEMENT", json.getJsonObject(0).getString("name"));
         Assert.assertEquals("Allows the management of users, teams, and API keys", json.getJsonObject(0).getString("description"));
     }

--- a/persistence-migration/src/main/resources/migration/changelog-v5.6.0.xml
+++ b/persistence-migration/src/main/resources/migration/changelog-v5.6.0.xml
@@ -2623,4 +2623,29 @@
             <column name="PROJECT_ID"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="v5.6.0-31" author="nscuro">
+        <sql splitStatements="true">
+            INSERT INTO "PERMISSION" ("NAME", "DESCRIPTION")
+            VALUES ('PORTFOLIO_ACCESS_CONTROL_BYPASS', 'Provides the ability to bypass portfolio access control, granting access to all projects');
+
+            INSERT INTO "TEAMS_PERMISSIONS" ("TEAM_ID", "PERMISSION_ID")
+            SELECT "TEAM_ID"
+                 , (SELECT "ID" FROM "PERMISSION" WHERE "NAME" = 'PORTFOLIO_ACCESS_CONTROL_BYPASS')
+              FROM "TEAMS_PERMISSIONS" AS tp
+             INNER JOIN "PERMISSION" AS p
+                ON p."ID" = tp."PERMISSION_ID"
+             WHERE p."NAME" IN ('ACCESS_MANAGEMENT', 'ACCESS_MANAGEMENT_CREATE')
+                ON CONFLICT ("TEAM_ID", "PERMISSION_ID") DO NOTHING;
+
+            INSERT INTO "USERS_PERMISSIONS" ("USER_ID", "PERMISSION_ID")
+            SELECT "USER_ID"
+                 , (SELECT "ID" FROM "PERMISSION" WHERE "NAME" = 'PORTFOLIO_ACCESS_CONTROL_BYPASS')
+              FROM "USERS_PERMISSIONS" AS up
+             INNER JOIN "PERMISSION" AS p
+                ON p."ID" = up."PERMISSION_ID"
+             WHERE p."NAME" IN ('ACCESS_MANAGEMENT', 'ACCESS_MANAGEMENT_CREATE')
+                ON CONFLICT ("USER_ID", "PERMISSION_ID") DO NOTHING;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds the new `PORTFOLIO_ACCESS_CONTROL_BYPASS` permission, which explicitly allows bypassing of portfolio access control checks.

With this, the `ACCESS_MANAGEMENT` permission is no longer bypassing access control checks. Having an explicit permission for this is more obvious and less confusing (see https://github.com/DependencyTrack/hyades/issues/1422).

Users and teams who currently have the `ACCESS_MANAGEMENT` permission will automatically receive the `PORTFOLIO_ACCESS_CONTROL_BYPASS` permission upon upgrade.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/1800
Relates to https://github.com/DependencyTrack/hyades/issues/1422

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
