### PR TITLE
Simplify CEL policy script host

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelCommonPolicyLibrary.java
@@ -21,6 +21,7 @@ package org.dependencytrack.policy.cel;
 import alpine.common.logging.Logger;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import com.google.api.expr.v1alpha1.Type;
 import io.github.nscuro.versatile.Vers;
 import io.github.nscuro.versatile.VersException;
 import jakarta.annotation.Nullable;
@@ -69,6 +70,7 @@ import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMPONENT;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
 import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_VERSION_DISTANCE;
+import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_VULNERABILITY;
 
 public class CelCommonPolicyLibrary implements Library {
 
@@ -81,6 +83,25 @@ public class CelCommonPolicyLibrary implements Library {
     static final String FUNC_MATCHES_RANGE = "matches_range";
     static final String FUNC_COMPARE_AGE = "compare_age";
     static final String FUNC_COMPARE_VERSION_DISTANCE = "version_distance";
+
+    static final Map<String, Map<Type, List<String>>> FUNCTION_FIELD_REQUIREMENTS = Map.ofEntries(
+            Map.entry(FUNC_DEPENDS_ON, Map.of(TYPE_PROJECT, List.of("uuid"), TYPE_COMPONENT, List.of("uuid"))),
+            Map.entry(FUNC_IS_DEPENDENCY_OF, Map.of(TYPE_COMPONENT, List.of("uuid"))),
+            Map.entry(FUNC_IS_EXCLUSIVE_DEPENDENCY_OF, Map.of(TYPE_COMPONENT, List.of("uuid"))),
+            Map.entry(FUNC_IS_DIRECT_DEPENDENCY_OF, Map.of(TYPE_COMPONENT, List.of("uuid"))),
+            Map.entry(FUNC_MATCHES_RANGE, Map.of(TYPE_PROJECT, List.of("version"), TYPE_COMPONENT, List.of("version"))),
+            Map.entry(FUNC_COMPARE_VERSION_DISTANCE, Map.of(TYPE_COMPONENT, List.of("purl", "uuid", "version", "latest_version"))),
+            Map.entry(FUNC_COMPARE_AGE, Map.of(TYPE_COMPONENT, List.of("purl", "published_at"))));
+
+    static final Map<Type, Map<String, List<String>>> FIELD_EXPANSIONS = Map.of(
+            TYPE_VULNERABILITY, Map.of(
+                    "severity", List.of(
+                            "cvssv2_base_score",
+                            "cvssv3_base_score",
+                            "cvssv4_score",
+                            "owasp_rr_likelihood_score",
+                            "owasp_rr_technical_impact_score",
+                            "owasp_rr_business_impact_score")));
 
     @Override
     public List<EnvOption> getCompileOptions() {

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptHost.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelPolicyScriptHost.java
@@ -43,19 +43,12 @@ import org.projectnessie.cel.tools.ScriptCreateException;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_COMPARE_AGE;
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_COMPARE_VERSION_DISTANCE;
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_DEPENDS_ON;
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_DEPENDENCY_OF;
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_DIRECT_DEPENDENCY_OF;
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_IS_EXCLUSIVE_DEPENDENCY_OF;
-import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNC_MATCHES_RANGE;
-import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_COMPONENT;
-import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_PROJECT;
-import static org.dependencytrack.policy.cel.definition.CelPolicyTypes.TYPE_VULNERABILITY;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FIELD_EXPANSIONS;
+import static org.dependencytrack.policy.cel.CelCommonPolicyLibrary.FUNCTION_FIELD_REQUIREMENTS;
 import static org.projectnessie.cel.Issues.newIssues;
 import static org.projectnessie.cel.common.Source.newTextSource;
 
@@ -151,48 +144,31 @@ public class CelPolicyScriptHost {
         final var visitor = new CelPolicyScriptVisitor(expr.getTypeMapMap());
         visitor.visit(expr.getExpr());
 
-        // Fields that are accessed directly are always a requirement.
         final MultiValuedMap<Type, String> requirements = visitor.getAccessedFieldsByType();
 
-        // Special case for vulnerability severity: The "true" severity may or may not be persisted
-        // in the SEVERITY database column. To compute the actual severity, CVSSv2, CVSSv3, CVSSv4, and OWASP RR
-        // scores may be required. See https://github.com/DependencyTrack/dependency-track/issues/2474
-        if (requirements.containsKey(TYPE_VULNERABILITY)
-            && requirements.get(TYPE_VULNERABILITY).contains("severity")) {
-            requirements.putAll(TYPE_VULNERABILITY, List.of(
-                    "cvssv2_base_score",
-                    "cvssv3_base_score",
-                    "cvssv4_score",
-                    "owasp_rr_likelihood_score",
-                    "owasp_rr_technical_impact_score",
-                    "owasp_rr_business_impact_score"
-            ));
+        for (final var expansion : FIELD_EXPANSIONS.entrySet()) {
+            final Type type = expansion.getKey();
+            if (!requirements.containsKey(type)) {
+                continue;
+            }
+
+            for (final var fieldExpansion : expansion.getValue().entrySet()) {
+                if (requirements.get(type).contains(fieldExpansion.getKey())) {
+                    requirements.putAll(type, fieldExpansion.getValue());
+                }
+            }
         }
 
-        // Custom functions may access certain fields implicitly, in a way that is not visible
-        // to the AST visitor. To compensate, we hardcode the functions' requirements here.
-        // TODO: This should be restructured to be more generic.
-        for (final FunctionSignature functionSignature : visitor.getUsedFunctionSignatures()) {
-            switch (functionSignature.function()) {
-                case FUNC_DEPENDS_ON, FUNC_IS_DEPENDENCY_OF, FUNC_IS_EXCLUSIVE_DEPENDENCY_OF, FUNC_IS_DIRECT_DEPENDENCY_OF -> {
-                    if (TYPE_PROJECT.equals(functionSignature.targetType())) {
-                        requirements.put(TYPE_PROJECT, "uuid");
-                    } else if (TYPE_COMPONENT.equals(functionSignature.targetType())) {
-                        requirements.put(TYPE_COMPONENT, "uuid");
-                    }
-                }
-                case FUNC_MATCHES_RANGE -> {
-                    if (TYPE_PROJECT.equals(functionSignature.targetType())) {
-                        requirements.put(TYPE_PROJECT, "version");
-                    } else if (TYPE_COMPONENT.equals(functionSignature.targetType())) {
-                        requirements.put(TYPE_COMPONENT, "version");
-                    }
-                }
-                case FUNC_COMPARE_VERSION_DISTANCE ->
-                        requirements.putAll(TYPE_COMPONENT, List.of("purl", "uuid", "version", "latest_version"));
+        for (final FunctionSignature funcSignature : visitor.getUsedFunctionSignatures()) {
+            final Map<Type, List<String>> funcRequirements =
+                    FUNCTION_FIELD_REQUIREMENTS.get(funcSignature.function());
+            if (funcRequirements == null) {
+                continue;
+            }
 
-                case FUNC_COMPARE_AGE -> requirements.putAll(TYPE_COMPONENT, List.of("purl", "published_at"));
-
+            final List<String> fields = funcRequirements.get(funcSignature.targetType());
+            if (fields != null) {
+                requirements.putAll(funcSignature.targetType(), fields);
             }
         }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Simplifies CEL policy script host.

Handles expansion of required fields through computed fields (e.g. severity) or function calls (e.g. depends_on) in a more generic way. This addresses an outstanding TODO.

Expansions are defined in the library class, not the script host itself.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
