### PR TITLE
Fix ineffective `@DefineApiProjectAclCondition` for user principals

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ApiRequestStatementCustomizer.java
@@ -66,7 +66,7 @@ import static org.jdbi.v3.core.generic.GenericTypes.parameterizeClass;
 class ApiRequestStatementCustomizer implements StatementCustomizer {
 
     static final String PARAMETER_PROJECT_ACL_TEAM_IDS = "projectAclTeamIds";
-    static final String PARAMETER_USER_ID = "projectAclUserId";
+    static final String PARAMETER_PROJECT_ACL_USER_ID = "projectAclUserId";
     static final String TEMPLATE_PROJECT_ACL_CONDITION = /* language=SQL */ """
             EXISTS(
               SELECT 1
@@ -210,7 +210,7 @@ class ApiRequestStatementCustomizer implements StatementCustomizer {
             case User user -> {
                 ctx.define(ATTRIBUTE_API_PROJECT_ACL_CONDITION,
                         TEMPLATE_USER_PROJECT_ACL_CONDITION.formatted(config.projectAclProjectIdColumn()));
-                ctx.getBinding().addNamed(PARAMETER_USER_ID, user.getId(), QualifiedType.of(Long.class));
+                ctx.getBinding().addNamed(PARAMETER_PROJECT_ACL_USER_ID, user.getId(), QualifiedType.of(Long.class));
             }
             case ApiKey apiKey when !principalTeamIds.isEmpty() -> {
                 ctx.define(ATTRIBUTE_API_PROJECT_ACL_CONDITION,

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/DefineApiProjectAclCondition.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/DefineApiProjectAclCondition.java
@@ -33,7 +33,9 @@ import java.lang.reflect.Method;
 import java.sql.PreparedStatement;
 
 import static org.dependencytrack.persistence.jdbi.ApiRequestStatementCustomizer.PARAMETER_PROJECT_ACL_TEAM_IDS;
+import static org.dependencytrack.persistence.jdbi.ApiRequestStatementCustomizer.PARAMETER_PROJECT_ACL_USER_ID;
 import static org.dependencytrack.persistence.jdbi.ApiRequestStatementCustomizer.TEMPLATE_PROJECT_ACL_CONDITION;
+import static org.dependencytrack.persistence.jdbi.ApiRequestStatementCustomizer.TEMPLATE_USER_PROJECT_ACL_CONDITION;
 import static org.dependencytrack.persistence.jdbi.JdbiAttributes.ATTRIBUTE_API_PROJECT_ACL_CONDITION;
 
 /**
@@ -89,7 +91,7 @@ public @interface DefineApiProjectAclCondition {
         private final String attributeName;
         private final String projectIdColumn;
 
-        private StatementCustomizer(final String attributeName, final String projectIdColumn) {
+        StatementCustomizer(final String attributeName, final String projectIdColumn) {
             this.attributeName = attributeName;
             this.projectIdColumn = projectIdColumn;
         }
@@ -114,6 +116,11 @@ public @interface DefineApiProjectAclCondition {
                 // so it's not a trivial TRUE or FALSE. Re-use those bindings by defining
                 // a new condition, using the chosen project table alias.
                 ctx.define(attributeName, TEMPLATE_PROJECT_ACL_CONDITION.formatted(projectIdColumn));
+            } else if (ctx.getBinding().findForName(PARAMETER_PROJECT_ACL_USER_ID, ctx).isPresent()) {
+                // The existing condition has defined a user ID for the ACL check already,
+                // so it's not a trivial TRUE or FALSE. Re-use that binding by defining
+                // a new condition, using the chosen project table alias.
+                ctx.define(attributeName, TEMPLATE_USER_PROJECT_ACL_CONDITION.formatted(projectIdColumn));
             } else {
                 // Likely a trivial TRUE or FALSE; Just re-use it.
                 ctx.define(attributeName, aclCondition);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes ineffective `@DefineApiProjectAclCondition` for user principals.

This caused ACL conditions to be inlined with wrong project ID column references.

For example, the `ComponentDao#isAccessible` method was impacted by it.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1251 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
