### PR TITLE
Add supporting indexes for global component search

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ComponentQueryManager.java
@@ -382,8 +382,11 @@ final class ComponentQueryManager extends QueryManager implements IQueryManager 
 
             result = loadComponents("(" + String.join(" && ", queryFilterElements) + ")", queryParams);
         } else if (identity.getPurl() != null) {
-            queryFilterElements.add("purl.toLowerCase().matches(:purl)");
-            queryParams.put("purl", ".*" + identity.getPurl().canonicalize().toLowerCase() + ".*");
+            // "contains" conditions with wildcards on both sides don't make sense here
+            // given we already require a valid PURL to be provided. There will always
+            // be a mandatory prefix such as "pkg:npm/foo".
+            queryFilterElements.add("purl.toLowerCase().startsWith(:purl)");
+            queryParams.put("purl", identity.getPurl().canonicalize().toLowerCase());
 
             result = loadComponents("(" + String.join(" && ", queryFilterElements) + ")", queryParams);
         } else if (identity.getCpe() != null) {

--- a/persistence-migration/src/main/resources/migration/changelog-v5.7.0.xml
+++ b/persistence-migration/src/main/resources/migration/changelog-v5.7.0.xml
@@ -145,4 +145,31 @@
             <column name="LAST_OCCURRENCE" descending="true"/>
         </createIndex>
     </changeSet>
+
+    <changeSet id="v5.7.0-7" author="nscuro">
+        <!--
+          Support global search of components by their coordinates.
+          Search is expected to be case-insensitive and have "contains" semantics.
+
+          DataNucleus is not smart enough to use ILIKE for case-insensitivity,
+          so we need to explicitly index on LOWER.
+        -->
+        <sql>
+            CREATE INDEX "COMPONENT_COORDINATES_SEARCH_IDX"
+                ON "COMPONENT" USING gin (LOWER("NAME") gin_trgm_ops, LOWER("VERSION") gin_trgm_ops, LOWER("GROUP") gin_trgm_ops);
+        </sql>
+    </changeSet>
+
+    <changeSet id="v5.7.0-8" author="nscuro">
+        <!--
+          We only allow searching by valid PURLs, which means there will always
+          be some prefix, like "pkg:npm/foo". text_pattern_ops can only support
+          prefix lookups, but is more lightweight than GIN indexes.
+        -->
+        <sql>
+            CREATE INDEX "COMPONENT_PURL_SEARCH_IDX"
+                ON "COMPONENT" (LOWER("PURL") text_pattern_ops)
+             WHERE "PURL" IS NOT NULL;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds supporting indexes for global component search.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/1854

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

This currently only covers search by coordinates (group, name, version) and PURL. While it is also possible to search by CPE or SWID Tag ID, those fields are a lot less common so we're postponing the indexing strategy for those.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
