### PR TITLE
Add /v1/project/batchDelete API method

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -47,6 +47,7 @@ import org.jdbi.v3.sqlobject.customizer.AllowUnusedBindings;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.customizer.DefineNamedBindings;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 import org.jspecify.annotations.Nullable;
@@ -55,6 +56,7 @@ import org.postgresql.util.PSQLException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -538,6 +540,23 @@ public interface ProjectDao extends SqlObject {
              WHERE "UUID" = :projectUuid
             """)
     int deleteProject(@Bind final UUID projectUuid);
+
+    @SqlUpdate("""
+            WITH cte_locked AS (
+              SELECT "ID"
+                FROM "PROJECT"
+               WHERE ${apiProjectAclCondition}
+                 AND "UUID" = ANY(:projectUuids)
+               ORDER BY "ID"
+                 FOR UPDATE
+            )
+            DELETE
+              FROM "PROJECT"
+             WHERE "ID" IN (SELECT "ID" FROM cte_locked)
+            RETURNING "UUID"
+            """)
+    @GetGeneratedKeys
+    Set<UUID> deleteProjects(@Bind Collection<UUID> projectUuids);
 
     @SqlQuery("""
              WITH "CTE" AS (

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -37,6 +37,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Validator;
+import jakarta.validation.constraints.Size;
 import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -75,6 +76,7 @@ import org.dependencytrack.resources.v1.vo.BomUploadResponse;
 import org.dependencytrack.resources.v1.vo.CloneProjectRequest;
 import org.dependencytrack.resources.v1.vo.ConciseProject;
 import org.jdbi.v3.core.Handle;
+import org.owasp.security.logging.SecurityMarkers;
 
 import javax.jdo.FetchGroup;
 import java.security.Principal;
@@ -94,6 +96,7 @@ import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
 import static org.dependencytrack.notification.api.NotificationFactory.createProjectCreatedNotification;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.createLocalJdbi;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 import static org.dependencytrack.util.PersistenceUtil.isPersistent;
 import static org.dependencytrack.util.PersistenceUtil.isUniqueConstraintViolation;
@@ -150,7 +153,7 @@ public class ProjectResource extends AbstractApiResource {
             }
             final PaginatedResult projectPages = withJdbiHandle(getAlpineRequest(), handle ->
                     (name != null) ? handle.attach(ProjectDao.class).getProjects(name, null, null, null, notAssignedToTeamWithUuid, excludeInactive, onlyRoot, false)
-                    : handle.attach(ProjectDao.class).getProjects(null, null, null, null, notAssignedToTeamWithUuid, excludeInactive, onlyRoot, true));
+                            : handle.attach(ProjectDao.class).getProjects(null, null, null, null, notAssignedToTeamWithUuid, excludeInactive, onlyRoot, true));
             return Response.ok(projectPages.getObjects()).header(TOTAL_COUNT_HEADER, projectPages.getTotal()).build();
         }
     }
@@ -502,9 +505,9 @@ public class ProjectResource extends AbstractApiResource {
             jsonProject.setClassifier(Classifier.APPLICATION);
         }
         try (final var qm = new QueryManager()) {
-            if(jsonProject.isLatest()) {
+            if (jsonProject.isLatest()) {
                 final Project oldLatest = qm.getLatestProjectVersion(jsonProject.getName());
-                if(oldLatest != null) {
+                if (oldLatest != null) {
                     requireAccess(qm, oldLatest);
                 }
             }
@@ -563,9 +566,9 @@ public class ProjectResource extends AbstractApiResource {
                             throw new ClientErrorException(Response
                                     .status(Response.Status.BAD_REQUEST)
                                     .entity("""
-                                        The team with %s can not be assigned because it does not exist, \
-                                        or is not accessible to the authenticated principal.\
-                                        """.formatted(chosenTeam.getUuid() != null
+                                            The team with %s can not be assigned because it does not exist, \
+                                            or is not accessible to the authenticated principal.\
+                                            """.formatted(chosenTeam.getUuid() != null
                                             ? "UUID " + chosenTeam.getUuid()
                                             : "name " + chosenTeam.getName()))
                                     .build());
@@ -688,7 +691,7 @@ public class ProjectResource extends AbstractApiResource {
                 // if project is newly set to latest, ensure user has access to current latest version to modify it
                 if (jsonProject.isLatest() && !project.isLatest()) {
                     final Project oldLatest = qm.getLatestProjectVersion(name);
-                    if(oldLatest != null) {
+                    if (oldLatest != null) {
                         requireAccess(qm, oldLatest);
                     }
                 }
@@ -717,8 +720,7 @@ public class ProjectResource extends AbstractApiResource {
 
             LOGGER.info("Project " + updatedProject + " updated by " + super.getPrincipal().getName());
             return Response.ok(updatedProject).build();
-        }
-        catch (RuntimeException e) {
+        } catch (RuntimeException e) {
             if (isUniqueConstraintViolation(e)) {
                 throw new ClientErrorException(Response
                         .status(Response.Status.CONFLICT)
@@ -791,7 +793,7 @@ public class ProjectResource extends AbstractApiResource {
                 if (jsonProject.isLatest() && !project.isLatest()) {
                     final var oldName = jsonProject.getName() != null ? jsonProject.getName() : project.getName();
                     final Project oldLatest = qm.getLatestProjectVersion(oldName);
-                    if(oldLatest != null) {
+                    if (oldLatest != null) {
                         requireAccess(qm, oldLatest);
                     }
                 }
@@ -961,6 +963,32 @@ public class ProjectResource extends AbstractApiResource {
         return Response.status(Response.Status.NO_CONTENT).build();
     }
 
+    @POST
+    @Path("/batchDelete")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(
+            summary = "Deletes a list of projects specified by their UUIDs",
+            description = "<p>Requires permission <strong>PORTFOLIO_MANAGEMENT</strong> or <strong>PORTFOLIO_MANAGEMENT_DELETE</strong></p>"
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "Projects removed successfully"),
+            @ApiResponse(responseCode = "401", description = "Unauthorized")
+    })
+    @PermissionRequired({
+            Permissions.Constants.PORTFOLIO_MANAGEMENT,
+            Permissions.Constants.PORTFOLIO_MANAGEMENT_DELETE
+    })
+    public Response deleteProjects(@Size(min = 1, max = 1000) final Set<UUID> uuids) {
+        final Set<UUID> deletedProjectUuids = inJdbiTransaction(
+                getAlpineRequest(),
+                handle -> handle.attach(ProjectDao.class).deleteProjects(uuids));
+        for (final UUID uuid : deletedProjectUuids) {
+            LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Deleted project {}", uuid);
+        }
+        return Response.status(Response.Status.NO_CONTENT).build();
+    }
+
     @PUT
     @Path("/clone")
     @Deprecated(since = "5.7.0")
@@ -1011,7 +1039,7 @@ public class ProjectResource extends AbstractApiResource {
                 // if project is newly set to latest, ensure user has access to current latest version to modify it
                 if (jsonRequest.makeCloneLatest() && !sourceProject.isLatest()) {
                     final Project oldLatest = qm.getLatestProjectVersion(sourceProject.getName());
-                    if(oldLatest != null) {
+                    if (oldLatest != null) {
                         requireAccess(qm, oldLatest);
                     }
                 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -2342,6 +2342,36 @@ class ProjectResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldBatchDeleteExistingAndAccessibleProjects() {
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("acme-app-a");
+        accessibleProject.addAccessTeam(super.team);
+        qm.persist(accessibleProject);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("acme-app-b");
+        qm.persist(inaccessibleProject);
+
+        final Response response = jersey
+                .target(V1_PROJECT + "/batchDelete")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json("""
+                        [
+                          "%s",
+                          "%s",
+                          "7638dd9a-a4ca-4cd6-98cc-10386bf0f2d6"
+                        ]
+                        """.formatted(accessibleProject.getUuid(), inaccessibleProject.getUuid())));
+        assertThat(response.getStatus()).isEqualTo(204);
+
+        assertThat(qm.doesProjectExist("acme-app-a", null)).isFalse();
+        assertThat(qm.doesProjectExist("acme-app-b", null)).isTrue();
+    }
+
+    @Test
     void patchProjectNotModifiedTest() {
         final var tags = Stream.of("tag1", "tag2").map(qm::createTag).collect(Collectors.toUnmodifiableList());
         final var p1 = qm.createProject("ABC", "Test project", "1.0", tags, null, null, null, false);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/4383

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2104

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Notable differences to original PR:

* Non-existent and inaccessible projects are filtered out at the SQL level and do not cause API errors.
* Row locks are acquired in deterministic order to prevent possible deadlocks.
* FK constraints with ON DELETE CASCADE void the necessity to delete related records manually.


### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
