### PR TITLE
Allow OIDC teams claim to be comma-delimited string

### DIFF
--- a/alpine/alpine-server/src/main/java/alpine/server/auth/OidcAuthenticationService.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/auth/OidcAuthenticationService.java
@@ -136,9 +136,7 @@ public class OidcAuthenticationService implements AuthenticationService {
             throw new AlpineAuthenticationException(AlpineAuthenticationException.CauseType.OTHER);
         }
 
-        final OidcProfileCreator profileCreator = claims -> {
-            return customizer.createProfile(claims);
-        };
+        final OidcProfileCreator profileCreator = customizer::createProfile;
 
         OidcProfile idTokenProfile = null;
         if (idToken != null) {

--- a/alpine/alpine-server/src/test/java/alpine/server/auth/DefaultOidcAuthenticationCustomizerTest.java
+++ b/alpine/alpine-server/src/test/java/alpine/server/auth/DefaultOidcAuthenticationCustomizerTest.java
@@ -1,0 +1,117 @@
+/*
+ * This file is part of Alpine.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) Steve Springett. All Rights Reserved.
+ */
+package alpine.server.auth;
+
+import com.nimbusds.openid.connect.sdk.claims.ClaimsSet;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultOidcAuthenticationCustomizerTest {
+
+    @Nested
+    class CreateProfileTest {
+
+        @Test
+        void shouldCreateProfile() {
+            final var customizer = new DefaultOidcAuthenticationCustomizer("username", "groups");
+
+            final var claims = new ClaimsSet(
+                    new JSONObject(
+                            Map.ofEntries(
+                                    Map.entry("sub", "subject-foo"),
+                                    Map.entry("username", "username"),
+                                    Map.entry("email", "user@example.com"),
+                                    Map.entry("groups", List.of("group-foo")))));
+
+            final OidcProfile profile = customizer.createProfile(claims);
+            assertThat(profile).isNotNull();
+            assertThat(profile.getSubject()).isEqualTo("subject-foo");
+            assertThat(profile.getUsername()).isEqualTo("username");
+            assertThat(profile.getEmail()).isEqualTo("user@example.com");
+            assertThat(profile.getGroups()).containsOnly("group-foo");
+        }
+
+        @Test
+        void shouldSupportTeamsClaimAsString() {
+            final var customizer = new DefaultOidcAuthenticationCustomizer("username", "groups");
+
+            final var claims = new ClaimsSet(
+                    new JSONObject(
+                            Map.ofEntries(
+                                    Map.entry("sub", "subject-foo"),
+                                    Map.entry("username", "username"),
+                                    Map.entry("email", "user@example.com"),
+                                    Map.entry("groups", "group-foo"))));
+
+            final OidcProfile profile = customizer.createProfile(claims);
+            assertThat(profile).isNotNull();
+            assertThat(profile.getSubject()).isEqualTo("subject-foo");
+            assertThat(profile.getUsername()).isEqualTo("username");
+            assertThat(profile.getEmail()).isEqualTo("user@example.com");
+            assertThat(profile.getGroups()).containsOnly("group-foo");
+        }
+
+        @Test
+        void shouldSupportTeamsClaimAsDelimitedString() {
+            final var customizer = new DefaultOidcAuthenticationCustomizer("username", "groups");
+
+            final var claims = new ClaimsSet(
+                    new JSONObject(
+                            Map.ofEntries(
+                                    Map.entry("sub", "subject-foo"),
+                                    Map.entry("username", "username"),
+                                    Map.entry("email", "user@example.com"),
+                                    Map.entry("groups", "group-foo, group-bar"))));
+
+            final OidcProfile profile = customizer.createProfile(claims);
+            assertThat(profile).isNotNull();
+            assertThat(profile.getSubject()).isEqualTo("subject-foo");
+            assertThat(profile.getUsername()).isEqualTo("username");
+            assertThat(profile.getEmail()).isEqualTo("user@example.com");
+            assertThat(profile.getGroups()).containsOnly("group-foo", "group-bar");
+        }
+
+        @Test
+        void shouldAssumeEmptyTeamsWhenTeamClaimIsNotPresent() {
+            final var customizer = new DefaultOidcAuthenticationCustomizer("username", "groups");
+
+            final var claims = new ClaimsSet(
+                    new JSONObject(
+                            Map.ofEntries(
+                                    Map.entry("sub", "subject-foo"),
+                                    Map.entry("username", "username"),
+                                    Map.entry("email", "user@example.com"))));
+
+            final OidcProfile profile = customizer.createProfile(claims);
+            assertThat(profile).isNotNull();
+            assertThat(profile.getSubject()).isEqualTo("subject-foo");
+            assertThat(profile.getUsername()).isEqualTo("username");
+            assertThat(profile.getEmail()).isEqualTo("user@example.com");
+            assertThat(profile.getGroups()).isEmpty();
+        }
+
+    }
+
+}

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -582,7 +582,7 @@ alpine.oidc.user.provisioning=false
 alpine.oidc.team.synchronization=false
 
 # Defines the name of the claim that contains group memberships or role assignments in the provider's userinfo endpoint.
-# The claim must be an array of strings. Most public identity providers do not support group or role management.
+# The claim must be an array of strings, or a comma-delimited string. Most public identity providers do not support group or role management.
 # When using a customizable / on-demand hosted identity provider, name, content, and inclusion in the userinfo endpoint
 # will most likely need to be configured.
 #


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows OIDC teams claim to be comma-delimited string.

This is to support cases where the IdP is unable to provide the claim as an array of strings.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
