### PR TITLE
Try to fix flaky `ProcessorManagerTest`

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/event/kafka/processor/api/ProcessorManagerTest.java
@@ -103,7 +103,7 @@ public class ProcessorManagerTest {
             processorManager.registerProcessor("foo", inputTopic, processor);
 
             for (int i = 0; i < 100; i++) {
-                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i));
+                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i)).get();
             }
 
             processorManager.startAll();
@@ -172,7 +172,7 @@ public class ProcessorManagerTest {
             processorManager.registerBatchProcessor("foo", inputTopic, recordProcessor);
 
             for (int i = 0; i < 1_000; i++) {
-                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i));
+                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i)).get();
             }
 
             processorManager.startAll();
@@ -203,7 +203,7 @@ public class ProcessorManagerTest {
             processorManager.registerProcessor("foo", inputTopic, processor);
 
             for (int i = 0; i < 100; i++) {
-                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i));
+                producer.send(new ProducerRecord<>("input", "foo" + i, "bar" + i)).get();
             }
 
             processorManager.startAll();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tries to fix the flaky `ProcessorManagerTest`.

There are occasional errors where the Kafka producer used in this test fails to send all records.

Change it to wait for each record to be ack-ed by the broker before continuing to the actual assertions. Let's see if this helps, I wasn't able to reproduce the flakiness locally.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
