### PR TITLE
Add `version` filter to concise project endpoint

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -66,6 +66,7 @@ public interface ProjectDao {
 
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="nameFilter" type="Boolean" -->
+            <#-- @ftlvariable name="versionFilter" type="Boolean" -->
             <#-- @ftlvariable name="classifierFilter" type="Boolean" -->
             <#-- @ftlvariable name="tagFilter" type="Boolean" -->
             <#-- @ftlvariable name="teamFilter" type="Boolean" -->
@@ -134,6 +135,9 @@ public interface ProjectDao {
             <#if nameFilter>
                AND "PROJECT"."NAME" = :nameFilter
             </#if>
+            <#if versionFilter>
+               AND "PROJECT"."VERSION" = :versionFilter
+            </#if>
             <#if classifierFilter>
                AND "PROJECT"."CLASSIFIER" = :classifierFilter
             </#if>
@@ -201,6 +205,7 @@ public interface ProjectDao {
     })
     List<ConciseProjectListRow> getPageConcise(
             @Bind String nameFilter,
+            @Bind String versionFilter,
             @Bind String classifierFilter,
             @Bind String tagFilter,
             @Bind String teamFilter,

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -171,6 +171,8 @@ public class ProjectResource extends AbstractApiResource {
     public Response getProjectsConcise(
             @Parameter(description = "Name to filter on. Must be exact match.")
             @QueryParam("name") final String nameFilter,
+            @Parameter(description = "Version to filter on. Must be exact match.")
+            @QueryParam("version") final String versionFilter,
             @Parameter(description = "Classifier to filter on. Must be exact match.")
             @QueryParam("classifier") final String classifierFilter,
             @Parameter(description = "Tag to filter on. Must be exact match.")
@@ -185,7 +187,7 @@ public class ProjectResource extends AbstractApiResource {
             @QueryParam("includeMetrics") final boolean includeMetrics
     ) {
         final List<ConciseProjectListRow> projectRows = withJdbiHandle(getAlpineRequest(), handle -> handle.attach(ProjectDao.class)
-                .getPageConcise(nameFilter, classifierFilter, tagFilter, teamFilter, activeFilter, onlyRootFilter, /* parentUuidFilter */ null, includeMetrics));
+                .getPageConcise(nameFilter, versionFilter, classifierFilter, tagFilter, teamFilter, activeFilter, onlyRootFilter, /* parentUuidFilter */ null, includeMetrics));
 
         final long totalCount = projectRows.isEmpty() ? 0 : projectRows.getFirst().totalCount();
         final List<ConciseProject> projects = projectRows.stream().map(ConciseProject::new).toList();
@@ -216,6 +218,8 @@ public class ProjectResource extends AbstractApiResource {
             @PathParam("uuid") final String parentUuid,
             @Parameter(description = "Name to filter on. Must be exact match.")
             @QueryParam("name") final String nameFilter,
+            @Parameter(description = "Version to filter on. Must be exact match.")
+            @QueryParam("version") final String versionFilter,
             @Parameter(description = "Classifier to filter on. Must be exact match.")
             @QueryParam("classifier") final String classifierFilter,
             @Parameter(description = "Tag to filter on. Must be exact match.")
@@ -228,7 +232,7 @@ public class ProjectResource extends AbstractApiResource {
             @QueryParam("includeMetrics") final boolean includeMetrics
     ) {
         final List<ConciseProjectListRow> projectRows = withJdbiHandle(getAlpineRequest(), handle -> handle.attach(ProjectDao.class)
-                .getPageConcise(nameFilter, classifierFilter, tagFilter, teamFilter, activeFilter, /* onlyRootFilter */ null, UUID.fromString(parentUuid), includeMetrics));
+                .getPageConcise(nameFilter, versionFilter, classifierFilter, tagFilter, teamFilter, activeFilter, /* onlyRootFilter */ null, UUID.fromString(parentUuid), includeMetrics));
 
         final long totalCount = projectRows.isEmpty() ? 0 : projectRows.getFirst().totalCount();
         final List<ConciseProject> projects = projectRows.stream().map(ConciseProject::new).toList();


### PR DESCRIPTION
### Description

As part of upstream issue, from now, list of projects filtered by name and version can be retrieved via endpoint `/v1/project/concise` instead of `/api/v1/project/lookup`.

### Addressed Issue

https://github.com/DependencyTrack/dependency-track/issues/4914

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
