### PR TITLE
Add BOM process failed notifications due to timeouts and vulnerability scan failures

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessor.java
+++ b/apiserver/src/main/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessor.java
@@ -43,6 +43,7 @@ import org.dependencytrack.persistence.jdbi.NotificationSubjectDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityScanDao;
 import org.dependencytrack.persistence.jdbi.WorkflowDao;
 import org.dependencytrack.proto.notification.v1.BomConsumedOrProcessedSubject;
+import org.dependencytrack.proto.notification.v1.BomProcessingFailedSubject;
 import org.dependencytrack.proto.notification.v1.Notification;
 import org.dependencytrack.proto.notification.v1.ProjectVulnAnalysisCompleteSubject;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
@@ -63,6 +64,7 @@ import static java.lang.Math.toIntExact;
 import static org.dependencytrack.common.ConfigKey.TMP_DELAY_BOM_PROCESSED_NOTIFICATION;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_BOM_PROCESSED;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_BOM_PROCESSING_FAILED;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_VULN_ANALYSIS_COMPLETE;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
@@ -100,7 +102,7 @@ public class ProcessedVulnerabilityScanResultProcessor implements BatchProcessor
             notifications.addAll(createVulnAnalysisCompleteNotifications(handle, completedVulnScans));
 
             if (shouldDispatchBomProcessedNotification) {
-                notifications.addAll(createBomProcessedNotifications(handle, completedVulnScans));
+                notifications.addAll(createBomProcessedOrFailedNotifications(handle, completedVulnScans));
             }
         });
 
@@ -242,7 +244,7 @@ public class ProcessedVulnerabilityScanResultProcessor implements BatchProcessor
         return notifications;
     }
 
-    private static List<KafkaEvent<?, ?>> createBomProcessedNotifications(final Handle jdbiHandle, final List<VulnerabilityScan> completedVulnScans) {
+    private static List<KafkaEvent<?, ?>> createBomProcessedOrFailedNotifications(final Handle jdbiHandle, final List<VulnerabilityScan> completedVulnScans) {
         // Collect the workflow tokens for all completed scans, as long as they target a project.
         // Dispatching BOM_PROCESSED notifications does not make sense when individual components,
         // or even the entire portfolio was scanned.
@@ -261,18 +263,23 @@ public class ProcessedVulnerabilityScanResultProcessor implements BatchProcessor
         final var workflowDao = jdbiHandle.attach(WorkflowDao.class);
         final Set<UUID> workflowTokensWithBomProcessed =
                 workflowDao.getTokensByStepAndStateAndTokenAnyOf(WorkflowStep.BOM_PROCESSING, WorkflowStatus.COMPLETED, workflowTokens);
-        if (workflowTokensWithBomProcessed.isEmpty()) {
-            LOGGER.debug("None of the possible %d workflows have %s steps with status %s"
-                    .formatted(workflowTokens.size(), WorkflowStep.BOM_PROCESSING, WorkflowStatus.COMPLETED));
+        final Set<UUID> workflowTokensWithBomProcessFailed =
+                workflowDao.getTokensByStepAndStateAndTokenAnyOf(WorkflowStep.BOM_PROCESSING, WorkflowStatus.FAILED, workflowTokens);
+
+        if (workflowTokensWithBomProcessed.isEmpty() && workflowTokensWithBomProcessFailed.isEmpty()) {
+            LOGGER.debug("None of the possible %d workflows have %s steps with status %s or %s"
+                    .formatted(workflowTokens.size(), WorkflowStep.BOM_PROCESSING, WorkflowStatus.COMPLETED, WorkflowStatus.FAILED));
             return Collections.emptyList();
         }
 
         final var notificationSubjectDao = jdbiHandle.attach(NotificationSubjectDao.class);
-        final List<BomConsumedOrProcessedSubject> notificationSubjects =
+        final List<BomConsumedOrProcessedSubject> notificationSubjectsForSuccess =
                 notificationSubjectDao.getForDelayedBomProcessed(workflowTokensWithBomProcessed);
+        final List<BomProcessingFailedSubject> notificationSubjectsForFailure =
+                notificationSubjectDao.getForBomProcessingFailed(workflowTokensWithBomProcessFailed);
 
         final var notifications = new ArrayList<KafkaEvent<?, ?>>(workflowTokensWithBomProcessed.size());
-        notificationSubjects.stream()
+        notificationSubjectsForSuccess.stream()
                 .map(subject -> Notification.newBuilder()
                         .setScope(SCOPE_PORTFOLIO)
                         .setGroup(GROUP_BOM_PROCESSED)
@@ -280,6 +287,19 @@ public class ProcessedVulnerabilityScanResultProcessor implements BatchProcessor
                         .setTimestamp(Timestamps.now())
                         .setTitle(NotificationConstants.Title.BOM_PROCESSED)
                         .setContent("A %s BOM was processed".formatted(subject.getBom().getFormat()))
+                        .setSubject(Any.pack(subject))
+                        .build())
+                .map(KafkaEventConverter::convert)
+                .forEach(notifications::add);
+
+        notificationSubjectsForFailure.stream()
+                .map(subject -> Notification.newBuilder()
+                        .setScope(SCOPE_PORTFOLIO)
+                        .setGroup(GROUP_BOM_PROCESSING_FAILED)
+                        .setLevel(LEVEL_INFORMATIONAL)
+                        .setTimestamp(Timestamps.now())
+                        .setTitle(NotificationConstants.Title.BOM_PROCESSING_FAILED)
+                        .setContent("A %s BOM processing failed".formatted(subject.getBom().getFormat()))
                         .setSubject(Any.pack(subject))
                         .build())
                 .map(KafkaEventConverter::convert)

--- a/apiserver/src/main/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessor.java
+++ b/apiserver/src/main/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessor.java
@@ -278,7 +278,7 @@ public class ProcessedVulnerabilityScanResultProcessor implements BatchProcessor
         final List<BomProcessingFailedSubject> notificationSubjectsForFailure =
                 notificationSubjectDao.getForBomProcessingFailed(workflowTokensWithBomProcessFailed);
 
-        final var notifications = new ArrayList<KafkaEvent<?, ?>>(workflowTokensWithBomProcessed.size());
+        final var notifications = new ArrayList<KafkaEvent<?, ?>>(workflowTokensWithBomProcessed.size() + workflowTokensWithBomProcessFailed.size());
         notificationSubjectsForSuccess.stream()
                 .map(subject -> Notification.newBuilder()
                         .setScope(SCOPE_PORTFOLIO)

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -25,11 +25,13 @@ import org.dependencytrack.persistence.jdbi.mapping.NotificationBomRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationComponentRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationProjectRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectBomConsumedOrProcessedRowMapper;
+import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectBomProcessingFailedRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectNewVulnerabilityRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectNewVulnerableDependencyRowReducer;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationSubjectProjectAuditChangeRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.NotificationVulnerabilityRowMapper;
 import org.dependencytrack.proto.notification.v1.BomConsumedOrProcessedSubject;
+import org.dependencytrack.proto.notification.v1.BomProcessingFailedSubject;
 import org.dependencytrack.proto.notification.v1.Component;
 import org.dependencytrack.proto.notification.v1.ComponentVulnAnalysisCompleteSubject;
 import org.dependencytrack.proto.notification.v1.NewVulnerabilitySubject;
@@ -356,6 +358,27 @@ public interface NotificationSubjectDao extends SqlObject {
             """)
     @RegisterRowMapper(NotificationSubjectBomConsumedOrProcessedRowMapper.class)
     List<BomConsumedOrProcessedSubject> getForDelayedBomProcessed(Collection<UUID> workflowTokens);
+
+    @SqlQuery("""
+            SELECT "P"."UUID" AS "projectUuid"
+                 , "P"."NAME"        AS "projectName"
+                 , "P"."VERSION"     AS "projectVersion"
+                 , 'CycloneDX'       AS "bomFormat"
+                 , 'Unknown'         AS "bomSpecVersion"
+                 , '(Omitted)'       AS "bomContent"
+                 , "WFS"."TOKEN"     AS "token"
+                 , "WFS"."FAILURE_REASON"     AS "cause"
+              FROM "VULNERABILITYSCAN" AS "VS"
+             INNER JOIN "PROJECT" AS "P"
+                ON "P"."UUID" = "VS"."TARGET_IDENTIFIER"
+             INNER JOIN "WORKFLOW_STATE" AS "WFS"
+                ON "WFS"."TOKEN" = "VS"."TOKEN"
+               AND "WFS"."STEP" = 'BOM_PROCESSING'
+               AND "WFS"."STATUS" = 'FAILED'
+             WHERE "VS"."TOKEN" = ANY(:workflowTokens)
+            """)
+    @RegisterRowMapper(NotificationSubjectBomProcessingFailedRowMapper.class)
+    List<BomProcessingFailedSubject> getForBomProcessingFailed(Collection<UUID> workflowTokens);
 
     @SqlQuery("""
             SELECT "P"."UUID" AS "projectUuid"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -382,6 +382,25 @@ public interface NotificationSubjectDao extends SqlObject {
 
     @SqlQuery("""
             SELECT "P"."UUID" AS "projectUuid"
+                 , "P"."NAME"        AS "projectName"
+                 , "P"."VERSION"     AS "projectVersion"
+                 , 'CycloneDX'       AS "bomFormat"
+                 , 'Unknown'         AS "bomSpecVersion"
+                 , '(Omitted)'       AS "bomContent"
+                 , "WFS"."TOKEN"     AS "token"
+                 , "WFS"."FAILURE_REASON"     AS "cause"
+              FROM "VULNERABILITYSCAN" AS "VS"
+             INNER JOIN "PROJECT" AS "P"
+                ON "P"."UUID" = "VS"."TARGET_IDENTIFIER"
+             INNER JOIN "WORKFLOW_STATE" AS "WFS"
+                ON "WFS"."TOKEN" = "VS"."TOKEN"
+             WHERE "WFS"."ID" = ANY(:failedWorkflowIds)
+            """)
+    @RegisterRowMapper(NotificationSubjectBomProcessingFailedRowMapper.class)
+    List<BomProcessingFailedSubject> getForBomProcessingTimedOut(Collection<Long> failedWorkflowIds);
+
+    @SqlQuery("""
+            SELECT "P"."UUID" AS "projectUuid"
                  , "P"."NAME" AS "projectName"
                  , "P"."VERSION" AS "projectVersion"
                  , "P"."DESCRIPTION" AS "projectDescription"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationSubjectBomProcessingFailedRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationSubjectBomProcessingFailedRowMapper.java
@@ -1,0 +1,51 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi.mapping;
+
+import org.dependencytrack.proto.notification.v1.Bom;
+import org.dependencytrack.proto.notification.v1.BomProcessingFailedSubject;
+import org.dependencytrack.proto.notification.v1.Project;
+import org.jdbi.v3.core.mapper.NoSuchMapperException;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.dependencytrack.persistence.jdbi.mapping.RowMapperUtil.maybeSet;
+
+public class NotificationSubjectBomProcessingFailedRowMapper implements RowMapper<BomProcessingFailedSubject> {
+
+    @Override
+    public BomProcessingFailedSubject map(final ResultSet rs, final StatementContext ctx) throws SQLException {
+        final RowMapper<Project> projectRowMapper = ctx.findRowMapperFor(Project.class)
+                .orElseThrow(() -> new NoSuchMapperException("No mapper registered for %s".formatted(Project.class)));
+        final RowMapper<Bom> bomRowMapper = ctx.findRowMapperFor(Bom.class)
+                .orElseThrow(() -> new NoSuchMapperException("No mapper registered for %s".formatted(Bom.class)));
+
+        final BomProcessingFailedSubject.Builder builder = BomProcessingFailedSubject.newBuilder()
+                .setProject(projectRowMapper.map(rs, ctx))
+                .setBom(bomRowMapper.map(rs, ctx));
+        maybeSet(rs, "token", ResultSet::getString, builder::setToken);
+        maybeSet(rs, "cause", ResultSet::getString, builder::setCause);
+
+        return builder.build();
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
@@ -34,6 +34,7 @@ import org.dependencytrack.model.WorkflowStatus;
 import org.dependencytrack.model.WorkflowStep;
 import org.dependencytrack.persistence.jdbi.WorkflowDao;
 import org.dependencytrack.proto.notification.v1.BomConsumedOrProcessedSubject;
+import org.dependencytrack.proto.notification.v1.BomProcessingFailedSubject;
 import org.dependencytrack.proto.notification.v1.Notification;
 import org.dependencytrack.proto.notification.v1.ProjectVulnAnalysisCompleteSubject;
 import org.dependencytrack.proto.vulnanalysis.v1.ScanResult;
@@ -53,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_BOM_PROCESSED;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_BOM_PROCESSING_FAILED;
 import static org.dependencytrack.proto.notification.v1.Group.GROUP_PROJECT_VULN_ANALYSIS_COMPLETE;
 import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
 import static org.dependencytrack.proto.notification.v1.ProjectVulnAnalysisStatus.PROJECT_VULN_ANALYSIS_STATUS_COMPLETED;
@@ -258,6 +260,63 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
                             assertThat(metricsUpdateEvent.getChainIdentifier()).isEqualTo(workflowToken);
                         }
                 ));
+    }
+
+    @Test
+    public void testProcessWithBomProcessingFailedNotification() throws Exception {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final UUID workflowToken = UUID.randomUUID();
+        qm.createWorkflowSteps(workflowToken);
+
+        // Transition BOM_PROCESSING step to FAILED status.
+        withJdbiHandle(handle -> handle.attach(WorkflowDao.class)
+                .updateState(WorkflowStep.BOM_PROCESSING, workflowToken, WorkflowStatus.FAILED, /* failureReason */ "Time out"));
+
+        final var vulnScan = new VulnerabilityScan();
+        vulnScan.setToken(workflowToken);
+        vulnScan.setTargetType(VulnerabilityScan.TargetType.PROJECT);
+        vulnScan.setTargetIdentifier(project.getUuid());
+        vulnScan.setStatus(VulnerabilityScan.Status.IN_PROGRESS);
+        vulnScan.setExpectedResults(1);
+        vulnScan.setFailureThreshold(0.1);
+        vulnScan.setStartedAt(new Date());
+        vulnScan.setUpdatedAt(vulnScan.getStartedAt());
+        qm.persist(vulnScan);
+
+        final var scanResult = ScanResult.newBuilder()
+                .addScannerResults(ScannerResult.newBuilder()
+                        .setScanner(SCANNER_INTERNAL)
+                        .setStatus(SCAN_STATUS_FAILED))
+                .build();
+
+        final var processor = new ProcessedVulnerabilityScanResultProcessor(/* shouldDispatchBomProcessedNotification */ true);
+        processor.process(List.of(aConsumerRecord(vulnScan.getToken().toString(), scanResult).build()));
+
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(
+                record -> assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_PROJECT_VULN_ANALYSIS_COMPLETE.name()),
+                record -> {
+                    assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name());
+
+                    final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_BOM, record);
+                    assertThat(recordKey).isEqualTo(project.getUuid().toString());
+
+                    final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_BOM, record);
+                    assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+                    assertThat(notification.getGroup()).isEqualTo(GROUP_BOM_PROCESSING_FAILED);
+                    assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                    assertThat(notification.getSubject().is(BomProcessingFailedSubject.class)).isTrue();
+
+                    final var subject = notification.getSubject().unpack(BomProcessingFailedSubject.class);
+                    assertThat(subject.getToken()).isEqualTo(workflowToken.toString());
+                    assertThat(subject.getCause()).isEqualTo("Time out");
+                    assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                }
+        );
+
+        assertThat(EVENTS).isEmpty();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/WorkflowMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/WorkflowMaintenanceTaskTest.java
@@ -19,10 +19,15 @@
 package org.dependencytrack.tasks.maintenance;
 
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.event.kafka.KafkaTopics;
 import org.dependencytrack.event.maintenance.WorkflowMaintenanceEvent;
+import org.dependencytrack.model.Project;
+import org.dependencytrack.model.VulnerabilityScan;
 import org.dependencytrack.model.WorkflowState;
 import org.dependencytrack.model.WorkflowStatus;
 import org.dependencytrack.model.WorkflowStep;
+import org.dependencytrack.proto.notification.v1.BomProcessingFailedSubject;
+import org.dependencytrack.proto.notification.v1.Notification;
 import org.junit.Test;
 
 import javax.jdo.JDOObjectNotFoundException;
@@ -36,6 +41,11 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_WORKFLOW_RETENTION_HOURS;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_WORKFLOW_STEP_TIMEOUT_MINUTES;
+import static org.dependencytrack.proto.notification.v1.Group.GROUP_BOM_PROCESSING_FAILED;
+import static org.dependencytrack.proto.notification.v1.Level.LEVEL_INFORMATIONAL;
+import static org.dependencytrack.proto.notification.v1.Scope.SCOPE_PORTFOLIO;
+import static org.dependencytrack.util.KafkaTestUtil.deserializeKey;
+import static org.dependencytrack.util.KafkaTestUtil.deserializeValue;
 
 public class WorkflowMaintenanceTaskTest extends PersistenceCapableTest {
 
@@ -123,6 +133,21 @@ public class WorkflowMaintenanceTaskTest extends PersistenceCapableTest {
         childState.setUpdatedAt(Date.from(timeoutCutoff.plus(1, ChronoUnit.HOURS)));
         qm.persist(childState);
 
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var vulnScan = new VulnerabilityScan();
+        vulnScan.setToken(token);
+        vulnScan.setTargetType(VulnerabilityScan.TargetType.PROJECT);
+        vulnScan.setTargetIdentifier(project.getUuid());
+        vulnScan.setStatus(VulnerabilityScan.Status.IN_PROGRESS);
+        vulnScan.setExpectedResults(1);
+        vulnScan.setFailureThreshold(0.1);
+        vulnScan.setStartedAt(new Date());
+        vulnScan.setUpdatedAt(vulnScan.getStartedAt());
+        qm.persist(vulnScan);
+
         final var task = new WorkflowMaintenanceTask();
         assertThatNoException().isThrownBy(() -> task.inform(new WorkflowMaintenanceEvent()));
 
@@ -133,6 +158,26 @@ public class WorkflowMaintenanceTaskTest extends PersistenceCapableTest {
         assertThat(childState.getStatus()).isEqualTo(WorkflowStatus.CANCELLED);
         assertThat(childState.getFailureReason()).isNull();
         assertThat(childState.getUpdatedAt()).isEqualTo(parentState.getUpdatedAt()); // Modified.
+
+        assertThat(kafkaMockProducer.history()).satisfiesExactly(
+                record -> {
+                    assertThat(record.topic()).isEqualTo(KafkaTopics.NOTIFICATION_BOM.name());
+
+                    final String recordKey = deserializeKey(KafkaTopics.NOTIFICATION_BOM, record);
+                    assertThat(recordKey).isEqualTo(project.getUuid().toString());
+
+                    final Notification notification = deserializeValue(KafkaTopics.NOTIFICATION_BOM, record);
+                    assertThat(notification.getScope()).isEqualTo(SCOPE_PORTFOLIO);
+                    assertThat(notification.getGroup()).isEqualTo(GROUP_BOM_PROCESSING_FAILED);
+                    assertThat(notification.getLevel()).isEqualTo(LEVEL_INFORMATIONAL);
+                    assertThat(notification.getSubject().is(BomProcessingFailedSubject.class)).isTrue();
+
+                    final var subject = notification.getSubject().unpack(BomProcessingFailedSubject.class);
+                    assertThat(subject.getToken()).isEqualTo(token.toString());
+                    assertThat(subject.getCause()).isEqualTo("Timed out");
+                    assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                }
+        );
     }
 
     @Test


### PR DESCRIPTION
### Description

Add BOM process failed notifications due to timeouts and vulnerability scan failures.

### Addressed Issue

NA

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
