### PR TITLE
Enable extensions to define types of their configs

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/filestorage/LocalFileStorageFactory.java
+++ b/apiserver/src/main/java/org/dependencytrack/filestorage/LocalFileStorageFactory.java
@@ -21,6 +21,7 @@ package org.dependencytrack.filestorage;
 import alpine.Config;
 import org.dependencytrack.plugin.api.config.ConfigDefinition;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.ConfigTypes;
 import org.dependencytrack.plugin.api.config.DeploymentConfigDefinition;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
 import org.dependencytrack.plugin.api.filestorage.FileStorageFactory;
@@ -30,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * @since 5.6.0
@@ -39,12 +39,12 @@ public final class LocalFileStorageFactory implements FileStorageFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalFileStorageFactory.class);
 
-    static final ConfigDefinition CONFIG_DIRECTORY =
-            new DeploymentConfigDefinition("directory", /* isRequired */ false);
-    static final ConfigDefinition CONFIG_COMPRESSION_THRESHOLD_BYTES =
-            new DeploymentConfigDefinition("compression.threshold.bytes", /* isRequired */ false);
-    static final ConfigDefinition CONFIG_COMPRESSION_LEVEL =
-            new DeploymentConfigDefinition("compression.level", /* isRequired */ false);
+    static final ConfigDefinition<Path> CONFIG_DIRECTORY =
+            new DeploymentConfigDefinition<>("directory", ConfigTypes.PATH, /* isRequired */ false);
+    static final ConfigDefinition<Integer> CONFIG_COMPRESSION_THRESHOLD_BYTES =
+            new DeploymentConfigDefinition<>("compression.threshold.bytes", ConfigTypes.INTEGER, /* isRequired */ false);
+    static final ConfigDefinition<Integer> CONFIG_COMPRESSION_LEVEL =
+            new DeploymentConfigDefinition<>("compression.level", ConfigTypes.INTEGER, /* isRequired */ false);
 
     private Path directoryPath;
     private int compressionThresholdBytes;
@@ -68,7 +68,6 @@ public final class LocalFileStorageFactory implements FileStorageFactory {
     @Override
     public void init(final ConfigRegistry configRegistry) {
         directoryPath = configRegistry.getOptionalValue(CONFIG_DIRECTORY)
-                .map(Paths::get)
                 .orElseGet(() -> Config.getInstance().getDataDirectorty().toPath().resolve("storage"))
                 .normalize()
                 .toAbsolutePath();
@@ -91,12 +90,8 @@ public final class LocalFileStorageFactory implements FileStorageFactory {
 
         LOGGER.debug("Files will be stored in {}", directoryPath);
 
-        compressionThresholdBytes = configRegistry.getOptionalValue(CONFIG_COMPRESSION_THRESHOLD_BYTES)
-                .map(Integer::parseInt)
-                .orElse(4096);
-        compressionLevel = configRegistry.getOptionalValue(CONFIG_COMPRESSION_LEVEL)
-                .map(Integer::parseInt)
-                .orElse(5);
+        compressionThresholdBytes = configRegistry.getOptionalValue(CONFIG_COMPRESSION_THRESHOLD_BYTES).orElse(4096);
+        compressionLevel = configRegistry.getOptionalValue(CONFIG_COMPRESSION_LEVEL).orElse(5);
     }
 
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/filestorage/S3FileStorageFactory.java
+++ b/apiserver/src/main/java/org/dependencytrack/filestorage/S3FileStorageFactory.java
@@ -23,6 +23,7 @@ import io.minio.BucketExistsArgs;
 import io.minio.MinioClient;
 import org.dependencytrack.plugin.api.config.ConfigDefinition;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.ConfigTypes;
 import org.dependencytrack.plugin.api.config.DeploymentConfigDefinition;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
 import org.dependencytrack.plugin.api.filestorage.FileStorageFactory;
@@ -38,20 +39,20 @@ public final class S3FileStorageFactory implements FileStorageFactory {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3FileStorageFactory.class);
 
-    static final ConfigDefinition CONFIG_ENDPOINT =
-            new DeploymentConfigDefinition("endpoint", /* isRequired */ true);
-    static final ConfigDefinition CONFIG_BUCKET =
-            new DeploymentConfigDefinition("bucket", /* isRequired */ true);
-    static final ConfigDefinition CONFIG_ACCESS_KEY =
-            new DeploymentConfigDefinition("access.key", /* isRequired */ false);
-    static final ConfigDefinition CONFIG_SECRET_KEY =
-            new DeploymentConfigDefinition("secret.key", /* isRequired */ false);
-    static final ConfigDefinition CONFIG_REGION =
-            new DeploymentConfigDefinition("region", /* isRequired */ false);
-    static final ConfigDefinition CONFIG_COMPRESSION_THRESHOLD_BYTES =
-            new DeploymentConfigDefinition("compression.threshold.bytes", /* isRequired */ false);
-    static final ConfigDefinition CONFIG_COMPRESSION_LEVEL =
-            new DeploymentConfigDefinition("compression.level", /* isRequired */ false);
+    static final ConfigDefinition<String> CONFIG_ENDPOINT =
+            new DeploymentConfigDefinition<>("endpoint", ConfigTypes.STRING, /* isRequired */ true);
+    static final ConfigDefinition<String> CONFIG_BUCKET =
+            new DeploymentConfigDefinition<>("bucket", ConfigTypes.STRING, /* isRequired */ true);
+    static final ConfigDefinition<String> CONFIG_ACCESS_KEY =
+            new DeploymentConfigDefinition<>("access.key", ConfigTypes.STRING, /* isRequired */ false);
+    static final ConfigDefinition<String> CONFIG_SECRET_KEY =
+            new DeploymentConfigDefinition<>("secret.key", ConfigTypes.STRING, /* isRequired */ false);
+    static final ConfigDefinition<String> CONFIG_REGION =
+            new DeploymentConfigDefinition<>("region", ConfigTypes.STRING, /* isRequired */ false);
+    static final ConfigDefinition<Integer> CONFIG_COMPRESSION_THRESHOLD_BYTES =
+            new DeploymentConfigDefinition<>("compression.threshold.bytes", ConfigTypes.INTEGER, /* isRequired */ false);
+    static final ConfigDefinition<Integer> CONFIG_COMPRESSION_LEVEL =
+            new DeploymentConfigDefinition<>("compression.level", ConfigTypes.INTEGER, /* isRequired */ false);
 
     private MinioClient s3Client;
     private String bucketName;
@@ -92,12 +93,8 @@ public final class S3FileStorageFactory implements FileStorageFactory {
                 Config.getInstance().getApplicationName(),
                 Config.getInstance().getApplicationVersion());
 
-        compressionThresholdBytes = configRegistry.getOptionalValue(CONFIG_COMPRESSION_THRESHOLD_BYTES)
-                .map(Integer::parseInt)
-                .orElse(4096);
-        compressionLevel = configRegistry.getOptionalValue(CONFIG_COMPRESSION_LEVEL)
-                .map(Integer::parseInt)
-                .orElse(5);
+        compressionThresholdBytes = configRegistry.getOptionalValue(CONFIG_COMPRESSION_THRESHOLD_BYTES).orElse(4096);
+        compressionLevel = configRegistry.getOptionalValue(CONFIG_COMPRESSION_LEVEL).orElse(5);
 
         LOGGER.debug("Verifying existence of bucket {}", bucketName);
         requireBucketExists(s3Client, bucketName);

--- a/apiserver/src/main/java/org/dependencytrack/plugin/PluginManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/plugin/PluginManager.java
@@ -25,6 +25,7 @@ import org.dependencytrack.plugin.api.ExtensionPoint;
 import org.dependencytrack.plugin.api.ExtensionPointSpec;
 import org.dependencytrack.plugin.api.Plugin;
 import org.dependencytrack.plugin.api.config.ConfigDefinition;
+import org.dependencytrack.plugin.api.config.ConfigTypes;
 import org.dependencytrack.plugin.api.config.DeploymentConfigDefinition;
 import org.slf4j.MDC;
 
@@ -63,10 +64,10 @@ public class PluginManager {
     private static final Logger LOGGER = Logger.getLogger(PluginManager.class);
     private static final Pattern EXTENSION_POINT_NAME_PATTERN = Pattern.compile("^[a-z0-9.]+$");
     private static final Pattern EXTENSION_NAME_PATTERN = EXTENSION_POINT_NAME_PATTERN;
-    private static final ConfigDefinition CONFIG_EXTENSION_ENABLED =
-            new DeploymentConfigDefinition("enabled", /* isRequired */ false);
-    private static final ConfigDefinition CONFIG_DEFAULT_EXTENSION =
-            new DeploymentConfigDefinition("default.extension", /* isRequired */ false);
+    private static final ConfigDefinition<Boolean> CONFIG_EXTENSION_ENABLED =
+            new DeploymentConfigDefinition<>("enabled", ConfigTypes.BOOLEAN, /* isRequired */ false);
+    private static final ConfigDefinition<String> CONFIG_DEFAULT_EXTENSION =
+            new DeploymentConfigDefinition<>("default.extension", ConfigTypes.STRING, /* isRequired */ false);
     private static final PluginManager INSTANCE = new PluginManager();
 
     private final SequencedMap<Class<? extends Plugin>, Plugin> loadedPluginByClass;
@@ -268,7 +269,7 @@ public class PluginManager {
         }
 
         final var configRegistry = ConfigRegistryImpl.forExtension(extensionPointSpec.name(), extensionIdentity.name());
-        final boolean isEnabled = configRegistry.getOptionalValue(CONFIG_EXTENSION_ENABLED).map(Boolean::parseBoolean).orElse(true);
+        final boolean isEnabled = configRegistry.getOptionalValue(CONFIG_EXTENSION_ENABLED).orElse(true);
         if (!isEnabled) {
             LOGGER.debug("Extension is disabled; Skipping");
             return;

--- a/apiserver/src/test/java/org/dependencytrack/plugin/ConfigRegistryImplTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/ConfigRegistryImplTest.java
@@ -24,6 +24,7 @@ import alpine.test.config.ConfigPropertyRule;
 import alpine.test.config.WithConfigProperty;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.ConfigTypes;
 import org.dependencytrack.plugin.api.config.DeploymentConfigDefinition;
 import org.dependencytrack.plugin.api.config.RuntimeConfigDefinition;
 import org.junit.Rule;
@@ -50,7 +51,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
         );
 
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", false, false);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, false, false);
         final Optional<String> optionalProperty = configRegistry.getOptionalValue(configDef);
         assertThat(optionalProperty).contains("qux");
     }
@@ -58,7 +59,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testGetRuntimeConfigValueThatDoesNotExist() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", false, false);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, false, false);
         final Optional<String> optionalProperty = configRegistry.getOptionalValue(configDef);
         assertThat(optionalProperty).isNotPresent();
     }
@@ -66,7 +67,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testGetRequiredRuntimeConfigValueThatDoesNotExist() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", true, false);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, true, false);
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> configRegistry.getOptionalValue(configDef))
                 .withMessage("Config baz is defined as required, but no value has been found");
@@ -83,7 +84,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
         );
 
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", false, true);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, false, true);
         final Optional<String> optionalProperty = configRegistry.getOptionalValue(configDef);
         assertThat(optionalProperty).contains("qux");
     }
@@ -99,7 +100,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
         );
 
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", false, true);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, false, true);
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> configRegistry.getOptionalValue(configDef))
                 .withMessage("Config baz is defined as secret, but its value is not encrypted");
@@ -109,7 +110,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @WithConfigProperty("foo.extension.bar.baz=qux")
     public void testDeploymentProperty() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new DeploymentConfigDefinition("baz", false);
+        final var configDef = new DeploymentConfigDefinition<>("baz", ConfigTypes.STRING, false);
         final Optional<String> optionalProperty = configRegistry.getOptionalValue(configDef);
         assertThat(optionalProperty).contains("qux");
     }
@@ -117,7 +118,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testDeploymentPropertyThatDoesNotExist() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new DeploymentConfigDefinition("baz", false);
+        final var configDef = new DeploymentConfigDefinition<>("baz", ConfigTypes.STRING, false);
         final Optional<String> optionalProperty = configRegistry.getOptionalValue(configDef);
         assertThat(optionalProperty).isNotPresent();
     }
@@ -125,7 +126,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testGetRequiredDeploymentConfigValueThatDoesNotExist() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new DeploymentConfigDefinition("baz", true);
+        final var configDef = new DeploymentConfigDefinition<>("baz", ConfigTypes.STRING, true);
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> configRegistry.getOptionalValue(configDef))
                 .withMessage("Config baz is defined as required, but no value has been found");
@@ -134,7 +135,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testSetValue() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", false, false);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, false, false);
         configRegistry.setValue(configDef, "qux");
         assertThat(configRegistry.getOptionalValue(configDef)).contains("qux");
     }
@@ -142,7 +143,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testSetValueWhenRequiredAndNull() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", true, false);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, true, false);
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> configRegistry.setValue(configDef, null))
                 .withMessage("Config baz is defined as required, but value is null");
@@ -151,7 +152,7 @@ public class ConfigRegistryImplTest extends PersistenceCapableTest {
     @Test
     public void testSetValueWhenSecret() {
         final ConfigRegistry configRegistry = ConfigRegistryImpl.forExtension("foo", "bar");
-        final var configDef = new RuntimeConfigDefinition("baz", "description", false, true);
+        final var configDef = new RuntimeConfigDefinition<>("baz", "description", ConfigTypes.STRING, false, true);
         configRegistry.setValue(configDef, "qux");
         assertThat(configRegistry.getOptionalValue(configDef)).contains("qux");
     }

--- a/apiserver/src/test/java/org/dependencytrack/plugin/DummyTestExtensionFactory.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/DummyTestExtensionFactory.java
@@ -21,13 +21,16 @@ package org.dependencytrack.plugin;
 import org.dependencytrack.plugin.api.ExtensionFactory;
 import org.dependencytrack.plugin.api.config.ConfigDefinition;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.ConfigTypes;
 import org.dependencytrack.plugin.api.config.DeploymentConfigDefinition;
 import org.dependencytrack.plugin.api.config.RuntimeConfigDefinition;
 
 public class DummyTestExtensionFactory implements ExtensionFactory<TestExtensionPoint> {
 
-    private static final ConfigDefinition CONFIG_FOO = new RuntimeConfigDefinition("foo", "description", false, false);
-    private static final ConfigDefinition CONFIG_BAR = new DeploymentConfigDefinition("bar", false);
+    private static final ConfigDefinition<String> CONFIG_FOO =
+            new RuntimeConfigDefinition<>("foo", "description", ConfigTypes.STRING, false, false);
+    private static final ConfigDefinition<String> CONFIG_BAR =
+            new DeploymentConfigDefinition<>("bar", ConfigTypes.STRING, false);
 
     private ConfigRegistry configRegistry;
 

--- a/plugin/api/pom.xml
+++ b/plugin/api/pom.xml
@@ -41,6 +41,18 @@
             <artifactId>proto</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigDefinition.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigDefinition.java
@@ -21,12 +21,17 @@ package org.dependencytrack.plugin.api.config;
 /**
  * @since 5.7.0
  */
-public sealed interface ConfigDefinition permits DeploymentConfigDefinition, RuntimeConfigDefinition {
+public sealed interface ConfigDefinition<T> permits DeploymentConfigDefinition, RuntimeConfigDefinition {
 
     /**
      * @return Name of the configuration.
      */
     String name();
+
+    /**
+     * @return Type of the configuration.
+     */
+    ConfigType<T> type();
 
     /**
      * @return Whether the configuration is required (value must not be {@code null}).

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigRegistry.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigRegistry.java
@@ -50,7 +50,7 @@ public interface ConfigRegistry {
      * @param config Definition of the config to retrieve.
      * @return The config's value, if any.
      */
-    Optional<String> getOptionalValue(final ConfigDefinition config);
+    <T> Optional<T> getOptionalValue(final ConfigDefinition<T> config);
 
     /**
      * Retrieve the value of a configuration, throwing if there is none.
@@ -59,7 +59,7 @@ public interface ConfigRegistry {
      * @return The config's value.
      * @throws NoSuchElementException When the config does not exist or is {@code null}.
      */
-    default String getValue(final ConfigDefinition config) {
+    default <T> T getValue(final ConfigDefinition<T> config) {
         return getOptionalValue(config).orElseThrow(NoSuchElementException::new);
     }
 
@@ -73,6 +73,6 @@ public interface ConfigRegistry {
      *                                  {@code true} but encryption failed.
      * @since 5.7.0
      */
-    void setValue(RuntimeConfigDefinition config, String value);
+    <T> void setValue(RuntimeConfigDefinition<T> config, T value);
 
 }

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigType.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigType.java
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.plugin.api.config;
+
+/**
+ * @since 5.7.0
+ */
+public sealed interface ConfigType<T> {
+
+    /**
+     * @return The Java class backing this type.
+     */
+    Class<T> clazz();
+
+    /**
+     * Convert a given {@link java.lang.String} to the corresponding {@code T} value.
+     *
+     * @param value The value to convert.
+     * @return The converted {@code T}, or {@code null} if {@code value} was {@code null}.
+     */
+    T fromString(java.lang.String value);
+
+    /**
+     * Convert a given {@code T} to the corresponding {@link java.lang.String} value.
+     *
+     * @param value The value to convert.
+     * @return The converted {@link java.lang.String}, or {@code null} if {@code value} was {@code null}.
+     */
+    java.lang.String toString(T value);
+
+    record Boolean() implements ConfigType<java.lang.Boolean> {
+
+        @Override
+        public Class<java.lang.Boolean> clazz() {
+            return java.lang.Boolean.class;
+        }
+
+        @Override
+        public java.lang.Boolean fromString(final java.lang.String value) {
+            return value != null ? java.lang.Boolean.parseBoolean(value) : null;
+        }
+
+        @Override
+        public java.lang.String toString(final java.lang.Boolean value) {
+            return value != null ? java.lang.Boolean.toString(value) : null;
+        }
+
+    }
+
+    record Duration() implements ConfigType<java.time.Duration> {
+
+        @Override
+        public Class<java.time.Duration> clazz() {
+            return java.time.Duration.class;
+        }
+
+        @Override
+        public java.time.Duration fromString(final java.lang.String value) {
+            return value != null ? java.time.Duration.parse(value) : null;
+        }
+
+        @Override
+        public java.lang.String toString(final java.time.Duration value) {
+            return value != null ? value.toString() : null;
+        }
+
+    }
+
+    record Instant() implements ConfigType<java.time.Instant> {
+
+        @Override
+        public Class<java.time.Instant> clazz() {
+            return java.time.Instant.class;
+        }
+
+        @Override
+        public java.time.Instant fromString(final java.lang.String value) {
+            return value != null ? java.time.Instant.parse(value) : null;
+        }
+
+        @Override
+        public java.lang.String toString(final java.time.Instant value) {
+            return value != null ? value.toString() : null;
+        }
+
+    }
+
+    record Integer() implements ConfigType<java.lang.Integer> {
+
+        @Override
+        public Class<java.lang.Integer> clazz() {
+            return java.lang.Integer.class;
+        }
+
+        @Override
+        public java.lang.Integer fromString(final java.lang.String value) {
+            return value != null ? java.lang.Integer.parseInt(value) : null;
+        }
+
+        @Override
+        public java.lang.String toString(final java.lang.Integer value) {
+            return value != null ? java.lang.Integer.toString(value) : null;
+        }
+
+    }
+
+    record Path() implements ConfigType<java.nio.file.Path> {
+
+        @Override
+        public Class<java.nio.file.Path> clazz() {
+            return java.nio.file.Path.class;
+        }
+
+        @Override
+        public java.nio.file.Path fromString(final java.lang.String value) {
+            return value != null ? java.nio.file.Path.of(value) : null;
+        }
+
+        @Override
+        public java.lang.String toString(final java.nio.file.Path value) {
+            return value != null ? value.toString() : null;
+        }
+
+    }
+
+    record String() implements ConfigType<java.lang.String> {
+
+        @Override
+        public Class<java.lang.String> clazz() {
+            return java.lang.String.class;
+        }
+
+        @Override
+        public java.lang.String fromString(final java.lang.String value) {
+            return value;
+        }
+
+        @Override
+        public java.lang.String toString(final java.lang.String value) {
+            return value;
+        }
+
+    }
+
+}

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigTypes.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/ConfigTypes.java
@@ -18,34 +18,23 @@
  */
 package org.dependencytrack.plugin.api.config;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
 
 /**
  * @since 5.7.0
  */
-public final class MockConfigRegistry implements ConfigRegistry {
+public final class ConfigTypes {
 
-    private final Map<String, String> properties;
+    public static final ConfigType<Boolean> BOOLEAN = new ConfigType.Boolean();
+    public static final ConfigType<Duration> DURATION = new ConfigType.Duration();
+    public static final ConfigType<Instant> INSTANT = new ConfigType.Instant();
+    public static final ConfigType<Integer> INTEGER = new ConfigType.Integer();
+    public static final ConfigType<Path> PATH = new ConfigType.Path();
+    public static final ConfigType<String> STRING = new ConfigType.String();
 
-    public MockConfigRegistry() {
-        this(new HashMap<>());
-    }
-
-    public MockConfigRegistry(final Map<String, String> properties) {
-        this.properties = properties;
-    }
-
-    @Override
-    public <T> Optional<T> getOptionalValue(final ConfigDefinition<T> config) {
-        final String value = properties.get(config.name());
-        return Optional.ofNullable(config.type().fromString(value));
-    }
-
-    @Override
-    public <T> void setValue(final RuntimeConfigDefinition<T> config, final T value) {
-        properties.put(config.name(), config.type().toString(value));
+    private ConfigTypes() {
     }
 
 }

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/DeploymentConfigDefinition.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/DeploymentConfigDefinition.java
@@ -29,12 +29,14 @@ import static java.util.Objects.requireNonNull;
  * @param isRequired Whether the config is required (value must not be {@code null}).
  * @since 5.7.0
  */
-public record DeploymentConfigDefinition(
+public record DeploymentConfigDefinition<T>(
         String name,
-        boolean isRequired) implements ConfigDefinition {
+        ConfigType<T> type,
+        boolean isRequired) implements ConfigDefinition<T> {
 
     public DeploymentConfigDefinition {
         requireNonNull(name, "name must not be null");
+        requireNonNull(type, "type must not be null");
     }
 
 }

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/RuntimeConfigDefinition.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/config/RuntimeConfigDefinition.java
@@ -32,15 +32,17 @@ import static java.util.Objects.requireNonNull;
  * @param isSecret    Whether the config is secret (value should be stored in encrypted form).
  * @since 5.7.0
  */
-public record RuntimeConfigDefinition(
+public record RuntimeConfigDefinition<T>(
         String name,
         String description,
+        ConfigType<T> type,
         boolean isRequired,
-        boolean isSecret) implements ConfigDefinition {
+        boolean isSecret) implements ConfigDefinition<T> {
 
     public RuntimeConfigDefinition {
         requireNonNull(name, "name must not be null");
         requireNonNull(description, "description must not be null");
+        requireNonNull(type, "type must not be null");
     }
 
 }

--- a/plugin/api/src/test/java/org/dependencytrack/plugin/api/config/ConfigTypeTest.java
+++ b/plugin/api/src/test/java/org/dependencytrack/plugin/api/config/ConfigTypeTest.java
@@ -1,0 +1,295 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.plugin.api.config;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ConfigTypeTest {
+
+    @Nested
+    class BooleanTest {
+
+        @Test
+        void shouldReturnCorrectTypeClass() {
+            final var configType = new ConfigType.Boolean();
+            assertThat(configType.clazz()).isEqualTo(Boolean.class);
+        }
+
+        private static Stream<Arguments> fromStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("false", false),
+                    Arguments.of("true", true));
+        }
+
+        @ParameterizedTest
+        @MethodSource("fromStringShouldReturnCorrectValueArguments")
+        void fromStringShouldReturnCorrectValue(final String inputValue, final Boolean expectedValue) {
+            final var configType = new ConfigType.Boolean();
+            assertThat(configType.fromString(inputValue)).isEqualTo(expectedValue);
+        }
+
+        @Test
+        void fromStringShouldReturnFalseForInvalidInputValue() {
+            final var configType = new ConfigType.Boolean();
+            assertThat(configType.fromString("invalid")).isEqualTo(false);
+        }
+
+        private static Stream<Arguments> toStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(false, "false"),
+                    Arguments.of(true, "true"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("toStringShouldReturnCorrectValueArguments")
+        void toStringShouldReturnCorrectValue(final Boolean inputValue, final String expectedValue) {
+            final var configType = new ConfigType.Boolean();
+            assertThat(configType.toString(inputValue)).isEqualTo(expectedValue);
+        }
+
+    }
+
+    @Nested
+    class DurationTest {
+
+        @Test
+        void shouldReturnCorrectTypeClass() {
+            final var configType = new ConfigType.Duration();
+            assertThat(configType.clazz()).isEqualTo(Duration.class);
+        }
+
+        private static Stream<Arguments> fromStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("PT0.5S", Duration.ofMillis(500)),
+                    Arguments.of("PT5M", Duration.ofMinutes(5)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("fromStringShouldReturnCorrectValueArguments")
+        void fromStringShouldReturnCorrectValue(final String inputValue, final Duration expectedValue) {
+            final var configType = new ConfigType.Duration();
+            assertThat(configType.fromString(inputValue)).isEqualTo(expectedValue);
+        }
+
+        @Test
+        void fromStringShouldThrowForInvalidInputValue() {
+            final var configType = new ConfigType.Duration();
+            assertThatExceptionOfType(DateTimeParseException.class)
+                    .isThrownBy(() -> configType.fromString("invalid"));
+        }
+
+        private static Stream<Arguments> toStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(Duration.ofMillis(500), "PT0.5S"),
+                    Arguments.of(Duration.ofMinutes(5), "PT5M"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("toStringShouldReturnCorrectValueArguments")
+        void toStringShouldReturnCorrectValue(final Duration inputValue, final String expectedValue) {
+            final var configType = new ConfigType.Duration();
+            assertThat(configType.toString(inputValue)).isEqualTo(expectedValue);
+        }
+
+    }
+
+    @Nested
+    class InstantTest {
+
+        @Test
+        void shouldReturnCorrectTypeClass() {
+            final var configType = new ConfigType.Instant();
+            assertThat(configType.clazz()).isEqualTo(Instant.class);
+        }
+
+        private static Stream<Arguments> fromStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("1970-01-08T17:11:06Z", Instant.ofEpochSecond(666666)));
+        }
+
+        @ParameterizedTest
+        @MethodSource("fromStringShouldReturnCorrectValueArguments")
+        void fromStringShouldReturnCorrectValue(final String inputValue, final Instant expectedValue) {
+            final var configType = new ConfigType.Instant();
+            assertThat(configType.fromString(inputValue)).isEqualTo(expectedValue);
+        }
+
+        @Test
+        void fromStringShouldThrowForInvalidInputValue() {
+            final var configType = new ConfigType.Instant();
+            assertThatExceptionOfType(DateTimeParseException.class)
+                    .isThrownBy(() -> configType.fromString("invalid"));
+        }
+
+        private static Stream<Arguments> toStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(Instant.ofEpochSecond(666666), "1970-01-08T17:11:06Z"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("toStringShouldReturnCorrectValueArguments")
+        void toStringShouldReturnCorrectValue(final Instant inputValue, final String expectedValue) {
+            final var configType = new ConfigType.Instant();
+            assertThat(configType.toString(inputValue)).isEqualTo(expectedValue);
+        }
+
+    }
+
+    @Nested
+    class IntegerTest {
+
+        @Test
+        void shouldReturnCorrectTypeClass() {
+            final var configType = new ConfigType.Integer();
+            assertThat(configType.clazz()).isEqualTo(Integer.class);
+        }
+
+        private static Stream<Arguments> fromStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("123", 123),
+                    Arguments.of("-123", -123));
+        }
+
+        @ParameterizedTest
+        @MethodSource("fromStringShouldReturnCorrectValueArguments")
+        void fromStringShouldReturnCorrectValue(final String inputValue, final Integer expectedValue) {
+            final var configType = new ConfigType.Integer();
+            assertThat(configType.fromString(inputValue)).isEqualTo(expectedValue);
+        }
+
+        @Test
+        void fromStringShouldThrowForInvalidInputValue() {
+            final var configType = new ConfigType.Integer();
+            assertThatExceptionOfType(NumberFormatException.class)
+                    .isThrownBy(() -> configType.fromString("invalid"));
+        }
+
+        private static Stream<Arguments> toStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(123, "123"),
+                    Arguments.of(-123, "-123"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("toStringShouldReturnCorrectValueArguments")
+        void toStringShouldReturnCorrectValue(final Integer inputValue, final String expectedValue) {
+            final var configType = new ConfigType.Integer();
+            assertThat(configType.toString(inputValue)).isEqualTo(expectedValue);
+        }
+
+    }
+
+    @Nested
+    class PathTest {
+
+        @Test
+        void shouldReturnCorrectTypeClass() {
+            final var configType = new ConfigType.Path();
+            assertThat(configType.clazz()).isEqualTo(Path.class);
+        }
+
+        private static Stream<Arguments> fromStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("foo", Path.of("foo")),
+                    Arguments.of("/foo/bar", Path.of("/foo/bar")));
+        }
+
+        @ParameterizedTest
+        @MethodSource("fromStringShouldReturnCorrectValueArguments")
+        void fromStringShouldReturnCorrectValue(final String inputValue, final Path expectedValue) {
+            final var configType = new ConfigType.Path();
+            assertThat(configType.fromString(inputValue)).isEqualTo(expectedValue);
+        }
+
+        private static Stream<Arguments> toStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of(Path.of("foo"), "foo"),
+                    Arguments.of(Path.of("/foo/bar"), "/foo/bar"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("toStringShouldReturnCorrectValueArguments")
+        void toStringShouldReturnCorrectValue(final Path inputValue, final String expectedValue) {
+            final var configType = new ConfigType.Path();
+            assertThat(configType.toString(inputValue)).isEqualTo(expectedValue);
+        }
+
+    }
+
+    @Nested
+    class StringTest {
+
+        @Test
+        void shouldReturnCorrectTypeClass() {
+            final var configType = new ConfigType.String();
+            assertThat(configType.clazz()).isEqualTo(String.class);
+        }
+
+        private static Stream<Arguments> fromStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("foo", "foo"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("fromStringShouldReturnCorrectValueArguments")
+        void fromStringShouldReturnCorrectValue(final String inputValue, final String expectedValue) {
+            final var configType = new ConfigType.String();
+            assertThat(configType.fromString(inputValue)).isEqualTo(expectedValue);
+        }
+
+        private static Stream<Arguments> toStringShouldReturnCorrectValueArguments() {
+            return Stream.of(
+                    Arguments.of(null, null),
+                    Arguments.of("foo", "foo"));
+        }
+
+        @ParameterizedTest
+        @MethodSource("toStringShouldReturnCorrectValueArguments")
+        void toStringShouldReturnCorrectValue(final String inputValue, final String expectedValue) {
+            final var configType = new ConfigType.String();
+            assertThat(configType.toString(inputValue)).isEqualTo(expectedValue);
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enables extensions to define types of their configs.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Previously, all configs were treated as strings, and extensions had to convert them on their own.

With this change, `ConfigDefinition`s can be typed, which centralizes the conversion logic and provides better type safety all around.

`ConfigType` being a sealed interface allows us to control which types are available. This is important for being able to render form inputs in the UI later. For example, `Boolean` would be a checkbox, `Instant` a time picker, and `Integer` a number input.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
