### PR TITLE
Enable PG testcontainer reuse across JVMs, and DataNucleus PMF reuse across classes

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -737,6 +737,18 @@
 
     <profiles>
         <profile>
+            <id>github-actions-apiserver</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_ACTIONS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <unitTestForkCount>1C</unitTestForkCount>
+            </properties>
+        </profile>
+        <profile>
             <id>dist</id>
             <build>
                 <plugins>

--- a/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/PersistenceCapableTest.java
@@ -22,17 +22,13 @@ import alpine.Config;
 import alpine.event.framework.EventService;
 import alpine.event.framework.SingleThreadedEventService;
 import alpine.server.auth.PasswordService;
-import alpine.server.persistence.PersistenceManagerFactory;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.event.kafka.KafkaProducerInitializer;
 import org.dependencytrack.persistence.QueryManager;
-import org.dependencytrack.support.config.source.memory.MemoryConfigSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.testcontainers.postgresql.PostgreSQLContainer;
 
 import java.sql.Connection;
 import java.sql.Statement;
@@ -41,30 +37,21 @@ import java.util.concurrent.TimeoutException;
 
 public abstract class PersistenceCapableTest {
 
-    protected static PostgresTestContainer postgresContainer;
     protected MockProducer<byte[], byte[]> kafkaMockProducer;
     protected QueryManager qm;
 
     protected static final String TEST_PASSWORD_HASH = new String(
-        PasswordService.createHash("testuser".toCharArray()));
+            PasswordService.createHash("testuser".toCharArray()));
 
     @BeforeAll
     public static void init() {
         Config.enableUnitTests();
-
-        postgresContainer = new PostgresTestContainer();
-        postgresContainer.start();
-
-        MemoryConfigSource.setProperty("dt.datasource.url", postgresContainer.getJdbcUrl());
-        MemoryConfigSource.setProperty("dt.datasource.username", postgresContainer.getUsername());
-        MemoryConfigSource.setProperty("dt.datasource.password", postgresContainer.getPassword());
-
-        new PersistenceManagerFactory().contextInitialized(null);
+        TestDatabaseManager.initialize();
     }
 
     @BeforeEach
     public void before() throws Exception {
-        truncateTables(postgresContainer);
+        truncateTables();
 
         qm = new QueryManager();
 
@@ -87,7 +74,7 @@ public abstract class PersistenceCapableTest {
         // code base can leave such a broken state behind if they run into unexpected
         // errors. See: https://github.com/DependencyTrack/dependency-track/issues/2677
         if (!qm.getPersistenceManager().isClosed()
-            && qm.getPersistenceManager().currentTransaction().isActive()) {
+                && qm.getPersistenceManager().currentTransaction().isActive()) {
             qm.getPersistenceManager().currentTransaction().rollback();
         }
 
@@ -96,35 +83,22 @@ public abstract class PersistenceCapableTest {
         KafkaProducerInitializer.tearDown();
     }
 
-    @AfterAll
-    public static void tearDownClass() {
-        PersistenceManagerFactory.tearDown();
-        DataSourceRegistry.getInstance().closeAll();
-
-        if (postgresContainer != null) {
-            postgresContainer.stopWhenNotReusing();
-        }
-    }
-
-    protected static void truncateTables(final PostgreSQLContainer postgresContainer) throws Exception {
-        // Truncate all tables to ensure each test starts from a clean slate.
-        // https://stackoverflow.com/a/63227261
-        try (final Connection connection = postgresContainer.createConnection("");
+    protected static void truncateTables() throws Exception {
+        try (final Connection connection = DataSourceRegistry.getInstance().getDefault().getConnection();
              final Statement statement = connection.createStatement()) {
             statement.execute("""
                     DO $$ DECLARE
-                        r RECORD;
+                        table_list TEXT;
                     BEGIN
-                        FOR r IN (
-                          SELECT tablename
-                            FROM pg_tables
-                           WHERE schemaname = CURRENT_SCHEMA()
-                           -- Do not truncate Liquibase / Flyway changelog tables.
-                             AND tablename != 'databasechangelog'
-                             AND tablename !~ '^.+schema_history$'
-                        ) LOOP
-                            EXECUTE FORMAT('TRUNCATE TABLE %I CASCADE', r.tablename);
-                        END LOOP;
+                        SELECT STRING_AGG(QUOTE_IDENT(tablename), ', ')
+                          INTO table_list
+                          FROM pg_tables
+                         WHERE schemaname = CURRENT_SCHEMA()
+                           AND tablename != 'databasechangelog'
+                           AND tablename !~ '^.+schema_history$';
+                        IF table_list IS NOT NULL THEN
+                            EXECUTE 'TRUNCATE TABLE ' || table_list || ' CASCADE';
+                        END IF;
                     END $$;
                     """);
 

--- a/apiserver/src/test/java/org/dependencytrack/PostgresTestContainer.java
+++ b/apiserver/src/test/java/org/dependencytrack/PostgresTestContainer.java
@@ -23,9 +23,7 @@ import org.dependencytrack.support.liquibase.MigrationExecutor;
 import org.postgresql.ds.PGSimpleDataSource;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
-import java.lang.management.ManagementFactory;
 import java.util.Map;
 
 public class PostgresTestContainer extends PostgreSQLContainer {
@@ -37,7 +35,7 @@ public class PostgresTestContainer extends PostgreSQLContainer {
         withUsername("dtrack");
         withPassword("dtrack");
         withDatabaseName("dtrack");
-        withLabel("owner", "hyades-apiserver-" + /* JVM name */ ManagementFactory.getRuntimeMXBean().getName());
+        withLabel("owner", "hyades-apiserver");
         withUrlParam("reWriteBatchedInserts", "true");
         withTmpFs(Map.of("/var/lib/postgresql/data", "rw"));
 
@@ -48,7 +46,7 @@ public class PostgresTestContainer extends PostgreSQLContainer {
         // NB: Container reuse won't be active unless either:
         //  - The environment variable TESTCONTAINERS_REUSE_ENABLE=true is set
         //  - testcontainers.reuse.enable=true is set in ~/.testcontainers.properties
-        withReuse(System.getenv("CI") != null);
+        withReuse(true);
     }
 
     @Override
@@ -69,12 +67,6 @@ public class PostgresTestContainer extends PostgreSQLContainer {
             new MigrationExecutor(dataSource, "migration/changelog-main.xml").executeMigration();
         } catch (Exception e) {
             throw new RuntimeException("Failed to execute migrations", e);
-        }
-    }
-
-    public void stopWhenNotReusing() {
-        if (!TestcontainersConfiguration.getInstance().environmentSupportsReuse() || !isShouldBeReused()) {
-            stop();
         }
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/ResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/ResourceTest.java
@@ -24,7 +24,6 @@ import alpine.event.framework.SingleThreadedEventService;
 import alpine.model.Permission;
 import alpine.model.Team;
 import alpine.server.auth.PasswordService;
-import alpine.server.persistence.PersistenceManagerFactory;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -32,12 +31,9 @@ import jakarta.json.JsonReader;
 import jakarta.ws.rs.core.Response;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.event.kafka.KafkaProducerInitializer;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.persistence.QueryManager;
-import org.dependencytrack.support.config.source.memory.MemoryConfigSource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +45,7 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 
 import static org.dependencytrack.PersistenceCapableTest.truncateTables;
+
 
 public abstract class ResourceTest {
 
@@ -103,8 +100,6 @@ public abstract class ResourceTest {
     // Hashing is expensive. Do it once and re-use across tests as much as possible.
     protected static final String TEST_USER_PASSWORD_HASH = new String(PasswordService.createHash("testuser".toCharArray()));
 
-    protected static PostgresTestContainer postgresContainer;
-
     protected QueryManager qm;
     protected MockProducer<byte[], byte[]> kafkaMockProducer;
     protected Team team;
@@ -113,20 +108,12 @@ public abstract class ResourceTest {
     @BeforeAll
     public static void init() {
         Config.enableUnitTests();
-
-        postgresContainer = new PostgresTestContainer();
-        postgresContainer.start();
-
-        MemoryConfigSource.setProperty("dt.datasource.url", postgresContainer.getJdbcUrl());
-        MemoryConfigSource.setProperty("dt.datasource.username", postgresContainer.getUsername());
-        MemoryConfigSource.setProperty("dt.datasource.password", postgresContainer.getPassword());
-
-        new PersistenceManagerFactory().contextInitialized(null);
+        TestDatabaseManager.initialize();
     }
 
     @BeforeEach
     public void before() throws Exception {
-        truncateTables(postgresContainer);
+        truncateTables();
 
         // Add a test user and team with API key. Optional if this is used, but its available to all tests.
         this.qm = new QueryManager();
@@ -157,16 +144,6 @@ public abstract class ResourceTest {
 
         qm.close();
         KafkaProducerInitializer.tearDown();
-    }
-
-    @AfterAll
-    public static void tearDownClass() {
-        PersistenceManagerFactory.tearDown();
-        DataSourceRegistry.getInstance().closeAll();
-
-        if (postgresContainer != null) {
-            postgresContainer.stopWhenNotReusing();
-        }
     }
 
     public void initializeWithPermissions(Permissions... permissions) {

--- a/apiserver/src/test/java/org/dependencytrack/TestDatabaseManager.java
+++ b/apiserver/src/test/java/org/dependencytrack/TestDatabaseManager.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack;
+
+import alpine.server.persistence.PersistenceManagerFactory;
+import org.dependencytrack.support.config.source.memory.MemoryConfigSource;
+
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+
+/**
+ * Manages a shared PostgreSQL testcontainer and per-JVM test database.
+ * <p>
+ * The container runs migrations on a template database. Each JVM gets its own
+ * database created via {@code CREATE DATABASE ... TEMPLATE}, providing isolation
+ * without repeating migrations. The PID of the JVM is used as the database name suffix
+ * to guarantee uniqueness.
+ */
+public final class TestDatabaseManager {
+
+    private static final ReentrantLock LOCK = new ReentrantLock();
+    private static boolean initialized;
+
+    private TestDatabaseManager() {
+    }
+
+    public static void initialize() {
+        if (initialized) {
+            return;
+        }
+
+        LOCK.lock();
+        try {
+            if (initialized) {
+                return;
+            }
+
+            // Serialize container startup across JVM instances using a file lock.
+            // Without this, concurrent forks that don't find a reusable container
+            // each create their own, defeating the purpose of testcontainer reuse
+            // and template databases.
+            final var container = new PostgresTestContainer();
+            final long pid = ProcessHandle.current().pid();
+            final String dbName = "dtrack_" + pid;
+
+            final Path lockFile = Path.of(
+                    System.getProperty("java.io.tmpdir"),
+                    "hyades-apiserver-postgres-testcontainer.lock");
+            try (final var channel = FileChannel.open(lockFile, CREATE, WRITE);
+                 final var ignored = channel.lock()) {
+                container.start();
+                dropStaleDatabases(container, pid);
+            } catch (IOException e) {
+                throw new IllegalStateException("Failed to acquire container lock", e);
+            }
+
+            // NB: Must connect to the "postgres" DB to create the test DB.
+            // Cannot connect to "dtrack" because CREATE DATABASE requires
+            // no active connections to the template.
+            try (final Connection connection = DriverManager.getConnection(
+                    container.getJdbcUrl().replace("/dtrack?", "/postgres?"),
+                    container.getUsername(),
+                    container.getPassword());
+                 final Statement statement = connection.createStatement()) {
+                statement.execute("CREATE DATABASE %s TEMPLATE dtrack".formatted(dbName));
+            } catch (SQLException e) {
+                throw new IllegalStateException("Failed to create test database " + dbName, e);
+            }
+
+            MemoryConfigSource.setProperty(
+                    "dt.datasource.url",
+                    container.getJdbcUrl().replace("/dtrack?", "/%s?".formatted(dbName)));
+            MemoryConfigSource.setProperty("dt.datasource.username", container.getUsername());
+            MemoryConfigSource.setProperty("dt.datasource.password", container.getPassword());
+
+            new PersistenceManagerFactory().contextInitialized(null);
+
+            initialized = true;
+        } finally {
+            LOCK.unlock();
+        }
+    }
+
+    private static void dropStaleDatabases(PostgresTestContainer container, long pid) {
+        try (final Connection connection = DriverManager.getConnection(
+                container.getJdbcUrl().replace("/dtrack?", "/postgres?"),
+                container.getUsername(),
+                container.getPassword());
+             final Statement statement = connection.createStatement()) {
+            final var staleDatabases = new ArrayList<String>();
+            try (final ResultSet rs = statement.executeQuery("""
+                    SELECT datname
+                      FROM pg_database
+                     WHERE datname ~ '^dtrack_[0-9]+$'
+                    """)) {
+                while (rs.next()) {
+                    final String existingDb = rs.getString(1);
+                    final String pidStr = existingDb.substring("dtrack_".length());
+                    try {
+                        final long existingPid = Long.parseLong(pidStr);
+                        if (ProcessHandle.of(existingPid).isEmpty() || existingPid == pid) {
+                            staleDatabases.add(existingDb);
+                        }
+                    } catch (NumberFormatException ignored) {
+                    }
+                }
+            }
+
+            for (final String db : staleDatabases) {
+                statement.execute("DROP DATABASE IF EXISTS %s WITH (FORCE)".formatted(db));
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to drop stale databases", e);
+        }
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/analysis/AnalyzeProjectWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/analysis/AnalyzeProjectWorkflowTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.analysis;
 
 import io.github.resilience4j.core.IntervalFunction;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.dex.api.ActivityContext;
 import org.dependencytrack.dex.api.WorkflowContext;
 import org.dependencytrack.dex.api.failure.TerminalApplicationFailureException;
@@ -58,7 +59,7 @@ class AnalyzeProjectWorkflowTest extends PersistenceCapableTest {
 
     @RegisterExtension
     private final WorkflowTestExtension workflowTest
-            = new WorkflowTestExtension(postgresContainer);
+            = new WorkflowTestExtension(DataSourceRegistry.getInstance().getDefault());
 
     private VulnAnalysisWorkflow vulnAnalysisWorkflowMock;
     private EvalProjectPoliciesActivity evalProjectPoliciesActivityMock;

--- a/apiserver/src/test/java/org/dependencytrack/csaf/DiscoverCsafProvidersWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/csaf/DiscoverCsafProvidersWorkflowTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.csaf;
 
 import io.github.resilience4j.core.IntervalFunction;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.common.pagination.PageIterator;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.TaskType;
@@ -53,7 +54,7 @@ class DiscoverCsafProvidersWorkflowTest extends PersistenceCapableTest {
 
     @RegisterExtension
     private final WorkflowTestExtension workflowTest =
-            new WorkflowTestExtension(postgresContainer);
+            new WorkflowTestExtension(DataSourceRegistry.getInstance().getDefault());
 
     private CsafClient csafClientMock;
     private Handle jdbiHandle;

--- a/apiserver/src/test/java/org/dependencytrack/csaf/ImportCsafDocumentsWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/csaf/ImportCsafDocumentsWorkflowTest.java
@@ -23,6 +23,7 @@ import io.csaf.schema.generated.Csaf;
 import io.github.resilience4j.core.IntervalFunction;
 import kotlinx.serialization.json.Json;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.TaskType;
@@ -63,7 +64,7 @@ class ImportCsafDocumentsWorkflowTest extends PersistenceCapableTest {
 
     @RegisterExtension
     private final WorkflowTestExtension workflowTest =
-            new WorkflowTestExtension(postgresContainer);
+            new WorkflowTestExtension(DataSourceRegistry.getInstance().getDefault());
 
     private CsafClient csafClientMock;
     private Handle jdbiHandle;

--- a/apiserver/src/test/java/org/dependencytrack/init/InitTaskExecutorTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/init/InitTaskExecutorTest.java
@@ -18,14 +18,13 @@
  */
 package org.dependencytrack.init;
 
-import alpine.test.config.ConfigPropertyExtension;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.postgresql.ds.PGSimpleDataSource;
 
+import javax.sql.DataSource;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,23 +33,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class InitTaskExecutorTest extends PersistenceCapableTest {
 
-    @RegisterExtension
-    private static final ConfigPropertyExtension configProperties = new ConfigPropertyExtension();
-
-    private PGSimpleDataSource dataSource;
+    private DataSource dataSource;
 
     @BeforeEach
     public void before() throws Exception {
         super.before();
 
-        dataSource = new PGSimpleDataSource();
-        dataSource.setUrl(postgresContainer.getJdbcUrl());
-        dataSource.setUser(postgresContainer.getUsername());
-        dataSource.setPassword(postgresContainer.getPassword());
-
-        configProperties.setProperty("testcontainers.postgres.jdbc-url",  dataSource.getUrl());
-        configProperties.setProperty("testcontainers.postgres.username", dataSource.getUser());
-        configProperties.setProperty("testcontainers.postgres.password", dataSource.getPassword());
+        dataSource = DataSourceRegistry.getInstance().getDefault();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/notification/PublishNotificationWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/PublishNotificationWorkflowTest.java
@@ -22,6 +22,7 @@ import io.github.resilience4j.core.IntervalFunction;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.dex.activity.DeleteFilesActivity;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.TaskType;
@@ -66,7 +67,7 @@ class PublishNotificationWorkflowTest extends PersistenceCapableTest {
 
     @RegisterExtension
     private final WorkflowTestExtension workflowTest =
-            new WorkflowTestExtension(postgresContainer);
+            new WorkflowTestExtension(DataSourceRegistry.getInstance().getDefault());
 
     private PluginManager pluginManager;
     private FileStorage fileStorage;

--- a/apiserver/src/test/java/org/dependencytrack/persistence/DatabaseSeedingInitTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/DatabaseSeedingInitTaskTest.java
@@ -24,6 +24,7 @@ import alpine.model.Permission;
 import alpine.model.Team;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.init.InitTaskContext;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.DefaultRepository;
@@ -34,24 +35,21 @@ import org.dependencytrack.model.Role;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.postgresql.ds.PGSimpleDataSource;
 
+import javax.sql.DataSource;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DatabaseSeedingInitTaskTest extends PersistenceCapableTest {
 
-    private PGSimpleDataSource dataSource;
+    private DataSource dataSource;
 
     @BeforeEach
     public void before() throws Exception {
         super.before();
 
-        dataSource = new PGSimpleDataSource();
-        dataSource.setUrl(postgresContainer.getJdbcUrl());
-        dataSource.setUser(postgresContainer.getUsername());
-        dataSource.setPassword(postgresContainer.getPassword());
+        dataSource = DataSourceRegistry.getInstance().getDefault();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/QueryTimingSqlLoggerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/QueryTimingSqlLoggerTest.java
@@ -23,13 +23,15 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.search.MeterNotFoundException;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.JdbiException;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.postgresql.ds.PGSimpleDataSource;
+
+import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -46,16 +48,13 @@ public class QueryTimingSqlLoggerTest extends PersistenceCapableTest {
 
     }
 
-    private PGSimpleDataSource dataSource;
+    private DataSource dataSource;
 
     @BeforeEach
     public void before() throws Exception {
         super.before();
 
-        dataSource = new PGSimpleDataSource();
-        dataSource.setUrl(postgresContainer.getJdbcUrl());
-        dataSource.setUser(postgresContainer.getUsername());
-        dataSource.setPassword(postgresContainer.getPassword());
+        dataSource = DataSourceRegistry.getInstance().getDefault();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/ImportBomWorkflowTest.java
@@ -20,6 +20,7 @@ package org.dependencytrack.tasks;
 
 import io.github.resilience4j.core.IntervalFunction;
 import org.dependencytrack.PersistenceCapableTest;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.dex.activity.DeleteFilesActivity;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.TaskType;
@@ -72,7 +73,7 @@ class ImportBomWorkflowTest extends PersistenceCapableTest {
 
     @RegisterExtension
     private final WorkflowTestExtension workflowTest
-            = new WorkflowTestExtension(postgresContainer);
+            = new WorkflowTestExtension(DataSourceRegistry.getInstance().getDefault());
 
     private FileStorage fileStorage;
 

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
@@ -26,6 +26,7 @@ import org.cyclonedx.proto.v1_6.VulnerabilityAffects;
 import org.cyclonedx.proto.v1_6.VulnerabilityReference;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.dex.activity.DeleteFilesActivity;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.TaskType;
@@ -103,7 +104,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
 
     @RegisterExtension
     private final WorkflowTestExtension workflowTest
-            = new WorkflowTestExtension(postgresContainer);
+            = new WorkflowTestExtension(DataSourceRegistry.getInstance().getDefault());
 
     private FileStorage fileStorage;
     private PluginManager pluginManager;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enables PG testcontainer reuse across JVMs, and DataNucleus PMF reuse across classes

Previously, each JVM fork spawned by the Maven Surefire plugin would launch its own Postgres testcontainer. This was necessary to provide isolation between tests.

While testcontainers were reused by each fork, the DataNucleus PersistenceManagerFactory was only reused within on a per-class basis, causing lots of redundant initialization work across all test classes.

Now, we reuse a single testcontainer across all JVM forks. To still provide isolation, we create a logical database for each fork. Database migrations only execute once. After migration, the migrated database is used as template (https://www.postgresql.org/docs/current/manage-ag-templatedbs.html). This procedure is inspired by https://dev.to/andrei-polukhin/pgdbtemplate-fast-postgresql-test-databases-in-go-using-templates-138n.

In addition, we also initialize the PMF once, after the fork database was created.

All this allows us to crank up test concurrency in CI to one per CPU core, hopefully leading to a much quicker test suite execution.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
