### PR TITLE
Fix HikariCP failure to create meter registry

### DIFF
--- a/alpine/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/persistence/PersistenceManagerFactory.java
@@ -25,6 +25,7 @@ import alpine.persistence.IPersistenceManagerFactory;
 import alpine.persistence.JdoProperties;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import org.datanucleus.PropertyNames;
@@ -347,7 +348,7 @@ public class PersistenceManagerFactory implements IPersistenceManagerFactory, Se
         hikariConfig.setPassword(Config.getInstance().getPropertyOrFile(Config.AlpineKey.DATABASE_PASSWORD));
 
         if (Config.getInstance().getPropertyAsBoolean(Config.AlpineKey.METRICS_ENABLED)) {
-            hikariConfig.setMetricRegistry(Metrics.getRegistry());
+            hikariConfig.setMetricsTrackerFactory(new MicrometerMetricsTrackerFactory(Metrics.getRegistry()));
         }
 
         return hikariConfig;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fix HikariCP failure to create meter registry.

Since upgrading to HikariCP v6.3.1, setting the meter registry no longer works:

```
java.lang.RuntimeException: java.lang.NoSuchMethodException: com.zaxxer.hikari.metrics.micrometer.MicrometerMetricsTrackerFactory.<init>(io.micrometer.prometheusmetrics.PrometheusMeterRegistry)
	at com.zaxxer.hikari.util.UtilityElf.createInstance(UtilityElf.java:123)
	at com.zaxxer.hikari.pool.HikariPool.setMetricRegistry(HikariPool.java:292)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:103)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:80)
	at alpine.server.persistence.PersistenceManagerFactory.createTxPooledDataSource(PersistenceManagerFactory.java:308)
```

Switching to `setMetricsTrackerFactory` resolves the issue. Seems like a reflection bug in HikariCP.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1332 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
