### PR TITLE
Port VulnDB analyzer

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -141,6 +141,11 @@
             <artifactId>vuln-analyzer-snyk</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analyzer-vuln-db</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.dependencytrack</groupId>

--- a/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/plugin/PluginInitializerTest.java
@@ -29,6 +29,7 @@ import org.dependencytrack.secret.management.SecretManager;
 import org.dependencytrack.vulnanalysis.internal.InternalVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.ossindex.OssIndexVulnAnalyzerPlugin;
 import org.dependencytrack.vulnanalysis.snyk.SnykVulnAnalyzerPlugin;
+import org.dependencytrack.vulnanalysis.vulndb.VulnDbVulnAnalyzerPlugin;
 import org.dependencytrack.vulndatasource.github.GitHubVulnDataSourcePlugin;
 import org.dependencytrack.vulndatasource.nvd.NvdVulnDataSourcePlugin;
 import org.dependencytrack.vulndatasource.osv.OsvVulnDataSourcePlugin;
@@ -96,7 +97,8 @@ class PluginInitializerTest extends PersistenceCapableTest {
                 plugin -> assertThat(plugin).isInstanceOf(NvdVulnDataSourcePlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(OssIndexVulnAnalyzerPlugin.class),
                 plugin -> assertThat(plugin).isInstanceOf(OsvVulnDataSourcePlugin.class),
-                plugin -> assertThat(plugin).isInstanceOf(SnykVulnAnalyzerPlugin.class));
+                plugin -> assertThat(plugin).isInstanceOf(SnykVulnAnalyzerPlugin.class),
+                plugin -> assertThat(plugin).isInstanceOf(VulnDbVulnAnalyzerPlugin.class));
 
         initializer.contextDestroyed(new ServletContextEvent(servletContextMock));
 

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -220,6 +220,12 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analyzer-vuln-db</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.dependencytrack</groupId>

--- a/vuln-analysis/pom.xml
+++ b/vuln-analysis/pom.xml
@@ -37,6 +37,7 @@
         <module>internal</module>
         <module>oss-index</module>
         <module>snyk</module>
+        <module>vuln-db</module>
     </modules>
 
     <properties>

--- a/vuln-analysis/vuln-db/pom.xml
+++ b/vuln-analysis/vuln-db/pom.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>vuln-analysis-parent</artifactId>
+        <version>5.7.0-alpha.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>vuln-analyzer-vuln-db</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Vulnerability Analysis :: Analyzer :: VulnDB</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>cache-provider-memory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>plugin-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analysis-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>us.springett</groupId>
+            <artifactId>cvss-calculator</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.javacrumbs.json-unit</groupId>
+            <artifactId>json-unit-assertj</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jsonschema2pojo</groupId>
+                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/resources/org/dependencytrack/vulnanalysis/vulndb</sourceDirectory>
+                    <targetPackage>org.dependencytrack.vulnanalysis.vulndb</targetPackage>
+                    <generateBuilders>true</generateBuilders>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbAccessTokenManager.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbAccessTokenManager.java
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.Nullable;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * @since 5.7.0
+ */
+final class VulnDbAccessTokenManager {
+
+    private static final Duration EXPIRY_BUFFER = Duration.ofSeconds(30);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    private @Nullable String accessToken;
+    private @Nullable Instant expiresAt;
+    private @Nullable String clientId;
+    private @Nullable String clientSecret;
+    private @Nullable URI tokenEndpoint;
+
+    VulnDbAccessTokenManager(HttpClient httpClient, ObjectMapper objectMapper) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+    }
+
+    String getAccessToken(
+            URI apiBaseUrl,
+            String clientId,
+            String clientSecret) throws IOException, InterruptedException {
+        final URI tokenEndpoint = apiBaseUrl.resolve("/oauth/token");
+
+        lock.lockInterruptibly();
+        try {
+            if (accessToken != null
+                    && expiresAt != null
+                    && Instant.now().isBefore(expiresAt)
+                    && Objects.equals(tokenEndpoint, this.tokenEndpoint)
+                    && Objects.equals(clientId, this.clientId)
+                    && Objects.equals(clientSecret, this.clientSecret)) {
+                return accessToken;
+            }
+
+            final var request = HttpRequest.newBuilder()
+                    .uri(tokenEndpoint)
+                    .header("Content-Type", "application/json")
+                    .header("Accept", "application/json")
+                    .timeout(Duration.ofSeconds(5))
+                    .POST(HttpRequest.BodyPublishers.ofString(
+                            objectMapper.writeValueAsString(new TokenRequest(clientId, clientSecret))))
+                    .build();
+
+            final HttpResponse<byte[]> response = httpClient.send(request, HttpResponse.BodyHandlers.ofByteArray());
+            if (response.statusCode() != 200) {
+                throw new IOException("OAuth2 token request failed with status " + response.statusCode());
+            }
+
+            final var tokenResponse = objectMapper.readValue(response.body(), TokenResponse.class);
+            accessToken = tokenResponse.accessToken();
+            expiresAt = Instant.now().plusSeconds(tokenResponse.expiresIn()).minus(EXPIRY_BUFFER);
+            this.tokenEndpoint = tokenEndpoint;
+            this.clientId = clientId;
+            this.clientSecret = clientSecret;
+
+            return accessToken;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private record TokenRequest(
+            @JsonProperty("client_id") String clientId,
+            @JsonProperty("client_secret") String clientSecret,
+            @JsonProperty("grant_type") String grantType) {
+
+        TokenRequest(String clientId, String clientSecret) {
+            this(clientId, clientSecret, "client_credentials");
+        }
+
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private record TokenResponse(
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("expires_in") long expiresIn) {
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbApiClient.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbApiClient.java
@@ -1,0 +1,118 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.PaginatedResponse;
+import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.Vulnerability;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @since 5.7.0
+ */
+final class VulnDbApiClient {
+
+    private static final int PAGE_SIZE = 100;
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final VulnDbAccessTokenManager tokenManager;
+    private final String clientId;
+    private final String clientSecret;
+    private final URI apiBaseUrl;
+
+    VulnDbApiClient(
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            VulnDbAccessTokenManager tokenManager,
+            String clientId,
+            String clientSecret,
+            URI apiBaseUrl) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.tokenManager = tokenManager;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.apiBaseUrl = apiBaseUrl;
+    }
+
+    List<Vulnerability> getVulnerabilitiesByCpe(String cpe) throws IOException, InterruptedException {
+        final var allVulnerabilities = new ArrayList<Vulnerability>();
+        int page = 1;
+
+        while (true) {
+            final var uri = URI.create(
+                    apiBaseUrl + "/api/v1/vulnerabilities/find_by_cpe"
+                            + "?cpe=" + URLEncoder.encode(cpe, StandardCharsets.UTF_8)
+                            + "&size=" + PAGE_SIZE
+                            + "&page=" + page);
+
+            final String accessToken = tokenManager.getAccessToken(apiBaseUrl, clientId, clientSecret);
+
+            final var request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .header("Accept", "application/json")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .timeout(Duration.ofSeconds(10))
+                    .GET()
+                    .build();
+
+            final HttpResponse<InputStream> response = httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            try (final InputStream body = response.body()) {
+                if (response.statusCode() == 200) {
+                    final var paginatedResponse = objectMapper.readValue(body, PaginatedResponse.class);
+                    if (paginatedResponse.results() != null) {
+                        allVulnerabilities.addAll(paginatedResponse.results());
+                    }
+
+                    final int totalEntries = paginatedResponse.totalEntries();
+                    if (page * PAGE_SIZE >= totalEntries) {
+                        break;
+                    }
+
+                    page++;
+                    continue;
+                }
+
+                body.transferTo(OutputStream.nullOutputStream());
+
+                if (response.statusCode() == 404) {
+                    return List.of();
+                }
+                throw new IOException("VulnDB API request failed with status " + response.statusCode());
+            }
+        }
+
+        return allVulnerabilities;
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbApiResponse.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbApiResponse.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * @since 5.7.0
+ */
+final class VulnDbApiResponse {
+
+    private VulnDbApiResponse() {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record PaginatedResponse(
+            @JsonProperty("current_page") int currentPage,
+            @JsonProperty("total_entries") int totalEntries,
+            List<Vulnerability> results) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Vulnerability(
+            @JsonProperty("vulndb_id") int vulndbId,
+            @Nullable String title,
+            @JsonProperty("disclosure_date") @Nullable String disclosureDate,
+            @Nullable String description,
+            @Nullable String solution,
+            @JsonProperty("vulndb_last_modified") @Nullable String lastModified,
+            @JsonProperty("manual_notes") @Nullable String manualNotes,
+            @JsonProperty("t_description") @Nullable String technicalDescription,
+            @Nullable List<Author> authors,
+            @JsonProperty("ext_references") @Nullable List<ExternalReference> extReferences,
+            @JsonProperty("cvss_metrics") @Nullable List<CvssV2Metric> cvssV2Metrics,
+            @JsonProperty("cvss_version_three_metrics") @Nullable List<CvssV3Metric> cvssV3Metrics,
+            @JsonProperty("nvd_additional_information") @Nullable List<NvdAdditionalInfo> nvdAdditionalInfo) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Author(
+            @Nullable String name,
+            @Nullable String company) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record ExternalReference(
+            @Nullable String type,
+            @Nullable String value) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record CvssV2Metric(
+            @JsonProperty("access_vector") @Nullable String accessVector,
+            @JsonProperty("access_complexity") @Nullable String accessComplexity,
+            @Nullable String authentication,
+            @JsonProperty("confidentiality_impact") @Nullable String confidentialityImpact,
+            @JsonProperty("integrity_impact") @Nullable String integrityImpact,
+            @JsonProperty("availability_impact") @Nullable String availabilityImpact,
+            @JsonProperty("calculated_cvss_base_score") double calculatedCvssBaseScore,
+            @JsonProperty("cve_id") @Nullable String cveId,
+            @Nullable String source) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record CvssV3Metric(
+            @JsonProperty("attack_vector") @Nullable String attackVector,
+            @JsonProperty("attack_complexity") @Nullable String attackComplexity,
+            @JsonProperty("privileges_required") @Nullable String privilegesRequired,
+            @JsonProperty("user_interaction") @Nullable String userInteraction,
+            @Nullable String scope,
+            @JsonProperty("confidentiality_impact") @Nullable String confidentialityImpact,
+            @JsonProperty("integrity_impact") @Nullable String integrityImpact,
+            @JsonProperty("availability_impact") @Nullable String availabilityImpact,
+            @JsonProperty("calculated_cvss_base_score") double calculatedCvssBaseScore,
+            @JsonProperty("cve_id") @Nullable String cveId,
+            @Nullable String source) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record NvdAdditionalInfo(
+            @Nullable String summary,
+            @JsonProperty("cwe_id") @Nullable String cweId,
+            @JsonProperty("cve_id") @Nullable String cveId) {
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbModelConverter.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbModelConverter.java
@@ -1,0 +1,401 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import org.cyclonedx.proto.v1_6.Advisory;
+import org.cyclonedx.proto.v1_6.Property;
+import org.cyclonedx.proto.v1_6.Source;
+import org.cyclonedx.proto.v1_6.Vulnerability;
+import org.cyclonedx.proto.v1_6.VulnerabilityRating;
+import org.cyclonedx.proto.v1_6.VulnerabilityReference;
+import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.CvssV2Metric;
+import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.CvssV3Metric;
+import org.dependencytrack.vulnanalysis.vulndb.VulnDbApiResponse.NvdAdditionalInfo;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import us.springett.cvss.CvssV2;
+import us.springett.cvss.CvssV3;
+import us.springett.cvss.Score;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.cyclonedx.proto.v1_6.ScoreMethod.SCORE_METHOD_CVSSV2;
+import static org.cyclonedx.proto.v1_6.ScoreMethod.SCORE_METHOD_CVSSV3;
+
+/**
+ * @since 5.7.0
+ */
+final class VulnDbModelConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VulnDbModelConverter.class);
+    private static final Pattern CWE_PATTERN = Pattern.compile("CWE-(\\d+)", Pattern.CASE_INSENSITIVE);
+    private static final Source SOURCE_NVD = Source.newBuilder().setName("NVD").build();
+    private static final Source SOURCE_VULNDB = Source.newBuilder().setName("VULNDB").build();
+
+    private VulnDbModelConverter() {
+    }
+
+    static Vulnerability.Builder convert(
+            VulnDbApiResponse.Vulnerability vuln,
+            boolean includeAliases) {
+        final var vulnBuilder = Vulnerability.newBuilder()
+                .setId(String.valueOf(vuln.vulndbId()))
+                .setSource(SOURCE_VULNDB);
+
+        final String description = buildDescription(vuln);
+        if (description != null) {
+            vulnBuilder.setDescription(description);
+        }
+
+        if (vuln.title() != null) {
+            vulnBuilder.addProperties(
+                    Property.newBuilder()
+                            .setName("dependency-track:vuln:title")
+                            .setValue(vuln.title())
+                            .build());
+        }
+
+        if (vuln.authors() != null && !vuln.authors().isEmpty()) {
+            final var credits = new StringBuilder();
+            for (final var author : vuln.authors()) {
+                if (author.name() != null) {
+                    if (!credits.isEmpty()) {
+                        credits.append(", ");
+                    }
+                    credits.append(author.name());
+                }
+            }
+            if (!credits.isEmpty()) {
+                vulnBuilder.addProperties(
+                        Property.newBuilder()
+                                .setName("dependency-track:vuln:credits")
+                                .setValue(credits.toString())
+                                .build());
+            }
+        }
+
+        if (vuln.extReferences() != null) {
+            for (final var extRef : vuln.extReferences()) {
+                if (extRef.value() != null && !extRef.value().isBlank()) {
+                    vulnBuilder.addAdvisories(
+                            Advisory.newBuilder()
+                                    .setUrl(extRef.value())
+                                    .build());
+                }
+            }
+        }
+
+        // Prefer NVD-sourced metrics (those with a cve_id) over VulnDB's own.
+        addCvssV2Rating(vulnBuilder, vuln.cvssV2Metrics());
+        addCvssV3Rating(vulnBuilder, vuln.cvssV3Metrics());
+
+        // Extract CVE aliases and CWEs from NVD additional info and CVSS metrics.
+        final var cveIds = new HashSet<String>();
+        extractCveIds(cveIds, vuln.cvssV2Metrics(), CvssV2Metric::cveId);
+        extractCveIds(cveIds, vuln.cvssV3Metrics(), CvssV3Metric::cveId);
+        extractCveIds(cveIds, vuln.nvdAdditionalInfo(), NvdAdditionalInfo::cveId);
+
+        if (includeAliases) {
+            for (final String cveId : cveIds) {
+                vulnBuilder.addReferences(
+                        VulnerabilityReference.newBuilder()
+                                .setId(cveId)
+                                .setSource(SOURCE_NVD)
+                                .build());
+            }
+        }
+
+        extractCwes(vulnBuilder, vuln.nvdAdditionalInfo());
+
+        return vulnBuilder;
+    }
+
+    private static @Nullable String buildDescription(VulnDbApiResponse.Vulnerability vuln) {
+        final var sb = new StringBuilder();
+        appendIfPresent(sb, vuln.description());
+        appendIfPresent(sb, vuln.technicalDescription());
+        appendIfPresent(sb, vuln.solution());
+        appendIfPresent(sb, vuln.manualNotes());
+        return sb.isEmpty() ? null : sb.toString();
+    }
+
+    private static void appendIfPresent(StringBuilder sb, @Nullable String value) {
+        if (value != null && !value.isBlank()) {
+            if (!sb.isEmpty()) {
+                sb.append("\n\n");
+            }
+            sb.append(value.strip());
+        }
+    }
+
+    private static void addCvssV2Rating(
+            Vulnerability.Builder vulnBuilder,
+            @Nullable List<CvssV2Metric> metrics) {
+        if (metrics == null || metrics.isEmpty()) {
+            return;
+        }
+
+        // Prefer NVD-sourced metric (has cveId).
+        CvssV2Metric preferred = null;
+        for (final var metric : metrics) {
+            if (metric.cveId() != null && !metric.cveId().isBlank()) {
+                preferred = metric;
+                break;
+            }
+        }
+        if (preferred == null) {
+            preferred = metrics.getFirst();
+        }
+
+        final CvssV2 cvss = buildCvssV2(preferred);
+        if (cvss == null) {
+            return;
+        }
+
+        final Score score = cvss.calculateScore();
+        vulnBuilder.addRatings(
+                VulnerabilityRating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV2)
+                        .setVector(cvss.getVector())
+                        .setScore(score.getBaseScore())
+                        .setSource(SOURCE_VULNDB)
+                        .build());
+    }
+
+    private static void addCvssV3Rating(
+            Vulnerability.Builder vulnBuilder,
+            @Nullable List<CvssV3Metric> metrics) {
+        if (metrics == null || metrics.isEmpty()) {
+            return;
+        }
+
+        CvssV3Metric preferred = null;
+        for (final var metric : metrics) {
+            if (metric.cveId() != null && !metric.cveId().isBlank()) {
+                preferred = metric;
+                break;
+            }
+        }
+        if (preferred == null) {
+            preferred = metrics.getFirst();
+        }
+
+        final CvssV3 cvss = buildCvssV3(preferred);
+        if (cvss == null) {
+            return;
+        }
+
+        final Score score = cvss.calculateScore();
+        vulnBuilder.addRatings(
+                VulnerabilityRating.newBuilder()
+                        .setMethod(SCORE_METHOD_CVSSV3)
+                        .setVector(cvss.getVector())
+                        .setScore(score.getBaseScore())
+                        .setSource(SOURCE_VULNDB)
+                        .build());
+    }
+
+    private static @Nullable CvssV2 buildCvssV2(CvssV2Metric metric) {
+        try {
+            final var cvss = new CvssV2();
+            if (metric.accessVector() != null) {
+                cvss.attackVector(mapCvssV2AttackVector(metric.accessVector()));
+            }
+            if (metric.accessComplexity() != null) {
+                cvss.attackComplexity(mapCvssV2AttackComplexity(metric.accessComplexity()));
+            }
+            if (metric.authentication() != null) {
+                cvss.authentication(mapCvssV2Authentication(metric.authentication()));
+            }
+            if (metric.confidentialityImpact() != null) {
+                cvss.confidentiality(mapCvssV2Cia(metric.confidentialityImpact()));
+            }
+            if (metric.integrityImpact() != null) {
+                cvss.integrity(mapCvssV2Cia(metric.integrityImpact()));
+            }
+            if (metric.availabilityImpact() != null) {
+                cvss.availability(mapCvssV2Cia(metric.availabilityImpact()));
+            }
+            return cvss;
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Failed to construct CVSS v2 vector from metric fields", e);
+            return null;
+        }
+    }
+
+    private static @Nullable CvssV3 buildCvssV3(CvssV3Metric metric) {
+        try {
+            final var cvss = new CvssV3();
+            if (metric.attackVector() != null) {
+                cvss.attackVector(mapCvssV3AttackVector(metric.attackVector()));
+            }
+            if (metric.attackComplexity() != null) {
+                cvss.attackComplexity(mapCvssV3AttackComplexity(metric.attackComplexity()));
+            }
+            if (metric.privilegesRequired() != null) {
+                cvss.privilegesRequired(mapCvssV3PrivilegesRequired(metric.privilegesRequired()));
+            }
+            if (metric.userInteraction() != null) {
+                cvss.userInteraction(mapCvssV3UserInteraction(metric.userInteraction()));
+            }
+            if (metric.scope() != null) {
+                cvss.scope(mapCvssV3Scope(metric.scope()));
+            }
+            if (metric.confidentialityImpact() != null) {
+                cvss.confidentiality(mapCvssV3Cia(metric.confidentialityImpact()));
+            }
+            if (metric.integrityImpact() != null) {
+                cvss.integrity(mapCvssV3Cia(metric.integrityImpact()));
+            }
+            if (metric.availabilityImpact() != null) {
+                cvss.availability(mapCvssV3Cia(metric.availabilityImpact()));
+            }
+            return cvss;
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Failed to construct CVSS v3 vector from metric fields", e);
+            return null;
+        }
+    }
+
+    private static CvssV2.AttackVector mapCvssV2AttackVector(String value) {
+        return switch (value.toUpperCase()) {
+            case "NETWORK" -> CvssV2.AttackVector.NETWORK;
+            case "ADJACENT", "ADJACENT_NETWORK" -> CvssV2.AttackVector.ADJACENT;
+            case "LOCAL" -> CvssV2.AttackVector.LOCAL;
+            default -> throw new IllegalArgumentException("Unknown CVSS v2 access vector: " + value);
+        };
+    }
+
+    private static CvssV2.AttackComplexity mapCvssV2AttackComplexity(String value) {
+        return switch (value.toUpperCase()) {
+            case "LOW" -> CvssV2.AttackComplexity.LOW;
+            case "MEDIUM" -> CvssV2.AttackComplexity.MEDIUM;
+            case "HIGH" -> CvssV2.AttackComplexity.HIGH;
+            default -> throw new IllegalArgumentException("Unknown CVSS v2 access complexity: " + value);
+        };
+    }
+
+    private static CvssV2.Authentication mapCvssV2Authentication(String value) {
+        return switch (value.toUpperCase()) {
+            case "NONE" -> CvssV2.Authentication.NONE;
+            case "SINGLE", "SINGLE_INSTANCE" -> CvssV2.Authentication.SINGLE;
+            case "MULTIPLE", "MULTIPLE_INSTANCES" -> CvssV2.Authentication.MULTIPLE;
+            default -> throw new IllegalArgumentException("Unknown CVSS v2 authentication: " + value);
+        };
+    }
+
+    private static CvssV2.CIA mapCvssV2Cia(String value) {
+        return switch (value.toUpperCase()) {
+            case "NONE" -> CvssV2.CIA.NONE;
+            case "PARTIAL" -> CvssV2.CIA.PARTIAL;
+            case "COMPLETE" -> CvssV2.CIA.COMPLETE;
+            default -> throw new IllegalArgumentException("Unknown CVSS v2 CIA: " + value);
+        };
+    }
+
+    private static CvssV3.AttackVector mapCvssV3AttackVector(String value) {
+        return switch (value.toUpperCase()) {
+            case "NETWORK" -> CvssV3.AttackVector.NETWORK;
+            case "ADJACENT", "ADJACENT_NETWORK" -> CvssV3.AttackVector.ADJACENT;
+            case "LOCAL" -> CvssV3.AttackVector.LOCAL;
+            case "PHYSICAL" -> CvssV3.AttackVector.PHYSICAL;
+            default -> throw new IllegalArgumentException("Unknown CVSS v3 attack vector: " + value);
+        };
+    }
+
+    private static CvssV3.AttackComplexity mapCvssV3AttackComplexity(String value) {
+        return switch (value.toUpperCase()) {
+            case "LOW" -> CvssV3.AttackComplexity.LOW;
+            case "HIGH" -> CvssV3.AttackComplexity.HIGH;
+            default -> throw new IllegalArgumentException("Unknown CVSS v3 attack complexity: " + value);
+        };
+    }
+
+    private static CvssV3.PrivilegesRequired mapCvssV3PrivilegesRequired(String value) {
+        return switch (value.toUpperCase()) {
+            case "NONE" -> CvssV3.PrivilegesRequired.NONE;
+            case "LOW" -> CvssV3.PrivilegesRequired.LOW;
+            case "HIGH" -> CvssV3.PrivilegesRequired.HIGH;
+            default -> throw new IllegalArgumentException("Unknown CVSS v3 privileges required: " + value);
+        };
+    }
+
+    private static CvssV3.UserInteraction mapCvssV3UserInteraction(String value) {
+        return switch (value.toUpperCase()) {
+            case "NONE" -> CvssV3.UserInteraction.NONE;
+            case "REQUIRED" -> CvssV3.UserInteraction.REQUIRED;
+            default -> throw new IllegalArgumentException("Unknown CVSS v3 user interaction: " + value);
+        };
+    }
+
+    private static CvssV3.Scope mapCvssV3Scope(String value) {
+        return switch (value.toUpperCase()) {
+            case "UNCHANGED" -> CvssV3.Scope.UNCHANGED;
+            case "CHANGED" -> CvssV3.Scope.CHANGED;
+            default -> throw new IllegalArgumentException("Unknown CVSS v3 scope: " + value);
+        };
+    }
+
+    private static CvssV3.CIA mapCvssV3Cia(String value) {
+        return switch (value.toUpperCase()) {
+            case "NONE" -> CvssV3.CIA.NONE;
+            case "LOW" -> CvssV3.CIA.LOW;
+            case "HIGH" -> CvssV3.CIA.HIGH;
+            default -> throw new IllegalArgumentException("Unknown CVSS v3 CIA: " + value);
+        };
+    }
+
+    private static <T> void extractCveIds(
+            HashSet<String> cveIds,
+            @Nullable List<T> items,
+            Function<T, @Nullable String> cveIdExtractor) {
+        if (items == null) {
+            return;
+        }
+
+        for (final var item : items) {
+            final String cveId = cveIdExtractor.apply(item);
+            if (cveId != null && !cveId.isBlank()) {
+                cveIds.add(cveId);
+            }
+        }
+    }
+
+    private static void extractCwes(Vulnerability.Builder vulnBuilder, @Nullable List<NvdAdditionalInfo> nvdInfos) {
+        if (nvdInfos == null) {
+            return;
+        }
+
+        for (final var info : nvdInfos) {
+            if (info.cweId() == null) {
+                continue;
+            }
+            final Matcher matcher = CWE_PATTERN.matcher(info.cweId());
+            if (matcher.find()) {
+                vulnBuilder.addCwes(Integer.parseInt(matcher.group(1)));
+            }
+        }
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzer.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzer.java
@@ -1,0 +1,226 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.cyclonedx.proto.v1_6.Bom;
+import org.cyclonedx.proto.v1_6.Component;
+import org.cyclonedx.proto.v1_6.Property;
+import org.cyclonedx.proto.v1_6.Vulnerability;
+import org.cyclonedx.proto.v1_6.VulnerabilityAffects;
+import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @since 5.7.0
+ */
+final class VulnDbVulnAnalyzer implements VulnAnalyzer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VulnDbVulnAnalyzer.class);
+    private static final JavaType VULNDB_VULNS_TYPE =
+            TypeFactory.defaultInstance().constructCollectionType(List.class, VulnDbApiResponse.Vulnerability.class);
+    private static final int CACHE_BATCH_SIZE = 500;
+
+    private final Cache resultsCache;
+    private final ObjectMapper objectMapper;
+    private final VulnDbApiClient apiClient;
+    private final boolean aliasSyncEnabled;
+
+    VulnDbVulnAnalyzer(
+            Cache resultsCache,
+            ObjectMapper objectMapper,
+            VulnDbApiClient apiClient,
+            boolean aliasSyncEnabled) {
+        this.resultsCache = resultsCache;
+        this.objectMapper = objectMapper;
+        this.apiClient = apiClient;
+        this.aliasSyncEnabled = aliasSyncEnabled;
+    }
+
+    @Override
+    public Bom analyze(Bom bom) throws InterruptedException {
+        final Map<String, Set<String>> bomRefsByCpe = collectAnalyzableCpes(bom);
+        if (bomRefsByCpe.isEmpty()) {
+            LOGGER.debug("No analyzable CPEs found; Skipping analysis");
+            return Bom.getDefaultInstance();
+        }
+
+        final var vulnsByCpe = new HashMap<String, List<VulnDbApiResponse.Vulnerability>>(bomRefsByCpe.size());
+        final var cpesToAnalyze = new LinkedHashSet<>(bomRefsByCpe.keySet());
+
+        for (final var cpeBatch : partition(List.copyOf(bomRefsByCpe.keySet()), CACHE_BATCH_SIZE)) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before all cache lookups could complete");
+            }
+
+            final Map<String, byte[]> cachedBytesByCpe = resultsCache.getMany(Set.copyOf(cpeBatch));
+            LOGGER.debug("Found cached results for {}/{} CPEs", cachedBytesByCpe.size(), cpeBatch.size());
+
+            for (final var entry : cachedBytesByCpe.entrySet()) {
+                final String cpe = entry.getKey();
+                final byte[] cachedBytes = entry.getValue();
+
+                cpesToAnalyze.remove(cpe);
+
+                if (cachedBytes == null) {
+                    continue;
+                }
+
+                try {
+                    vulnsByCpe.put(cpe, objectMapper.readValue(cachedBytes, VULNDB_VULNS_TYPE));
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to deserialize cached results for CPE '{}'; Will re-fetch", cpe, e);
+                    cpesToAnalyze.add(cpe);
+                }
+            }
+        }
+
+        vulnsByCpe.putAll(fetchAndCacheVulnerabilities(cpesToAnalyze));
+
+        return assembleVdr(vulnsByCpe, bomRefsByCpe);
+    }
+
+    private Map<String, Set<String>> collectAnalyzableCpes(Bom bom) {
+        final var bomRefsByCpe = new LinkedHashMap<String, Set<String>>();
+
+        for (final Component component : bom.getComponentsList()) {
+            if (!component.hasBomRef() || !component.hasCpe()) {
+                continue;
+            }
+            if (component.getPropertiesCount() > 0
+                    && component.getPropertiesList().stream()
+                    .map(Property::getName)
+                    .anyMatch("dependencytrack:internal:is-internal-component"::equalsIgnoreCase)) {
+                continue;
+            }
+
+            bomRefsByCpe
+                    .computeIfAbsent(component.getCpe(), k -> new HashSet<>())
+                    .add(component.getBomRef());
+        }
+
+        return bomRefsByCpe;
+    }
+
+    private Map<String, List<VulnDbApiResponse.Vulnerability>> fetchAndCacheVulnerabilities(
+            Collection<String> cpes) throws InterruptedException {
+        if (cpes.isEmpty()) {
+            return Map.of();
+        }
+
+        LOGGER.debug("Fetching vulnerabilities for {} CPEs from VulnDB", cpes.size());
+
+        final var entriesToCache = new HashMap<String, byte @Nullable []>(cpes.size());
+        final var vulnsByCpe = new HashMap<String, List<VulnDbApiResponse.Vulnerability>>();
+
+        for (final String cpe : cpes) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before all CPEs could be analyzed");
+            }
+
+            final List<VulnDbApiResponse.Vulnerability> vulns;
+            try {
+                vulns = apiClient.getVulnerabilitiesByCpe(cpe);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to fetch vulnerabilities for CPE '%s'".formatted(cpe), e);
+            }
+
+            if (!vulns.isEmpty()) {
+                vulnsByCpe.put(cpe, vulns);
+                try {
+                    entriesToCache.put(cpe, objectMapper.writeValueAsBytes(vulns));
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to serialize results for CPE '{}'; Skipping cache", cpe, e);
+                }
+            } else {
+                entriesToCache.put(cpe, null);
+            }
+        }
+
+        resultsCache.putMany(entriesToCache);
+        return vulnsByCpe;
+    }
+
+    private Bom assembleVdr(
+            Map<String, List<VulnDbApiResponse.Vulnerability>> vulnsByCpe,
+            Map<String, Set<String>> bomRefsByCpe) {
+        final var vulnBuilderByVulnId = new HashMap<String, Vulnerability.Builder>();
+
+        for (final var entry : vulnsByCpe.entrySet()) {
+            final String cpe = entry.getKey();
+            final List<VulnDbApiResponse.Vulnerability> vulnDbVulns = entry.getValue();
+
+            final Set<String> bomRefs = bomRefsByCpe.get(cpe);
+            if (bomRefs == null) {
+                LOGGER.warn("""
+                        Received vulnerabilities for CPE '{}', but no component \
+                        with this CPE was submitted for analysis""", cpe);
+                continue;
+            }
+
+            for (final var vulnDbVuln : vulnDbVulns) {
+                final String vulnId = String.valueOf(vulnDbVuln.vulndbId());
+                final Vulnerability.Builder vulnBuilder =
+                        vulnBuilderByVulnId.computeIfAbsent(
+                                vulnId,
+                                ignored -> VulnDbModelConverter.convert(vulnDbVuln, aliasSyncEnabled));
+
+                for (final String bomRef : bomRefs) {
+                    vulnBuilder.addAffects(
+                            VulnerabilityAffects.newBuilder()
+                                    .setRef(bomRef)
+                                    .build());
+                }
+            }
+        }
+
+        return Bom.newBuilder()
+                .addAllVulnerabilities(
+                        vulnBuilderByVulnId.values().stream()
+                                .map(Vulnerability.Builder::build)
+                                .toList())
+                .build();
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int batchSize) {
+        final var partitions = new ArrayList<List<T>>();
+        for (int i = 0; i < list.size(); i += batchSize) {
+            partitions.add(list.subList(i, Math.min(i + batchSize, list.size())));
+        }
+        return partitions;
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerFactory.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerFactory.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.plugin.api.ExtensionContext;
+import org.dependencytrack.plugin.api.ExtensionHttpContext;
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException;
+import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzerFactory;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzerRequirement;
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.util.EnumSet;
+
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 5.7.0
+ */
+final class VulnDbVulnAnalyzerFactory implements VulnAnalyzerFactory {
+
+    private @Nullable ConfigRegistry configRegistry;
+    private @Nullable CacheManager cacheManager;
+    private @Nullable ExtensionHttpContext httpContext;
+    private @Nullable ObjectMapper objectMapper;
+
+    @Override
+    public String extensionName() {
+        return "vuln-db";
+    }
+
+    @Override
+    public Class<? extends VulnAnalyzer> extensionClass() {
+        return VulnDbVulnAnalyzer.class;
+    }
+
+    @Override
+    public void init(ExtensionContext ctx) {
+        configRegistry = ctx.configRegistry();
+        cacheManager = ctx.cacheManager();
+        httpContext = ctx.http();
+        objectMapper = new ObjectMapper()
+                .disable(FAIL_ON_UNKNOWN_PROPERTIES);
+    }
+
+    @Override
+    public VulnAnalyzer create() {
+        requireNonNull(configRegistry);
+        requireNonNull(cacheManager);
+        requireNonNull(httpContext);
+        requireNonNull(objectMapper);
+
+        final var config = configRegistry.getRuntimeConfig(VulnDbVulnAnalyzerConfigV1.class);
+        if (!config.isEnabled()) {
+            throw new IllegalStateException("Analyzer is disabled");
+        }
+
+        final var tokenManager = new VulnDbAccessTokenManager(httpContext.client(), objectMapper);
+        final var apiClient = new VulnDbApiClient(
+                httpContext.client(),
+                objectMapper,
+                tokenManager,
+                config.getOauth2ClientId(),
+                config.getOauth2ClientSecret(),
+                config.getApiUrl());
+
+        return new VulnDbVulnAnalyzer(
+                cacheManager.getCache("results"),
+                objectMapper,
+                apiClient,
+                config.isAliasSyncEnabled());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        requireNonNull(configRegistry);
+        return configRegistry.getRuntimeConfig(VulnDbVulnAnalyzerConfigV1.class).isEnabled();
+    }
+
+    @Override
+    public EnumSet<VulnAnalyzerRequirement> analyzerRequirements() {
+        return EnumSet.of(VulnAnalyzerRequirement.COMPONENT_CPE);
+    }
+
+    @Override
+    public RuntimeConfigSpec runtimeConfigSpec() {
+        return RuntimeConfigSpec.of(
+                new VulnDbVulnAnalyzerConfigV1()
+                        .withEnabled(false)
+                        .withApiUrl(URI.create("https://vulndb.flashpoint.io")),
+                config -> {
+                    if (!config.isEnabled()) {
+                        return;
+                    }
+                    if (config.getApiUrl() == null) {
+                        throw new InvalidRuntimeConfigException("No API URL provided");
+                    }
+                    if (config.getOauth2ClientId() == null) {
+                        throw new InvalidRuntimeConfigException("No OAuth2 client ID provided");
+                    }
+                    if (config.getOauth2ClientSecret() == null) {
+                        throw new InvalidRuntimeConfigException("No OAuth2 client secret provided");
+                    }
+                });
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerPlugin.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.api.ExtensionPoint;
+import org.dependencytrack.plugin.api.Plugin;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @since 5.7.0
+ */
+public final class VulnDbVulnAnalyzerPlugin implements Plugin {
+
+    @Override
+    public Collection<? extends ExtensionFactory<? extends ExtensionPoint>> extensionFactories() {
+        return List.of(new VulnDbVulnAnalyzerFactory());
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/package-info.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+@NullMarked
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import org.jspecify.annotations.NullMarked;

--- a/vuln-analysis/vuln-db/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
+++ b/vuln-analysis/vuln-db/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
@@ -1,0 +1,1 @@
+org.dependencytrack.vulnanalysis.vulndb.VulnDbVulnAnalyzerPlugin

--- a/vuln-analysis/vuln-db/src/main/resources/org/dependencytrack/vulnanalysis/vulndb/vuln-db-vuln-analyzer-config-v1.schema.json
+++ b/vuln-analysis/vuln-db/src/main/resources/org/dependencytrack/vulnanalysis/vulndb/vuln-db-vuln-analyzer-config-v1.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dependencytrack.org/schemas/vuln-db-vuln-analyzer-config-v1.schema.json",
+  "type": "object",
+  "javaInterfaces": [
+    "org.dependencytrack.plugin.api.config.RuntimeConfig"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Whether the VulnDB vulnerability analyzer should be enabled.",
+      "existingJavaType": "boolean"
+    },
+    "aliasSyncEnabled": {
+      "type": "boolean",
+      "title": "Alias Synchronization Enabled",
+      "description": "Whether to include alias information in vulnerability data.",
+      "existingJavaType": "boolean"
+    },
+    "apiUrl": {
+      "type": "string",
+      "title": "API URL",
+      "description": "URL of VulnDB's REST API.",
+      "format": "uri",
+      "minLength": 1
+    },
+    "oauth2ClientId": {
+      "type": "string",
+      "title": "OAuth2 Client ID",
+      "description": "OAuth 2.0 client ID for authentication with the VulnDB REST API.",
+      "minLength": 1
+    },
+    "oauth2ClientSecret": {
+      "type": "string",
+      "title": "OAuth2 Client Secret",
+      "description": "OAuth 2.0 client secret for authentication with the VulnDB REST API.",
+      "minLength": 1,
+      "x-secret-ref": true
+    }
+  },
+  "required": [
+    "enabled"
+  ]
+}

--- a/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbAccessTokenManagerTest.java
+++ b/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbAccessTokenManagerTest.java
@@ -1,0 +1,148 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class VulnDbAccessTokenManagerTest {
+
+    private VulnDbAccessTokenManager tokenManager;
+    private URI apiBaseUrl;
+
+    @BeforeEach
+    void beforeEach(WireMockRuntimeInfo wmRuntimeInfo) {
+        apiBaseUrl = URI.create(wmRuntimeInfo.getHttpBaseUrl());
+        tokenManager = new VulnDbAccessTokenManager(
+                HttpClient.newHttpClient(),
+                new ObjectMapper());
+    }
+
+    @Test
+    void shouldAcquireToken() throws Exception {
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-123", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "client-id", "client-secret");
+        assertThat(token).isEqualTo("tok-123");
+    }
+
+    @Test
+    void shouldCacheToken() throws Exception {
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-cached", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token1 = tokenManager.getAccessToken(apiBaseUrl, "client-id", "client-secret");
+        final String token2 = tokenManager.getAccessToken(apiBaseUrl, "client-id", "client-secret");
+
+        assertThat(token1).isEqualTo("tok-cached");
+        assertThat(token2).isEqualTo("tok-cached");
+        verify(1, postRequestedFor(urlPathEqualTo("/oauth/token")));
+    }
+
+    @Test
+    void shouldRefreshExpiredToken() throws Exception {
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-expired", "token_type": "Bearer", "expires_in": 0}
+                                """)));
+
+        tokenManager.getAccessToken(apiBaseUrl, "client-id", "client-secret");
+
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-refreshed", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "client-id", "client-secret");
+        assertThat(token).isEqualTo("tok-refreshed");
+        verify(2, postRequestedFor(urlPathEqualTo("/oauth/token")));
+    }
+
+    @Test
+    void shouldInvalidateOnCredentialChange() throws Exception {
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-old", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        tokenManager.getAccessToken(apiBaseUrl, "client-id-1", "secret-1");
+
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "tok-new", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final String token = tokenManager.getAccessToken(apiBaseUrl, "client-id-2", "secret-2");
+        assertThat(token).isEqualTo("tok-new");
+        verify(2, postRequestedFor(urlPathEqualTo("/oauth/token")));
+    }
+
+    @Test
+    void shouldThrowOnTokenEndpointError() {
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withBody("Unauthorized")));
+
+        assertThatThrownBy(() -> tokenManager.getAccessToken(apiBaseUrl, "bad-id", "bad-secret"))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("401");
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerFactoryTest.java
+++ b/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerFactoryTest.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import org.dependencytrack.plugin.testing.AbstractExtensionFactoryTest;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+
+class VulnDbVulnAnalyzerFactoryTest extends AbstractExtensionFactoryTest<VulnAnalyzer, VulnDbVulnAnalyzerFactory> {
+
+    VulnDbVulnAnalyzerFactoryTest() {
+        super(VulnDbVulnAnalyzerFactory.class);
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerTest.java
+++ b/vuln-analysis/vuln-db/src/test/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzerTest.java
@@ -1,0 +1,310 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.vulndb;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.protobuf.util.JsonFormat;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.cyclonedx.proto.v1_6.Bom;
+import org.cyclonedx.proto.v1_6.Component;
+import org.cyclonedx.proto.v1_6.Property;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.cache.memory.MemoryCacheProvider;
+import org.dependencytrack.plugin.api.ExtensionContext;
+import org.dependencytrack.plugin.api.storage.InMemoryExtensionKVStore;
+import org.dependencytrack.plugin.testing.MockConfigRegistry;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.anyUrl;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WireMockTest
+class VulnDbVulnAnalyzerTest {
+
+    private CacheManager cacheManager;
+    private VulnDbVulnAnalyzerFactory analyzerFactory;
+    private VulnAnalyzer analyzer;
+
+    @BeforeEach
+    void beforeEach(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(post(urlPathEqualTo("/oauth/token"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(/* language=JSON */ """
+                                {"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600}
+                                """)));
+
+        final var cacheProvider = new MemoryCacheProvider(new SmallRyeConfigBuilder().build());
+        cacheManager = cacheProvider.create();
+
+        analyzerFactory = new VulnDbVulnAnalyzerFactory();
+
+        final var configRegistry = new MockConfigRegistry(
+                analyzerFactory.runtimeConfigSpec(),
+                new VulnDbVulnAnalyzerConfigV1()
+                        .withEnabled(true)
+                        .withAliasSyncEnabled(true)
+                        .withApiUrl(URI.create(wmRuntimeInfo.getHttpBaseUrl()))
+                        .withOauth2ClientId("test-client-id")
+                        .withOauth2ClientSecret("test-client-secret"));
+
+        analyzerFactory.init(
+                new ExtensionContext(
+                        configRegistry,
+                        cacheManager,
+                        new InMemoryExtensionKVStore(),
+                        null));
+
+        analyzer = analyzerFactory.create();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        if (analyzerFactory != null) {
+            analyzerFactory.close();
+        }
+        if (cacheManager != null) {
+            cacheManager.close();
+        }
+    }
+
+    @Test
+    void shouldAnalyzeAndCacheWithVulns() throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("vulndb-response-with-vulns.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("example-lib")
+                                .setCpe("cpe:2.3:a:example:lib:1.0:*:*:*:*:*:*:*")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThatJson(JsonFormat.printer().print(vdr)).isEqualTo(/* language=JSON */ """
+                {
+                  "vulnerabilities": [
+                    {
+                      "id": "123456",
+                      "source": {
+                        "name": "VULNDB"
+                      },
+                      "ratings": [
+                        {
+                          "source": { "name": "VULNDB" },
+                          "score": 5.0,
+                          "method": "SCORE_METHOD_CVSSV2",
+                          "vector": "(AV:N/AC:L/Au:N/C:P/I:N/A:N)"
+                        },
+                        {
+                          "source": { "name": "VULNDB" },
+                          "score": 7.5,
+                          "method": "SCORE_METHOD_CVSSV3",
+                          "vector": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+                        }
+                      ],
+                      "cwes": [120],
+                      "description": "A vulnerability was found in Example Library.\\n\\nBuffer overflow in parsing module.\\n\\nUpgrade to version 2.0 or later.",
+                      "advisories": [
+                        { "url": "https://example.com/advisory/123" }
+                      ],
+                      "references": [
+                        { "id": "CVE-2023-12345", "source": { "name": "NVD" } }
+                      ],
+                      "affects": [
+                        { "ref": "1" }
+                      ],
+                      "properties": [
+                        { "name": "dependency-track:vuln:title", "value": "Test Vulnerability in Example Library" },
+                        { "name": "dependency-track:vuln:credits", "value": "John Doe" }
+                      ]
+                    }
+                  ]
+                }
+                """);
+
+        // Second call should use cache.
+        final Bom secondVdr = analyzer.analyze(bom);
+        assertThat(secondVdr).isEqualTo(vdr);
+
+        verify(1, getRequestedFor(anyUrl())
+                .withHeader("Authorization", equalTo("Bearer test-token")));
+    }
+
+    @Test
+    void shouldAnalyzeAndCacheWithNoVulns() throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("vulndb-response-no-vulns.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("safe-lib")
+                                .setCpe("cpe:2.3:a:example:safe-lib:1.0:*:*:*:*:*:*:*")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        final Bom secondVdr = analyzer.analyze(bom);
+        assertThat(secondVdr).isEqualTo(vdr);
+
+        verify(1, getRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldNotAnalyzeComponentWithoutBomRef() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setName("example-lib")
+                                .setCpe("cpe:2.3:a:example:lib:1.0:*:*:*:*:*:*:*")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, getRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldNotAnalyzeComponentWithoutCpe() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("example-lib")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, getRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldNotAnalyzeInternalComponents() throws Exception {
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("internal-lib")
+                                .setCpe("cpe:2.3:a:example:internal:1.0:*:*:*:*:*:*:*")
+                                .addProperties(
+                                        Property.newBuilder()
+                                                .setName("dependencytrack:internal:is-internal-component")
+                                                .setValue("does-not-matter")
+                                                .build())
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(0, getRequestedFor(anyUrl()));
+    }
+
+    @Test
+    void shouldHandlePagination() throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .withQueryParam("page", equalTo("1"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("vulndb-response-with-vulns-page1.json")));
+
+        stubFor(get(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .withQueryParam("page", equalTo("2"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("vulndb-response-with-vulns-page2.json")));
+
+        final var bom = Bom.newBuilder()
+                .addComponents(
+                        Component.newBuilder()
+                                .setBomRef("1")
+                                .setName("example-lib")
+                                .setCpe("cpe:2.3:a:example:lib:1.0:*:*:*:*:*:*:*")
+                                .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+        assertThat(vdr.getVulnerabilitiesCount()).isEqualTo(2);
+
+        verify(1, getRequestedFor(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .withQueryParam("page", equalTo("1")));
+        verify(1, getRequestedFor(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .withQueryParam("page", equalTo("2")));
+    }
+
+    @Test
+    void shouldAnalyzeMultipleCpes() throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/vulnerabilities/find_by_cpe"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("vulndb-response-no-vulns.json")));
+
+        final var bomBuilder = Bom.newBuilder();
+        for (int i = 0; i < 10; i++) {
+            bomBuilder.addComponents(
+                    Component.newBuilder()
+                            .setBomRef(String.valueOf(i))
+                            .setName("lib-" + i)
+                            .setCpe("cpe:2.3:a:example:lib-" + i + ":1.0:*:*:*:*:*:*:*")
+                            .build());
+        }
+
+        final Bom vdr = analyzer.analyze(bomBuilder.build());
+        assertThat(vdr).isEqualTo(Bom.getDefaultInstance());
+
+        verify(10, getRequestedFor(anyUrl()));
+    }
+
+}

--- a/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-no-vulns.json
+++ b/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-no-vulns.json
@@ -1,0 +1,5 @@
+{
+  "current_page": 1,
+  "total_entries": 0,
+  "results": []
+}

--- a/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-nvd-info.json
+++ b/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-nvd-info.json
@@ -1,0 +1,51 @@
+{
+  "current_page": 1,
+  "total_entries": 1,
+  "results": [
+    {
+      "vulndb_id": 789012,
+      "title": "SQL Injection in Database Module",
+      "disclosure_date": "2023-06-01T00:00:00.000Z",
+      "description": "SQL injection allows remote attackers to execute arbitrary SQL commands.",
+      "solution": null,
+      "vulndb_last_modified": "2023-06-15T00:00:00.000Z",
+      "manual_notes": "Vendor confirmed the issue.",
+      "t_description": null,
+      "authors": [],
+      "ext_references": [
+        {
+          "type": "Advisory",
+          "value": "https://example.com/advisory/789"
+        },
+        {
+          "type": "Other",
+          "value": "https://example.com/blog/sql-injection"
+        }
+      ],
+      "cvss_metrics": [],
+      "cvss_version_three_metrics": [
+        {
+          "attack_vector": "Network",
+          "attack_complexity": "Low",
+          "privileges_required": "Low",
+          "user_interaction": "None",
+          "scope": "Changed",
+          "confidentiality_impact": "High",
+          "integrity_impact": "High",
+          "availability_impact": "High",
+          "calculated_cvss_base_score": 9.9,
+          "cve_id": "CVE-2023-67890",
+          "source": "NVD",
+          "generated_on": "2023-06-10"
+        }
+      ],
+      "nvd_additional_information": [
+        {
+          "summary": "SQL injection vulnerability",
+          "cwe_id": "CWE-89",
+          "cve_id": "CVE-2023-67890"
+        }
+      ]
+    }
+  ]
+}

--- a/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-vulns-page1.json
+++ b/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-vulns-page1.json
@@ -1,0 +1,65 @@
+{
+  "current_page": 1,
+  "total_entries": 101,
+  "results": [
+    {
+      "vulndb_id": 123456,
+      "title": "Test Vulnerability in Example Library",
+      "disclosure_date": "2023-01-15T00:00:00.000Z",
+      "description": "A vulnerability was found in Example Library.",
+      "solution": "Upgrade to version 2.0 or later.",
+      "vulndb_last_modified": "2023-02-01T00:00:00.000Z",
+      "manual_notes": null,
+      "t_description": "Buffer overflow in parsing module.",
+      "authors": [
+        {
+          "name": "John Doe",
+          "company": "Security Corp"
+        }
+      ],
+      "ext_references": [
+        {
+          "type": "Advisory",
+          "value": "https://example.com/advisory/123"
+        }
+      ],
+      "cvss_metrics": [
+        {
+          "access_vector": "Network",
+          "access_complexity": "Low",
+          "authentication": "None",
+          "confidentiality_impact": "Partial",
+          "integrity_impact": "None",
+          "availability_impact": "None",
+          "calculated_cvss_base_score": 5.0,
+          "cve_id": "CVE-2023-12345",
+          "source": "NVD",
+          "generated_on": "2023-01-20"
+        }
+      ],
+      "cvss_version_three_metrics": [
+        {
+          "attack_vector": "Network",
+          "attack_complexity": "Low",
+          "privileges_required": "None",
+          "user_interaction": "None",
+          "scope": "Unchanged",
+          "confidentiality_impact": "High",
+          "integrity_impact": "None",
+          "availability_impact": "None",
+          "calculated_cvss_base_score": 7.5,
+          "cve_id": "CVE-2023-12345",
+          "source": "NVD",
+          "generated_on": "2023-01-20"
+        }
+      ],
+      "nvd_additional_information": [
+        {
+          "summary": "Buffer overflow vulnerability",
+          "cwe_id": "CWE-120",
+          "cve_id": "CVE-2023-12345"
+        }
+      ]
+    }
+  ]
+}

--- a/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-vulns-page2.json
+++ b/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-vulns-page2.json
@@ -1,0 +1,21 @@
+{
+  "current_page": 2,
+  "total_entries": 101,
+  "results": [
+    {
+      "vulndb_id": 789012,
+      "title": "Second Vulnerability",
+      "disclosure_date": "2023-06-01T00:00:00.000Z",
+      "description": "Another vulnerability.",
+      "solution": null,
+      "vulndb_last_modified": "2023-06-15T00:00:00.000Z",
+      "manual_notes": null,
+      "t_description": null,
+      "authors": [],
+      "ext_references": [],
+      "cvss_metrics": [],
+      "cvss_version_three_metrics": [],
+      "nvd_additional_information": []
+    }
+  ]
+}

--- a/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-vulns.json
+++ b/vuln-analysis/vuln-db/src/test/resources/__files/vulndb-response-with-vulns.json
@@ -1,0 +1,65 @@
+{
+  "current_page": 1,
+  "total_entries": 1,
+  "results": [
+    {
+      "vulndb_id": 123456,
+      "title": "Test Vulnerability in Example Library",
+      "disclosure_date": "2023-01-15T00:00:00.000Z",
+      "description": "A vulnerability was found in Example Library.",
+      "solution": "Upgrade to version 2.0 or later.",
+      "vulndb_last_modified": "2023-02-01T00:00:00.000Z",
+      "manual_notes": null,
+      "t_description": "Buffer overflow in parsing module.",
+      "authors": [
+        {
+          "name": "John Doe",
+          "company": "Security Corp"
+        }
+      ],
+      "ext_references": [
+        {
+          "type": "Advisory",
+          "value": "https://example.com/advisory/123"
+        }
+      ],
+      "cvss_metrics": [
+        {
+          "access_vector": "Network",
+          "access_complexity": "Low",
+          "authentication": "None",
+          "confidentiality_impact": "Partial",
+          "integrity_impact": "None",
+          "availability_impact": "None",
+          "calculated_cvss_base_score": 5.0,
+          "cve_id": "CVE-2023-12345",
+          "source": "NVD",
+          "generated_on": "2023-01-20"
+        }
+      ],
+      "cvss_version_three_metrics": [
+        {
+          "attack_vector": "Network",
+          "attack_complexity": "Low",
+          "privileges_required": "None",
+          "user_interaction": "None",
+          "scope": "Unchanged",
+          "confidentiality_impact": "High",
+          "integrity_impact": "None",
+          "availability_impact": "None",
+          "calculated_cvss_base_score": 7.5,
+          "cve_id": "CVE-2023-12345",
+          "source": "NVD",
+          "generated_on": "2023-01-20"
+        }
+      ],
+      "nvd_additional_information": [
+        {
+          "summary": "Buffer overflow vulnerability",
+          "cwe_id": "CWE-120",
+          "cve_id": "CVE-2023-12345"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports the VulnDB analyzer from Dependency-Track v4. Note that it was not previously ported to hyades and thus wasn't part of the initial vuln-analyzer service decommission work.

In contrast to the v4 implementation, this one uses OAuth2 to authorize with the VulnDB API, instead of OAuth1.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/286

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
