### PR TITLE
Add exists query for dex workflow runs

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/EventResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/EventResource.java
@@ -39,7 +39,7 @@ import jakarta.ws.rs.core.Response;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
 import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
-import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
+import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
 import org.dependencytrack.model.validation.ValidUuid;
 import org.dependencytrack.persistence.jdbi.WorkflowDao;
 import org.dependencytrack.resources.v1.vo.IsTokenBeingProcessedResponse;
@@ -121,14 +121,10 @@ public class EventResource extends AlpineResource {
     }
 
     private boolean hasNonTerminalDexRun(UUID token) {
-        final boolean hasNonTerminalByLabel = !dexEngine
-                .listRuns(
-                        new ListWorkflowRunsRequest()
-                                .withLabels(Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString()))
-                                .withStatuses(WorkflowRunStatus.NON_TERMINAL_STATUSES)
-                                .withLimit(1))
-                .items()
-                .isEmpty();
+        final boolean hasNonTerminalByLabel =
+                dexEngine.existsRun(new ExistsWorkflowRunRequest(
+                        WorkflowRunStatus.NON_TERMINAL_STATUSES,
+                        Map.of(WF_LABEL_BOM_UPLOAD_TOKEN, token.toString())));
         if (hasNonTerminalByLabel) {
             return true;
         }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/EventResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/EventResourceTest.java
@@ -24,11 +24,10 @@ import jakarta.ws.rs.core.Response;
 import org.apache.http.HttpStatus;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
-import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
 import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
-import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
+import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
 import org.dependencytrack.model.WorkflowState;
 import org.glassfish.jersey.inject.hk2.AbstractBinder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -39,8 +38,6 @@ import org.mockito.Mockito;
 
 import java.time.Instant;
 import java.util.Date;
-import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
@@ -94,7 +91,7 @@ class EventResourceTest extends ResourceTest {
         qm.persist(workflowState2);
 
         doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(any());
-        doReturn(Page.empty()).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
+        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
 
         final Response response = jersey
                 .target(V1_EVENT + "/token/" + uuid)
@@ -128,7 +125,7 @@ class EventResourceTest extends ResourceTest {
         qm.persist(workflowState2);
 
         doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(any());
-        doReturn(Page.empty()).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
+        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
 
         final Response response = jersey
                 .target(V1_EVENT + "/token/" + uuid)
@@ -161,7 +158,7 @@ class EventResourceTest extends ResourceTest {
                 Instant.now(),
                 null,
                 null);
-        doReturn(Page.empty()).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
+        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
         doReturn(runMetadata).when(DEX_ENGINE_MOCK).getRunMetadataById(runId);
 
         final Response response = jersey
@@ -180,40 +177,9 @@ class EventResourceTest extends ResourceTest {
     @Test
     void isTokenBeingProcessedDexRunByLabelTest() {
         final var bomUploadToken = UUID.fromString("2ff20ad6-587c-4db6-8788-cca7a9b0dc1b");
-        final var importBomRun = new WorkflowRunMetadata(
-                UUID.randomUUID(),
-                "import-bom",
-                1,
-                null,
-                "default",
-                WorkflowRunStatus.COMPLETED,
-                null,
-                0,
-                null,
-                Map.of("bom_upload_token", bomUploadToken.toString()),
-                Instant.now(),
-                Instant.now(),
-                Instant.now(),
-                Instant.now());
-        final var analyzeProjectRun = new WorkflowRunMetadata(
-                UUID.randomUUID(),
-                "analyze-project",
-                1,
-                null,
-                "default",
-                WorkflowRunStatus.RUNNING,
-                null,
-                0,
-                null,
-                Map.of("bom_upload_token", bomUploadToken.toString()),
-                Instant.now(),
-                Instant.now(),
-                Instant.now(),
-                null);
 
         doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(bomUploadToken);
-        doReturn(new Page<>(List.of(importBomRun, analyzeProjectRun)))
-                .when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
+        doReturn(true).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
 
         final Response response = jersey
                 .target(V1_EVENT + "/token/2ff20ad6-587c-4db6-8788-cca7a9b0dc1b")
@@ -231,7 +197,7 @@ class EventResourceTest extends ResourceTest {
     @Test
     void isTokenBeingProcessedNotExistsTest() {
         doReturn(null).when(DEX_ENGINE_MOCK).getRunMetadataById(any());
-        doReturn(Page.empty()).when(DEX_ENGINE_MOCK).listRuns(any(ListWorkflowRunsRequest.class));
+        doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));
 
         final Response response = jersey
                 .target(V1_EVENT + "/token/089dcdbe-31cf-489a-a8f3-0743ea7f3cc5")

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/DexEngine.java
@@ -28,6 +28,7 @@ import org.dependencytrack.dex.engine.api.event.DexEngineEvent;
 import org.dependencytrack.dex.engine.api.event.DexEngineEventListener;
 import org.dependencytrack.dex.engine.api.request.CreateTaskQueueRequest;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
 import org.dependencytrack.dex.engine.api.request.ListTaskQueuesRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
@@ -167,6 +168,14 @@ public interface DexEngine extends Closeable {
     WorkflowRunMetadata getRunMetadataByInstanceId(String instanceId);
 
     Page<WorkflowRunMetadata> listRuns(ListWorkflowRunsRequest request);
+
+    /**
+     * Check whether at least one workflow run matching the given criteria exists.
+     *
+     * @param request Filter criteria for the lookup.
+     * @return {@code true} when a matching run exists, {@code false} otherwise.
+     */
+    boolean existsRun(ExistsWorkflowRunRequest request);
 
     /**
      * Request the cancellation of a workflow run.

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/request/ExistsWorkflowRunRequest.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/request/ExistsWorkflowRunRequest.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine.api.request;
+
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Map;
+import java.util.Set;
+
+public record ExistsWorkflowRunRequest(
+        @Nullable Set<WorkflowRunStatus> statuses,
+        @Nullable Map<String, String> labels) {
+
+    public ExistsWorkflowRunRequest {
+        if ((statuses == null || statuses.isEmpty())
+                && (labels == null || labels.isEmpty())) {
+            throw new IllegalArgumentException("At least one filter must be provided");
+        }
+    }
+
+    public ExistsWorkflowRunRequest withStatuses(@Nullable Set<WorkflowRunStatus> statuses) {
+        return new ExistsWorkflowRunRequest(statuses, this.labels);
+    }
+
+    public ExistsWorkflowRunRequest withLabels(@Nullable Map<String, String> labels) {
+        return new ExistsWorkflowRunRequest(this.statuses, labels);
+    }
+
+}

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -56,6 +56,7 @@ import org.dependencytrack.dex.engine.api.event.WorkflowRunsCompletedEvent;
 import org.dependencytrack.dex.engine.api.event.WorkflowRunsCompletedEventListener;
 import org.dependencytrack.dex.engine.api.request.CreateTaskQueueRequest;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
 import org.dependencytrack.dex.engine.api.request.ListTaskQueuesRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
@@ -723,6 +724,11 @@ final class DexEngineImpl implements DexEngine {
     @Override
     public Page<WorkflowRunMetadata> listRuns(ListWorkflowRunsRequest request) {
         return jdbi.withHandle(handle -> new WorkflowRunDao(handle).listRuns(request));
+    }
+
+    @Override
+    public boolean existsRun(ExistsWorkflowRunRequest request) {
+        return jdbi.withHandle(handle -> new WorkflowRunDao(handle).existsRun(request));
     }
 
     @Override

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowRunDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowRunDao.java
@@ -25,6 +25,7 @@ import org.dependencytrack.common.pagination.SortDirection;
 import org.dependencytrack.dex.engine.api.WorkflowRunHistoryEntry;
 import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
 import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
 import org.jdbi.v3.core.Handle;
@@ -56,6 +57,47 @@ public final class WorkflowRunDao extends AbstractDao {
             ListWorkflowRunsRequest.SortBy sortBy,
             SortDirection sortDirection,
             TotalCount totalCount) implements PageToken {
+    }
+
+    public boolean existsRun(ExistsWorkflowRunRequest request) {
+        requireNonNull(request, "request must not be null");
+
+        final Query query = jdbiHandle.createQuery(/* language=InjectedFreeMarker */ """
+                <#-- @ftlvariable name="statuses" type="boolean" -->
+                <#-- @ftlvariable name="labels" type="boolean" -->
+                select exists(
+                  select 1
+                    from dex_workflow_run
+                   where true
+                  <#if statuses!false>
+                     and status = ANY(:statuses)
+                  </#if>
+                  <#if labels!false>
+                     and labels @> cast(:labels as jsonb)
+                  </#if>
+                )
+                """);
+
+        if (request.statuses() != null && !request.statuses().isEmpty()) {
+            query.bind(
+                    "statuses",
+                    request.statuses().stream()
+                            .map(WorkflowRunStatus::name)
+                            .toArray(String[]::new));
+        }
+        if (request.labels() != null && !request.labels().isEmpty()) {
+            final JsonMapper.TypedJsonMapper jsonMapper = jdbiHandle
+                    .getConfig(JsonConfig.class).getJsonMapper()
+                    .forType(new GenericType<Map<String, String>>() {
+                    }.getType(), jdbiHandle.getConfig());
+            query.bind("labels", jsonMapper.toJson(
+                    request.labels(), jdbiHandle.getConfig()));
+        }
+
+        return query
+                .defineNamedBindings()
+                .mapTo(boolean.class)
+                .one();
     }
 
     public Page<WorkflowRunMetadata> listRuns(final ListWorkflowRunsRequest request) {

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -47,6 +47,7 @@ import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
 import org.dependencytrack.dex.engine.api.event.WorkflowRunsCompletedEventListener;
 import org.dependencytrack.dex.engine.api.request.CreateTaskQueueRequest;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ExistsWorkflowRunRequest;
 import org.dependencytrack.dex.engine.api.request.ListTaskQueuesRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
@@ -69,6 +70,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -1354,6 +1356,69 @@ class DexEngineImplTest {
                         .withLimit(5));
         assertThat(runsPage.items()).hasSize(5);
         assertThat(runsPage.nextPageToken()).isNull();
+    }
+
+    @Nested
+    class ExistsRunTest {
+
+        @Test
+        void shouldReturnTrueWhenRunExistsWithMatchingStatus() {
+            registerWorkflow("test", (ctx, arg) -> null);
+            engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+            assertThat(engine.existsRun(new ExistsWorkflowRunRequest(
+                    Set.of(WorkflowRunStatus.CREATED), null))).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseWhenNoRunExistsWithMatchingStatus() {
+            registerWorkflow("test", (ctx, arg) -> null);
+            engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+            assertThat(engine.existsRun(new ExistsWorkflowRunRequest(
+                    Set.of(WorkflowRunStatus.COMPLETED), null))).isFalse();
+        }
+
+        @Test
+        void shouldReturnTrueWhenRunExistsWithMatchingLabels() {
+            registerWorkflow("test", (ctx, arg) -> null);
+            engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                    .withLabels(Map.of("foo", "bar")));
+
+            assertThat(engine.existsRun(new ExistsWorkflowRunRequest(
+                    null, Map.of("foo", "bar")))).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseWhenNoRunExistsWithMatchingLabels() {
+            registerWorkflow("test", (ctx, arg) -> null);
+            engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                    .withLabels(Map.of("foo", "bar")));
+
+            assertThat(engine.existsRun(new ExistsWorkflowRunRequest(
+                    null, Map.of("foo", "baz")))).isFalse();
+        }
+
+        @Test
+        void shouldReturnTrueWhenRunExistsWithMatchingStatusAndLabels() {
+            registerWorkflow("test", (ctx, arg) -> null);
+            engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                    .withLabels(Map.of("foo", "bar")));
+
+            assertThat(engine.existsRun(new ExistsWorkflowRunRequest(
+                    Set.of(WorkflowRunStatus.CREATED), Map.of("foo", "bar")))).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseWhenRunExistsWithMatchingStatusButNotLabels() {
+            registerWorkflow("test", (ctx, arg) -> null);
+            engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                    .withLabels(Map.of("foo", "bar")));
+
+            assertThat(engine.existsRun(new ExistsWorkflowRunRequest(
+                    Set.of(WorkflowRunStatus.CREATED), Map.of("foo", "baz")))).isFalse();
+        }
+
     }
 
     @Nested


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds exists query for dex workflow runs.

Using listRuns for the purpose of checking whether a non-terminal run exists was overly wasteful.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
