### PR TITLE
Relocate SmallRye Config's profile properties to the dt. prefix

### DIFF
--- a/alpine/alpine-common/src/test/java/alpine/ConfigTest.java
+++ b/alpine/alpine-common/src/test/java/alpine/ConfigTest.java
@@ -47,7 +47,7 @@ public class ConfigTest {
 
     @Test
     @RestoreEnvironmentVariables
-    @SetEnvironmentVariable(key = "SMALLRYE_CONFIG_PROFILE", value = "dev")
+    @SetEnvironmentVariable(key = "DT_CONFIG_PROFILE", value = "dev")
     @SetEnvironmentVariable(key = "ALPINE_DATABASE_URL", value = "defaultUrl")
     @SetEnvironmentVariable(key = "_DEV_ALPINE_DATABASE_URL", value = "devUrl")
     @SetEnvironmentVariable(key = "ALPINE_DATABASE_USERNAME", value = "defaultUser")

--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -794,7 +794,7 @@
                                     <mainClass>org.dependencytrack.Application</mainClass>
                                     <systemProperties>
                                         <systemProperty>
-                                            <key>smallrye.config.profile</key>
+                                            <key>dt.config.profile</key>
                                             <value>dev</value>
                                         </systemProperty>
                                         <systemProperty>

--- a/common/config/src/main/java/org/dependencytrack/common/config/ConfigPropertyRelocateCustomizer.java
+++ b/common/config/src/main/java/org/dependencytrack/common/config/ConfigPropertyRelocateCustomizer.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.common.config;
+
+import io.smallrye.config.ConfigSourceInterceptor;
+import io.smallrye.config.ConfigSourceInterceptorContext;
+import io.smallrye.config.ConfigSourceInterceptorFactory;
+import io.smallrye.config.Priorities;
+import io.smallrye.config.RelocateConfigSourceInterceptor;
+import io.smallrye.config.SmallRyeConfigBuilder;
+import io.smallrye.config.SmallRyeConfigBuilderCustomizer;
+
+import java.util.OptionalInt;
+
+import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_LOG_VALUES;
+import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE;
+import static io.smallrye.config.SmallRyeConfig.SMALLRYE_CONFIG_PROFILE_PARENT;
+
+/**
+ * @since 5.7.0
+ */
+public final class ConfigPropertyRelocateCustomizer implements SmallRyeConfigBuilderCustomizer {
+
+    @Override
+    public void configBuilder(SmallRyeConfigBuilder builder) {
+        builder.withInterceptorFactories(new ConfigSourceInterceptorFactory() {
+
+            @Override
+            public ConfigSourceInterceptor getInterceptor(ConfigSourceInterceptorContext context) {
+                return new RelocateConfigSourceInterceptor(name -> switch (name) {
+                    case SMALLRYE_CONFIG_LOG_VALUES -> "dt.config.log.values";
+                    case SMALLRYE_CONFIG_PROFILE -> "dt.config.profile";
+                    case SMALLRYE_CONFIG_PROFILE_PARENT -> "dt.config.profile.parent";
+                    default -> name;
+                });
+            }
+
+            @Override
+            public OptionalInt getPriority() {
+                // NB: Must be just below ProfileConfigSourceInterceptor (LIBRARY + 200).
+                return OptionalInt.of(Priorities.LIBRARY + 200 - 10);
+            }
+
+        });
+    }
+
+}

--- a/common/config/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
+++ b/common/config/src/main/resources/META-INF/services/io.smallrye.config.SmallRyeConfigBuilderCustomizer
@@ -1,1 +1,2 @@
+org.dependencytrack.common.config.ConfigPropertyRelocateCustomizer
 org.dependencytrack.common.config.LegacyPropertyFallbackCustomizer


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Relocates SmallRye Config's profile properties to the `dt.` prefix.

Users shouldn't know (or care) about SmallRye Config being used when configuring DT. The `dt.` prefix makes it consistent with all other config properties.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1888 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
