### PR TITLE
Remove unused database config properties

### DIFF
--- a/alpine/alpine-common/src/main/java/alpine/Config.java
+++ b/alpine/alpine-common/src/main/java/alpine/Config.java
@@ -113,27 +113,11 @@ public class Config {
         DATABASE_PASSWORD                      ("alpine.database.password",          ""),
         DATABASE_PASSWORD_FILE                 ("alpine.database.password.file",     null),
         DATABASE_POOL_ENABLED                  ("alpine.database.pool.enabled",      true),
-        DATABASE_POOL_TX_ONLY                  ("alpine.database.pool.tx.only",      false),
-        @Deprecated
         DATABASE_POOL_MAX_SIZE                 ("alpine.database.pool.max.size",     20),
-        DATABASE_POOL_TX_MAX_SIZE              ("alpine.database.pool.tx.max.size", null),        // null for backward compatibility
-        DATABASE_POOL_NONTX_MAX_SIZE           ("alpine.database.pool.nontx.max.size", null),     // null for backward compatibility
-        @Deprecated
         DATABASE_POOL_IDLE_TIMEOUT             ("alpine.database.pool.idle.timeout", 300000),
-        DATABASE_POOL_TX_IDLE_TIMEOUT          ("alpine.database.pool.tx.idle.timeout", null),    // null for backward compatibility
-        DATABASE_POOL_NONTX_IDLE_TIMEOUT       ("alpine.database.pool.nontx.idle.timeout", null), // null for backward compatibility
-        @Deprecated
         DATABASE_POOL_MIN_IDLE                 ("alpine.database.pool.min.idle",     10),
-        DATABASE_POOL_TX_MIN_IDLE              ("alpine.database.pool.tx.min.idle", null),        // null for backward compatibility
-        DATABASE_POOL_NONTX_MIN_IDLE           ("alpine.database.pool.nontx.min.idle", null),     // null for backward compatibility
-        @Deprecated
         DATABASE_POOL_MAX_LIFETIME             ("alpine.database.pool.max.lifetime", 600000),
-        DATABASE_POOL_TX_MAX_LIFETIME          ("alpine.database.pool.tx.max.lifetime", null),    // null for backward compatibility
-        DATABASE_POOL_NONTX_MAX_LIFETIME       ("alpine.database.pool.nontx.max.lifetime", null), // null for backward compatibility
-        @Deprecated
         DATABASE_POOL_KEEPALIVE_INTERVAL       ("alpine.database.pool.keepalive.interval", 0),
-        DATABASE_POOL_TX_KEEPALIVE_INTERVAL    ("alpine.database.pool.tx.keepalive.interval", null),
-        DATABASE_POOL_NONTX_KEEPALIVE_INTERVAL ("alpine.database.pool.nontx.keepalive.interval", null),
         ENFORCE_AUTHENTICATION                 ("alpine.enforce.authentication",     true),
         ENFORCE_AUTHORIZATION                  ("alpine.enforce.authorization",      true),
         BCRYPT_ROUNDS                          ("alpine.bcrypt.rounds",              14),

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -93,18 +93,6 @@ alpine.database.password=dtrack
 # @type:     boolean
 alpine.database.pool.enabled=true
 
-# Specifies if only the transactional connection pool shall be created,
-# and re-used for non-transactional operations. This can make sense
-# for applications that handle schema migrations outside the ORM,
-# and do not use value generation strategies that require database
-# connections. The overhead of maintaining two connection pools can
-# be avoided in this case.
-#
-# @category: Database
-# @type:     boolean
-# @hidden
-alpine.database.pool.tx.only=true
-
 # This property controls the maximum size that the pool is allowed to reach,
 # including both idle and in-use connections.
 #


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes unused database config properties.

We no longer support separate connection pools for DataNucleus transactional / non-transactional usage.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
