### PR TITLE
Expose proxy selector to extensions

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/common/ProxySelector.java
+++ b/apiserver/src/main/java/org/dependencytrack/common/ProxySelector.java
@@ -1,0 +1,77 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common;
+
+import alpine.common.util.ProxyConfig;
+import alpine.common.util.ProxyUtil;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.List;
+
+/**
+ * A {@link ProxySelector} based on Alpine's {@link ProxyConfig}.
+ *
+ * @since 5.7.0
+ */
+public class ProxySelector extends java.net.ProxySelector {
+
+    private final ProxyConfig proxyConfig;
+
+    ProxySelector(final ProxyConfig proxyConfig) {
+        this.proxyConfig = proxyConfig;
+    }
+
+    public ProxySelector() {
+        this(ProxyUtil.getProxyConfig());
+    }
+
+    @Override
+    public List<Proxy> select(final URI uri) {
+        if (!"http".equals(uri.getScheme()) && !"https".equals(uri.getScheme())) {
+            return List.of(Proxy.NO_PROXY);
+        }
+
+        if (proxyConfig == null) {
+            return List.of(Proxy.NO_PROXY);
+        }
+
+        final URL url;
+        try {
+            url = uri.toURL();
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Failed to construct URL from %s".formatted(uri), e);
+        }
+
+        if (!proxyConfig.shouldProxy(url)) {
+            return List.of(Proxy.NO_PROXY);
+        }
+
+        return List.of(proxyConfig.getProxy());
+    }
+
+    @Override
+    public void connectFailed(final URI uri, final SocketAddress sa, final IOException ioe) {
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/filestorage/LocalFileStorageFactory.java
+++ b/apiserver/src/main/java/org/dependencytrack/filestorage/LocalFileStorageFactory.java
@@ -19,8 +19,8 @@
 package org.dependencytrack.filestorage;
 
 import alpine.Config;
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.config.ConfigDefinition;
-import org.dependencytrack.plugin.api.config.ConfigRegistry;
 import org.dependencytrack.plugin.api.config.ConfigTypes;
 import org.dependencytrack.plugin.api.config.DeploymentConfigDefinition;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
@@ -66,8 +66,8 @@ public final class LocalFileStorageFactory implements FileStorageFactory {
     }
 
     @Override
-    public void init(final ConfigRegistry configRegistry) {
-        directoryPath = configRegistry.getOptionalValue(CONFIG_DIRECTORY)
+    public void init(final ExtensionContext ctx) {
+        directoryPath = ctx.configRegistry().getOptionalValue(CONFIG_DIRECTORY)
                 .orElseGet(() -> Config.getInstance().getDataDirectorty().toPath().resolve("storage"))
                 .normalize()
                 .toAbsolutePath();
@@ -90,8 +90,8 @@ public final class LocalFileStorageFactory implements FileStorageFactory {
 
         LOGGER.debug("Files will be stored in {}", directoryPath);
 
-        compressionThresholdBytes = configRegistry.getOptionalValue(CONFIG_COMPRESSION_THRESHOLD_BYTES).orElse(4096);
-        compressionLevel = configRegistry.getOptionalValue(CONFIG_COMPRESSION_LEVEL).orElse(5);
+        compressionThresholdBytes = ctx.configRegistry().getOptionalValue(CONFIG_COMPRESSION_THRESHOLD_BYTES).orElse(4096);
+        compressionLevel = ctx.configRegistry().getOptionalValue(CONFIG_COMPRESSION_LEVEL).orElse(5);
     }
 
     @Override

--- a/apiserver/src/main/java/org/dependencytrack/filestorage/MemoryFileStorageFactory.java
+++ b/apiserver/src/main/java/org/dependencytrack/filestorage/MemoryFileStorageFactory.java
@@ -18,7 +18,7 @@
  */
 package org.dependencytrack.filestorage;
 
-import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
 import org.dependencytrack.plugin.api.filestorage.FileStorageFactory;
 
@@ -48,7 +48,7 @@ public final class MemoryFileStorageFactory implements FileStorageFactory {
     }
 
     @Override
-    public void init(final ConfigRegistry configRegistry) {
+    public void init(final ExtensionContext ctx) {
         fileContentByKey = new ConcurrentHashMap<>();
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/plugin/PluginManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/plugin/PluginManager.java
@@ -20,6 +20,8 @@ package org.dependencytrack.plugin;
 
 import alpine.common.logging.Logger;
 import org.dependencytrack.common.MdcScope;
+import org.dependencytrack.common.ProxySelector;
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.ExtensionFactory;
 import org.dependencytrack.plugin.api.ExtensionPoint;
 import org.dependencytrack.plugin.api.ExtensionPointSpec;
@@ -286,7 +288,7 @@ public class PluginManager {
 
         LOGGER.debug("Initializing extension");
         try {
-            extensionFactory.init(configRegistry);
+            extensionFactory.init(new ExtensionContext(configRegistry, new ProxySelector()));
         } catch (RuntimeException e) {
             throw new IllegalStateException(
                     "Failed to initialize extension %s from plugin %s".formatted(

--- a/apiserver/src/test/java/org/dependencytrack/common/ProxySelectorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/common/ProxySelectorTest.java
@@ -1,0 +1,44 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common;
+
+import alpine.common.util.ProxyConfig;
+import org.junit.Test;
+
+import java.net.Proxy;
+import java.net.URI;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ProxySelectorTest {
+
+    @Test
+    public void testSelect() {
+        final var proxyConfig = new ProxyConfig();
+        proxyConfig.setHost("example.com");
+        proxyConfig.setPort(6666);
+        proxyConfig.setNoProxy(Set.of("subdomain.example.com"));
+
+        final var proxySelector = new ProxySelector(proxyConfig);
+        assertThat(proxySelector.select(URI.create("https://subdomain.example.com"))).containsOnly(Proxy.NO_PROXY);
+        assertThat(proxySelector.select(URI.create("https://foo.example.com"))).containsOnly(proxyConfig.getProxy());
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/filestorage/LocalFileStorageTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/filestorage/LocalFileStorageTest.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.filestorage;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.config.MockConfigRegistry;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
 import org.dependencytrack.proto.filestorage.v1.FileMetadata;
@@ -65,8 +66,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void shouldStoreGetAndDeleteFile() throws Exception {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -91,9 +92,9 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void storeShouldCompressFileWithSizeAboveCompressionThreshold() throws Exception {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.ofEntries(
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.ofEntries(
                 Map.entry(CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()),
-                Map.entry(CONFIG_COMPRESSION_THRESHOLD_BYTES.name(), "64"))));
+                Map.entry(CONFIG_COMPRESSION_THRESHOLD_BYTES.name(), "64")))));
 
         final var storage = (LocalFileStorage) storageFactory.create();
 
@@ -119,8 +120,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void storeShouldOverwriteExistingFile() throws Exception {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -141,8 +142,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void storeShouldThrowWhenFileNameAttemptsTraversal() {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -157,8 +158,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void storeShouldThrowWhenFileHasInvalidName() {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -171,8 +172,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void getShouldThrowWhenFileLocationHasInvalidScheme() {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -188,8 +189,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void getShouldThrowWhenFileNameAttemptsTraversal() {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -208,8 +209,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void getShouldThrowWhenFileDoesNotExist() {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -225,8 +226,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void getShouldThrowWhenFileWithDigestMismatch() throws Exception {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -250,8 +251,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void deleteShouldReturnFalseWhenFileDoesNotExist() throws Exception {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 
@@ -266,8 +267,8 @@ public class LocalFileStorageTest {
     @SuppressWarnings("resource")
     public void deleteShouldThrowWhenFileLocationHasInvalidScheme() {
         final var storageFactory = new LocalFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Map.of(
-                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString())));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Map.of(
+                CONFIG_DIRECTORY.name(), tempDirPath.toAbsolutePath().toString()))));
 
         final FileStorage storage = storageFactory.create();
 

--- a/apiserver/src/test/java/org/dependencytrack/filestorage/MemoryFileStorageTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/filestorage/MemoryFileStorageTest.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.filestorage;
 
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.config.MockConfigRegistry;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
 import org.dependencytrack.proto.filestorage.v1.FileMetadata;
@@ -50,7 +51,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void shouldStoreGetAndDeleteFile() throws Exception {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 
@@ -73,7 +74,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void storeShouldOverwriteExistingFile() throws Exception {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 
@@ -94,7 +95,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void storeShouldThrowWhenFileHasInvalidName() {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 
@@ -107,7 +108,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void getShouldThrowWhenFileDoesNotExist() {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 
@@ -123,7 +124,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void getShouldThrowWhenFileLocationHasInvalidScheme() {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 
@@ -139,7 +140,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void deleteShouldReturnFalseWhenFileDoesNotExist() throws Exception {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 
@@ -154,7 +155,7 @@ public class MemoryFileStorageTest {
     @SuppressWarnings("resource")
     public void deleteShouldThrowWhenFileLocationHasInvalidScheme() {
         final var storageFactory = new MemoryFileStorageFactory();
-        storageFactory.init(new MockConfigRegistry(Collections.emptyMap()));
+        storageFactory.init(new ExtensionContext(new MockConfigRegistry(Collections.emptyMap())));
 
         final FileStorage storage = storageFactory.create();
 

--- a/apiserver/src/test/java/org/dependencytrack/filestorage/S3FileStorageTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/filestorage/S3FileStorageTest.java
@@ -23,6 +23,7 @@ import io.minio.GetObjectResponse;
 import io.minio.MakeBucketArgs;
 import io.minio.MinioClient;
 import org.apache.commons.codec.digest.DigestUtils;
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.config.MockConfigRegistry;
 import org.dependencytrack.plugin.api.filestorage.FileStorage;
 import org.dependencytrack.proto.filestorage.v1.FileMetadata;
@@ -99,7 +100,7 @@ public class S3FileStorageTest {
 
         try (final var storageFactory = new S3FileStorageFactory()) {
             assertThatExceptionOfType(IllegalStateException.class)
-                    .isThrownBy(() -> storageFactory.init(configRegistry))
+                    .isThrownBy(() -> storageFactory.init(new ExtensionContext(configRegistry)))
                     .withMessage("Bucket does-not-exist does not exist");
         }
     }
@@ -116,7 +117,7 @@ public class S3FileStorageTest {
             minioContainer.stop();
 
             assertThatExceptionOfType(IllegalStateException.class)
-                    .isThrownBy(() -> storageFactory.init(configRegistry))
+                    .isThrownBy(() -> storageFactory.init(new ExtensionContext(configRegistry)))
                     .withMessage("Failed to determine if bucket does-not-exist exists");
         }
     }
@@ -130,7 +131,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -158,7 +159,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_COMPRESSION_THRESHOLD_BYTES.name(), "64")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -194,7 +195,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -221,7 +222,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -242,7 +243,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -262,7 +263,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -284,7 +285,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -307,7 +308,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 
@@ -327,7 +328,7 @@ public class S3FileStorageTest {
                 Map.entry(CONFIG_BUCKET.name(), "test")));
 
         try (final var storageFactory = new S3FileStorageFactory()) {
-            storageFactory.init(configRegistry);
+            storageFactory.init(new ExtensionContext(configRegistry));
 
             final FileStorage storage = storageFactory.create();
 

--- a/apiserver/src/test/java/org/dependencytrack/plugin/DummyTestExtensionFactory.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/DummyTestExtensionFactory.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.plugin;
 
+import org.dependencytrack.plugin.api.ExtensionContext;
 import org.dependencytrack.plugin.api.ExtensionFactory;
 import org.dependencytrack.plugin.api.config.ConfigDefinition;
 import org.dependencytrack.plugin.api.config.ConfigRegistry;
@@ -50,8 +51,8 @@ public class DummyTestExtensionFactory implements ExtensionFactory<TestExtension
     }
 
     @Override
-    public void init(final ConfigRegistry configRegistry) {
-        this.configRegistry = configRegistry;
+    public void init(final ExtensionContext ctx) {
+        this.configRegistry = ctx.configRegistry();
     }
 
     @Override

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionContext.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionContext.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.plugin.api;
+
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+
+import java.net.ProxySelector;
+import java.util.Objects;
+
+/**
+ * @since 5.7.0
+ */
+public final class ExtensionContext {
+
+    private final ConfigRegistry configRegistry;
+    private final ProxySelector proxySelector;
+
+    public ExtensionContext(
+            final ConfigRegistry configRegistry,
+            final ProxySelector proxySelector) {
+        this.configRegistry = Objects.requireNonNull(configRegistry, "configRegistry must not be null");
+        this.proxySelector = proxySelector != null ? proxySelector : ProxySelector.getDefault();
+    }
+
+    public ExtensionContext(final ConfigRegistry configRegistry) {
+        this(configRegistry, null);
+    }
+
+    public ConfigRegistry configRegistry() {
+        return configRegistry;
+    }
+
+    public ProxySelector proxySelector() {
+        return proxySelector;
+    }
+
+}

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
@@ -18,8 +18,6 @@
  */
 package org.dependencytrack.plugin.api;
 
-import org.dependencytrack.plugin.api.config.ConfigRegistry;
-
 import java.io.Closeable;
 
 /**
@@ -49,9 +47,9 @@ public interface ExtensionFactory<T extends ExtensionPoint> extends Closeable {
     /**
      * Initialize the factory. This method is called <em>once</em> during application startup.
      *
-     * @param configRegistry A {@link ConfigRegistry} to read configuration from.
+     * @param ctx The {@link ExtensionContext} the factory is initialized in.
      */
-    void init(final ConfigRegistry configRegistry);
+    void init(ExtensionContext ctx);
 
     /**
      * @return An extension instance.

--- a/plugin/api/src/test/java/org/dependencytrack/plugin/api/ExtensionContextTest.java
+++ b/plugin/api/src/test/java/org/dependencytrack/plugin/api/ExtensionContextTest.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.plugin.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ExtensionContextTest {
+
+    @Test
+    void constructorShouldThrowWhenConfigRegistryIsNull() {
+        assertThatExceptionOfType(NullPointerException.class)
+                .isThrownBy(() -> new ExtensionContext(null))
+                .withMessage("configRegistry must not be null");
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Exposes proxy selector to extensions.

We anticipate that many / most extensions will perform some type of network interaction, which potentially requires proxy configuration.

For a consistent proxy configuration experience, it makes sense for us to pass a fully initialized `ProxySelector` to extensions during initialization.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
