### PR TITLE
Remove recursive parent ref from workflow states response

### DIFF
--- a/api/src/main/openapi/components/schemas/list-workflow-states-response-item.yaml
+++ b/api/src/main/openapi/components/schemas/list-workflow-states-response-item.yaml
@@ -16,8 +16,6 @@
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 type: object
 properties:
-  parent:
-    $ref: './list-workflow-states-response-item.yaml'
   step:
     type: string
     enum:

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/WorkflowsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/WorkflowsResource.java
@@ -59,9 +59,6 @@ public class WorkflowsResource implements WorkflowsApi {
                 .step(ListWorkflowStatesResponseItem.StepEnum.fromString(workflowState.getStep().name()))
                 .failureReason(workflowState.getFailureReason())
                 .build();
-        if (workflowState.getParent() != null) {
-            mappedState.setParent(mapWorkflowStateResponse(workflowState.getParent()));
-        }
         if (workflowState.getStartedAt() != null) {
             mappedState.setStartedAt(workflowState.getStartedAt().getTime());
         }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes recursive parent ref from workflow states response.

It causes issues with OpenAPI renderers who end up in an endless loop trying to resolve the reference.

Since the response already contains all steps for a given token, it is not necessary to include redundant nested steps.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
