### PR TITLE
Add missing active project count mapping for vulnerability list

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -328,6 +328,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
             final AffectedProjectCountRow affectedProjects = affectedProjectCountRows.get(vulnerability.getId());
             if (affectedProjects != null) {
                 vulnerability.setAffectedProjectCount(affectedProjects.totalProjectCount());
+                vulnerability.setAffectedActiveProjectCount(affectedProjects.activeProjectCount());
                 vulnerability.setAffectedInactiveProjectCount(affectedProjects.totalProjectCount() - affectedProjects.activeProjectCount());
             }
             vulnerability.setAliases(getVulnerabilityAliases(vulnerability));


### PR DESCRIPTION
### Description

Currently, the active affected project count is not mapped to the vulnerability which is resulting into 0 count for each vulnerability while listing all vulnerabilities.

Affected endpoint: `GET /v1/vulnerability`

### Addressed Issue

NA

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
