### PR TITLE
Allow secret management KEK to be provided as base64-encoded config value

### DIFF
--- a/apiserver/src/main/resources/application-dev.properties
+++ b/apiserver/src/main/resources/application-dev.properties
@@ -5,3 +5,4 @@ dt.datasource.username=dtrack
 dt.metrics.enabled=true
 dt.notification-publisher.email.allow-local-connections=true
 dt.notification-publisher.kafka.allow-local-connections=true
+dt.secret-management.database.kek=Ccbo1y2QTKVHZbANVb/ER5yvTn5yZe5UtIpZ+eRSnTg=

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -352,9 +352,26 @@ dt.secret-management.provider=database
 # @type:     string
 dt.secret-management.database.datasource.name=default
 
+# Defines a base64-encoded AES-256 key (32 bytes) to use as the key encryption key (KEK)
+# for the database secret manager.
+# <br/><br/>
+# A secure key may be generated using OpenSSL like this: `openssl rand -base64 32`
+# <br/><br/>
+# When set, takes precedence over dt.secret-management.database.kek-keyset.path.
+# Unlike the keyset file approach, this option does not support KEK rotation.
+# <br/><br/>
+# Must be the same for all nodes in the cluster. When different keys are detected,
+# the application will fail to start.
+#
+# @category: Secrets
+# @type:     string
+# dt.secret-management.database.kek=
+
 # Defines the path to the key encryption keyset to use for the database secret manager.
 # <br/><br/>
-# Required when dt.secret-management.provider is `database`.
+# Must point to the same file for all nodes in the cluster, e.g. using a shared volume
+# or mounted k8s secret. When different keysets are detected, the application will fail
+# to start.
 #
 # @category: Secrets
 # @type:     string

--- a/secret-management/src/main/java/org/dependencytrack/secret/management/database/Crypto.java
+++ b/secret-management/src/main/java/org/dependencytrack/secret/management/database/Crypto.java
@@ -25,12 +25,16 @@ import com.google.crypto.tink.RegistryConfiguration;
 import com.google.crypto.tink.TinkJsonProtoKeysetFormat;
 import com.google.crypto.tink.TinkProtoKeysetFormat;
 import com.google.crypto.tink.aead.AeadConfig;
+import com.google.crypto.tink.aead.AesGcmKey;
 import com.google.crypto.tink.aead.PredefinedAeadParameters;
+import com.google.crypto.tink.util.SecretBytes;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.FileAttribute;
 import java.nio.file.attribute.PosixFilePermission;
@@ -101,12 +105,51 @@ final class Crypto {
         return new EncryptionResult(cipherText, serializedDek);
     }
 
-    private Aead loadKek(final DatabaseSecretManagerConfig config) {
+    private Aead loadKek(DatabaseSecretManagerConfig config) {
         // The KEK is usually meant to be fetched from an external KMS.
         // We can't make KMSes a mandatory requirement, hence we support
-        // loading the KEK keyset from file instead. However, support for
-        // external KMSes would be relatively easy to add if requested.
+        // fixed keys from config, or loading the KEK keyset from file instead.
+        // However, support for external KMSes would be relatively easy to add if requested.
         // https://developers.google.com/tink/key-management-overview
+
+        final Logger logger = LoggerFactory.getLogger(DatabaseSecretManager.class);
+
+        final byte[] kekBytes = config.getKek();
+        if (kekBytes != null) {
+            logger.info("Loading KEK from config");
+
+            // Derive a stable key ID from the key bytes.
+            // Note that Tink by convention uses positive key IDs,
+            // while hashCode can yield negative values.
+            // Clear the sign bit to ensure we're always following the Tink convention.
+            final int keyId = Arrays.hashCode(kekBytes) & 0x7FFFFFFF | 1;
+
+            try {
+                final var key = AesGcmKey.builder()
+                        .setIdRequirement(keyId)
+                        .setParameters(PredefinedAeadParameters.AES256_GCM)
+                        .setKeyBytes(SecretBytes.copyFrom(kekBytes, InsecureSecretKeyAccess.get()))
+                        .build();
+
+                final var keysetHandle = KeysetHandle.newBuilder()
+                        .addEntry(KeysetHandle
+                                .importKey(key)
+                                .withFixedId(keyId)
+                                .makePrimary())
+                        .build();
+
+                return doLocked(connection -> {
+                    verifyOrStoreKekKeyIds(connection, keysetHandle);
+                    return keysetHandle.getPrimitive(RegistryConfiguration.get(), Aead.class);
+                });
+            } catch (GeneralSecurityException e) {
+                throw new IllegalStateException("Failed to load KEK from config", e);
+            }
+        }
+
+        // NB: Throws when not configured.
+        // Calling it here so we don't even open a DB connection if missing.
+        final Path kekKeysetPath = config.getKekKeysetPath();
 
         return doLocked(connection -> {
             // This must execute in a locked context to avoid race conditions
@@ -114,19 +157,17 @@ final class Crypto {
             // and the create-if-missing option is enabled.
 
             final KeysetHandle keysetHandle;
-            if (Files.exists(config.getKekKeysetPath())) {
-                LoggerFactory.getLogger(DatabaseSecretManager.class).info(
-                        "Loading existing KEK keyset from {}", config.getKekKeysetPath());
+            if (Files.exists(kekKeysetPath)) {
+                logger.info("Loading existing KEK keyset from {}", kekKeysetPath);
                 keysetHandle =
                         TinkJsonProtoKeysetFormat.parseKeyset(
-                                Files.readString(config.getKekKeysetPath()), InsecureSecretKeyAccess.get());
+                                Files.readString(kekKeysetPath), InsecureSecretKeyAccess.get());
             } else if (config.isCreateKekKeysetIfMissing()) {
-                LoggerFactory.getLogger(DatabaseSecretManager.class).info(
-                        "KEK keyset at {} does not exist yet; Creating it", config.getKekKeysetPath());
-                keysetHandle = KeysetHandle.generateNew(PredefinedAeadParameters.AES128_GCM);
+                logger.info("KEK keyset at {} does not exist yet; Creating it", kekKeysetPath);
+                keysetHandle = KeysetHandle.generateNew(PredefinedAeadParameters.AES256_GCM);
 
                 // Ensure all directories leading up to the keyset exist.
-                Files.createDirectories(config.getKekKeysetPath().getParent());
+                Files.createDirectories(kekKeysetPath.getParent());
 
                 // Create the file with as restrictive permissions as possible.
                 // Note that GROUP_READ is necessary for OpenShift deployments,
@@ -138,16 +179,16 @@ final class Crypto {
                                 PosixFilePermission.GROUP_READ));
 
                 if (!System.getProperty("os.name").toLowerCase().startsWith("win")) {
-                    Files.createFile(config.getKekKeysetPath(), posixPermissionsAttribute);
+                    Files.createFile(kekKeysetPath, posixPermissionsAttribute);
                 } else {
                     // POSIX permissions don't work on Windows.
                     // Note that this fallback is mainly for developers working on Windows
                     // machines, since our official distribution is a Linux-based container image.
-                    Files.createFile(config.getKekKeysetPath());
+                    Files.createFile(kekKeysetPath);
                 }
 
                 Files.writeString(
-                        config.getKekKeysetPath(),
+                        kekKeysetPath,
                         TinkJsonProtoKeysetFormat.serializeKeyset(keysetHandle, InsecureSecretKeyAccess.get()),
                         StandardOpenOption.WRITE);
             } else {
@@ -155,7 +196,7 @@ final class Crypto {
                         KEK keyset at %s does not exist and \
                         dt.secret-management.database.kek-keyset.create-if-missing \
                         is false. Can not continue without a valid KEK keyset.\
-                        """.formatted(config.getKekKeysetPath()));
+                        """.formatted(kekKeysetPath));
             }
 
             verifyOrStoreKekKeyIds(connection, keysetHandle);

--- a/secret-management/src/main/java/org/dependencytrack/secret/management/database/DatabaseSecretManagerConfig.java
+++ b/secret-management/src/main/java/org/dependencytrack/secret/management/database/DatabaseSecretManagerConfig.java
@@ -19,8 +19,10 @@
 package org.dependencytrack.secret.management.database;
 
 import org.eclipse.microprofile.config.Config;
+import org.jspecify.annotations.Nullable;
 
 import java.nio.file.Path;
+import java.util.Base64;
 
 /**
  * @since 5.7.0
@@ -37,6 +39,34 @@ final class DatabaseSecretManagerConfig {
 
     String getDataSourceName() {
         return config.getValue(PREFIX + "datasource.name", String.class);
+    }
+
+    byte @Nullable [] getKek() {
+        final String propertyName = PREFIX + "kek";
+
+        final String encodedKek = config
+                .getOptionalValue(propertyName, String.class)
+                .orElse(null);
+        if (encodedKek == null) {
+            return null;
+        }
+
+        final byte[] kekBytes;
+        try {
+            kekBytes = Base64.getDecoder().decode(encodedKek);
+        } catch (IllegalArgumentException e) {
+            // NB: Original exception is intentionally not logged to avoid leaking the key.
+            throw new IllegalStateException(
+                    "The provided %s value is not base64 encoded".formatted(propertyName));
+        }
+
+        if (kekBytes.length != 32) {
+            throw new IllegalStateException(
+                    "KEK provided via %s must be 32 bytes, but is %d".formatted(
+                            propertyName, kekBytes.length));
+        }
+
+        return kekBytes;
     }
 
     Path getKekKeysetPath() {

--- a/secret-management/src/test/java/org/dependencytrack/secret/management/database/CryptoTest.java
+++ b/secret-management/src/test/java/org/dependencytrack/secret/management/database/CryptoTest.java
@@ -38,10 +38,13 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.SecureRandom;
 import java.sql.Connection;
 import java.sql.Statement;
+import java.util.Base64;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
@@ -152,6 +155,53 @@ class CryptoTest {
 
         final DatabaseSecretManagerConfig configB = createConfig(kekPathB, false);
         assertThatNoException().isThrownBy(() -> new Crypto(dataSource, configB));
+    }
+
+    @Test
+    void shouldEncryptAndDecryptWithConfigKek() throws Exception {
+        final byte[] kekBytes = new byte[32];
+        new SecureRandom().nextBytes(kekBytes);
+
+        final DatabaseSecretManagerConfig config = createConfigWithKek(kekBytes);
+        final var crypto = new Crypto(dataSource, config);
+
+        final Crypto.EncryptionResult result = crypto.encrypt("secret-value");
+        assertThat(crypto.decrypt(result.cipherText(), result.serializedDek())).isEqualTo("secret-value");
+    }
+
+    @Test
+    void shouldRejectDifferentConfigKek() {
+        final byte[] kekBytesA = new byte[32];
+        new SecureRandom().nextBytes(kekBytesA);
+        new Crypto(dataSource, createConfigWithKek(kekBytesA));
+
+        final byte[] kekBytesB = new byte[32];
+        new SecureRandom().nextBytes(kekBytesB);
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> new Crypto(dataSource, createConfigWithKek(kekBytesB)))
+                .withMessageContaining("KEK keyset mismatch");
+    }
+
+    @Test
+    void shouldAcceptSameConfigKek() {
+        final byte[] kekBytes = new byte[32];
+        new SecureRandom().nextBytes(kekBytes);
+
+        new Crypto(dataSource, createConfigWithKek(kekBytes));
+        assertThatNoException().isThrownBy(() -> new Crypto(dataSource, createConfigWithKek(kekBytes)));
+    }
+
+    private DatabaseSecretManagerConfig createConfigWithKek(byte[] kekBytes) {
+        final String encodedKek = Base64.getEncoder().encodeToString(kekBytes);
+        return new DatabaseSecretManagerConfig(
+                new SmallRyeConfigBuilder()
+                        .withDefaultValues(Map.ofEntries(
+                                Map.entry("dt.datasource.secrets.url", postgresContainer.getJdbcUrl()),
+                                Map.entry("dt.datasource.secrets.username", postgresContainer.getUsername()),
+                                Map.entry("dt.datasource.secrets.password", postgresContainer.getPassword()),
+                                Map.entry("dt.secret-management.database.datasource.name", "secrets"),
+                                Map.entry("dt.secret-management.database.kek", encodedKek)))
+                        .build());
     }
 
     private DatabaseSecretManagerConfig createConfig(Path kekPath, boolean createIfMissing) {

--- a/secret-management/src/test/java/org/dependencytrack/secret/management/database/DatabaseSecretManagerConfigTest.java
+++ b/secret-management/src/test/java/org/dependencytrack/secret/management/database/DatabaseSecretManagerConfigTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.secret.management.database;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class DatabaseSecretManagerConfigTest {
+
+    @Test
+    void shouldReturnNullWhenKekNotConfigured() {
+        final var config = new DatabaseSecretManagerConfig(
+                new SmallRyeConfigBuilder().build());
+
+        assertThat(config.getKek()).isNull();
+    }
+
+    @Test
+    void shouldReturnDecodedKekBytes() {
+        final byte[] expectedBytes = new byte[32];
+        for (int i = 0; i < 32; i++) {
+            expectedBytes[i] = (byte) i;
+        }
+
+        final var config = new DatabaseSecretManagerConfig(
+                new SmallRyeConfigBuilder()
+                        .withDefaultValues(Map.of(
+                                "dt.secret-management.database.kek",
+                                Base64.getEncoder().encodeToString(expectedBytes)))
+                        .build());
+
+        assertThat(config.getKek()).isEqualTo(expectedBytes);
+    }
+
+    @Test
+    void shouldThrowWhenKekNotBase64() {
+        final var config = new DatabaseSecretManagerConfig(
+                new SmallRyeConfigBuilder()
+                        .withDefaultValues(Map.of(
+                                "dt.secret-management.database.kek", "invalid-base64"))
+                        .build());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(config::getKek)
+                .withMessageContaining("not base64 encoded");
+    }
+
+    @Test
+    void shouldThrowWhenKekWrongLength() {
+        final byte[] shortKey = new byte[16];
+        final var config = new DatabaseSecretManagerConfig(
+                new SmallRyeConfigBuilder()
+                        .withDefaultValues(Map.of(
+                                "dt.secret-management.database.kek",
+                                Base64.getEncoder().encodeToString(shortKey)))
+                        .build());
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(config::getKek)
+                .withMessageContaining("must be 32 bytes, but is 16");
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows secret management KEK to be provided as base64-encoded config value

Makes it easier for users who don't necessarily care about KEK rotation, as it voids the need to deal with a KEK keyset file.

Also changes the default key length to 256bit. Existing 128bit keys will continue to work.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Docs PR: https://github.com/DependencyTrack/hyades/pull/2101

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
