### PR TITLE
Support reuse of dev containers

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/dev/DevServices.java
+++ b/apiserver/src/main/java/org/dependencytrack/dev/DevServices.java
@@ -43,6 +43,7 @@ public class DevServices implements AutoCloseable {
     private final Config config = ConfigProvider.getConfig();
     private AutoCloseable postgresContainer;
     private AutoCloseable frontendContainer;
+    private boolean isContainerReuseEnabled;
 
     public void start() {
         if (!config.getValue("dt.dev.services.enabled", boolean.class)) {
@@ -56,6 +57,8 @@ public class DevServices implements AutoCloseable {
         } catch (ClassNotFoundException e) {
             throw new IllegalStateException("Dev services are not available for production builds");
         }
+
+        isContainerReuseEnabled = config.getValue("dev.services.container-reuse-enabled", boolean.class);
 
         // Infer database port and name from the JDBC URL of the primary data source.
         final URI defaultDataSourceUri = URI.create(
@@ -86,12 +89,16 @@ public class DevServices implements AutoCloseable {
             postgresContainerClass.getMethod("withPassword", String.class).invoke(postgresContainer, postgresPassword);
             postgresContainerClass.getMethod("withDatabaseName", String.class).invoke(postgresContainer, postgresDatabase);
             postgresContainerClass.getMethod("withUrlParam", String.class, String.class).invoke(postgresContainer, "reWriteBatchedInserts", "true");
+            postgresContainerClass.getMethod("withLabel", String.class, String.class).invoke(postgresContainer, "owner", "hyades-apiserver-dev");
+            postgresContainerClass.getMethod("withReuse",  boolean.class).invoke(postgresContainer, isContainerReuseEnabled);
             addFixedExposedPortMethod.invoke(postgresContainer, /* hostPort */ postgresPort, /* containerPort */  5432);
 
             final Constructor<?> genericContainerConstructor = genericContainerClass.getDeclaredConstructor(String.class);
             frontendContainer = (AutoCloseable) genericContainerConstructor.newInstance(config.getValue(DEV_SERVICES_IMAGE_FRONTEND.getPropertyName(), String.class));
             genericContainerClass.getMethod("withEnv", String.class, String.class).invoke(frontendContainer, "API_BASE_URL", "http://localhost:8080");
             genericContainerClass.getMethod("withExposedPorts", Integer[].class).invoke(frontendContainer, (Object) new Integer[]{8080});
+            genericContainerClass.getMethod("withLabel", String.class, String.class).invoke(frontendContainer, "owner", "hyades-apiserver-dev");
+            genericContainerClass.getMethod("withReuse",  boolean.class).invoke(frontendContainer, isContainerReuseEnabled);
             addFixedExposedPortMethod.invoke(frontendContainer, /* hostPort */ frontendPort, /* containerPort */ 8080);
             if (config.getValue(DEV_SERVICES_IMAGE_FRONTEND.getPropertyName(), String.class).endsWith(":snapshot")) {
                 genericContainerClass.getMethod("withImagePullPolicy", imagePullPolicyClass).invoke(frontendContainer, alwaysPullPolicy);
@@ -110,7 +117,7 @@ public class DevServices implements AutoCloseable {
 
     @Override
     public void close() {
-        if (postgresContainer != null) {
+        if (postgresContainer != null && !isContainerReuseEnabled) {
             LOGGER.info("Stopping postgres container");
             try {
                 postgresContainer.close();
@@ -118,7 +125,7 @@ public class DevServices implements AutoCloseable {
                 LOGGER.error("Failed to stop PostgreSQL container", e);
             }
         }
-        if (frontendContainer != null) {
+        if (frontendContainer != null && !isContainerReuseEnabled) {
             LOGGER.info("Stopping frontend container");
             try {
                 frontendContainer.close();

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1194,6 +1194,14 @@ dt.init.and.exit=false
 # @type:     boolean
 dt.dev.services.enabled=false
 
+# Defines whether dev services containers should be reused.
+# <br/><br/>
+# Refer to <https://java.testcontainers.org/features/reuse/> for details.
+#
+# @category: Development
+# @type:     boolean
+dev.services.container-reuse-enabled=true
+
 # The image to use for the frontend dev services container.
 #
 # @category: Development


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports reuse of dev containers.

Allows database state to be reused across restarts, and more generally makes startup faster.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
