### PR TITLE
Add delay to abandoned dex tasks

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -955,12 +955,13 @@ final class DexEngineImpl implements DexEngine {
     private void abandonWorkflowTasksInternal(
             WorkflowDao dao,
             Collection<WorkflowTaskAbandonedEvent> events) {
-        final int unlockedWorkflowRuns = dao.unlockWorkflowTasks(
+        final int abandonedTasks = dao.abandonWorkflowTasks(
                 this.config.instanceId(),
                 events.stream()
                         .map(WorkflowTaskAbandonedEvent::task)
                         .toList());
-        assert unlockedWorkflowRuns == events.size();
+        assert abandonedTasks == events.size()
+                : "Abandoned tasks: actual=%d, expected=%d".formatted(abandonedTasks, events.size());
     }
 
     private void completeWorkflowTasksInternal(
@@ -1257,12 +1258,12 @@ final class DexEngineImpl implements DexEngine {
     private void abandonActivityTasksInternal(
             ActivityDao activityDao,
             Collection<ActivityTaskAbandonedEvent> events) {
-        final int abandonedTasks = activityDao.unlockActivityTasks(
+        final int abandonedTasks = activityDao.abandonActivityTasks(
                 events.stream()
                         .map(ActivityTaskAbandonedEvent::task)
                         .toList());
         assert abandonedTasks == events.size()
-                : "Abandoned tasks: actual=%d, expected=%d".formatted(abandonedTasks, 1);
+                : "Abandoned tasks: actual=%d, expected=%d".formatted(abandonedTasks, events.size());
     }
 
     private void completeActivityTasksInternal(

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/ActivityDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/ActivityDao.java
@@ -343,7 +343,7 @@ public final class ActivityDao extends AbstractDao {
                 .execute();
     }
 
-    public int unlockActivityTasks(Collection<ActivityTask> activityTasks) {
+    public int abandonActivityTasks(Collection<ActivityTask> activityTasks) {
         final var queueNames = new String[activityTasks.size()];
         final var workflowRunIds = new UUID[activityTasks.size()];
         final var createdEventIds = new int[activityTasks.size()];
@@ -366,7 +366,7 @@ public final class ActivityDao extends AbstractDao {
                 )
                 update dex_activity_task as dat
                    set locked_by = null
-                     , locked_until = null
+                     , locked_until = now() + interval '15 seconds'
                      , updated_at = now()
                   from cte_cmd
                  where cte_cmd.workflow_run_id = dat.workflow_run_id

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
@@ -494,12 +494,11 @@ public final class WorkflowDao extends AbstractDao {
                 .collectToMap(PolledWorkflowTask::runId, Function.identity());
     }
 
-    public int unlockWorkflowTasks(String engineInstanceId, Collection<WorkflowTask> tasks) {
+    public int abandonWorkflowTasks(String engineInstanceId, Collection<WorkflowTask> tasks) {
         final Update update = jdbiHandle.createUpdate("""
                 update dex_workflow_task as task
                    set locked_by = null
-                     , locked_until = null
-                     , lock_version = null
+                     , locked_until = now() + interval '15 seconds'
                   from unnest(:queueNames, :runIds, :lockVersions)
                     as t(queue_name, run_id, lock_version)
                  where task.queue_name = t.queue_name


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds delay to abandoned dex tasks.

When a worker abandons a task, it should not *immediately* be picked up by another instance.

Instead of clearing the locked_until timestamp during abandonment, set it to a time 15s in the future. This provides a reasonable delay before the task becomes eligible for processing again.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
