### PR TITLE
Abandon dex tasks on unexpected errors or no new workflow events

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
@@ -293,7 +293,8 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                                 try {
                                     executeTask(polledTask, permitAcquiredLatch);
                                 } catch (RuntimeException e) {
-                                    logger.error("Unexpected error occurred during task execution", e);
+                                    logger.error("Unexpected error occurred during task execution; Abandoning task", e);
+                                    abandon(polledTask);
                                 }
                             }));
                 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
@@ -124,7 +124,8 @@ final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
             }
 
             if (eventsAdded == 0) {
-                logger.warn("No new events");
+                logger.warn("No new events; Abandoning task");
+                abandon(task);
                 return;
             }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Abandons dex tasks on unexpected errors or no new workflow events.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
