### PR TITLE
Replace invocations of vuln-analysis workflow with analyze-project workflow

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -46,6 +46,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.dependencytrack.analysis.AnalyzeProjectWorkflow;
 import org.dependencytrack.auth.Permissions;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
@@ -63,13 +64,12 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.RepositoryQueryManager;
 import org.dependencytrack.persistence.jdbi.FindingDao;
 import org.dependencytrack.persistence.jdbi.RepositoryMetaDao;
-import org.dependencytrack.proto.internal.workflow.v1.VulnAnalysisWorkflowArg;
+import org.dependencytrack.proto.internal.workflow.v1.AnalyzeProjectWorkflowArg;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v1.openapi.PaginatedApi;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 import org.dependencytrack.resources.v1.vo.BomUploadResponse;
 import org.dependencytrack.util.PurlUtil;
-import org.dependencytrack.vulnanalysis.VulnAnalysisWorkflow;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -264,15 +264,15 @@ public class FindingResource extends AbstractApiResource {
         useJdbiHandle(handle -> requireProjectAccess(handle, UUID.fromString(uuid)));
 
         final UUID runId = dexEngine.createRun(
-                new CreateWorkflowRunRequest<>(VulnAnalysisWorkflow.class)
-                        .withWorkflowInstanceId("manual-vuln-analysis:" + uuid)
-                        .withConcurrencyKey("vuln-analysis:" + uuid)
+                new CreateWorkflowRunRequest<>(AnalyzeProjectWorkflow.class)
+                        .withWorkflowInstanceId("analyze-project-manual:" + uuid)
+                        .withConcurrencyKey("analyze-project:" + uuid)
                         .withLabels(Map.ofEntries(
                                 Map.entry(WF_LABEL_PROJECT_UUID, uuid),
                                 Map.entry(WF_LABEL_TRIGGERED_BY, getPrincipal().getName())))
                         .withPriority(75)
                         .withArgument(
-                                VulnAnalysisWorkflowArg.newBuilder()
+                                AnalyzeProjectWorkflowArg.newBuilder()
                                         .setProjectUuid(uuid)
                                         .setTrigger(ANALYSIS_TRIGGER_MANUAL)
                                         .build()));

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/WorkflowResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/WorkflowResource.java
@@ -94,7 +94,7 @@ public class WorkflowResource {
         // This is really only necessary for workflows that can be triggered manually.
         final WorkflowRunMetadata runMetadata = dexEngine.getRunMetadataById(token);
         if (runMetadata != null) {
-            if ("vuln-analysis".equals(runMetadata.workflowName())) {
+            if ("analyze-project".equals(runMetadata.workflowName())) {
                 final var workflowState = new WorkflowState();
                 workflowState.setStep(WorkflowStep.VULN_ANALYSIS);
                 workflowState.setStatus(switch (runMetadata.status()) {

--- a/apiserver/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/VulnerabilityAnalysisTask.java
@@ -21,11 +21,11 @@ package org.dependencytrack.tasks;
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
 import net.javacrumbs.shedlock.core.LockingTaskExecutor;
+import org.dependencytrack.analysis.AnalyzeProjectWorkflow;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
 import org.dependencytrack.event.PortfolioVulnerabilityAnalysisEvent;
-import org.dependencytrack.proto.internal.workflow.v1.VulnAnalysisWorkflowArg;
-import org.dependencytrack.vulnanalysis.VulnAnalysisWorkflow;
+import org.dependencytrack.proto.internal.workflow.v1.AnalyzeProjectWorkflowArg;
 import org.jdbi.v3.core.statement.SqlStatements;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -79,12 +79,12 @@ public class VulnerabilityAnalysisTask implements Subscriber {
                     new ArrayList<CreateWorkflowRunRequest<?>>(projectsPage.size());
             for (final Project project : projectsPage) {
                 final var workflowRunRequest =
-                        new CreateWorkflowRunRequest<>(VulnAnalysisWorkflow.class)
-                                .withWorkflowInstanceId("scheduled-vuln-analysis:" + project.uuid())
-                                .withConcurrencyKey("vuln-analysis:" + project.uuid())
+                        new CreateWorkflowRunRequest<>(AnalyzeProjectWorkflow.class)
+                                .withWorkflowInstanceId("analyze-project-scheduled:" + project.uuid())
+                                .withConcurrencyKey("analyze-project:" + project.uuid())
                                 .withLabels(Map.of("project_uuid", project.uuid().toString()))
                                 .withArgument(
-                                        VulnAnalysisWorkflowArg.newBuilder()
+                                        AnalyzeProjectWorkflowArg.newBuilder()
                                                 .setProjectUuid(project.uuid().toString())
                                                 .setTrigger(ANALYSIS_TRIGGER_SCHEDULE)
                                                 .build());

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1979,7 +1979,7 @@ dt.dex-engine.activity-worker.vuln-analysis-reconciliation.max-concurrency=5
 #
 # @category: Durable Execution
 # @type:     boolean
-dt.dex-engine.activity-worker.policy-evaluation.enabled=false
+# dt.dex-engine.activity-worker.policy-evaluation.enabled=true
 
 # @hidden
 dt.dex-engine.activity-worker.policy-evaluation.queue-name=policy-evaluations
@@ -1995,7 +1995,7 @@ dt.dex-engine.activity-worker.policy-evaluation.max-concurrency=5
 #
 # @category: Durable Execution
 # @type:     boolean
-dt.dex-engine.activity-worker.metrics-update.enabled=false
+# dt.dex-engine.activity-worker.metrics-update.enabled=true
 
 # @hidden
 dt.dex-engine.activity-worker.metrics-update.queue-name=metrics-updates

--- a/apiserver/src/test/java/org/dependencytrack/dex/listener/LegacyWorkflowStepCompleterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/dex/listener/LegacyWorkflowStepCompleterTest.java
@@ -52,7 +52,7 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
 
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.COMPLETED,
                         Map.ofEntries(
                                 Map.entry(WF_LABEL_PROJECT_UUID, UUID.randomUUID().toString()),
@@ -75,11 +75,11 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
                 },
                 state -> {
                     assertThat(state.getStep()).isEqualTo(WorkflowStep.POLICY_EVALUATION);
-                    assertThat(state.getStatus()).isEqualTo(WorkflowStatus.PENDING);
+                    assertThat(state.getStatus()).isEqualTo(WorkflowStatus.COMPLETED);
                 },
                 state -> {
                     assertThat(state.getStep()).isEqualTo(WorkflowStep.METRICS_UPDATE);
-                    assertThat(state.getStatus()).isEqualTo(WorkflowStatus.PENDING);
+                    assertThat(state.getStatus()).isEqualTo(WorkflowStatus.COMPLETED);
                 });
     }
 
@@ -90,7 +90,7 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
 
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.FAILED,
                         Map.ofEntries(
                                 Map.entry(WF_LABEL_PROJECT_UUID, UUID.randomUUID().toString()),
@@ -130,13 +130,13 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
 
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.COMPLETED,
                         Map.ofEntries(
                                 Map.entry(WF_LABEL_PROJECT_UUID, UUID.randomUUID().toString()),
                                 Map.entry(WF_LABEL_BOM_UPLOAD_TOKEN, tokenA.toString()))),
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.FAILED,
                         Map.ofEntries(
                                 Map.entry(WF_LABEL_PROJECT_UUID, UUID.randomUUID().toString()),
@@ -150,7 +150,9 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
                     assertThat(state.getFailureReason()).isNull();
                 });
         assertThat(qm.getWorkflowStateByTokenAndStep(tokenA, WorkflowStep.POLICY_EVALUATION))
-                .satisfies(state -> assertThat(state.getStatus()).isEqualTo(WorkflowStatus.PENDING));
+                .satisfies(state -> assertThat(state.getStatus()).isEqualTo(WorkflowStatus.COMPLETED));
+        assertThat(qm.getWorkflowStateByTokenAndStep(tokenA, WorkflowStep.METRICS_UPDATE))
+                .satisfies(state -> assertThat(state.getStatus()).isEqualTo(WorkflowStatus.COMPLETED));
 
         assertThat(qm.getWorkflowStateByTokenAndStep(tokenB, WorkflowStep.VULN_ANALYSIS))
                 .satisfies(state -> {
@@ -184,7 +186,7 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
     void shouldIgnoreRunsWithNoLabels() {
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.COMPLETED,
                         null))));
     }
@@ -196,7 +198,7 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
 
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.COMPLETED,
                         Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString())))));
 
@@ -208,7 +210,7 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
     void shouldIgnoreRunsWithMissingBomUploadToken() {
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.COMPLETED,
                         Map.of(WF_LABEL_PROJECT_UUID, UUID.randomUUID().toString())))));
     }
@@ -222,7 +224,7 @@ class LegacyWorkflowStepCompleterTest extends PersistenceCapableTest {
     void shouldHandleTokenWithNoMatchingWorkflowState() {
         completer.onEvent(new WorkflowRunsCompletedEvent(List.of(
                 createRunMetadata(
-                        "vuln-analysis",
+                        "analyze-project",
                         WorkflowRunStatus.COMPLETED,
                         Map.ofEntries(
                                 Map.entry(WF_LABEL_PROJECT_UUID, UUID.randomUUID().toString()),

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -622,7 +622,7 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @Test
-    public void analyzeProjectShouldCreateVulnAnalysisWorkflowRun() {
+    public void analyzeProjectShouldCreateAnalyzeProjectWorkflowRun() {
         var project = new Project();
         project.setName("Acme Example");
         project = qm.persist(project);
@@ -648,10 +648,10 @@ public class FindingResourceTest extends ResourceTest {
         verify(DEX_ENGINE_MOCK).createRun(dexCreateRunCaptor.capture());
 
         CreateWorkflowRunRequest<?> createDexRunRequest = dexCreateRunCaptor.getValue();
-        assertThat(createDexRunRequest.workflowName()).isEqualTo("vuln-analysis");
+        assertThat(createDexRunRequest.workflowName()).isEqualTo("analyze-project");
         assertThat(createDexRunRequest.workflowVersion()).isEqualTo(1);
-        assertThat(createDexRunRequest.workflowInstanceId()).isEqualTo("manual-vuln-analysis:" + project.getUuid());
-        assertThat(createDexRunRequest.concurrencyKey()).isEqualTo("vuln-analysis:" + project.getUuid());
+        assertThat(createDexRunRequest.workflowInstanceId()).isEqualTo("analyze-project-manual:" + project.getUuid());
+        assertThat(createDexRunRequest.concurrencyKey()).isEqualTo("analyze-project:" + project.getUuid());
         assertThat(createDexRunRequest.labels()).containsEntry("project_uuid", project.getUuid().toString());
         assertThat(createDexRunRequest.labels()).hasEntrySatisfying("triggered_by", value -> assertThat(value).startsWith("odt_"));
         assertThat(createDexRunRequest.priority()).isEqualTo(75);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/WorkflowResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/WorkflowResourceTest.java
@@ -167,7 +167,7 @@ public class WorkflowResourceTest extends ResourceTest {
 
         final var runMetadata = new WorkflowRunMetadata(
                 UUID.fromString("a3c39f8a-0c02-4a8c-8a3a-2f77e203809c"),
-                "vuln-analysis",
+                "analyze-project",
                 1,
                 null,
                 "taskQueue",
@@ -209,7 +209,7 @@ public class WorkflowResourceTest extends ResourceTest {
 
         final var runMetadata = new WorkflowRunMetadata(
                 UUID.fromString("a3c39f8a-0c02-4a8c-8a3a-2f77e203809c"),
-                "vuln-analysis",
+                "analyze-project",
                 1,
                 null,
                 "taskQueue",

--- a/apiserver/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/BomUploadProcessingTaskTest.java
@@ -92,7 +92,6 @@ import static org.dependencytrack.model.ConfigPropertyConstants.ACCEPT_ARTIFACT_
 import static org.dependencytrack.model.WorkflowStatus.CANCELLED;
 import static org.dependencytrack.model.WorkflowStatus.COMPLETED;
 import static org.dependencytrack.model.WorkflowStatus.FAILED;
-import static org.dependencytrack.model.WorkflowStatus.NOT_APPLICABLE;
 import static org.dependencytrack.model.WorkflowStatus.PENDING;
 import static org.dependencytrack.model.WorkflowStep.BOM_CONSUMPTION;
 import static org.dependencytrack.model.WorkflowStep.BOM_PROCESSING;
@@ -400,14 +399,14 @@ class BomUploadProcessingTaskTest extends PersistenceCapableTest {
                 },
                 state -> {
                     assertThat(state.getStep()).isEqualTo(VULN_ANALYSIS);
-                    assertThat(state.getStatus()).isEqualTo(NOT_APPLICABLE);
+                    assertThat(state.getStatus()).isEqualTo(PENDING);
                     assertThat(state.getParent()).isNotNull();
                     assertThat(state.getStartedAt()).isNull();
                     assertThat(state.getUpdatedAt()).isBefore(Date.from(Instant.now()));
                 },
                 state -> {
                     assertThat(state.getStep()).isEqualTo(POLICY_EVALUATION);
-                    assertThat(state.getStatus()).isEqualTo(NOT_APPLICABLE);
+                    assertThat(state.getStatus()).isEqualTo(PENDING);
                     assertThat(state.getParent()).isNotNull();
                     assertThat(state.getStartedAt()).isNull();
                     assertThat(state.getUpdatedAt()).isBefore(Date.from(Instant.now()));

--- a/apiserver/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/VulnerabilityAnalysisTaskTest.java
@@ -67,10 +67,10 @@ class VulnerabilityAnalysisTaskTest extends PersistenceCapableTest {
         verify(dexEngineMock).createRuns(requestsCaptor.capture());
 
         assertThat(requestsCaptor.getValue()).satisfiesExactly(request -> {
-            assertThat(request.workflowName()).isEqualTo("vuln-analysis");
+            assertThat(request.workflowName()).isEqualTo("analyze-project");
             assertThat(request.workflowVersion()).isEqualTo(1);
-            assertThat(request.withWorkflowInstanceId("scheduled-vuln-analysis:" + projectA.getUuid()));
-            assertThat(request.concurrencyKey()).isEqualTo("vuln-analysis:" + projectA.getUuid());
+            assertThat(request.workflowInstanceId()).isEqualTo("analyze-project-scheduled:" + projectA.getUuid());
+            assertThat(request.concurrencyKey()).isEqualTo("analyze-project:" + projectA.getUuid());
             assertThat(request.labels()).containsOnly(Map.entry("project_uuid", projectA.getUuid().toString()));
             assertThat(request.priority()).isZero();
         });


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Replaces invocations of vuln-analysis workflow with analyze-project workflow.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to ADR-002: https://dependencytrack.github.io/hyades/snapshot/architecture/decisions/002-workflow-orchestration/
Follow-up to https://github.com/DependencyTrack/hyades-apiserver/pull/1831

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
