### PR TITLE
Implement nudging of dex task schedulers and workers when new work is available

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
@@ -38,6 +38,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 final class ActivityTaskScheduler implements Closeable {
@@ -49,8 +52,10 @@ final class ActivityTaskScheduler implements Closeable {
     private final MeterRegistry meterRegistry;
     private final long pollIntervalMillis;
     private final IntervalFunction pollBackoffFunction;
+    private final Consumer<String> onTasksScheduledCallback;
     private final Thread pollThread;
     private volatile boolean stopped = false;
+    private volatile boolean nudged = false;
     private @Nullable Counter pollsCounter;
     private @Nullable MeterProvider<Timer> taskSchedulingLatencyTimer;
     private @Nullable MeterProvider<Counter> tasksScheduledCounter;
@@ -60,12 +65,14 @@ final class ActivityTaskScheduler implements Closeable {
             Supplier<Boolean> leadershipSupplier,
             MeterRegistry meterRegistry,
             Duration pollIntervalMillis,
-            IntervalFunction pollBackoffFunction) {
+            IntervalFunction pollBackoffFunction,
+            Consumer<String> onTasksScheduledCallback) {
         this.jdbi = jdbi;
         this.leadershipSupplier = leadershipSupplier;
         this.meterRegistry = meterRegistry;
         this.pollIntervalMillis = pollIntervalMillis.toMillis();
         this.pollBackoffFunction = pollBackoffFunction;
+        this.onTasksScheduledCallback = onTasksScheduledCallback;
         this.pollThread = Thread.ofPlatform()
                 .name(ActivityTaskScheduler.class.getSimpleName())
                 .unstarted(this::pollLoop);
@@ -85,11 +92,17 @@ final class ActivityTaskScheduler implements Closeable {
         pollThread.start();
     }
 
+    void nudge() {
+        nudged = true;
+        LockSupport.unpark(pollThread);
+    }
+
     @Override
     public void close() {
         if (pollThread.isAlive()) {
             LOGGER.debug("Waiting for poll thread to stop");
             stopped = true;
+            LockSupport.unpark(pollThread);
 
             try {
                 final boolean terminated = pollThread.join(Duration.ofSeconds(3));
@@ -114,6 +127,11 @@ final class ActivityTaskScheduler implements Closeable {
         int consecutiveErrors = 0;
 
         while (!stopped && !Thread.currentThread().isInterrupted()) {
+            if (nudged) {
+                nudged = false;
+                pollsWithoutSchedules = 0;
+            }
+
             if (pollsWithoutSchedules < 3 && consecutiveErrors == 0) {
                 nowMillis = System.currentTimeMillis();
                 nextPollAtMillis = lastPolledAtMillis + pollIntervalMillis;
@@ -135,11 +153,8 @@ final class ActivityTaskScheduler implements Closeable {
 
             if (nextPollDueInMillis > 0) {
                 LOGGER.debug("Waiting for next poll to be due in {}ms", nextPollDueInMillis);
-                try {
-                    Thread.sleep(nextPollDueInMillis);
-                } catch (InterruptedException e) {
-                    LOGGER.debug("Interrupted while waiting for next poll to be due");
-                    Thread.currentThread().interrupt();
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(nextPollDueInMillis));
+                if (Thread.currentThread().isInterrupted() || stopped) {
                     break;
                 }
             }
@@ -290,15 +305,20 @@ final class ActivityTaskScheduler implements Closeable {
                 .mapTo(String.class)
                 .list();
 
+        final boolean didSchedule = !scheduledActivityNames.isEmpty();
         handle.afterCommit(() -> {
             for (final String activityName : scheduledActivityNames) {
                 tasksScheduledCounter
                         .withTag("activityName", activityName)
                         .increment();
             }
+
+            if (didSchedule) {
+                onTasksScheduledCallback.accept(queue.name());
+            }
         });
 
-        return !scheduledActivityNames.isEmpty();
+        return didSchedule;
     }
 
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskWorker.java
@@ -49,6 +49,8 @@ interface TaskWorker extends Closeable {
 
     void start();
 
+    void nudge();
+
     Status status();
 
     @Override


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Implements nudging of dex task schedulers and workers when new work is available.

Nudging of a task scheduler or worker causes the exponential polling backoff to be cut short. Workers are only nudged when tasks were scheduled on the queue they're subscribed to.

This makes dex more responsive when new work arrives after the system was idle for a while.

The mechanism is entirely in-memory for now. External mechanisms are not worth the operational overhead they introduce.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
