### PR TITLE
Fix finding status not being considered in multiple queries

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -178,6 +178,13 @@ public interface VulnerabilityDao {
             <#if activeFilter>
                  AND "PROJECT"."INACTIVE_SINCE" IS NULL
             </#if>
+                 AND EXISTS (
+                   SELECT 1
+                     FROM "FINDINGATTRIBUTION" AS fa
+                    WHERE fa."COMPONENT_ID" = "COMPONENT"."ID"
+                      AND fa."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+                      AND fa."DELETED_AT" IS NULL
+                 )
             )
             SELECT "UUID" AS "uuid"
                  , "NAME" AS "name"
@@ -285,6 +292,13 @@ public interface VulnerabilityDao {
             <#if apiFilterParameter??>
                AND (LOWER("V"."VULNID") LIKE ('%' || LOWER(${apiFilterParameter}) || '%'))
             </#if>
+               AND EXISTS (
+                 SELECT 1
+                   FROM "FINDINGATTRIBUTION" AS fa
+                  WHERE fa."COMPONENT_ID" = "COMPONENT"."ID"
+                    AND fa."VULNERABILITY_ID" = "V"."ID"
+                    AND fa."DELETED_AT" IS NULL
+               )
             ORDER BY "V"."ID"
             """)
     @RegisterRowMapper(VulnerabilityRowMapper.class)
@@ -313,6 +327,13 @@ public interface VulnerabilityDao {
                AND "ANALYSIS"."SUPPRESSED" IS DISTINCT FROM TRUE
             </#if>
                AND ${apiProjectAclCondition}
+               AND EXISTS (
+                 SELECT 1
+                   FROM "FINDINGATTRIBUTION" AS fa
+                  WHERE fa."COMPONENT_ID" = "COMPONENT"."ID"
+                    AND fa."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+                    AND fa."DELETED_AT" IS NULL
+               )
              GROUP BY "VULNERABILITY"."ID"
             """)
     @RegisterConstructorMapper(AffectedProjectCountRow.class)
@@ -392,6 +413,13 @@ public interface VulnerabilityDao {
             <#if apiFilterParameter??>
                AND (LOWER("V"."VULNID") LIKE ('%' || LOWER(${apiFilterParameter}) || '%'))
             </#if>
+               AND EXISTS (
+                 SELECT 1
+                   FROM "FINDINGATTRIBUTION" AS fa
+                  WHERE fa."COMPONENT_ID" = "COMPONENT"."ID"
+                    AND fa."VULNERABILITY_ID" = "V"."ID"
+                    AND fa."DELETED_AT" IS NULL
+               )
              GROUP BY "V"."ID", "EPSS"."SCORE", "EPSS"."PERCENTILE"
              ORDER BY "V"."ID"
             """)
@@ -399,50 +427,57 @@ public interface VulnerabilityDao {
     List<Vulnerability> getVulnerabilitiesByProject(@Bind long projectId, @Define boolean includeSuppressed);
 
     @SqlQuery("""
-         SELECT distinct "C"."ID",
-            "C"."NAME",
-            "C"."AUTHORS",
-            "C"."BLAKE2B_256",
-            "C"."BLAKE2B_384",
-            "C"."BLAKE2B_512",
-            "C"."BLAKE3",
-            "C"."CLASSIFIER",
-            "C"."COPYRIGHT",
-            "C"."CPE",
-            "C"."PUBLISHER",
-            "C"."PURL",
-            "C"."PURLCOORDINATES",
-            "C"."DESCRIPTION",
-            "C"."DIRECT_DEPENDENCIES",
-            "C"."EXTENSION",
-            "C"."EXTERNAL_REFERENCES",
-            "C"."FILENAME",
-            "C"."GROUP",
-            "C"."INTERNAL",
-            "C"."LAST_RISKSCORE",
-            "C"."LICENSE",
-            "C"."LICENSE_EXPRESSION",
-            "C"."LICENSE_URL",
-            "C"."TEXT",
-            "C"."MD5",
-            "C"."SHA1",
-            "C"."SHA_256",
-            "C"."SHA_384",
-            "C"."SHA_512",
-            "C"."SHA3_256",
-            "C"."SHA3_384",
-            "C"."SHA3_512",
-            "C"."SWIDTAGID",
-            "C"."UUID",
-            "C"."VERSION"
-         FROM "COMPONENT" AS "C"
-         INNER JOIN "COMPONENTS_VULNERABILITIES"
-            ON "C"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
-         INNER JOIN "VULNERABILITY"
-             ON "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
-         WHERE "VULNERABILITY"."ID" = ANY(:vulnerabilityIds)
-         and "C"."PROJECT_ID" = :projectId
-         """)
+            SELECT DISTINCT "C"."ID"
+                 , "C"."NAME"
+                 , "C"."AUTHORS"
+                 , "C"."BLAKE2B_256"
+                 , "C"."BLAKE2B_384"
+                 , "C"."BLAKE2B_512"
+                 , "C"."BLAKE3"
+                 , "C"."CLASSIFIER"
+                 , "C"."COPYRIGHT"
+                 , "C"."CPE"
+                 , "C"."PUBLISHER"
+                 , "C"."PURL"
+                 , "C"."PURLCOORDINATES"
+                 , "C"."DESCRIPTION"
+                 , "C"."DIRECT_DEPENDENCIES"
+                 , "C"."EXTENSION"
+                 , "C"."EXTERNAL_REFERENCES"
+                 , "C"."FILENAME"
+                 , "C"."GROUP"
+                 , "C"."INTERNAL"
+                 , "C"."LAST_RISKSCORE"
+                 , "C"."LICENSE"
+                 , "C"."LICENSE_EXPRESSION"
+                 , "C"."LICENSE_URL"
+                 , "C"."TEXT"
+                 , "C"."MD5"
+                 , "C"."SHA1"
+                 , "C"."SHA_256"
+                 , "C"."SHA_384"
+                 , "C"."SHA_512"
+                 , "C"."SHA3_256"
+                 , "C"."SHA3_384"
+                 , "C"."SHA3_512"
+                 , "C"."SWIDTAGID"
+                 , "C"."UUID"
+                 , "C"."VERSION"
+              FROM "COMPONENT" AS "C"
+             INNER JOIN "COMPONENTS_VULNERABILITIES"
+                ON "C"."ID" = "COMPONENTS_VULNERABILITIES"."COMPONENT_ID"
+             INNER JOIN "VULNERABILITY"
+                ON "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+             WHERE "VULNERABILITY"."ID" = ANY(:vulnerabilityIds)
+               AND "C"."PROJECT_ID" = :projectId
+               AND EXISTS (
+                   SELECT 1
+                     FROM "FINDINGATTRIBUTION" AS "FA"
+                    WHERE "FA"."COMPONENT_ID" = "C"."ID"
+                      AND "FA"."VULNERABILITY_ID" = "VULNERABILITY"."ID"
+                      AND "FA"."DELETED_AT" IS NULL
+                 )
+            """)
     @RegisterFieldMapper(Component.class)
     @RegisterColumnMapper(OrganizationalContactMapper.class)
     @RegisterColumnMapper(ExternalReferenceMapper.class)
@@ -467,12 +502,18 @@ public interface VulnerabilityDao {
 
     @SqlQuery("""
             SELECT EXISTS(
-                SELECT 1 FROM "COMPONENTS_VULNERABILITIES"
-                WHERE "COMPONENT_ID" IN
-                (
-                    SELECT "ID" FROM "COMPONENT"
-                    WHERE "PROJECT_ID" = :projectId
-                )
+                SELECT 1
+                  FROM "COMPONENT" AS c
+                 INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
+                    ON cv."COMPONENT_ID" = c."ID"
+                 WHERE c."PROJECT_ID" = :projectId
+                   AND EXISTS (
+                     SELECT 1
+                       FROM "FINDINGATTRIBUTION" AS fa
+                      WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
+                        AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
+                        AND fa."DELETED_AT" IS NULL
+                   )
             )
             """)
     boolean hasVulnerabilities(@Bind final long projectId);

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyQueryManager.java
@@ -132,16 +132,20 @@ class CelPolicyQueryManager implements AutoCloseable {
      * @return A {@link List} of {@link ComponentsVulnerabilitiesProjection}
      */
     List<ComponentsVulnerabilitiesProjection> fetchAllComponentsVulnerabilities(final long projectId) {
-        final Query<?> query = pm.newQuery(Query.SQL, """
-                SELECT
-                  "CV"."COMPONENT_ID" AS "componentId",
-                  "CV"."VULNERABILITY_ID" AS "vulnerabilityId"
-                FROM
-                  "COMPONENTS_VULNERABILITIES" AS "CV"
-                INNER JOIN
-                  "COMPONENT" AS "C" ON "C"."ID" = "CV"."COMPONENT_ID"
-                WHERE
-                  "C"."PROJECT_ID" = ?
+        final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                SELECT "CV"."COMPONENT_ID" AS "componentId"
+                     , "CV"."VULNERABILITY_ID" AS "vulnerabilityId"
+                  FROM "COMPONENTS_VULNERABILITIES" AS "CV"
+                 INNER JOIN "COMPONENT" AS "C"
+                    ON "C"."ID" = "CV"."COMPONENT_ID"
+                 WHERE "C"."PROJECT_ID" = ?
+                   AND EXISTS (
+                     SELECT 1
+                       FROM "FINDINGATTRIBUTION" AS fa
+                      WHERE fa."COMPONENT_ID" = "C"."ID"
+                        AND fa."VULNERABILITY_ID" = "CV"."VULNERABILITY_ID"
+                        AND fa."DELETED_AT" IS NULL
+                   )
                 """);
         query.setParameters(projectId);
         try {
@@ -260,18 +264,24 @@ class CelPolicyQueryManager implements AutoCloseable {
             sqlSelectColumns += ", \"EP\".\"PERCENTILE\" AS \"epssPercentile\"";
         }
 
-        final Query<?> query = pm.newQuery(Query.SQL, """
-                SELECT DISTINCT
-                  %s
-                FROM
-                  "VULNERABILITY" AS "V"
-                INNER JOIN
-                  "COMPONENTS_VULNERABILITIES" AS "CV" ON "CV"."VULNERABILITY_ID" = "V"."ID"
-                INNER JOIN
-                  "COMPONENT" AS "C" ON "C"."ID" = "CV"."COMPONENT_ID"
-                LEFT JOIN "EPSS" AS "EP" ON "V"."VULNID" = "EP"."CVE" AND :shouldFetchEpss
-                WHERE
-                  "C"."PROJECT_ID" = :projectId
+        final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                SELECT DISTINCT %s
+                  FROM "VULNERABILITY" AS "V"
+                 INNER JOIN "COMPONENTS_VULNERABILITIES" AS "CV"
+                    ON "CV"."VULNERABILITY_ID" = "V"."ID"
+                 INNER JOIN "COMPONENT" AS "C"
+                    ON "C"."ID" = "CV"."COMPONENT_ID"
+                  LEFT JOIN "EPSS" AS "EP"
+                    ON "V"."VULNID" = "EP"."CVE"
+                   AND :shouldFetchEpss
+                 WHERE "C"."PROJECT_ID" = :projectId
+                   AND EXISTS (
+                     SELECT 1
+                       FROM "FINDINGATTRIBUTION" AS fa
+                      WHERE fa."COMPONENT_ID" = "C"."ID"
+                        AND fa."VULNERABILITY_ID" = "V"."ID"
+                        AND fa."DELETED_AT" IS NULL
+                   )
                 """.formatted(sqlSelectColumns));
         query.setNamedParameters(Map.of(
                 "projectId", projectId,

--- a/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
@@ -86,13 +86,15 @@ public class VulnerabilityQueryManagerTest extends PersistenceCapableTest {
             author.setName("author");
             component.setAuthors(List.of(author));
 
-            component.setVulnerabilities(List.of(vulnA, vulnB));
+            qm.addVulnerability(vulnA, component, "none");
+            qm.addVulnerability(vulnB, component, "none");
 
             Component component2 = new Component();
             component2.setProject(project);
             component2.setName("ABCD");
             component2.setPurl("pkg:maven/org.acme/abcd");
-            component2.setVulnerabilities(List.of(vulnA));
+
+            qm.addVulnerability(vulnA, component2, "none");
 
             qm.persist(component, component2);
         }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/VulnerabilityDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/VulnerabilityDaoTest.java
@@ -73,6 +73,54 @@ public class VulnerabilityDaoTest extends PersistenceCapableTest {
     }
 
     @Test
+    public void testProjectHasVulnerabilitiesWithDeletedFinding() {
+        final var project = qm.createProject("acme-app", "Description 1", "1.0.0", null, null, null, null, false);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("2.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(NVD);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
+        assertThat(vulnerabilityDao.hasVulnerabilities(project.getId())).isTrue();
+
+        final var attributions = qm.getFindingAttributions(vuln, component);
+        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
+
+        assertThat(vulnerabilityDao.hasVulnerabilities(project.getId())).isFalse();
+    }
+
+    @Test
+    public void testGetVulnerableComponentsWithDeletedFinding() {
+        final var project = qm.createProject("acme-app", "Description 1", "1.0.0", null, null, null, null, false);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("2.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(NVD);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
+        assertThat(vulnerabilityDao.getVulnerableComponents(project.getId(), java.util.List.of(vuln.getId()))).hasSize(1);
+
+        final var attributions = qm.getFindingAttributions(vuln, component);
+        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
+
+        assertThat(vulnerabilityDao.getVulnerableComponents(project.getId(), java.util.List.of(vuln.getId()))).isEmpty();
+    }
+
+    @Test
     public void testGetVulnerabilityId() {
         final var vuln = new Vulnerability();
         vuln.setVulnId("INT-123");

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -47,6 +47,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -113,6 +114,41 @@ public class VulnerabilityResourceTest extends ResourceTest {
                     }
                 ]
                 """);
+    }
+
+    @Test
+    public void getVulnerabilitiesByComponentUuidWithDeletedFindingTest() {
+        var project = qm.createProject("Project 1", null, null, null, null, null, null, false);
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Component 1");
+        qm.createComponent(component, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, component, "none");
+
+        Response response = jersey
+                .target(V1_VULNERABILITY + "/component/" + component.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("1", response.getHeaderString(TOTAL_COUNT_HEADER));
+
+        var attributions = qm.getFindingAttributions(vuln, component);
+        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
+
+        response = jersey
+                .target(V1_VULNERABILITY + "/component/" + component.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("0", response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
@@ -321,6 +357,41 @@ public class VulnerabilityResourceTest extends ResourceTest {
                      }
                  ]
                 """);
+    }
+
+    @Test
+    public void getVulnerabilitiesByProjectWithDeletedFindingTest() {
+        var project = qm.createProject("Project 1", null, null, null, null, null, null, false);
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Component 1");
+        qm.createComponent(component, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, component, "none");
+
+        Response response = jersey
+                .target(V1_VULNERABILITY + "/project/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("1", response.getHeaderString(TOTAL_COUNT_HEADER));
+
+        var attributions = qm.getFindingAttributions(vuln, component);
+        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
+
+        response = jersey
+                .target(V1_VULNERABILITY + "/project/" + project.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("0", response.getHeaderString(TOTAL_COUNT_HEADER));
     }
 
     @Test
@@ -557,6 +628,41 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getAffectedProjectWithDeletedFindingTest() {
+        var project = qm.createProject("Project 1", null, null, null, null, null, null, false);
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Component 1");
+        qm.createComponent(component, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, component, "none");
+
+        Response response = jersey
+                .target(V1_VULNERABILITY + "/source/" + vuln.getSource() + "/vuln/" + vuln.getVulnId() + "/projects")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("1", response.getHeaderString(TOTAL_COUNT_HEADER));
+
+        var attributions = qm.getFindingAttributions(vuln, component);
+        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
+
+        response = jersey
+                .target(V1_VULNERABILITY + "/source/" + vuln.getSource() + "/vuln/" + vuln.getVulnId() + "/projects")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals("0", response.getHeaderString(TOTAL_COUNT_HEADER));
+    }
+
+    @Test
     public void getAffectedProjectWithVulnerabilityNotExistingTest() {
         new SampleData();
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/blah/projects").request()
@@ -631,6 +737,43 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assertions.assertEquals("INT-5", json.getJsonObject(4).getString("vulnId"));
         Assertions.assertEquals(1, json.getJsonObject(4).getInt("affectedProjectCount"));
         Assertions.assertNull(json.getJsonObject(4).getJsonObject("components"));
+    }
+
+    @Test
+    public void getAllVulnerabilitiesWithDeletedFindingTest() {
+        var project = qm.createProject("Project 1", null, null, null, null, null, null, false);
+        var component = new Component();
+        component.setProject(project);
+        component.setName("Component 1");
+        qm.createComponent(component, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("INT-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        qm.createVulnerability(vuln, false);
+        qm.addVulnerability(vuln, component, "none");
+
+        Response response = jersey
+                .target(V1_VULNERABILITY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        JsonArray json = parseJsonArray(response);
+        Assertions.assertEquals(1, json.getJsonObject(0).getInt("affectedProjectCount"));
+
+        var attributions = qm.getFindingAttributions(vuln, component);
+        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
+
+        response = jersey
+                .target(V1_VULNERABILITY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        Assertions.assertEquals(200, response.getStatus());
+        json = parseJsonArray(response);
+        Assertions.assertEquals(0, json.getJsonObject(0).getInt("affectedProjectCount"));
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

As per ADR-013, a finding is only considered active when at least one non-deleted attribution exists for it.

This logic was not yet encoded in all queries that select vulnerabilities, which caused for example projects to be listed as affected by a vulnerability that had no active finding.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
