### PR TITLE
Fix flaky `RoleResourceTest`

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -65,7 +65,6 @@ import static org.dependencytrack.util.LockProvider.executeWithLockWaiting;
 public class DefaultObjectGenerator implements ServletContextListener {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultObjectGenerator.class);
-    private static final Map<String, Permission> PERMISSIONS_MAP = new HashMap<>();
 
     private static final Map<String, List<String>> DEFAULT_TEAM_PERMISSIONS = Map.of(
             "Administrators", Stream.of(Permissions.values())
@@ -115,6 +114,8 @@ public class DefaultObjectGenerator implements ServletContextListener {
                     Permissions.Constants.VIEW_PORTFOLIO,
                     Permissions.Constants.VIEW_VULNERABILITY,
                     Permissions.Constants.VIEW_BADGES));
+
+    private final Map<String, Permission> persistentPermissionByName = new HashMap<>();
 
     /**
      * {@inheritDoc}
@@ -278,7 +279,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
         for (final Permissions value : Permissions.values())
             if (!existing.contains(value.name())) {
                 LOGGER.debug("Creating permission: " + value.name());
-                PERMISSIONS_MAP.put(value.name(), qm.createPermission(value.name(), value.getDescription()));
+                persistentPermissionByName.put(value.name(), qm.createPermission(value.name(), value.getDescription()));
             }
     }
 
@@ -327,7 +328,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
      * @return list of {@link Permission}s
      */
     private List<Permission> getPermissionsByName(List<String> names) {
-        return names.stream().map(PERMISSIONS_MAP::get).filter(Objects::nonNull).toList();
+        return names.stream().map(persistentPermissionByName::get).filter(Objects::nonNull).toList();
     }
 
     public void loadDefaultRoles() {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes flaky `RoleResourceTest`.

Occasionally, `RoleResourceTest` would fail in CI with the following exception(s):

```
javax.jdo.JDOUserException: Object with id "" is managed by a different persistence manager
	at org.datanucleus.api.jdo.JDOAdapter.getJDOExceptionForNucleusException(JDOAdapter.java:701)
	at org.datanucleus.api.jdo.JDOPersistenceManager.jdoMakePersistent(JDOPersistenceManager.java:702)
	at org.datanucleus.api.jdo.JDOPersistenceManager.makePersistent(JDOPersistenceManager.java:722)
	at alpine.persistence.AbstractAlpineQueryManager.lambda$persist$1(AbstractAlpineQueryManager.java:316)
	at alpine.persistence.Transaction.call(Transaction.java:139)
	at alpine.persistence.AbstractAlpineQueryManager.callInTransaction(AbstractAlpineQueryManager.java:542)
	at alpine.persistence.AbstractAlpineQueryManager.callInTransaction(AbstractAlpineQueryManager.java:553)
	at alpine.persistence.AbstractAlpineQueryManager.persist(AbstractAlpineQueryManager.java:316)
	at org.dependencytrack.persistence.RoleQueryManager.createRole(RoleQueryManager.java:60)
	at org.dependencytrack.persistence.QueryManager.createRole(QueryManager.java:815)
	at org.dependencytrack.persistence.DefaultObjectGenerator.loadDefaultRoles(DefaultObjectGenerator.java:350)
	at org.dependencytrack.persistence.DefaultObjectGenerator.loadDefaultRoles(DefaultObjectGenerator.java:335)
	at org.dependencytrack.resources.v1.RoleResourceTest.before(RoleResourceTest.java:62)
```

This happens because `DefaultObjectGenerator` populates a static map with persistent objects. Due to the map being static, it's shared across all tests.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
