### PR TITLE
Issue-1837 : Log more details when timing out and failing workflow steps

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/common/MdcKeys.java
+++ b/apiserver/src/main/java/org/dependencytrack/common/MdcKeys.java
@@ -43,6 +43,7 @@ public final class MdcKeys {
     public static final String MDC_PROJECT_UUID = "projectUuid";
     public static final String MDC_PROJECT_VERSION = "projectVersion";
     public static final String MDC_SCAN_TOKEN = "scanToken";
+    public static final String MDC_WORKFLOW_TOKEN = "workflowToken";
 
     private MdcKeys() {
     }

--- a/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/NotificationModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/NotificationModelConverter.java
@@ -342,6 +342,7 @@ public final class NotificationModelConverter {
                 .orElseGet(Collections::emptySet).stream()
                 .map(Tag::getName)
                 .forEach(builder::addTags);
+        Optional.ofNullable(project.isActive()).ifPresent(builder::setIsActive);
 
         return builder.build();
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDao.java
@@ -82,6 +82,7 @@ public interface NotificationSubjectDao extends SqlObject {
               "P"."VERSION"                    AS "projectVersion",
               "P"."DESCRIPTION"                AS "projectDescription",
               "P"."PURL"                       AS "projectPurl",
+              ("P"."INACTIVE_SINCE" IS NULL)   AS "isActive",
               (SELECT
                  ARRAY_AGG(DISTINCT "T"."NAME")
                FROM
@@ -172,6 +173,7 @@ public interface NotificationSubjectDao extends SqlObject {
               "P"."VERSION"                    AS "projectVersion",
               "P"."DESCRIPTION"                AS "projectDescription",
               "P"."PURL"                       AS "projectPurl",
+              ("P"."INACTIVE_SINCE" IS NULL)   AS "isActive",
               (SELECT
                  ARRAY_AGG(DISTINCT "T"."NAME")
                FROM
@@ -258,6 +260,7 @@ public interface NotificationSubjectDao extends SqlObject {
               "P"."VERSION"                    AS "projectVersion",
               "P"."DESCRIPTION"                AS "projectDescription",
               "P"."PURL"                       AS "projectPurl",
+              ("P"."INACTIVE_SINCE" IS NULL)   AS "isActive",
               (SELECT
                  ARRAY_AGG(DISTINCT "T"."NAME")
                FROM
@@ -337,6 +340,7 @@ public interface NotificationSubjectDao extends SqlObject {
                  , "P"."VERSION"     AS "projectVersion"
                  , "P"."DESCRIPTION" AS "projectDescription"
                  , "P"."PURL"        AS "projectPurl"
+                 , ("P"."INACTIVE_SINCE" IS NULL)     AS "isActive"
                  , (SELECT ARRAY_AGG(DISTINCT "T"."NAME")
                       FROM "TAG" AS "T"
                      INNER JOIN "PROJECTS_TAGS" AS "PT"
@@ -364,6 +368,7 @@ public interface NotificationSubjectDao extends SqlObject {
             SELECT "P"."UUID" AS "projectUuid"
                  , "P"."NAME"        AS "projectName"
                  , "P"."VERSION"     AS "projectVersion"
+                 , ("P"."INACTIVE_SINCE" IS NULL) AS "isActive"
                  , 'CycloneDX'       AS "bomFormat"
                  , 'Unknown'         AS "bomSpecVersion"
                  , '(Omitted)'       AS "bomContent"
@@ -408,6 +413,7 @@ public interface NotificationSubjectDao extends SqlObject {
                  , "P"."VERSION" AS "projectVersion"
                  , "P"."DESCRIPTION" AS "projectDescription"
                  , "P"."PURL" AS "projectPurl"
+                 , ("P"."INACTIVE_SINCE" IS NULL) AS "isActive"
                  , (SELECT ARRAY_AGG(DISTINCT "T"."NAME")
                       FROM "TAG" AS "T"
                      INNER JOIN "PROJECTS_TAGS" AS "PT"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/WorkflowDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/WorkflowDao.java
@@ -158,7 +158,7 @@ public interface WorkflowDao extends SqlObject {
     /**
      * @since 5.6.0
      */
-    default List<Long> transitionAllTimedOutStepsToFailedForTimeout(final Duration timeoutDuration) {
+    default List<WorkflowState> transitionAllTimedOutStepsToFailedForTimeout(final Duration timeoutDuration) {
         // NB: Can't use interface method here due to https://github.com/jdbi/jdbi/issues/1807.
         return getHandle().createUpdate("""
                         UPDATE "WORKFLOW_STATE"
@@ -167,11 +167,11 @@ public interface WorkflowDao extends SqlObject {
                              , "UPDATED_AT" = NOW()
                          WHERE "STATUS" = 'TIMED_OUT'
                            AND "UPDATED_AT" < (NOW() - :timeoutDuration)
-                        RETURNING "ID"
+                        RETURNING *
                         """)
                 .bind("timeoutDuration", timeoutDuration)
                 .executeAndReturnGeneratedKeys()
-                .mapTo(Long.class)
+                .mapToBean(WorkflowState.class)
                 .list();
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationProjectRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/NotificationProjectRowMapper.java
@@ -38,6 +38,7 @@ public class NotificationProjectRowMapper implements RowMapper<Project> {
         maybeSet(rs, "projectDescription", ResultSet::getString, builder::setDescription);
         maybeSet(rs, "projectPurl", ResultSet::getString, builder::setPurl);
         maybeSet(rs, "projectTags", RowMapperUtil::stringArray, builder::addAllTags);
+        maybeSet(rs, "isActive", ResultSet::getBoolean, builder::setIsActive);
         return builder.build();
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/event/kafka/processor/ProcessedVulnerabilityScanResultProcessorTest.java
@@ -170,6 +170,7 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
             assertThat(subject.getToken()).isEqualTo(workflowToken.toString());
             assertThat(subject.getStatus()).isEqualTo(PROJECT_VULN_ANALYSIS_STATUS_FAILED);
             assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+            assertThat(subject.getProject().getIsActive()).isTrue();
             assertThat(subject.getFindingsCount()).isZero();
         });
 
@@ -241,6 +242,7 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
             final var subject = notification.getSubject().unpack(ProjectVulnAnalysisCompleteSubject.class);
             assertThat(subject.getStatus()).isEqualTo(PROJECT_VULN_ANALYSIS_STATUS_COMPLETED);
             assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+            assertThat(subject.getProject().getIsActive()).isTrue();
             assertThat(subject.getFindingsCount()).isZero();
         });
 
@@ -313,6 +315,7 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
                     final var subject = notification.getSubject().unpack(BomConsumedOrProcessedSubject.class);
                     assertThat(subject.getToken()).isEqualTo(workflowToken.toString());
                     assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                    assertThat(subject.getProject().getIsActive()).isTrue();
                 }
         );
 
@@ -328,6 +331,7 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
     public void testProcessWithDelayedBomProcessedNotificationWhenVulnerabilityScanFailed() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
+        project.setInactiveSince(new Date());
         qm.persist(project);
 
         final UUID workflowToken = UUID.randomUUID();
@@ -376,6 +380,7 @@ public class ProcessedVulnerabilityScanResultProcessorTest extends AbstractProce
                     final var subject = notification.getSubject().unpack(BomProcessingFailedSubject.class);
                     assertThat(subject.getToken()).isEqualTo(workflowToken.toString());
                     assertThat(subject.getProject().getUuid()).isEqualTo(project.getUuid().toString());
+                    assertThat(subject.getProject().getIsActive()).isFalse();
                 }
         );
 

--- a/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/NotificationModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/NotificationModelConverterTest.java
@@ -596,6 +596,7 @@ public class NotificationModelConverterTest {
         assertThat(project.getDescription()).isEqualTo(project.getDescription());
         assertThat(project.getPurl()).isEqualTo("pkg:maven/org.acme/acme-app@projectVersion");
         assertThat(project.getTagsList()).containsOnly("tag1", "tag2");
+        assertThat(project.getIsActive()).isTrue();
     }
 
     private org.dependencytrack.model.Component createComponent(final org.dependencytrack.model.Project project) {

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/NotificationSubjectDaoTest.java
@@ -122,6 +122,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                       "description": "projectDescription",
                                       "name": "projectName",
                                       "purl": "projectPurl",
+                                      "isActive":true,
                                       "tags": [
                                         "projecttaga",
                                         "projecttagb"
@@ -145,6 +146,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                     "description": "projectDescription",
                                     "name": "projectName",
                                     "purl": "projectPurl",
+                                    "isActive":true,
                                     "tags": [
                                       "projecttaga",
                                       "projecttagb"
@@ -249,7 +251,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                           },
                           "project": {
                             "uuid": "${json-unit.matches:projectUuid}",
-                            "name": "projectName"
+                            "name": "projectName",
+                            "isActive":true
                           },
                           "vulnerability": {
                             "uuid": "${json-unit.matches:vulnUuid}",
@@ -263,7 +266,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                           "affectedProjects": [
                             {
                               "uuid": "${json-unit.matches:projectUuid}",
-                              "name": "projectName"
+                              "name": "projectName",
+                              "isActive":true
                             }
                           ],
                           "affectedProjectsReference": {
@@ -362,6 +366,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                             "version": "projectVersion",
                             "description": "projectDescription",
                             "purl": "projectPurl",
+                            "isActive":true,
                             "tags": [
                               "projecttaga",
                               "projecttagb"
@@ -460,7 +465,8 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                           },
                           "project": {
                             "uuid": "${json-unit.matches:projectUuid}",
-                            "name": "projectName"
+                            "name": "projectName",
+                            "isActive":true
                           },
                           "vulnerabilities": [
                             {
@@ -559,6 +565,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                          "name": "projectName",
                                          "version": "projectVersion",
                                          "description": "projectDescription",
+                                         "isActive":true,
                                          "purl": "projectPurl",
                                          "tags": [
                                              "projecttaga",
@@ -617,6 +624,7 @@ public class NotificationSubjectDaoTest extends PersistenceCapableTest {
                                              "version": "projectVersion",
                                              "description": "projectDescription",
                                              "purl": "projectPurl",
+                                             "isActive":true,
                                              "tags": [
                                                  "projecttaga",
                                                  "projecttagb"

--- a/proto/src/main/proto/org/dependencytrack/notification/v1/notification.proto
+++ b/proto/src/main/proto/org/dependencytrack/notification/v1/notification.proto
@@ -159,6 +159,7 @@ message Project {
   optional string description = 4;
   optional string purl = 5;
   repeated string tags = 6;
+  optional bool is_active = 7;
 }
 
 message PolicyViolation {


### PR DESCRIPTION
### Description

1. Add logging for each `TIMED_OUT -> FAILED` workflow state.
2. Add project status in related notifications.

### Addressed Issue

Closes https://github.com/DependencyTrack/hyades/issues/1837

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
