### PR TITLE
Add support for more granular log level config

### DIFF
--- a/apiserver/src/main/docker/Dockerfile
+++ b/apiserver/src/main/docker/Dockerfile
@@ -44,8 +44,6 @@ ARG UID
 ARG GID
 
 ENV TZ=Etc/UTC \
-    # Dependency-Track's default logging level
-    LOGGING_LEVEL=INFO \
     # JVM Options that are passed at runtime by default
     JAVA_OPTIONS="-XX:+UseG1GC -XX:+UseStringDeduplication -XX:+UseCompactObjectHeaders -XX:MaxGCPauseMillis=250 -XX:MaxRAMPercentage=80.0" \
     # JVM Options that can be passed at runtime, while maintaining also those set in JAVA_OPTIONS.
@@ -89,7 +87,6 @@ CMD [ \
         --add-opens java.base/java.util.concurrent=ALL-UNNAMED \
         --enable-native-access=ALL-UNNAMED \
         --sun-misc-unsafe-memory-access=allow \
-        -DdependencyTrack.logging.level=${LOGGING_LEVEL} \
         -cp 'dependency-track-apiserver.jar:lib/*' \
         org.dependencytrack.Application \
         -context ${CONTEXT}" \

--- a/apiserver/src/main/docker/logback-json.xml
+++ b/apiserver/src/main/docker/logback-json.xml
@@ -19,15 +19,15 @@
         </encoder>
     </appender>
 
-    <logger name="alpine" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
+    <logger name="alpine" level="INFO" additivity="false">
         <appender-ref ref="JSON_STDOUT" />
     </logger>
 
-    <logger name="org.dependencytrack" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
+    <logger name="org.dependencytrack" level="INFO" additivity="false">
         <appender-ref ref="JSON_STDOUT" />
     </logger>
 
-    <logger name="org.eclipse.jetty" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
+    <logger name="org.eclipse.jetty" level="INFO" additivity="false">
         <appender-ref ref="JSON_STDOUT" />
     </logger>
 

--- a/apiserver/src/main/java/org/dependencytrack/Application.java
+++ b/apiserver/src/main/java/org/dependencytrack/Application.java
@@ -21,6 +21,7 @@ package org.dependencytrack;
 import alpine.server.AlpineServlet;
 import alpine.server.filters.WhitelistUrlFilter;
 import alpine.server.persistence.PersistenceManagerFactory;
+import ch.qos.logback.classic.LoggerContext;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
 import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.Meter;
@@ -52,6 +53,7 @@ import org.dependencytrack.init.InitTaskExecutor;
 import org.dependencytrack.init.InitTasksHealthCheck;
 import org.dependencytrack.notification.DefaultNotificationPublisherInitializer;
 import org.dependencytrack.notification.NotificationSubsystemInitializer;
+import org.dependencytrack.observability.LoggingConfiguration;
 import org.dependencytrack.observability.ManagementServer;
 import org.dependencytrack.plugin.PluginInitializer;
 import org.dependencytrack.plugin.PluginManagerBinder;
@@ -108,6 +110,7 @@ public final class Application {
         SLF4JBridgeHandler.install();
 
         final Config config = ConfigProvider.getConfig();
+        new LoggingConfiguration(config).apply((LoggerContext) LoggerFactory.getILoggerFactory());
 
         // Start dev services (if enabled) before anything else.
         final var devServices = new DevServices();

--- a/apiserver/src/main/java/org/dependencytrack/observability/LoggingConfiguration.java
+++ b/apiserver/src/main/java/org/dependencytrack/observability/LoggingConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.observability;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import io.smallrye.config.SmallRyeConfig;
+import org.eclipse.microprofile.config.Config;
+
+/**
+ * @since 5.7.0
+ */
+public final class LoggingConfiguration {
+
+    private final Config config;
+
+    public LoggingConfiguration(Config config) {
+        this.config = config;
+    }
+
+    public void apply(LoggerContext loggerContext) {
+        final var smallRyeConfig = config.unwrap(SmallRyeConfig.class);
+        for (final var entry : smallRyeConfig.getMapKeys("dt.logging.level").entrySet()) {
+            final String loggerName = entry.getKey();
+            final var level = Level.toLevel(config.getValue(entry.getValue(), String.class));
+
+            loggerContext.getLogger(loggerName).setLevel(level);
+        }
+    }
+
+}

--- a/apiserver/src/main/resources/logback.xml
+++ b/apiserver/src/main/resources/logback.xml
@@ -8,15 +8,15 @@
         </encoder>
     </appender>
 
-    <logger name="alpine" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
+    <logger name="alpine" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <logger name="org.dependencytrack" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
+    <logger name="org.dependencytrack" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 
-    <logger name="org.eclipse.jetty" level="${dependencyTrack.logging.level:-INFO}" additivity="false">
+    <logger name="org.eclipse.jetty" level="INFO" additivity="false">
         <appender-ref ref="STDOUT" />
     </logger>
 

--- a/apiserver/src/test/java/org/dependencytrack/observability/LoggingConfigurationTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/observability/LoggingConfigurationTest.java
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.observability;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.eclipse.microprofile.config.Config;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LoggingConfigurationTest {
+
+    private LoggerContext loggerContext;
+
+    @BeforeEach
+    void beforeEach() {
+        loggerContext = new LoggerContext();
+    }
+
+    @Test
+    void shouldApplyPerLoggerOverride() {
+        final Config config = new SmallRyeConfigBuilder()
+                .withDefaultValue("dt.logging.level.\"org.dependencytrack\"", "TRACE")
+                .withDefaultValue("dt.logging.level.\"org.eclipse.jetty\"", "ERROR")
+                .build();
+
+        new LoggingConfiguration(config).apply(loggerContext);
+
+        assertThat(loggerContext.getLogger("org.dependencytrack").getLevel()).isEqualTo(Level.TRACE);
+        assertThat(loggerContext.getLogger("org.eclipse.jetty").getLevel()).isEqualTo(Level.ERROR);
+    }
+
+    @Test
+    void shouldApplyRootLoggerOverride() {
+        final Config config = new SmallRyeConfigBuilder()
+                .withDefaultValue("dt.logging.level.\"ROOT\"", "ERROR")
+                .build();
+
+        new LoggingConfiguration(config).apply(loggerContext);
+
+        assertThat(loggerContext.getLogger("ROOT").getLevel()).isEqualTo(Level.ERROR);
+    }
+
+    @Test
+    void shouldNotChangeLevelsWhenNoConfigProvided() {
+        final Config config = new SmallRyeConfigBuilder().build();
+
+        new LoggingConfiguration(config).apply(loggerContext);
+
+        assertThat(loggerContext.getLogger("org.dependencytrack").getLevel()).isNull();
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds support for more granular log level config.

Makes log levels configurable on a per-logger basis, and via the established config mechanism. Before, the logback.xml file had to be customized, which was, quite frankly, annoying.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Docs PR: https://github.com/DependencyTrack/hyades/pull/2092

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
