### PR TITLE
Various REST API v2 fixes

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/MetricsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/MetricsResource.java
@@ -32,11 +32,13 @@ import org.dependencytrack.persistence.pagination.Page;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
+import jakarta.ws.rs.ext.Provider;
 
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.persistence.pagination.PageUtil.createPaginationMetadata;
 
+@Provider
 public class MetricsResource extends AlpineResource implements MetricsApi {
 
     @Context

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/OpenApiResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/OpenApiResource.java
@@ -20,17 +20,12 @@ package org.dependencytrack.resources.v2;
 
 import alpine.server.auth.AuthenticationNotRequired;
 import io.swagger.v3.oas.annotations.Operation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.ServerErrorException;
-import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URISyntaxException;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -39,7 +34,6 @@ import static java.util.Objects.requireNonNull;
 @Path("/openapi.yaml")
 public class OpenApiResource {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(OpenApiResource.class);
     private static final ReadWriteLock LOCK = new ReentrantReadWriteLock();
     private static String OPENAPI_YAML;
 
@@ -47,7 +41,7 @@ public class OpenApiResource {
     @Produces("application/yaml")
     @Operation(hidden = true)
     @AuthenticationNotRequired
-    public String getOpenApi() {
+    public String getOpenApi() throws IOException {
         LOCK.readLock().lock();
         try {
             if (OPENAPI_YAML == null) {
@@ -60,9 +54,6 @@ public class OpenApiResource {
                     }
 
                     LOCK.readLock().lock();
-                } catch (URISyntaxException | IOException e) {
-                    LOGGER.error("Failed to load OpenAPI spec YAML", e);
-                    throw new ServerErrorException(Response.Status.INTERNAL_SERVER_ERROR);
                 } finally {
                     LOCK.writeLock().unlock();
                 }
@@ -74,7 +65,7 @@ public class OpenApiResource {
         }
     }
 
-    private static String loadOpenapiYaml() throws URISyntaxException, IOException {
+    private static String loadOpenapiYaml() throws IOException {
         try (final InputStream inputStream =
                      OpenApiResource.class.getResourceAsStream(
                              "/org/dependencytrack/api/v2/openapi.yaml")) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/TeamsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/TeamsResource.java
@@ -149,6 +149,7 @@ public class TeamsResource implements TeamsApi {
     }
 
     @Override
+    @PermissionRequired(Permissions.Constants.ACCESS_MANAGEMENT)
     public Response listTeamMemberships(final String team, final String user, final Integer limit, final String pageToken) {
         final Page<ListTeamMembershipsRow> membershipsPage = inJdbiTransaction(
                 handle -> handle.attach(TeamDao.class).listTeamMembers(team, user, limit, pageToken));
@@ -168,6 +169,7 @@ public class TeamsResource implements TeamsApi {
     }
 
     @Override
+    @PermissionRequired(Permissions.Constants.ACCESS_MANAGEMENT)
     public Response createTeamMembership(final CreateTeamMembershipRequest request) {
         try (final var qm = new QueryManager()) {
             qm.runInTransaction(() -> {
@@ -201,6 +203,7 @@ public class TeamsResource implements TeamsApi {
     }
 
     @Override
+    @PermissionRequired(Permissions.Constants.ACCESS_MANAGEMENT)
     public Response deleteTeamMembership(final String team, final String user) {
         final boolean deleted = inJdbiTransaction(
                 handle -> handle.attach(TeamDao.class).deleteTeamMembership(team, user));

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/MetricsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/MetricsResourceTest.java
@@ -18,8 +18,6 @@
  */
 package org.dependencytrack.resources.v2;
 
-import alpine.server.filters.ApiFilter;
-import alpine.server.filters.AuthenticationFeature;
 import net.javacrumbs.jsonunit.core.Option;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
@@ -28,7 +26,6 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.ProjectMetrics;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.persistence.jdbi.MetricsTestDao;
-import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -47,10 +44,7 @@ import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 public class MetricsResourceTest extends ResourceTest {
 
     @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(MetricsResource.class)
-                    .register(ApiFilter.class)
-                    .register(AuthenticationFeature.class));
+    public static JerseyTestRule jersey = new JerseyTestRule(new ResourceConfig());
 
     @Test
     public void getCurrentPortfolioMetricsEmptyTest() {

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/WorkflowsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/WorkflowsResourceTest.java
@@ -18,14 +18,12 @@
  */
 package org.dependencytrack.resources.v2;
 
-import alpine.server.filters.ApiFilter;
-import alpine.server.filters.AuthenticationFeature;
 import net.javacrumbs.jsonunit.core.Option;
 import org.apache.http.HttpStatus;
 import org.dependencytrack.JerseyTestRule;
 import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.model.WorkflowState;
-import org.glassfish.jersey.server.ResourceConfig;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -45,13 +43,12 @@ import static org.hamcrest.CoreMatchers.equalTo;
 public class WorkflowsResourceTest extends ResourceTest {
 
     @ClassRule
-    public static JerseyTestRule jersey = new JerseyTestRule(
-            new ResourceConfig(WorkflowsResource.class)
-                    .register(ApiFilter.class)
-                    .register(AuthenticationFeature.class));
+    public static JerseyTestRule jersey = new JerseyTestRule(new ResourceConfig());
 
     @Test
     public void getWorkflowStatusOk() {
+        initializeWithPermissions(Permissions.BOM_UPLOAD);
+
         UUID uuid = UUID.randomUUID();
         WorkflowState workflowState1 = new WorkflowState();
         workflowState1.setParent(null);
@@ -107,6 +104,8 @@ public class WorkflowsResourceTest extends ResourceTest {
 
     @Test
     public void getWorkflowStatusNotFound() {
+        initializeWithPermissions(Permissions.BOM_UPLOAD);
+
         WorkflowState workflowState1 = new WorkflowState();
         workflowState1.setParent(null);
         workflowState1.setFailureReason(null);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

* Add missing permission checks to team-memberships endpoints
* Fix `MetricsResource` not being discovered at runtime due to missing `@Provider` annotation.
* Ensure all v2 API tests use the main `ResourceConfig` instead of individual resource and filter registrations.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1245 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
