### PR TITLE
Add architecture test to enforce JDBI DAOs not returning JDO model classes

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/DaoArchitectureTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/DaoArchitectureTest.java
@@ -1,0 +1,176 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaParameterizedType;
+import com.tngtech.archunit.core.domain.JavaType;
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeJars;
+import com.tngtech.archunit.core.importer.ImportOption.DoNotIncludeTests;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import com.tngtech.archunit.library.freeze.FreezingArchRule;
+import org.jdbi.v3.sqlobject.statement.SqlBatch;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+@AnalyzeClasses(
+        packages = "org.dependencytrack.persistence.jdbi",
+        importOptions = {DoNotIncludeTests.class, DoNotIncludeJars.class})
+class DaoArchitectureTest {
+
+    private static final Set<String> WRAPPER_TYPES = Set.of(
+            "java.util.List",
+            "java.util.Set",
+            "java.util.Collection",
+            "java.util.Optional",
+            "java.util.Map",
+            "org.dependencytrack.common.pagination.Page");
+
+    @ArchTest
+    static final ArchRule daoQueryMethodsMustNotReturnJdoModelClasses =
+            FreezingArchRule.freeze(
+                    methods()
+                            .that().areDeclaredInClassesThat().haveSimpleNameEndingWith("Dao")
+                            .and().areDeclaredInClassesThat().resideInAPackage("org.dependencytrack.persistence.jdbi")
+                            .and().areNotAnnotatedWith(SqlUpdate.class)
+                            .and().areNotAnnotatedWith(SqlBatch.class)
+                            .should(new ArchCondition<>("not return model classes") {
+                                @Override
+                                public void check(JavaMethod method, ConditionEvents events) {
+                                    for (JavaClass leafType : extractLeafTypes(method.getReturnType())) {
+                                        if (isModelClass(leafType)) {
+                                            events.add(SimpleConditionEvent.violated(
+                                                    method,
+                                                    "%s returns model class %s".formatted(
+                                                            method.getFullName(), leafType.getName())));
+                                        }
+                                    }
+                                }
+                            }));
+
+    @ArchTest
+    static final ArchRule daosMustNotUseBeanMapperWithJdoClasses =
+            FreezingArchRule.freeze(
+                    classes()
+                            .that().haveSimpleNameEndingWith("Dao")
+                            .and().resideInAPackage("org.dependencytrack.persistence.jdbi")
+                            .should(new ArchCondition<>("not use @RegisterBeanMapper with model classes") {
+                                @Override
+                                public void check(JavaClass daoClass, ConditionEvents events) {
+                                    for (JavaAnnotation<?> annotation : daoClass.getAnnotations()) {
+                                        checkBeanMapperAnnotation(daoClass, "<class>", annotation, events);
+                                    }
+                                    daoClass.getMethods().forEach(method -> {
+                                        for (JavaAnnotation<?> annotation : method.getAnnotations()) {
+                                            checkBeanMapperAnnotation(daoClass, method.getName(), annotation, events);
+                                        }
+                                    });
+                                }
+                            }));
+
+    @ArchTest
+    static final ArchRule rowMappersMustNotTargetJdoModelClasses =
+            FreezingArchRule.freeze(
+                    classes()
+                            .that().resideInAPackage("org.dependencytrack.persistence.jdbi..")
+                            .and().implement(org.jdbi.v3.core.mapper.RowMapper.class)
+                            .should(new ArchCondition<>("not target model classes") {
+                                @Override
+                                public void check(JavaClass mapperClass, ConditionEvents events) {
+                                    for (JavaType iface : mapperClass.getInterfaces()) {
+                                        if (iface instanceof final JavaParameterizedType paramType
+                                                && paramType.toErasure().isEquivalentTo(org.jdbi.v3.core.mapper.RowMapper.class)) {
+                                            for (JavaType arg : paramType.getActualTypeArguments()) {
+                                                if (arg instanceof final JavaClass targetClass && isModelClass(targetClass)) {
+                                                    events.add(SimpleConditionEvent.violated(
+                                                            mapperClass,
+                                                            "%s maps to model class %s".formatted(
+                                                                    mapperClass.getName(), targetClass.getName())));
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }));
+
+    private static boolean isModelClass(JavaClass javaClass) {
+        // NB: Records in the model package (FindingKey etc.) are the migration target, not the problem.
+        if (javaClass.isRecord()) {
+            return false;
+        }
+
+        return javaClass.getPackageName().equals("org.dependencytrack.model")
+                || javaClass.getPackageName().equals("alpine.model");
+    }
+
+    private static Set<JavaClass> extractLeafTypes(JavaType type) {
+        var result = new HashSet<JavaClass>();
+        collectLeafTypes(type, result);
+        return result;
+    }
+
+    private static void collectLeafTypes(JavaType type, Set<JavaClass> result) {
+        if (type instanceof final JavaParameterizedType paramType) {
+            if (WRAPPER_TYPES.contains(paramType.toErasure().getName())) {
+                for (JavaType arg : paramType.getActualTypeArguments()) {
+                    collectLeafTypes(arg, result);
+                }
+            } else {
+                result.add(paramType.toErasure());
+            }
+        } else if (type instanceof JavaClass javaClass) {
+            result.add(javaClass);
+        }
+    }
+
+    private static void checkBeanMapperAnnotation(
+            JavaClass owner, String location, JavaAnnotation<?> annotation, ConditionEvents events) {
+        String annotationType = annotation.getRawType().getName();
+        if ("org.jdbi.v3.sqlobject.config.RegisterBeanMapper".equals(annotationType)) {
+            annotation.get("value").ifPresent(value -> {
+                if (value instanceof final JavaClass targetClass && isModelClass(targetClass)) {
+                    events.add(SimpleConditionEvent.violated(owner,
+                            "%s#%s uses @RegisterBeanMapper with model class %s".formatted(
+                                    owner.getName(), location, targetClass.getName())));
+                }
+            });
+        } else if ("org.jdbi.v3.sqlobject.config.RegisterBeanMappers".equals(annotationType)) {
+            annotation.get("value").ifPresent(value -> {
+                if (value instanceof final JavaAnnotation<?>[] nested) {
+                    for (JavaAnnotation<?> inner : nested) {
+                        checkBeanMapperAnnotation(owner, location, inner, events);
+                    }
+                }
+            });
+        }
+    }
+
+}

--- a/apiserver/src/test/resources/archunit.properties
+++ b/apiserver/src/test/resources/archunit.properties
@@ -1,0 +1,3 @@
+freeze.store.default.path=src/test/resources/archunit_store
+freeze.store.default.allowStoreCreation=false
+freeze.store.default.allowStoreUpdate=false

--- a/apiserver/src/test/resources/archunit_store/214fb774-c145-436c-bd1c-d442e8e4fe26
+++ b/apiserver/src/test/resources/archunit_store/214fb774-c145-436c-bd1c-d442e8e4fe26
@@ -1,0 +1,11 @@
+org.dependencytrack.persistence.jdbi.ComponentDao#getOccurrences uses @RegisterBeanMapper with model class org.dependencytrack.model.ComponentOccurrence
+org.dependencytrack.persistence.jdbi.ConfigPropertyDao#getOptional uses @RegisterBeanMapper with model class alpine.model.ConfigProperty
+org.dependencytrack.persistence.jdbi.MetricsDao#getCollectionProjectMetricsSince uses @RegisterBeanMapper with model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getDependencyMetricsSince uses @RegisterBeanMapper with model class org.dependencytrack.model.DependencyMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getMostRecentCollectionProjectMetrics uses @RegisterBeanMapper with model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getMostRecentDependencyMetrics uses @RegisterBeanMapper with model class org.dependencytrack.model.DependencyMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getMostRecentDependencyMetrics uses @RegisterBeanMapper with model class org.dependencytrack.model.DependencyMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getMostRecentProjectMetrics uses @RegisterBeanMapper with model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getMostRecentProjectMetrics uses @RegisterBeanMapper with model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getPortfolioMetricsForDays uses @RegisterBeanMapper with model class org.dependencytrack.model.PortfolioMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao#getProjectMetricsSince uses @RegisterBeanMapper with model class org.dependencytrack.model.ProjectMetrics

--- a/apiserver/src/test/resources/archunit_store/abb951d9-b11c-45d0-a35c-0d8977fd78e3
+++ b/apiserver/src/test/resources/archunit_store/abb951d9-b11c-45d0-a35c-0d8977fd78e3
@@ -1,0 +1,25 @@
+org.dependencytrack.persistence.jdbi.ComponentDao.getOccurrences(java.util.UUID) returns model class org.dependencytrack.model.ComponentOccurrence
+org.dependencytrack.persistence.jdbi.ComponentDao.listProjectComponents(long, int, java.lang.Boolean, java.lang.Boolean, java.lang.String, java.lang.String, java.lang.Long) returns model class org.dependencytrack.model.Component
+org.dependencytrack.persistence.jdbi.ComponentDao.listProjectComponents(long, java.lang.Boolean, java.lang.Boolean, int, java.lang.String) returns model class org.dependencytrack.model.Component
+org.dependencytrack.persistence.jdbi.ConfigPropertyDao.getOptional(java.lang.String, java.lang.String) returns model class alpine.model.ConfigProperty
+org.dependencytrack.persistence.jdbi.FindingDao.getFindings(long, boolean) returns model class org.dependencytrack.model.Finding
+org.dependencytrack.persistence.jdbi.MetricsDao.getCollectionProjectMetricsSince(long, java.time.Instant) returns model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getDependencyMetricsSince(long, java.time.Instant) returns model class org.dependencytrack.model.DependencyMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentCollectionProjectMetrics(java.util.Collection) returns model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentCollectionProjectMetrics(long) returns model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentDependencyMetrics(java.util.Collection) returns model class org.dependencytrack.model.DependencyMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentDependencyMetrics(long) returns model class org.dependencytrack.model.DependencyMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentPortfolioMetrics() returns model class org.dependencytrack.model.PortfolioMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentProjectMetrics(java.util.Collection) returns model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getMostRecentProjectMetrics(long) returns model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getPortfolioMetricsForDays(int) returns model class org.dependencytrack.model.PortfolioMetrics
+org.dependencytrack.persistence.jdbi.MetricsDao.getProjectMetricsSince(long, java.time.Instant) returns model class org.dependencytrack.model.ProjectMetrics
+org.dependencytrack.persistence.jdbi.ScheduledNotificationDao.getScheduledNotificationRuleByName(java.lang.String) returns model class org.dependencytrack.model.NotificationRule
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getByUuid(java.util.UUID) returns model class org.dependencytrack.model.Vulnerability
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getByUuidOrVulnIdAndSource(java.util.UUID, java.lang.String, java.lang.String) returns model class org.dependencytrack.model.Vulnerability
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getByVulnIdAndSource(java.lang.String, java.lang.String) returns model class org.dependencytrack.model.Vulnerability
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getVulnerabilitiesByComponent(java.lang.Long, boolean) returns model class org.dependencytrack.model.Vulnerability
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getVulnerabilitiesByProject(long, boolean) returns model class org.dependencytrack.model.Vulnerability
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getVulnerableComponents(long, java.util.List) returns model class org.dependencytrack.model.Component
+org.dependencytrack.persistence.jdbi.VulnerabilityDao.getVulnerableSoftwareByVulnId(long) returns model class org.dependencytrack.model.VulnerableSoftware
+org.dependencytrack.persistence.jdbi.VulnerabilityPolicyDao.unassignFromAnalysesByName(java.lang.String) returns model class org.dependencytrack.model.Analysis

--- a/apiserver/src/test/resources/archunit_store/f3b37c20-3a23-4355-a1a0-626adddec514
+++ b/apiserver/src/test/resources/archunit_store/f3b37c20-3a23-4355-a1a0-626adddec514
@@ -1,0 +1,5 @@
+org.dependencytrack.persistence.jdbi.ComponentDao$ComponentListRowMapper maps to model class org.dependencytrack.model.Component
+org.dependencytrack.persistence.jdbi.mapping.AnalysisRowMapper maps to model class org.dependencytrack.model.Analysis
+org.dependencytrack.persistence.jdbi.mapping.NotificationRuleRowMapper maps to model class org.dependencytrack.model.NotificationRule
+org.dependencytrack.persistence.jdbi.mapping.VulnerabilityRowMapper maps to model class org.dependencytrack.model.Vulnerability
+org.dependencytrack.persistence.jdbi.mapping.VulnerableSoftwareRowMapper maps to model class org.dependencytrack.model.VulnerableSoftware

--- a/apiserver/src/test/resources/archunit_store/stored.rules
+++ b/apiserver/src/test/resources/archunit_store/stored.rules
@@ -1,0 +1,5 @@
+#
+#Tue Apr 14 11:35:31 CEST 2026
+classes\ that\ have\ simple\ name\ ending\ with\ 'Dao'\ and\ reside\ in\ a\ package\ 'org.dependencytrack.persistence.jdbi'\ should\ not\ use\ @RegisterBeanMapper\ with\ model\ classes=214fb774-c145-436c-bd1c-d442e8e4fe26
+classes\ that\ reside\ in\ a\ package\ 'org.dependencytrack.persistence.jdbi..'\ and\ implement\ org.jdbi.v3.core.mapper.RowMapper\ should\ not\ target\ model\ classes=f3b37c20-3a23-4355-a1a0-626adddec514
+methods\ that\ are\ declared\ in\ classes\ that\ have\ simple\ name\ ending\ with\ 'Dao'\ and\ are\ declared\ in\ classes\ that\ reside\ in\ a\ package\ 'org.dependencytrack.persistence.jdbi'\ and\ are\ not\ annotated\ with\ @SqlUpdate\ and\ are\ not\ annotated\ with\ @SqlBatch\ should\ not\ return\ model\ classes=abb951d9-b11c-45d0-a35c-0d8977fd78e3


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds architecture test to enforce JDBI DAOs not returning JDO model classes

Mixing the two persistence approaches causes all sorts of hard coupling and inconsistencies. JDBI code should only return specific projection records that reflect the exact result set.

We already accumulated violations of this. They are documented via ArchUnit freeze files (https://www.archunit.org/userguide/html/000_Index.html#_freezing_arch_rules). We will resolve those violations over time.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
