### PR TITLE
Add pagination to `/api/v1/team` -> `getTeams`

### DIFF
--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -581,14 +581,11 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
      * @return a List of Teams
      * @since 1.0.0
      */
-    public List<Team> getTeams() {
+    public PaginatedResult getTeams() {
         final Query<Team> query = pm.newQuery(Team.class);
         query.getFetchPlan().addGroup(Team.FetchGroup.ALL.name());
         query.setOrdering("name asc");
-        if (pagination != null && pagination.isPaginated()) {
-            query.setRange(pagination.getOffset(), pagination.getOffset() + pagination.getLimit());
-        }
-        return executeAndCloseList(query);
+        return execute(query);
     }
 
     /**

--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -578,16 +578,15 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
 
     /**
      * Returns a complete list of all Team objects, in ascending order by name.
-     * @param filterByName The name of the team to filter
      * @return a List of Teams
      * @since 1.0.0
      */
-    public PaginatedResult getTeams(String filterByName) {
+    public PaginatedResult getTeams() {
         final Query<Team> query = pm.newQuery(Team.class);
         query.getFetchPlan().addGroup(Team.FetchGroup.ALL.name());
-        if (filterByName != null) {
+        if (filter != null) {
             query.setFilter("name.toLowerCase().matches(:filter)");
-            final String filterString = ".*" + filterByName.toLowerCase() + ".*";
+            final String filterString = ".*" + filter.toLowerCase() + ".*";
             return execute(query, filterString);
         }
         query.setOrdering("name asc");

--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -578,12 +578,18 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
 
     /**
      * Returns a complete list of all Team objects, in ascending order by name.
+     * @param filterByName The name of the team to filter
      * @return a List of Teams
      * @since 1.0.0
      */
-    public PaginatedResult getTeams() {
+    public PaginatedResult getTeams(String filterByName) {
         final Query<Team> query = pm.newQuery(Team.class);
         query.getFetchPlan().addGroup(Team.FetchGroup.ALL.name());
+        if (filterByName != null) {
+            query.setFilter("name.toLowerCase().matches(:filter)");
+            final String filterString = ".*" + filterByName.toLowerCase() + ".*";
+            return execute(query, filterString);
+        }
         query.setOrdering("name asc");
         return execute(query);
     }

--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -37,6 +37,7 @@ import alpine.model.Team;
 import alpine.model.User;
 import alpine.resources.AlpineRequest;
 import alpine.security.ApiKeyGenerator;
+import org.datanucleus.store.rdbms.query.JDOQLQuery;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
@@ -49,8 +50,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.datanucleus.store.rdbms.query.JDOQLQuery;
 
 /**
  * This QueryManager provides a concrete extension of {@link AbstractAlpineQueryManager} by
@@ -586,6 +585,9 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
         final Query<Team> query = pm.newQuery(Team.class);
         query.getFetchPlan().addGroup(Team.FetchGroup.ALL.name());
         query.setOrdering("name asc");
+        if (pagination != null && pagination.isPaginated()) {
+            query.setRange(pagination.getOffset(), pagination.getOffset() + pagination.getLimit());
+        }
         return executeAndCloseList(query);
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -293,7 +293,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
      * Loads the default users and teams
      */
     private void loadDefaultPersonas(final QueryManager qm) {
-        if (!qm.getManagedUsers().isEmpty() && !qm.getTeams().isEmpty())
+        if (!qm.getManagedUsers().isEmpty() && qm.getTeams().getTotal() != 0)
             return;
 
         LOGGER.info("Adding default users and teams to datastore");

--- a/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -293,7 +293,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
      * Loads the default users and teams
      */
     private void loadDefaultPersonas(final QueryManager qm) {
-        if (!qm.getManagedUsers().isEmpty() && qm.getTeams(null).getTotal() != 0)
+        if (!qm.getManagedUsers().isEmpty() && qm.getTeams().getTotal() != 0)
             return;
 
         LOGGER.info("Adding default users and teams to datastore");

--- a/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/DefaultObjectGenerator.java
@@ -293,7 +293,7 @@ public class DefaultObjectGenerator implements ServletContextListener {
      * Loads the default users and teams
      */
     private void loadDefaultPersonas(final QueryManager qm) {
-        if (!qm.getManagedUsers().isEmpty() && qm.getTeams().getTotal() != 0)
+        if (!qm.getManagedUsers().isEmpty() && qm.getTeams(null).getTotal() != 0)
             return;
 
         LOGGER.info("Adding default users and teams to datastore");

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -503,7 +503,7 @@ public class ProjectResource extends AbstractApiResource {
                     }
 
                     boolean isAdmin = qm.hasAccessManagementPermission(principal);
-                    List<Team> visibleTeams = isAdmin ? qm.getTeams(null).getList(Team.class) : userTeams;
+                    List<Team> visibleTeams = isAdmin ? qm.getTeams().getList(Team.class) : userTeams;
                     final var visibleTeamByUuid = new HashMap<UUID, Team>(visibleTeams.size());
                     final var visibleTeamByName = new HashMap<String, Team>(visibleTeams.size());
                     for (final Team visibleTeam : visibleTeams) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -503,7 +503,7 @@ public class ProjectResource extends AbstractApiResource {
                     }
 
                     boolean isAdmin = qm.hasAccessManagementPermission(principal);
-                    List<Team> visibleTeams = isAdmin ? qm.getTeams().getList(Team.class) : userTeams;
+                    List<Team> visibleTeams = isAdmin ? qm.getTeams(null).getList(Team.class) : userTeams;
                     final var visibleTeamByUuid = new HashMap<UUID, Team>(visibleTeams.size());
                     final var visibleTeamByName = new HashMap<String, Team>(visibleTeams.size());
                     for (final Team visibleTeam : visibleTeams) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -503,7 +503,7 @@ public class ProjectResource extends AbstractApiResource {
                     }
 
                     boolean isAdmin = qm.hasAccessManagementPermission(principal);
-                    List<Team> visibleTeams = isAdmin ? qm.getTeams() : userTeams;
+                    List<Team> visibleTeams = isAdmin ? qm.getTeams().getList(Team.class) : userTeams;
                     final var visibleTeamByUuid = new HashMap<UUID, Team>(visibleTeams.size());
                     final var visibleTeamByName = new HashMap<String, Team>(visibleTeams.size());
                     for (final Team visibleTeam : visibleTeams) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -48,7 +48,6 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
@@ -100,10 +99,9 @@ public class TeamResource extends AlpineResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_READ})
-    public Response getTeams(@Parameter(description = "Filter by team name")
-                                 @QueryParam("name") String name) {
+    public Response getTeams() {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final PaginatedResult result = qm.getTeams(name);
+            final PaginatedResult result = qm.getTeams();
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }
@@ -248,7 +246,7 @@ public class TeamResource extends AlpineResource {
             boolean isAllTeams = qm.hasAccessManagementPermission(getPrincipal());
             List<Team> teams = new ArrayList<>();
             if (isAllTeams) {
-                var paginatedResult = qm.getTeams(null);
+                var paginatedResult = qm.getTeams();
                 teams = paginatedResult.getList(Team.class);
             } else {
                 if (getPrincipal() instanceof final User user) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -48,6 +48,7 @@ import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.dependencytrack.auth.Permissions;
@@ -99,9 +100,10 @@ public class TeamResource extends AlpineResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_READ})
-    public Response getTeams() {
+    public Response getTeams(@Parameter(description = "Filter by team name")
+                                 @QueryParam("name") String name) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final PaginatedResult result = qm.getTeams();
+            final PaginatedResult result = qm.getTeams(name);
             return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }
@@ -246,7 +248,7 @@ public class TeamResource extends AlpineResource {
             boolean isAllTeams = qm.hasAccessManagementPermission(getPrincipal());
             List<Team> teams = new ArrayList<>();
             if (isAllTeams) {
-                var paginatedResult = qm.getTeams();
+                var paginatedResult = qm.getTeams(null);
                 teams = paginatedResult.getList(Team.class);
             } else {
                 if (getPrincipal() instanceof final User user) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -38,15 +38,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.model.validation.ValidUuid;
-import org.dependencytrack.persistence.QueryManager;
-import org.dependencytrack.persistence.jdbi.TeamDao;
-import org.dependencytrack.resources.v1.vo.TeamSelfResponse;
-import org.dependencytrack.resources.v1.vo.VisibleTeams;
-import org.jdbi.v3.core.Handle;
-import org.owasp.security.logging.SecurityMarkers;
-
 import jakarta.validation.Validator;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -58,6 +49,16 @@ import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.model.validation.ValidUuid;
+import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.TeamDao;
+import org.dependencytrack.resources.v1.openapi.PaginatedApi;
+import org.dependencytrack.resources.v1.vo.TeamSelfResponse;
+import org.dependencytrack.resources.v1.vo.VisibleTeams;
+import org.jdbi.v3.core.Handle;
+import org.owasp.security.logging.SecurityMarkers;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -86,6 +87,7 @@ public class TeamResource extends AlpineResource {
             summary = "Returns a list of all teams",
             description = "<p>Requires permission <strong>ACCESS_MANAGEMENT</strong> or <strong>ACCESS_MANAGEMENT_READ</strong></p>"
     )
+    @PaginatedApi
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/TeamResource.java
@@ -23,6 +23,7 @@ import alpine.common.logging.Logger;
 import alpine.model.ApiKey;
 import alpine.model.Team;
 import alpine.model.User;
+import alpine.persistence.PaginatedResult;
 import alpine.security.ApiKeyDecoder;
 import alpine.security.InvalidApiKeyFormatException;
 import alpine.server.auth.PermissionRequired;
@@ -100,9 +101,8 @@ public class TeamResource extends AlpineResource {
     @PermissionRequired({Permissions.Constants.ACCESS_MANAGEMENT, Permissions.Constants.ACCESS_MANAGEMENT_READ})
     public Response getTeams() {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
-            final long totalCount = qm.getCount(Team.class);
-            final List<Team> teams = qm.getTeams();
-            return Response.ok(teams).header(TOTAL_COUNT_HEADER, totalCount).build();
+            final PaginatedResult result = qm.getTeams();
+            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }
 
@@ -246,7 +246,8 @@ public class TeamResource extends AlpineResource {
             boolean isAllTeams = qm.hasAccessManagementPermission(getPrincipal());
             List<Team> teams = new ArrayList<>();
             if (isAllTeams) {
-                teams = qm.getTeams();
+                var paginatedResult = qm.getTeams();
+                teams = paginatedResult.getList(Team.class);
             } else {
                 if (getPrincipal() instanceof final User user) {
                     teams = user.getTeams();

--- a/apiserver/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -128,7 +128,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
     public void testLoadDefaultPersonas() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         generator.loadDefaultPersonas();
-        Assert.assertEquals(4, qm.getTeams().getTotal());
+        Assert.assertEquals(4, qm.getTeams(null).getTotal());
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -128,7 +128,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
     public void testLoadDefaultPersonas() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         generator.loadDefaultPersonas();
-        Assert.assertEquals(4, qm.getTeams().size());
+        Assert.assertEquals(4, qm.getTeams().getTotal());
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/DefaultObjectGeneratorTest.java
@@ -128,7 +128,7 @@ public class DefaultObjectGeneratorTest extends PersistenceCapableTest {
     public void testLoadDefaultPersonas() throws Exception {
         DefaultObjectGenerator generator = new DefaultObjectGenerator();
         generator.loadDefaultPersonas();
-        Assert.assertEquals(4, qm.getTeams(null).getTotal());
+        Assert.assertEquals(4, qm.getTeams().getTotal());
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -88,10 +88,11 @@ public class TeamResourceTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
         Assert.assertEquals(200, response.getStatus(), 0);
+        // There's already a built-in team in ResourceTest
         Assert.assertEquals(String.valueOf(1001), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assert.assertNotNull(json);
-        Assert.assertEquals(1001, json.size()); // There's already a built-in team in ResourceTest
+        Assert.assertEquals(100, json.size()); // Max size on one page
         Assert.assertEquals("Team 0", json.getJsonObject(0).getString("name"));
     }
 
@@ -268,7 +269,7 @@ public class TeamResourceTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
                 .put(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
-        team = qm.getTeams().get(0);
+        team = qm.getTeams().getList(Team.class).get(0);
         Assert.assertEquals(1, team.getApiKeys().size());
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -310,7 +310,7 @@ public class TeamResourceTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
                 .put(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
-        team = qm.getTeams(null).getList(Team.class).get(0);
+        team = qm.getTeams().getList(Team.class).get(0);
         Assert.assertEquals(1, team.getApiKeys().size());
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -135,7 +135,7 @@ public class TeamResourceTest extends ResourceTest {
         }
 
         Response response = jersey.target(V1_TEAM)
-                .queryParam("name", "1")
+                .queryParam("searchText", "1")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TeamResourceTest.java
@@ -127,6 +127,47 @@ public class TeamResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getTeamsFilterByNameTest() {
+        for (int i = 0; i < 11; i++) {
+            final var team = new Team();
+            team.setName("team " + i);
+            qm.persist(team);
+        }
+
+        Response response = jersey.target(V1_TEAM)
+                .queryParam("name", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Assertions.assertThat(response.getStatus()).isEqualTo(200);
+        Assertions.assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("2");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("""
+                [ {
+                  "uuid" : "${json-unit.any-string}",
+                  "name" : "team 1",
+                  "apiKeys" : [ ],
+                  "mappedLdapGroups" : [ ],
+                  "mappedOidcGroups" : [ ],
+                  "permissions" : [ ],
+                  "ldapUsers" : [ ],
+                  "oidcUsers" : [ ],
+                  "managedUsers" : [ ]
+                }, {
+                  "uuid" : "${json-unit.any-string}",
+                  "name" : "team 10",
+                  "apiKeys" : [ ],
+                  "mappedLdapGroups" : [ ],
+                  "mappedOidcGroups" : [ ],
+                  "permissions" : [ ],
+                  "ldapUsers" : [ ],
+                  "oidcUsers" : [ ],
+                  "managedUsers" : [ ]
+                } ]
+                """);
+    }
+
+    @Test
     public void getTeamTest() {
         Team team = qm.createTeam("ABC");
         Response response = jersey.target(V1_TEAM + "/" + team.getUuid())
@@ -269,7 +310,7 @@ public class TeamResourceTest extends ResourceTest {
                 .property(ClientProperties.SUPPRESS_HTTP_COMPLIANCE_VALIDATION, true)
                 .put(Entity.entity(null, MediaType.APPLICATION_JSON));
         Assert.assertEquals(201, response.getStatus(), 0);
-        team = qm.getTeams().getList(Team.class).get(0);
+        team = qm.getTeams(null).getList(Team.class).get(0);
         Assert.assertEquals(1, team.getApiKeys().size());
     }
 


### PR DESCRIPTION
### Description

Add pagination to `/api/v1/team` -> `getTeams`

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1798

### Additional Details

Frontend changes not required. Pagination is already `true` for `teams`.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
