### PR TITLE
Have Maven resolver only cache relevant data

### DIFF
--- a/package-metadata/resolution/pom.xml
+++ b/package-metadata/resolution/pom.xml
@@ -39,6 +39,12 @@
     <dependencies>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>cache-provider-memory</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>package-metadata-api</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>
@@ -99,6 +105,12 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.smallrye.config</groupId>
+            <artifactId>smallrye-config-core</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoCrateMetadata.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoCrateMetadata.java
@@ -24,6 +24,6 @@ import java.time.Instant;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 record CargoCrateMetadata(
-        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) Instant resolvedAt,
+        Instant resolvedAt,
         String latestVersion) {
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoCrateVersionMetadata.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoCrateVersionMetadata.java
@@ -27,7 +27,7 @@ import java.time.format.DateTimeParseException;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 record CargoCrateVersionMetadata(
-        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) @Nullable Instant publishedAt,
+        @Nullable Instant publishedAt,
         @Nullable String sha256) {
 
     static @Nullable CargoCrateVersionMetadata of(CargoCrateDocument.Version crateVersion) {

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageInfo.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageInfo.java
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.pkgmetadata.resolution.maven;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.Instant;
+
+@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+record MavenPackageInfo(
+        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) Instant resolvedAt,
+        String latestVersion) {
+}

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageInfo.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageInfo.java
@@ -24,6 +24,6 @@ import java.time.Instant;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 record MavenPackageInfo(
-        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) Instant resolvedAt,
+        Instant resolvedAt,
         String latestVersion) {
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
@@ -18,6 +18,7 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.maven;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.cache.api.Cache;
 import org.dependencytrack.pkgmetadata.resolution.api.HashAlgorithm;
@@ -60,10 +61,12 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
     private static final Pattern VERSION_PATTERN = Pattern.compile("<version>([^<]+)</version>");
 
     private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
     private final Cache cache;
 
-    MavenPackageMetadataResolver(HttpClient httpClient, Cache cache) {
+    MavenPackageMetadataResolver(HttpClient httpClient, ObjectMapper objectMapper, Cache cache) {
         this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
         this.cache = cache;
     }
 
@@ -78,8 +81,8 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
                 purl.getNamespace().replace('.', '/'),
                 purl.getName());
 
-        final String latestVersion = resolveLatestVersion(baseUrl, purl, repository);
-        if (latestVersion == null) {
+        final MavenPackageInfo packageInfo = resolvePackageInfo(baseUrl, purl, repository);
+        if (packageInfo == null) {
             return null;
         }
         if (Thread.interrupted()) {
@@ -100,35 +103,44 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
             hashes.put(HashAlgorithm.SHA1, sha1);
         }
 
-        final var resolvedAt = Instant.now();
+        final var resolvedAt = packageInfo.resolvedAt();
         return new PackageMetadata(
-                latestVersion,
+                packageInfo.latestVersion(),
                 resolvedAt,
                 !hashes.isEmpty() || publishedAt != null
                         ? new PackageArtifactMetadata(resolvedAt, publishedAt, hashes)
                         : null);
     }
 
-    private @Nullable String resolveLatestVersion(
+    private @Nullable MavenPackageInfo resolvePackageInfo(
             String baseUrl,
             PackageURL purl,
             PackageRepository repository)
             throws InterruptedException {
         final String metadataCacheKey = CacheKeys.build(repository, purl.getNamespace(), purl.getName());
 
-        byte[] cachedMetadataBytes = cache.get(metadataCacheKey);
-        if (cachedMetadataBytes == null) {
-            cachedMetadataBytes = fetchMetadata(baseUrl, repository);
-            if (cachedMetadataBytes == null) {
-                return null;
-            }
-
-            cache.put(metadataCacheKey, cachedMetadataBytes);
+        final byte[] cachedBytes = cache.get(metadataCacheKey);
+        if (cachedBytes != null) {
+            return deserialize(cachedBytes, MavenPackageInfo.class);
         }
 
-        final String content = new String(cachedMetadataBytes, StandardCharsets.UTF_8);
+        final byte[] xmlBytes = fetchMetadata(baseUrl, repository);
+        if (xmlBytes == null) {
+            return null;
+        }
 
-        final Matcher latestMatcher = LATEST_PATTERN.matcher(content);
+        final String latestVersion = parseLatestVersion(new String(xmlBytes, StandardCharsets.UTF_8));
+        if (latestVersion == null) {
+            return null;
+        }
+
+        final var packageInfo = new MavenPackageInfo(Instant.now(), latestVersion);
+        cache.put(metadataCacheKey, serialize(packageInfo));
+        return packageInfo;
+    }
+
+    private static @Nullable String parseLatestVersion(String xml) {
+        final Matcher latestMatcher = LATEST_PATTERN.matcher(xml);
         if (latestMatcher.find()) {
             return latestMatcher.group(1);
         }
@@ -136,12 +148,28 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
         // Fall back to last <version> in <versions> list.
         // Sometimes the latest version is not explicitly recorded.
         String lastVersion = null;
-        final Matcher versionMatcher = VERSION_PATTERN.matcher(content);
+        final Matcher versionMatcher = VERSION_PATTERN.matcher(xml);
         while (versionMatcher.find()) {
             lastVersion = versionMatcher.group(1);
         }
 
         return lastVersion;
+    }
+
+    private byte[] serialize(Object value) {
+        try {
+            return objectMapper.writeValueAsBytes(value);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private <T> T deserialize(byte[] bytes, Class<T> type) {
+        try {
+            return objectMapper.readValue(bytes, type);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     private byte @Nullable [] fetchMetadata(

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverFactory.java
@@ -18,6 +18,9 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.maven;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
@@ -33,6 +36,7 @@ import java.util.Map;
 public final class MavenPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
 
     private @Nullable HttpClient httpClient;
+    private @Nullable ObjectMapper objectMapper;
     private @Nullable Cache cache;
 
     @Override
@@ -85,12 +89,15 @@ public final class MavenPackageMetadataResolverFactory implements PackageMetadat
     @Override
     public void init(ExtensionContext ctx) {
         httpClient = ctx.http().client();
+        objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
         cache = ctx.cacheManager().getCache("responses");
     }
 
     @Override
     public PackageMetadataResolver create() {
-        return new MavenPackageMetadataResolver(httpClient, cache);
+        return new MavenPackageMetadataResolver(httpClient, objectMapper, cache);
     }
 
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageDocument.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageDocument.java
@@ -40,13 +40,13 @@ record NpmPackageDocument(
 
     @JsonFormat(shape = JsonFormat.Shape.ARRAY)
     record PackageInfo(
-            @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) Instant resolvedAt,
+            Instant resolvedAt,
             String version) {
     }
 
     @JsonFormat(shape = JsonFormat.Shape.ARRAY)
     record VersionInfo(
-            @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) @Nullable Instant publishedAt,
+            @Nullable Instant publishedAt,
             @Nullable String shasum,
             @Nullable String integrity) {
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadata.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadata.java
@@ -24,6 +24,6 @@ import java.time.Instant;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 record NugetPackageMetadata(
-        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) Instant resolvedAt,
+        Instant resolvedAt,
         String latestVersion) {
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetVersionMetadata.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetVersionMetadata.java
@@ -25,5 +25,5 @@ import java.time.Instant;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 record NugetVersionMetadata(
-        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) @Nullable Instant publishedAt) {
+        @Nullable Instant publishedAt) {
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadata.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadata.java
@@ -24,6 +24,6 @@ import java.time.Instant;
 
 @JsonFormat(shape = JsonFormat.Shape.ARRAY)
 record PypiPackageMetadata(
-        @JsonFormat(shape = JsonFormat.Shape.NUMBER_INT) Instant resolvedAt,
+        Instant resolvedAt,
         String latestVersion) {
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
@@ -21,45 +21,64 @@ package org.dependencytrack.pkgmetadata.resolution.maven;
 import com.github.packageurl.PackageURLBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.cache.memory.MemoryCacheProvider;
 import org.dependencytrack.pkgmetadata.resolution.api.HashAlgorithm;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
 import org.dependencytrack.pkgmetadata.resolution.api.RetryableResolutionException;
 import org.dependencytrack.plugin.api.ExtensionContext;
+import org.dependencytrack.plugin.api.storage.InMemoryExtensionKVStore;
 import org.dependencytrack.plugin.testing.MockConfigRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.within;
 
 @WireMockTest
 class MavenPackageMetadataResolverTest {
 
+    private CacheManager cacheManager;
     private MavenPackageMetadataResolverFactory factory;
     private PackageMetadataResolver resolver;
 
     @BeforeEach
     void beforeEach() {
+        final var cacheProvider = new MemoryCacheProvider(new SmallRyeConfigBuilder().build());
+        cacheManager = cacheProvider.create();
+
         factory = new MavenPackageMetadataResolverFactory();
-        factory.init(new ExtensionContext(new MockConfigRegistry(Map.of(), null, null, null)));
+        factory.init(new ExtensionContext(
+                new MockConfigRegistry(Map.of(), null, null, null),
+                cacheManager,
+                new InMemoryExtensionKVStore(),
+                null));
         resolver = factory.create();
     }
 
     @AfterEach
-    void afterEach() {
+    void afterEach() throws Exception {
         if (factory != null) {
             factory.close();
+        }
+        if (cacheManager != null) {
+            cacheManager.close();
         }
     }
 
@@ -389,6 +408,48 @@ class MavenPackageMetadataResolverTest {
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
                 .isThrownBy(() -> resolver.resolve(purl, repo));
+    }
+
+    @Test
+    void shouldUseCachedMetadataOnSecondResolve(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <groupId>com.example</groupId>
+                          <artifactId>mylib</artifactId>
+                          <versioning>
+                            <latest>2.0.0</latest>
+                          </versioning>
+                        </metadata>
+                        """)));
+        stubFor(head(urlPathEqualTo("/com/example/mylib/2.0.0/mylib-2.0.0.jar"))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Last-Modified", "Sat, 04 Nov 2023 12:00:00 GMT")));
+        stubFor(get(urlPathEqualTo("/com/example/mylib/2.0.0/mylib-2.0.0.jar.sha1"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .withVersion("2.0.0")
+                .build();
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata firstResult = resolver.resolve(purl, repo);
+        final PackageMetadata secondResult = resolver.resolve(purl, repo);
+
+        assertThat(firstResult).isNotNull();
+        assertThat(firstResult.latestVersion()).isEqualTo("2.0.0");
+        assertThat(secondResult).isNotNull();
+        assertThat(secondResult.latestVersion()).isEqualTo("2.0.0");
+
+        verify(1, getRequestedFor(urlPathEqualTo("/com/example/mylib/maven-metadata.xml")));
+
+        assertThat(secondResult.resolvedAt())
+                .isCloseTo(firstResult.resolvedAt(), within(1, ChronoUnit.MILLIS));
     }
 
     @Test

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverTest.java
@@ -18,29 +18,25 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.pypi;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.packageurl.PackageURLBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
-import org.dependencytrack.cache.api.Cache;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.cache.memory.MemoryCacheProvider;
 import org.dependencytrack.pkgmetadata.resolution.api.HashAlgorithm;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
 import org.dependencytrack.pkgmetadata.resolution.api.RetryableResolutionException;
 import org.dependencytrack.plugin.api.ExtensionContext;
+import org.dependencytrack.plugin.api.storage.InMemoryExtensionKVStore;
 import org.dependencytrack.plugin.testing.MockConfigRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.net.http.HttpClient;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
@@ -84,20 +80,31 @@ class PypiPackageMetadataResolverTest {
             }
             """;
 
+    private CacheManager cacheManager;
     private PypiPackageMetadataResolverFactory factory;
-    private PypiPackageMetadataResolver resolver;
+    private PackageMetadataResolver resolver;
 
     @BeforeEach
     void beforeEach() {
+        final var cacheProvider = new MemoryCacheProvider(new SmallRyeConfigBuilder().build());
+        cacheManager = cacheProvider.create();
+
         factory = new PypiPackageMetadataResolverFactory();
-        factory.init(new ExtensionContext(new MockConfigRegistry(Map.of(), null, null, null)));
-        resolver = (PypiPackageMetadataResolver) factory.create();
+        factory.init(new ExtensionContext(
+                new MockConfigRegistry(Map.of(), null, null, null),
+                cacheManager,
+                new InMemoryExtensionKVStore(),
+                null));
+        resolver = factory.create();
     }
 
     @AfterEach
-    void afterEach() {
+    void afterEach() throws Exception {
         if (factory != null) {
             factory.close();
+        }
+        if (cacheManager != null) {
+            cacheManager.close();
         }
     }
 
@@ -188,8 +195,6 @@ class PypiPackageMetadataResolverTest {
 
     @Test
     void shouldNegativeCacheUnmatchedFileName(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-        final var cachingResolver = createResolverWithCache();
-
         stubFor(get(urlPathEqualTo("/pypi/mypackage/json"))
                 .willReturn(aResponse().withStatus(200).withBody(PYPI_RESPONSE)));
 
@@ -201,62 +206,14 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        cachingResolver.resolve(purl, repo);
+        resolver.resolve(purl, repo);
 
-        final PackageMetadata secondResult = cachingResolver.resolve(purl, repo);
+        final PackageMetadata secondResult = resolver.resolve(purl, repo);
         assertThat(secondResult).isNotNull();
         assertThat(secondResult.latestVersion()).isEqualTo("2.0.0");
         assertThat(secondResult.artifactMetadata()).isNull();
 
         verify(1, getRequestedFor(urlPathEqualTo("/pypi/mypackage/json")));
-    }
-
-    private static PypiPackageMetadataResolver createResolverWithCache() {
-        final var objectMapper = new ObjectMapper()
-                .registerModule(new JavaTimeModule())
-                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
-        final var store = new ConcurrentHashMap<String, byte[]>();
-        final var cache = new Cache() {
-            @Override
-            public byte[] get(String key, Function<String, byte[]> loader) {
-                return store.computeIfAbsent(key, loader);
-            }
-
-            @Override
-            public Map<String, byte[]> getMany(Set<String> keys) {
-                final var result = new HashMap<String, byte[]>();
-                for (final String key : keys) {
-                    final byte[] value = store.get(key);
-                    if (value != null) {
-                        result.put(key, value);
-                    }
-                }
-                return result;
-            }
-
-            @Override
-            public void put(String key, byte[] value) {
-                if (value != null) {
-                    store.put(key, value);
-                }
-            }
-
-            @Override
-            public void putMany(Map<String, byte[]> entries) {
-                entries.forEach((k, v) -> { if (v != null) store.put(k, v); });
-            }
-
-            @Override
-            public void invalidateMany(Set<String> keys) {
-                keys.forEach(store::remove);
-            }
-
-            @Override
-            public void invalidateAll() {
-                store.clear();
-            }
-        };
-        return new PypiPackageMetadataResolver(HttpClient.newHttpClient(), objectMapper, cache);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Have Maven resolver only cache relevant data.

Instead of caching the full `maven-metadata.xml` content, only cache the extracted latest version, and when it was resolved.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
