### PR TITLE
Add note about quiet Maven output to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ If Maven needs to be invoked directly, only do so from the repository root.
 * Lint (OpenAPI): `make lint-openapi`
 * Lint (Protobuf): `make lint-proto`
 
+> [!NOTE]
+> Maven is configured to run in quiet mode. Successful test runs produce no output.
+> A zero exit code is sufficient to confirm success. Do not re-run tests or investigate
+> further when output is empty but the command succeeds.
+
 ## GitHub Issues and PRs
 
 * Never create an issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ If Maven needs to be invoked directly, only do so from the repository root.
 * Lint (Protobuf): `make lint-proto`
 
 > [!NOTE]
-> Maven is configured to run in quiet mode. Successful test runs produce no output.
-> A zero exit code is sufficient to confirm success. Do not re-run tests or investigate
-> further when output is empty but the command succeeds.
+> When running Maven via `make … AGENT=1`, Maven is invoked in quiet mode (`-q`), so successful test runs may produce little or no output.
+> In this mode, a zero exit code is sufficient to confirm success; do not re-run tests or investigate
+> further solely because the output is empty. When invoking Maven directly or running `make` without `AGENT=1`, normal Maven output will be shown.
 
 ## GitHub Issues and PRs
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds note about quiet Maven output to `AGENTS.md`.

We configured Maven to produce minimal output when executed via `make`, to make it less noisy for local workflows.

This frequently seems to confuse agents, as they don't see tests executing unless they fail.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
