### PR TITLE
Add REST API endpoints for extensions

### DIFF
--- a/api/src/main/openapi/components/schemas/extension-config-type.yaml
+++ b/api/src/main/openapi/components/schemas/extension-config-type.yaml
@@ -1,0 +1,33 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: string
+description: |-
+  The type of an extension config.
+  
+  * `BOOLEAN` represents a boolean value of either `true` or `false`.
+  * `DURATION` represents a duration in milliseconds, e.g. `500` for 500 milliseconds.
+  * `INSTANT` represents a timestamp in epoch milliseconds.
+  * `INTEGER` represents an integer, e.g. `666`.
+  * `PATH` represents a file path, e.g. `/foo/bar.baz`.
+  * `STRING` represents a simple string, e.g. `foo bar baz`.
+enum:
+- BOOLEAN
+- DURATION
+- INSTANT
+- INTEGER
+- PATH
+- STRING

--- a/api/src/main/openapi/components/schemas/extension-config.yaml
+++ b/api/src/main/openapi/components/schemas/extension-config.yaml
@@ -1,0 +1,48 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  name:
+    description: Name of the config.
+    type: string
+  description:
+    type: string
+  type:
+    $ref: "./extension-config-type.yaml"
+  is_required:
+    description: >-
+      Whether this configuration is required.
+      Required configs can not be set to `null`.
+    type: boolean
+  is_secret:
+    description: >-
+      Whether this configuration's value is to be treated as secret.
+      Secret values are stored encrypted and not readable by API clients.
+    type: boolean
+  value:
+    description: |-
+      Value of the config.
+      
+      If the config is a secret, and the value is non-`null`, the value
+      returned by the API will be `***SECRET-PLACEHOLDER***`.
+    type: string
+required:
+- name
+- description
+- type
+- is_required
+- is_secret

--- a/api/src/main/openapi/components/schemas/invalid-extension-config.yaml
+++ b/api/src/main/openapi/components/schemas/invalid-extension-config.yaml
@@ -1,0 +1,30 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  name:
+    type: string
+    description: Name of the config that was found to be invalid
+  value:
+    type: string
+    description: The invalid value, if applicable
+  message:
+    type: string
+    description: Message explaining the error
+required:
+- name
+- message

--- a/api/src/main/openapi/components/schemas/invalid-extension-configs-problem-details.yaml
+++ b/api/src/main/openapi/components/schemas/invalid-extension-configs-problem-details.yaml
@@ -1,0 +1,27 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+allOf:
+- $ref: "./problem-details.yaml"
+properties:
+  invalid_configs:
+    type: array
+    items:
+      $ref: "./invalid-extension-config.yaml"
+    minItems: 1
+required:
+- invalid_configs

--- a/api/src/main/openapi/components/schemas/list-extension-configs-response.yaml
+++ b/api/src/main/openapi/components/schemas/list-extension-configs-response.yaml
@@ -1,0 +1,24 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  configs:
+    type: array
+    items:
+      $ref: "./extension-config.yaml"
+required:
+- configs

--- a/api/src/main/openapi/components/schemas/list-extension-points-response-item.yaml
+++ b/api/src/main/openapi/components/schemas/list-extension-points-response-item.yaml
@@ -1,0 +1,22 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  name:
+    type: string
+required:
+- name

--- a/api/src/main/openapi/components/schemas/list-extension-points-response.yaml
+++ b/api/src/main/openapi/components/schemas/list-extension-points-response.yaml
@@ -1,0 +1,24 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  extension_points:
+    type: array
+    items:
+      $ref: "./list-extension-points-response-item.yaml"
+required:
+- extension_points

--- a/api/src/main/openapi/components/schemas/list-extensions-response-item.yaml
+++ b/api/src/main/openapi/components/schemas/list-extensions-response-item.yaml
@@ -1,0 +1,22 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  name:
+    type: string
+required:
+- name

--- a/api/src/main/openapi/components/schemas/list-extensions-response.yaml
+++ b/api/src/main/openapi/components/schemas/list-extensions-response.yaml
@@ -1,0 +1,24 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  extensions:
+    type: array
+    items:
+      $ref: "./list-extensions-response-item.yaml"
+required:
+- extensions

--- a/api/src/main/openapi/components/schemas/update-extension-configs-request-item.yaml
+++ b/api/src/main/openapi/components/schemas/update-extension-configs-request-item.yaml
@@ -1,0 +1,33 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  name:
+    description: Name of the config.
+    type: string
+    minLength: 1
+  value:
+    description: |-
+      Value of the config. Must match the config's type.
+      
+      If the corresponding config is a secret, the value `***SECRET-PLACEHOLDER***`
+      may be used to prevent it from being overwritten without having
+      to provide the clear text secret again.
+    type: string
+required:
+- name
+- value

--- a/api/src/main/openapi/components/schemas/update-extension-configs-request.yaml
+++ b/api/src/main/openapi/components/schemas/update-extension-configs-request.yaml
@@ -1,0 +1,25 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  configs:
+    type: array
+    items:
+      $ref: "./update-extension-configs-request-item.yaml"
+    minItems: 1
+required:
+- configs

--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -34,6 +34,8 @@ servers:
 tags:
 - name: Components
   description: Endpoints related to components
+- name: Extensions
+  description: Endpoints related to extensions
 - name: Metrics
   description: Endpoints related to metrics
 - name: Projects
@@ -46,6 +48,12 @@ tags:
 paths:
   /components:
     $ref: "./paths/components.yaml"
+  /extension-points:
+    $ref: "./paths/extension-points.yaml"
+  /extension-points/{extensionPointName}/extensions:
+    $ref: "./paths/extension-points__name__extensions.yaml"
+  /extension-points/{extensionPointName}/extensions/{extensionName}/configs:
+    $ref: "./paths/extension-points__name__extensions__name__configs.yaml"
   /projects/{uuid}/components:
     $ref: "./paths/projects_uuid_components.yaml"
   /metrics/portfolio/current:

--- a/api/src/main/openapi/paths/extension-points.yaml
+++ b/api/src/main/openapi/paths/extension-points.yaml
@@ -1,0 +1,38 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: listExtensionPoints
+  summary: List all extension points
+  description: |-
+    Returns a list of extension points, sorted by name in ascending order.
+    
+    Requires the `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_READ` permission.
+  tags:
+  - Extensions
+  responses:
+    "200":
+      description: List of extension points
+      content:
+        application/json:
+          schema:
+            $ref: "../components/schemas/list-extension-points-response.yaml"
+    "401":
+      $ref: "../components/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../components/responses/generic-forbidden-error.yaml"
+    default:
+      $ref: "../components/responses/generic-error.yaml"

--- a/api/src/main/openapi/paths/extension-points__name__extensions.yaml
+++ b/api/src/main/openapi/paths/extension-points__name__extensions.yaml
@@ -1,0 +1,47 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: listExtensions
+  summary: List all extensions
+  description: |-
+    Returns a list of extensions for a given extension point, sorted by name in ascending order.
+    
+    Requires the `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_READ` permission.
+  tags:
+  - Extensions
+  parameters:
+  - name: extensionPointName
+    description: Name of the extension point
+    in: path
+    required: true
+    schema:
+      type: string
+  responses:
+    "200":
+      description: List of extensions
+      content:
+        application/json:
+          schema:
+            $ref: "../components/schemas/list-extensions-response.yaml"
+    "401":
+      $ref: "../components/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../components/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../components/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../components/responses/generic-error.yaml"

--- a/api/src/main/openapi/paths/extension-points__name__extensions__name__configs.yaml
+++ b/api/src/main/openapi/paths/extension-points__name__extensions__name__configs.yaml
@@ -1,0 +1,103 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: listExtensionConfigs
+  summary: List all extension configs
+  description: |-
+    Returns a list of configs for a given extension, sorted by name in ascending order.
+    
+    Requires the `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_READ` permission.
+  tags:
+  - Extensions
+  parameters:
+  - name: extensionPointName
+    description: Name of the extension point
+    in: path
+    required: true
+    schema:
+      type: string
+  - name: extensionName
+    description: Name of the extension
+    in: path
+    required: true
+    schema:
+      type: string
+  responses:
+    "200":
+      description: List of configs
+      content:
+        application/json:
+          schema:
+            $ref: "../components/schemas/list-extension-configs-response.yaml"
+    "401":
+      $ref: "../components/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../components/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../components/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../components/responses/generic-error.yaml"
+
+put:
+  operationId: updateExtensionConfigs
+  summary: Update extension configs
+  description: |-
+    Updates configuration values of a given extension point.
+    
+    Must provide values for all configs. Partial updates are not allowed.
+    
+    Requires the `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_UPDATE` permission.
+  tags:
+  - Extensions
+  parameters:
+  - name: extensionPointName
+    description: Name of the extension point
+    in: path
+    required: true
+    schema:
+      type: string
+  - name: extensionName
+    description: Name of the extension
+    in: path
+    required: true
+    schema:
+      type: string
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "../components/schemas/update-extension-configs-request.yaml"
+  responses:
+    "204":
+      description: Configs updated successfully
+    "400":
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            oneOf:
+            - $ref: "../components/schemas/invalid-extension-configs-problem-details.yaml"
+            - $ref: "../components/schemas/invalid-request-problem-details.yaml"
+    "401":
+      $ref: "../components/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../components/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../components/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../components/responses/generic-error.yaml"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ConfigPropertyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ConfigPropertyDao.java
@@ -22,31 +22,29 @@ import alpine.model.ConfigProperty;
 import alpine.model.IConfigProperty.PropertyType;
 import alpine.security.crypto.DataEncryption;
 import org.dependencytrack.model.ConfigPropertyConstants;
+import org.jdbi.v3.sqlobject.SqlObject;
 import org.jdbi.v3.sqlobject.config.RegisterBeanMapper;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
+import java.util.Collection;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 
 /**
  * @since 5.6.0
  */
-public interface ConfigPropertyDao {
+public interface ConfigPropertyDao extends SqlObject {
 
-    @SqlUpdate("""
+    @SqlBatch("""
             INSERT INTO "CONFIGPROPERTY" ("GROUPNAME", "PROPERTYNAME", "PROPERTYTYPE", "DESCRIPTION", "PROPERTYVALUE")
-            VALUES (:group, :name, :type, :description, :value)
+            VALUES (:groupName, :propertyName, :propertyType, :description, :propertyValue)
             ON CONFLICT ("GROUPNAME", "PROPERTYNAME") DO NOTHING
             """)
-    void maybeCreate(
-            @Bind String group,
-            @Bind String name,
-            @Bind PropertyType type,
-            @Bind String description,
-            @Bind String value);
+    void maybeCreateAll(@BindBean Collection<ConfigProperty> property);
 
     @SqlQuery("""
             SELECT *

--- a/apiserver/src/main/java/org/dependencytrack/plugin/PluginManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/plugin/PluginManager.java
@@ -42,10 +42,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.SequencedCollection;
 import java.util.SequencedMap;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
@@ -100,7 +100,11 @@ public class PluginManager {
         return INSTANCE;
     }
 
-    public List<Plugin> getLoadedPlugins() {
+    public SequencedCollection<ExtensionPointSpec<?>> getExtensionPoints() {
+        return List.copyOf(specByExtensionPointClass.values());
+    }
+
+    public SequencedCollection<Plugin> getLoadedPlugins() {
         return List.copyOf(loadedPluginByClass.sequencedValues());
     }
 
@@ -140,10 +144,10 @@ public class PluginManager {
     }
 
     @SuppressWarnings("unchecked")
-    public <T extends ExtensionPoint, U extends ExtensionFactory<T>> SortedSet<U> getFactories(final Class<T> extensionPointClass) {
+    public <T extends ExtensionPoint, U extends ExtensionFactory<T>> SequencedCollection<U> getFactories(final Class<T> extensionPointClass) {
         final Set<String> extensionNames = extensionNamesByExtensionPointClass.get(extensionPointClass);
         if (extensionNames == null) {
-            return Collections.emptySortedSet();
+            return Collections.emptyList();
         }
 
         final var factories = new TreeSet<U>(factoryComparator);
@@ -286,6 +290,9 @@ public class PluginManager {
             );
         }
 
+        LOGGER.debug("Creating runtime extension configs with defaults if necessary");
+        configRegistry.createWithDefaultsIfNotExist(extensionFactory.runtimeConfigs());
+
         LOGGER.debug("Initializing extension");
         try {
             extensionFactory.init(new ExtensionContext(configRegistry, new ProxySelector()));
@@ -321,7 +328,7 @@ public class PluginManager {
                     Map.entry(MDC_EXTENSION_POINT_NAME, extensionPointSpec.name())))) {
                 LOGGER.debug("Determining default extension");
 
-                final SortedSet<? extends ExtensionFactory<?>> factories = getFactories(extensionPointClass);
+                final SequencedCollection<? extends ExtensionFactory<?>> factories = getFactories(extensionPointClass);
                 if (factories == null || factories.isEmpty()) {
                     LOGGER.warn("No extension available; Skipping");
                     continue;
@@ -333,7 +340,7 @@ public class PluginManager {
                 final ExtensionFactory<?> extensionFactory;
                 if (defaultExtensionName.isEmpty()) {
                     LOGGER.debug("No default extension configured; Choosing based on priority");
-                    extensionFactory = factories.first();
+                    extensionFactory = factories.getFirst();
                     LOGGER.debug("Chose extension %s (%s) with priority %d as default".formatted(
                             extensionFactory.extensionName(),
                             extensionFactory.extensionClass().getName(),

--- a/apiserver/src/main/java/org/dependencytrack/plugin/PluginManagerBinder.java
+++ b/apiserver/src/main/java/org/dependencytrack/plugin/PluginManagerBinder.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.plugin;
+
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import jakarta.inject.Singleton;
+
+/**
+ * @since 5.7.0
+ */
+public final class PluginManagerBinder extends AbstractBinder {
+
+    @Override
+    protected void configure() {
+        bindFactory(new Factory<PluginManager>() {
+            @Override
+            public PluginManager provide() {
+                return PluginManager.getInstance();
+            }
+
+            @Override
+            public void dispose(final PluginManager instance) {
+                // Lifecycle is managed elsewhere.
+            }
+        }).to(PluginManager.class).in(Singleton.class);
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ExtensionsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ExtensionsResource.java
@@ -1,0 +1,291 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import alpine.server.auth.PermissionRequired;
+import org.dependencytrack.api.v2.ExtensionsApi;
+import org.dependencytrack.api.v2.model.ExtensionConfig;
+import org.dependencytrack.api.v2.model.ExtensionConfigType;
+import org.dependencytrack.api.v2.model.InvalidExtensionConfig;
+import org.dependencytrack.api.v2.model.InvalidExtensionConfigsProblemDetails;
+import org.dependencytrack.api.v2.model.ListExtensionConfigsResponse;
+import org.dependencytrack.api.v2.model.ListExtensionPointsResponse;
+import org.dependencytrack.api.v2.model.ListExtensionPointsResponseItem;
+import org.dependencytrack.api.v2.model.ListExtensionsResponse;
+import org.dependencytrack.api.v2.model.ListExtensionsResponseItem;
+import org.dependencytrack.api.v2.model.UpdateExtensionConfigsRequest;
+import org.dependencytrack.api.v2.model.UpdateExtensionConfigsRequestItem;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.plugin.ConfigRegistryImpl;
+import org.dependencytrack.plugin.PluginManager;
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.api.ExtensionPointSpec;
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.ConfigType;
+import org.dependencytrack.plugin.api.config.RuntimeConfigDefinition;
+import org.dependencytrack.resources.v2.exception.ProblemDetailsException;
+import org.owasp.security.logging.SecurityMarkers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.SequencedCollection;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * @since 5.7.0
+ */
+@Provider
+public class ExtensionsResource implements ExtensionsApi {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExtensionsResource.class);
+    private static final String SECRET_VALUE_PLACEHOLDER = "***SECRET-PLACEHOLDER***";
+
+    @Inject
+    private PluginManager pluginManager;
+
+    @Override
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
+    public Response listExtensionPoints() {
+        final SequencedCollection<ExtensionPointSpec<?>> extensionPoints =
+                pluginManager.getExtensionPoints();
+
+        final var response = ListExtensionPointsResponse.builder()
+                .extensionPoints(
+                        extensionPoints.stream()
+                                .map(ExtensionPointSpec::name)
+                                .sorted()
+                                .<ListExtensionPointsResponseItem>map(
+                                        name -> ListExtensionPointsResponseItem.builder()
+                                                .name(name)
+                                                .build())
+                                .toList())
+                .build();
+
+        return Response.ok(response).build();
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
+    public Response listExtensions(final String extensionPointName) {
+        final ExtensionPointSpec<?> extensionPoint =
+                pluginManager.getExtensionPoints().stream()
+                        .filter(spec -> spec.name().equals(extensionPointName))
+                        .findAny()
+                        .orElseThrow(NotFoundException::new);
+
+        final SequencedCollection<ExtensionFactory> extensionFactories =
+                pluginManager.getFactories(extensionPoint.extensionPointClass());
+
+        final var response = ListExtensionsResponse.builder()
+                .extensions(
+                        extensionFactories.stream()
+                                .map(ExtensionFactory::extensionName)
+                                .sorted()
+                                .<ListExtensionsResponseItem>map(
+                                        extensionName -> ListExtensionsResponseItem.builder()
+                                                .name(extensionName)
+                                                .build())
+                                .toList())
+                .build();
+
+        return Response.ok(response).build();
+    }
+
+    @Override
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
+    public Response listExtensionConfigs(
+            final String extensionPointName,
+            final String extensionName) {
+        final ExtensionPointSpec<?> extensionPoint =
+                pluginManager.getExtensionPoints().stream()
+                        .filter(spec -> spec.name().equals(extensionPointName))
+                        .findAny()
+                        .orElseThrow(NotFoundException::new);
+
+        final ExtensionFactory<?> extensionFactory =
+                pluginManager.getFactories(extensionPoint.extensionPointClass()).stream()
+                        .filter(factory -> factory.extensionName().equals(extensionName))
+                        .findAny()
+                        .orElseThrow(NotFoundException::new);
+
+        final var configRegistry = ConfigRegistryImpl.forExtension(extensionPointName, extensionName);
+
+        var responseItems = extensionFactory.runtimeConfigs().stream()
+                .<ExtensionConfig>map(
+                        configDef -> ExtensionConfig.builder()
+                                .name(configDef.name())
+                                .description(configDef.description())
+                                .type(switch (configDef.type()) {
+                                    case ConfigType.Boolean ignored -> ExtensionConfigType.BOOLEAN;
+                                    case ConfigType.Duration ignored -> ExtensionConfigType.DURATION;
+                                    case ConfigType.Instant ignored -> ExtensionConfigType.INSTANT;
+                                    case ConfigType.Integer ignored -> ExtensionConfigType.INTEGER;
+                                    case ConfigType.Path ignored -> ExtensionConfigType.PATH;
+                                    case ConfigType.String ignored -> ExtensionConfigType.STRING;
+                                })
+                                .isRequired(configDef.isRequired())
+                                .isSecret(configDef.isSecret())
+                                .value(getConfigValue(configRegistry, configDef))
+                                .build())
+                .toList();
+
+        final var response = ListExtensionConfigsResponse.builder()
+                .configs(responseItems)
+                .build();
+
+        return Response.ok(response).build();
+    }
+
+    @Override
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
+    })
+    public Response updateExtensionConfigs(
+            final String extensionPointName,
+            final String extensionName,
+            final UpdateExtensionConfigsRequest request) {
+        final ExtensionPointSpec<?> extensionPoint =
+                pluginManager.getExtensionPoints().stream()
+                        .filter(spec -> spec.name().equals(extensionPointName))
+                        .findAny()
+                        .orElseThrow(NotFoundException::new);
+
+        final ExtensionFactory<?> extensionFactory =
+                pluginManager.getFactories(extensionPoint.extensionPointClass()).stream()
+                        .filter(factory -> factory.extensionName().equals(extensionName))
+                        .findAny()
+                        .orElseThrow(NotFoundException::new);
+
+        final Map<String, RuntimeConfigDefinition<?>> configByName =
+                extensionFactory.runtimeConfigs().stream()
+                        .collect(Collectors.toMap(
+                                RuntimeConfigDefinition::name,
+                                Function.identity()));
+
+        final var valueByConfig = new HashMap<RuntimeConfigDefinition, Object>(request.getConfigs().size());
+        final var providedConfigNames = new HashSet<String>(request.getConfigs().size());
+        final var invalidConfigs = new ArrayList<InvalidExtensionConfig>();
+
+        for (final UpdateExtensionConfigsRequestItem item : request.getConfigs()) {
+            final RuntimeConfigDefinition<?> config = configByName.get(item.getName());
+            if (config == null) {
+                invalidConfigs.add(InvalidExtensionConfig.builder()
+                        .name(item.getName())
+                        .message("Not a known extension config")
+                        .build());
+                continue;
+            }
+
+            providedConfigNames.add(item.getName());
+
+            if (config.isSecret() && SECRET_VALUE_PLACEHOLDER.equals(item.getValue())) {
+                // Avoid secret values from being overwritten with placeholder.
+                continue;
+            }
+
+            final Object value;
+            try {
+                value = config.type().fromString(item.getValue());
+            } catch (RuntimeException e) {
+                invalidConfigs.add(InvalidExtensionConfig.builder()
+                        .name(item.getName())
+                        .value(item.getValue())
+                        .message("Unable to convert to expected type")
+                        .build());
+                continue;
+            }
+
+            valueByConfig.put(config, value);
+        }
+
+        if (!providedConfigNames.equals(configByName.keySet())) {
+            for (final String configName : configByName.keySet()) {
+                if (!providedConfigNames.contains(configName)) {
+                    invalidConfigs.add(InvalidExtensionConfig.builder()
+                            .name(configName)
+                            .message("Not provided")
+                            .build());
+                }
+            }
+        }
+
+        if (!invalidConfigs.isEmpty()) {
+            throw new ProblemDetailsException(
+                    InvalidExtensionConfigsProblemDetails.builder()
+                            .status(400)
+                            .title("Invalid Extension Configs")
+                            .detail("The provided extensions configs are invalid.")
+                            .invalidConfigs(invalidConfigs)
+                            .build());
+        }
+
+        // TODO: Use a bulk update mechanism to preserve atomicity.
+        final var configRegistry = ConfigRegistryImpl.forExtension(
+                extensionPointName, extensionName);
+        for (final Map.Entry<RuntimeConfigDefinition, Object> entry : valueByConfig.entrySet()) {
+            configRegistry.setValue(entry.getKey(), entry.getValue());
+        }
+
+        // TODO: Log all modified values (except secrets, d'uh).
+        //  Needs ConfigRegistry to report which values have actually changed.
+        //  Should emit a log line for each modified config.
+        LOGGER.info(
+                SecurityMarkers.SECURITY_AUDIT,
+                "Extension configuration updated: {}/{}",
+                extensionPointName,
+                extensionName);
+        return Response.noContent().build();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private String getConfigValue(final ConfigRegistry configRegistry, final RuntimeConfigDefinition configDef) {
+        final Object value = configRegistry.getOptionalValue(configDef).orElse(null);
+        if (value == null) {
+            return null;
+        }
+
+        if (configDef.isSecret()) {
+            return SECRET_VALUE_PLACEHOLDER;
+        }
+
+        return configDef.type().toString(value);
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
@@ -26,6 +26,7 @@ import alpine.server.filters.HeaderFilter;
 import alpine.server.filters.RequestIdFilter;
 import alpine.server.filters.RequestMdcEnrichmentFilter;
 import org.dependencytrack.filters.JerseyMetricsFeature;
+import org.dependencytrack.plugin.PluginManagerBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
@@ -54,6 +55,8 @@ public final class ResourceConfig extends org.glassfish.jersey.server.ResourceCo
         register(MultiPartFeature.class);
         register(RequestIdFilter.class);
         register(RequestMdcEnrichmentFilter.class);
+
+        register(PluginManagerBinder.class);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/LoggingProblemDetailsExceptionMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/LoggingProblemDetailsExceptionMapper.java
@@ -34,6 +34,11 @@ abstract class LoggingProblemDetailsExceptionMapper<E extends Exception, P exten
     @Override
     @SuppressWarnings("unchecked")
     P map(final E exception) {
+        if (exception instanceof final ProblemDetailsException pde) {
+            // Already has properly mapped problem details. Nothing to do here.
+            return (P) pde.getProblemDetails();
+        }
+
         logger.error("Uncaught exception occurred during request processing", exception);
 
         final int status = exception instanceof final ServerErrorException see

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemDetailsException.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemDetailsException.java
@@ -1,0 +1,40 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2.exception;
+
+import org.dependencytrack.api.v2.model.ProblemDetails;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 5.7.0
+ */
+public final class ProblemDetailsException extends RuntimeException {
+
+    private final ProblemDetails problemDetails;
+
+    public ProblemDetailsException(ProblemDetails problemDetails) {
+        this.problemDetails = requireNonNull(problemDetails, "Problem details must not be null");
+    }
+
+    public ProblemDetails getProblemDetails() {
+        return problemDetails;
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/plugin/DummyTestExtensionFactory.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/DummyTestExtensionFactory.java
@@ -29,7 +29,7 @@ import org.dependencytrack.plugin.api.config.RuntimeConfigDefinition;
 public class DummyTestExtensionFactory implements ExtensionFactory<TestExtensionPoint> {
 
     private static final ConfigDefinition<String> CONFIG_FOO =
-            new RuntimeConfigDefinition<>("foo", "description", ConfigTypes.STRING, false, false);
+            new RuntimeConfigDefinition<>("foo", "description", ConfigTypes.STRING, null, false, false);
     private static final ConfigDefinition<String> CONFIG_BAR =
             new DeploymentConfigDefinition<>("bar", ConfigTypes.STRING, false);
 

--- a/apiserver/src/test/java/org/dependencytrack/plugin/PluginManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/PluginManagerTest.java
@@ -29,8 +29,7 @@ import org.dependencytrack.plugin.api.Plugin;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.List;
-import java.util.SortedSet;
+import java.util.SequencedCollection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -45,7 +44,8 @@ public class PluginManagerTest extends PersistenceCapableTest {
 
     @Test
     public void testGetLoadedPlugins() {
-        final List<Plugin> loadedPlugins = PluginManager.getInstance().getLoadedPlugins();
+        final SequencedCollection<Plugin> loadedPlugins =
+                PluginManager.getInstance().getLoadedPlugins();
         assertThat(loadedPlugins).satisfiesExactlyInAnyOrder(
                 plugin -> assertThat(plugin).isOfAnyClassIn(DummyPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(FileStoragePlugin.class));
@@ -120,7 +120,7 @@ public class PluginManagerTest extends PersistenceCapableTest {
 
     @Test
     public void testGetFactories() {
-        final SortedSet<ExtensionFactory<TestExtensionPoint>> factories =
+        final SequencedCollection<ExtensionFactory<TestExtensionPoint>> factories =
                 PluginManager.getInstance().getFactories(TestExtensionPoint.class);
         assertThat(factories).satisfiesExactly(factory ->
                 assertThat(factory).isExactlyInstanceOf(DummyTestExtensionFactory.class));
@@ -128,7 +128,7 @@ public class PluginManagerTest extends PersistenceCapableTest {
 
     @Test
     public void testGetFactoriesForUnknownExtensionPoint() {
-        final SortedSet<ExtensionFactory<UnknownExtensionPoint>> factories =
+        final SequencedCollection<ExtensionFactory<UnknownExtensionPoint>> factories =
                 PluginManager.getInstance().getFactories(UnknownExtensionPoint.class);
         assertThat(factories).isEmpty();
     }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
@@ -1,0 +1,470 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import org.dependencytrack.JerseyTestRule;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.persistence.jdbi.ConfigPropertyDao;
+import org.dependencytrack.plugin.ConfigRegistryImpl;
+import org.dependencytrack.plugin.PluginManager;
+import org.dependencytrack.plugin.api.ExtensionContext;
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.api.ExtensionPoint;
+import org.dependencytrack.plugin.api.ExtensionPointSpec;
+import org.dependencytrack.plugin.api.config.ConfigTypes;
+import org.dependencytrack.plugin.api.config.RuntimeConfigDefinition;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.Response;
+import java.util.Collections;
+import java.util.List;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+
+public class ExtensionsResourceTest extends ResourceTest {
+
+    private static final PluginManager PLUGIN_MANAGER_MOCK = mock(PluginManager.class);
+
+    @ClassRule
+    public static JerseyTestRule jersey = new JerseyTestRule(
+            new ResourceConfig()
+                    .register(new AbstractBinder() {
+                        @Override
+                        protected void configure() {
+                            bind(PLUGIN_MANAGER_MOCK).to(PluginManager.class);
+                        }
+                    }));
+
+    @After
+    public void after() {
+        reset(PLUGIN_MANAGER_MOCK);
+        super.after();
+    }
+
+    @Test
+    public void listExtensionPointsShouldListAllExtensionPoints() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+
+        final Response response = jersey.target("/extension-points")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "extension_points": [
+                    {
+                      "name": "foo"
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    public void listExtensionsShouldListAllExtensions() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+        final var extensionFactory = new DummyExtensionFactory("bar");
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+        doReturn(List.of(extensionFactory)).when(PLUGIN_MANAGER_MOCK).getFactories(eq(DummyExtensionPoint.class));
+
+        final Response response = jersey.target("/extension-points/foo/extensions")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "extensions":[
+                    {
+                      "name": "bar"
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    public void listExtensionsShouldReturnNotFoundWhenExtensionPointDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        doReturn(Collections.emptyList()).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+
+        final Response response = jersey.target("/extension-points/foo/extensions")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 404,
+                  "type": "about:blank",
+                  "title": "Not Found",
+                  "detail": "The requested resource could not be found."
+                }
+                """);
+    }
+
+    @Test
+    public void listExtensionConfigsShouldListAllExtensionConfigs() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+        final var extensionFactory = new DummyExtensionFactory("bar", List.of(
+                new RuntimeConfigDefinition<>("enabled", "", ConfigTypes.BOOLEAN, true, true, false),
+                new RuntimeConfigDefinition<>("access.token", "", ConfigTypes.STRING, "secretValue", true, true)));
+        final var configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
+        configRegistry.createWithDefaultsIfNotExist(extensionFactory.runtimeConfigs());
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+        doReturn(List.of(extensionFactory)).when(PLUGIN_MANAGER_MOCK).getFactories(eq(DummyExtensionPoint.class));
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "configs": [
+                    {
+                      "name": "enabled",
+                      "description": "",
+                      "type": "BOOLEAN",
+                      "is_required": true,
+                      "is_secret": false,
+                      "value": "true"
+                    },
+                    {
+                      "name": "access.token",
+                      "description": "",
+                      "type": "STRING",
+                      "is_required": true,
+                      "is_secret": true,
+                      "value": "***SECRET-PLACEHOLDER***"
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    public void listExtensionConfigsShouldReturnNotFoundWhenExtensionPointDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        doReturn(Collections.emptyList()).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 404,
+                  "type": "about:blank",
+                  "title": "Not Found",
+                  "detail": "The requested resource could not be found."
+                }
+                """);
+    }
+
+    @Test
+    public void listExtensionConfigsShouldReturnNotFoundWhenExtensionDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 404,
+                  "type": "about:blank",
+                  "title": "Not Found",
+                  "detail": "The requested resource could not be found."
+                }
+                """);
+    }
+
+    @Test
+    public void updateExtensionConfigsShouldUpdateExtensionConfigValues() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+        final var extensionFactory = new DummyExtensionFactory("bar", List.of(
+                new RuntimeConfigDefinition<>("enabled", "", ConfigTypes.BOOLEAN, null, true, false),
+                new RuntimeConfigDefinition<>("access.token", "", ConfigTypes.STRING, null, true, true)));
+        final var configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
+        configRegistry.createWithDefaultsIfNotExist(extensionFactory.runtimeConfigs());
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+        doReturn(List.of(extensionFactory)).when(PLUGIN_MANAGER_MOCK).getFactories(eq(DummyExtensionPoint.class));
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "configs": [
+                            {
+                              "name": "enabled",
+                              "value": "false"
+                            },
+                            {
+                              "name": "access.token",
+                              "value": "foobarbaz"
+                            }
+                          ]
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        useJdbiHandle(handle -> {
+            final var dao = handle.attach(ConfigPropertyDao.class);
+            assertThat(dao.getOptional("foo", "extension.bar.enabled"))
+                    .hasValueSatisfying(configProperty -> assertThat(
+                            configProperty.getPropertyValue()).isEqualTo("false"));
+            assertThat(dao.getOptional("foo", "extension.bar.access.token"))
+                    .hasValueSatisfying(configProperty -> assertThat(
+                            configProperty.getPropertyValue()).isNotNull().isNotEqualTo("foobarbaz"));
+        });
+    }
+
+    @Test
+    public void updateExtensionConfigsShouldReturnBadRequestForUnknownOrInvalidOrNotProvidedConfigs() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+        final var extensionFactory = new DummyExtensionFactory("bar", List.of(
+                new RuntimeConfigDefinition<>("enabled", "", ConfigTypes.BOOLEAN, null, true, false),
+                new RuntimeConfigDefinition<>("some.number", "", ConfigTypes.INTEGER, null, false, false)));
+        final var configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
+        configRegistry.createWithDefaultsIfNotExist(extensionFactory.runtimeConfigs());
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+        doReturn(List.of(extensionFactory)).when(PLUGIN_MANAGER_MOCK).getFactories(eq(DummyExtensionPoint.class));
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "configs": [
+                            {
+                              "name": "does.not.exist",
+                              "value": "foo"
+                            },
+                            {
+                              "name": "some.number",
+                              "value": "foobarbaz"
+                            }
+                          ]
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 400,
+                  "type": "about:blank",
+                  "title": "Invalid Extension Configs",
+                  "detail": "The provided extensions configs are invalid.",
+                  "invalid_configs": [
+                    {
+                      "name": "does.not.exist",
+                      "message": "Not a known extension config"
+                    },
+                    {
+                      "name": "some.number",
+                      "value": "foobarbaz",
+                      "message": "Unable to convert to expected type"
+                    },
+                    {
+                      "name": "enabled",
+                      "message": "Not provided"
+                    }
+                  ]
+                }
+                """);
+    }
+
+    @Test
+    public void updateExtensionConfigsShouldReturnNotFoundWhenExtensionPointDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        doReturn(Collections.emptyList()).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "configs": [
+                            {
+                              "name": "enabled",
+                              "value": "false"
+                            }
+                          ]
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 404,
+                  "type": "about:blank",
+                  "title": "Not Found",
+                  "detail": "The requested resource could not be found."
+                }
+                """);
+    }
+
+    @Test
+    public void updateExtensionConfigsShouldReturnNotFoundWhenExtensionDoesNotExist() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final var extensionPointSpec = new DummyExtensionPointSpec("foo");
+
+        doReturn(List.of(extensionPointSpec)).when(PLUGIN_MANAGER_MOCK).getExtensionPoints();
+
+        final Response response = jersey.target("/extension-points/foo/extensions/bar/configs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.json(/* language=JSON */ """
+                        {
+                          "configs": [
+                            {
+                              "name": "enabled",
+                              "value": "false"
+                            }
+                          ]
+                        }
+                        """));
+        assertThat(response.getStatus()).isEqualTo(404);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": 404,
+                  "type": "about:blank",
+                  "title": "Not Found",
+                  "detail": "The requested resource could not be found."
+                }
+                """);
+    }
+
+    private interface DummyExtensionPoint extends ExtensionPoint {
+    }
+
+    private static class DummyExtensionPointSpec implements ExtensionPointSpec<DummyExtensionPoint> {
+
+        private final String name;
+
+        private DummyExtensionPointSpec(final String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+        @Override
+        public boolean required() {
+            return false;
+        }
+
+        @Override
+        public Class<DummyExtensionPoint> extensionPointClass() {
+            return DummyExtensionPoint.class;
+        }
+
+    }
+
+    private static class DummyExtension implements DummyExtensionPoint {
+    }
+
+    private static class DummyExtensionFactory implements ExtensionFactory<DummyExtensionPoint> {
+
+        private final String name;
+        private final List<RuntimeConfigDefinition<?>> configs;
+
+        private DummyExtensionFactory(final String name) {
+            this(name, Collections.emptyList());
+        }
+
+        private DummyExtensionFactory(
+                final String name,
+                final List<RuntimeConfigDefinition<?>> configs) {
+            this.name = name;
+            this.configs = configs;
+        }
+
+        @Override
+        public String extensionName() {
+            return name;
+        }
+
+        @Override
+        public Class<? extends DummyExtensionPoint> extensionClass() {
+            return DummyExtensionPoint.class;
+        }
+
+        @Override
+        public int priority() {
+            return 0;
+        }
+
+        @Override
+        public List<RuntimeConfigDefinition<?>> runtimeConfigs() {
+            return configs;
+        }
+
+        @Override
+        public void init(final ExtensionContext ctx) {
+        }
+
+        @Override
+        public DummyExtensionPoint create() {
+            return new DummyExtension();
+        }
+
+    }
+
+}

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
@@ -18,7 +18,11 @@
  */
 package org.dependencytrack.plugin.api;
 
+import org.dependencytrack.plugin.api.config.RuntimeConfigDefinition;
+
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.SequencedCollection;
 
 /**
  * @since 5.6.0
@@ -43,6 +47,14 @@ public interface ExtensionFactory<T extends ExtensionPoint> extends Closeable {
      * (highest priority) and {@value #PRIORITY_LOWEST} (lowest priority).
      */
     int priority();
+
+    /**
+     * @return The supported runtime configuration definitions.
+     * @since 5.7.0
+     */
+    default SequencedCollection<RuntimeConfigDefinition<?>> runtimeConfigs() {
+        return Collections.emptyList();
+    }
 
     /**
      * Initialize the factory. This method is called <em>once</em> during application startup.

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/RuntimeConfigDefinition.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/RuntimeConfigDefinition.java
@@ -26,16 +26,19 @@ import static java.util.Objects.requireNonNull;
  * Configurations of this type are mutable and may be changed by users and / or extensions
  * while the application is running.
  *
- * @param name        Name of the config.
- * @param description Description of the config.
- * @param isRequired  Whether the config is required (value must not be {@code null}).
- * @param isSecret    Whether the config is secret (value should be stored in encrypted form).
+ * @param name         Name of the config.
+ * @param description  Description of the config.
+ * @param type         Type of the config.
+ * @param defaultValue Default value of the config.
+ * @param isRequired   Whether the config is required (value must not be {@code null}).
+ * @param isSecret     Whether the config is secret (value should be stored in encrypted form).
  * @since 5.7.0
  */
 public record RuntimeConfigDefinition<T>(
         String name,
         String description,
         ConfigType<T> type,
+        T defaultValue,
         boolean isRequired,
         boolean isSecret) implements ConfigDefinition<T> {
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Exposes new REST endpoints to:

* List available extension points
* List available extensions for a given extension point
* List available runtime configs for a given extension
* Update a given extension's runtime configs

Also adds support for runtime configs to define default values.

This will eventually enable extensions to be configurable via UI.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Addresses the REST API portion of https://github.com/DependencyTrack/hyades/issues/1859

UI draft: https://github.com/DependencyTrack/hyades-frontend/pull/341

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
