### PR TITLE
Disable caching of tests and JaCoCo coverage

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -25,11 +25,6 @@
         <local>
             <maxBuildsCached>3</maxBuildsCached>
         </local>
-        <attachedOutputs>
-            <dirNames>
-                <dirName glob="jacoco.exec"></dirName>
-            </dirNames>
-        </attachedOutputs>
     </configuration>
     <input>
         <global>
@@ -45,6 +40,11 @@
                 <execution artifactId="maven-dependency-plugin">
                     <execIds>
                         <execId>copy-dependencies</execId>
+                    </execIds>
+                </execution>
+                <execution artifactId="maven-surefire-plugin">
+                    <execIds>
+                        <execId>default-test</execId>
                     </execIds>
                 </execution>
                 <execution artifactId="jacoco-maven-plugin">


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Disables caching of tests and JaCoCo coverage.

Would've been great to benefit from cached test runs, but that seems to introduce some cross-contamination WRT coverage reporting.

Instead, always run tests, and don't cache JaCoCo coverage reports. The build cache still helps for the compilation itself, though.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
