### PR TITLE
Add JDBI support module for translating constraint violation exceptions

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -270,6 +270,11 @@
             <artifactId>cvss-calculator</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>jdbi-support</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
         </dependency>

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
@@ -28,6 +28,7 @@ import org.dependencytrack.common.pagination.SimplePageTokenEncoder;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.mapping.PackageMetadataRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.PurlColumnMapper;
+import org.dependencytrack.support.jdbi.exception.ExceptionTranslationPlugin;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.HandleCallback;
 import org.jdbi.v3.core.HandleConsumer;
@@ -172,6 +173,7 @@ public class JdbiFactory {
                 .installPlugin(new SqlObjectPlugin())
                 .installPlugin(new PostgresPlugin())
                 .installPlugin(new Jackson2Plugin())
+                .installPlugin(new ExceptionTranslationPlugin())
                 .setTemplateEngine(FreemarkerEngine.instance())
                 .setSqlLogger(new QueryTimingSqlLogger(Metrics.globalRegistry))
                 .registerArrayType(Date.class, "TIMESTAMPTZ")

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>common</module>
         <module>support/cyclonedx-proto</module>
         <module>support/datanucleus-plugin</module>
+        <module>support/jdbi</module>
         <module>support/liquibase</module>
         <module>support/smallrye-config-source-memory</module>
         <module>api</module>

--- a/support/jdbi/pom.xml
+++ b/support/jdbi/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>dependency-track-parent</artifactId>
+        <version>5.7.0-alpha.3-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>jdbi-support</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Support :: JDBI</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jdbi</groupId>
+            <artifactId>jdbi3-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-nop</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/CheckConstraintViolationException.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/CheckConstraintViolationException.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @since 5.7.0
+ */
+public final class CheckConstraintViolationException extends ConstraintViolationException {
+
+    public CheckConstraintViolationException(
+            String message,
+            Throwable cause,
+            @Nullable String constraintName,
+            @Nullable String tableName,
+            @Nullable String columnName,
+            String sqlState) {
+        super(message, cause, constraintName, tableName, columnName, sqlState);
+    }
+
+}

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ConstraintViolationException.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ConstraintViolationException.java
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jspecify.annotations.Nullable;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
+
+/**
+ * @since 5.7.0
+ */
+public sealed class ConstraintViolationException extends RuntimeException
+        permits UniqueConstraintViolationException,
+        CheckConstraintViolationException,
+        NotNullConstraintViolationException {
+
+    private final @Nullable String constraintName;
+    private final @Nullable String tableName;
+    private final @Nullable String columnName;
+    private final String sqlState;
+
+    protected ConstraintViolationException(
+            String message,
+            Throwable cause,
+            @Nullable String constraintName,
+            @Nullable String tableName,
+            @Nullable String columnName,
+            String sqlState) {
+        super(message, cause);
+        this.constraintName = constraintName;
+        this.tableName = tableName;
+        this.columnName = columnName;
+        this.sqlState = sqlState;
+    }
+
+    public static @Nullable ConstraintViolationException of(Throwable throwable) {
+        final PSQLException psqlException = findPSQLException(throwable);
+        if (psqlException == null) {
+            return null;
+        }
+
+        final String sqlState = psqlException.getSQLState();
+        if (sqlState == null) {
+            return null;
+        }
+
+        final ServerErrorMessage serverError = psqlException.getServerErrorMessage();
+        final String constraintName = serverError != null
+                ? serverError.getConstraint()
+                : null;
+        final String tableName = serverError != null
+                ? serverError.getTable()
+                : null;
+        final String columnName = serverError != null
+                ? serverError.getColumn()
+                : null;
+        final String message = psqlException.getMessage();
+
+        return switch (sqlState) {
+            case "23505" -> new UniqueConstraintViolationException(
+                    message, throwable, constraintName, tableName, columnName, sqlState);
+            case "23514" -> new CheckConstraintViolationException(
+                    message, throwable, constraintName, tableName, columnName, sqlState);
+            case "23502" -> new NotNullConstraintViolationException(
+                    message, throwable, constraintName, tableName, columnName, sqlState);
+            default -> null;
+        };
+    }
+
+    public @Nullable String getConstraintName() {
+        return constraintName;
+    }
+
+    public @Nullable String getTableName() {
+        return tableName;
+    }
+
+    public @Nullable String getColumnName() {
+        return columnName;
+    }
+
+    public String getSqlState() {
+        return sqlState;
+    }
+
+    private static @Nullable PSQLException findPSQLException(Throwable throwable) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (current instanceof PSQLException psql) {
+                return psql;
+            }
+            current = current.getCause();
+        }
+        return null;
+    }
+
+}

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationCallbackDecorator.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationCallbackDecorator.java
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jdbi.v3.core.HandleCallback;
+import org.jdbi.v3.core.HandleCallbackDecorator;
+
+final class ExceptionTranslationCallbackDecorator implements HandleCallbackDecorator {
+
+    private final HandleCallbackDecorator delegate;
+
+    ExceptionTranslationCallbackDecorator(HandleCallbackDecorator delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public <R, X extends Exception> HandleCallback<R, X> decorate(HandleCallback<R, X> callback) {
+        final HandleCallback<R, X> delegated = delegate.decorate(callback);
+        return handle -> {
+            try {
+                return delegated.withHandle(handle);
+            } catch (RuntimeException e) {
+                final ConstraintViolationException translated = ConstraintViolationException.of(e);
+                if (translated != null) {
+                    throw translated;
+                }
+                throw e;
+            }
+        };
+    }
+
+}

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationPlugin.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationPlugin.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.spi.JdbiPlugin;
+
+/**
+ * @since 5.7.0
+ */
+public final class ExceptionTranslationPlugin extends JdbiPlugin.Singleton {
+
+    @Override
+    public void customizeJdbi(Jdbi jdbi) {
+        final var previousDecorator = jdbi.getHandleCallbackDecorator();
+        jdbi.setHandleCallbackDecorator(new ExceptionTranslationCallbackDecorator(previousDecorator));
+    }
+
+}

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/NotNullConstraintViolationException.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/NotNullConstraintViolationException.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @since 5.7.0
+ */
+public final class NotNullConstraintViolationException extends ConstraintViolationException {
+
+    public NotNullConstraintViolationException(
+            String message,
+            Throwable cause,
+            @Nullable String constraintName,
+            @Nullable String tableName,
+            @Nullable String columnName,
+            String sqlState) {
+        super(message, cause, constraintName, tableName, columnName, sqlState);
+    }
+
+}

--- a/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/UniqueConstraintViolationException.java
+++ b/support/jdbi/src/main/java/org/dependencytrack/support/jdbi/exception/UniqueConstraintViolationException.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @since 5.7.0
+ */
+public final class UniqueConstraintViolationException extends ConstraintViolationException {
+
+    public UniqueConstraintViolationException(
+            String message,
+            Throwable cause,
+            @Nullable String constraintName,
+            @Nullable String tableName,
+            @Nullable String columnName,
+            String sqlState) {
+        super(message, cause, constraintName, tableName, columnName, sqlState);
+    }
+
+}

--- a/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/ConstraintViolationExceptionTest.java
+++ b/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/ConstraintViolationExceptionTest.java
@@ -1,0 +1,169 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.junit.jupiter.api.Test;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.ServerErrorMessage;
+
+import java.lang.reflect.Constructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConstraintViolationExceptionTest {
+
+    @Test
+    void shouldTranslateUniqueViolation() {
+        final var psqlException = createPSQLException(
+                "23505", "VULNERABILITY_POLICY_NAME_IDX", "VULNERABILITY_POLICY", null);
+        final var wrapping = new UnableToExecuteStatementException(psqlException, null);
+
+        final var result = ConstraintViolationException.of(wrapping);
+
+        assertThat(result).isInstanceOf(UniqueConstraintViolationException.class);
+        assertThat(result.getConstraintName()).isEqualTo("VULNERABILITY_POLICY_NAME_IDX");
+        assertThat(result.getTableName()).isEqualTo("VULNERABILITY_POLICY");
+        assertThat(result.getColumnName()).isNull();
+        assertThat(result.getSqlState()).isEqualTo("23505");
+        assertThat(result.getCause()).isSameAs(wrapping);
+    }
+
+    @Test
+    void shouldTranslateCheckViolation() {
+        final var psqlException = createPSQLException(
+                "23514", "VULNERABILITY_POLICY_PRIORITY_check", "VULNERABILITY_POLICY", null);
+        final var wrapping = new UnableToExecuteStatementException(psqlException, null);
+
+        final var result = ConstraintViolationException.of(wrapping);
+
+        assertThat(result).isInstanceOf(CheckConstraintViolationException.class);
+        assertThat(result.getConstraintName()).isEqualTo("VULNERABILITY_POLICY_PRIORITY_check");
+        assertThat(result.getTableName()).isEqualTo("VULNERABILITY_POLICY");
+        assertThat(result.getSqlState()).isEqualTo("23514");
+    }
+
+    @Test
+    void shouldTranslateNotNullViolation() {
+        final var psqlException = createPSQLException(
+                "23502", null, "VULNERABILITY_POLICY", "NAME");
+        final var wrapping = new UnableToExecuteStatementException(psqlException, null);
+
+        final var result = ConstraintViolationException.of(wrapping);
+
+        assertThat(result).isInstanceOf(NotNullConstraintViolationException.class);
+        assertThat(result.getConstraintName()).isNull();
+        assertThat(result.getTableName()).isEqualTo("VULNERABILITY_POLICY");
+        assertThat(result.getColumnName()).isEqualTo("NAME");
+        assertThat(result.getSqlState()).isEqualTo("23502");
+    }
+
+    @Test
+    void shouldReturnNullForForeignKeyViolation() {
+        final var psqlException = createPSQLException("23503", "some_fk", "SOME_TABLE", null);
+        final var wrapping = new UnableToExecuteStatementException(psqlException, null);
+
+        assertThat(ConstraintViolationException.of(wrapping)).isNull();
+    }
+
+    @Test
+    void shouldReturnNullForNonPSQLException() {
+        final var wrapping = new UnableToExecuteStatementException(
+                new RuntimeException("not a psql error"), null);
+
+        assertThat(ConstraintViolationException.of(wrapping)).isNull();
+    }
+
+    @Test
+    void shouldReturnNullForNullSqlState() {
+        final var psqlException = new PSQLException("error", null);
+        final var wrapping = new UnableToExecuteStatementException(psqlException, null);
+
+        assertThat(ConstraintViolationException.of(wrapping)).isNull();
+    }
+
+    @Test
+    void shouldFindPSQLExceptionInDeepCauseChain() {
+        final var psqlException = createPSQLException(
+                "23505", "some_idx", "SOME_TABLE", null);
+        final var mid = new RuntimeException("mid", psqlException);
+        final var outer = new UnableToExecuteStatementException(mid, null);
+
+        final var result = ConstraintViolationException.of(outer);
+
+        assertThat(result).isInstanceOf(UniqueConstraintViolationException.class);
+        assertThat(result.getConstraintName()).isEqualTo("some_idx");
+    }
+
+    @Test
+    void shouldPreserveOriginalExceptionAsCause() {
+        final var psqlException = createPSQLException(
+                "23505", "some_idx", "SOME_TABLE", null);
+        final var wrapping = new UnableToExecuteStatementException(psqlException, null);
+
+        final var result = ConstraintViolationException.of(wrapping);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getCause()).isSameAs(wrapping);
+    }
+
+    private static PSQLException createPSQLException(
+            String sqlState,
+            String constraintName,
+            String tableName,
+            String columnName) {
+        try {
+            final String encodedMessage = buildEncodedServerErrorMessage(
+                    sqlState, constraintName, tableName, columnName);
+            final Constructor<ServerErrorMessage> constructor =
+                    ServerErrorMessage.class.getDeclaredConstructor(String.class);
+            constructor.setAccessible(true);
+            final ServerErrorMessage serverErrorMessage = constructor.newInstance(encodedMessage);
+            return new PSQLException(serverErrorMessage);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("Failed to create PSQLException for test", e);
+        }
+    }
+
+    /**
+     * @see <a href="https://www.postgresql.org/docs/current/protocol-error-fields.html">Protocol Error Fields</a>
+     */
+    private static String buildEncodedServerErrorMessage(
+            String sqlState,
+            String constraintName,
+            String tableName,
+            String columnName) {
+        final var sb = new StringBuilder();
+        sb.append('S').append("ERROR").append('\0');
+        sb.append('C').append(sqlState).append('\0');
+        sb.append('M').append("test error message").append('\0');
+        if (tableName != null) {
+            sb.append('t').append(tableName).append('\0');
+        }
+        if (columnName != null) {
+            sb.append('c').append(columnName).append('\0');
+        }
+        if (constraintName != null) {
+            sb.append('n').append(constraintName).append('\0');
+        }
+        sb.append('\0');
+        return sb.toString();
+    }
+
+}

--- a/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationPluginTest.java
+++ b/support/jdbi/src/test/java/org/dependencytrack/support/jdbi/exception/ExceptionTranslationPluginTest.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.jdbi.exception;
+
+import org.jdbi.v3.core.Jdbi;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@Testcontainers
+class ExceptionTranslationPluginTest {
+
+    @Container
+    private static final PostgreSQLContainer POSTGRES =
+            new PostgreSQLContainer("postgres:14-alpine");
+
+    private static Jdbi jdbi;
+
+    @BeforeAll
+    static void beforeAll() {
+        jdbi = Jdbi
+                .create(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+                .installPlugin(new ExceptionTranslationPlugin());
+
+        jdbi.useHandle(handle -> handle.execute("""
+                CREATE TABLE "TEST_TABLE" (
+                    "ID" SERIAL PRIMARY KEY,
+                    "NAME" TEXT NOT NULL,
+                    "STATUS" TEXT NOT NULL CHECK ("STATUS" IN ('ACTIVE', 'INACTIVE')),
+                    UNIQUE ("NAME")
+                )"""));
+    }
+
+    @Test
+    void shouldTranslateUniqueConstraintViolation() {
+        jdbi.useHandle(handle -> handle.execute("""
+                INSERT INTO "TEST_TABLE" ("NAME", "STATUS") VALUES ('foo', 'ACTIVE')"""));
+
+        assertThatExceptionOfType(UniqueConstraintViolationException.class)
+                .isThrownBy(() -> jdbi.useHandle(handle -> handle.execute("""
+                        INSERT INTO "TEST_TABLE" ("NAME", "STATUS") VALUES ('foo', 'ACTIVE')""")))
+                .satisfies(e -> {
+                    assertThat(e.getTableName()).isEqualToIgnoringCase("TEST_TABLE");
+                    assertThat(e.getConstraintName()).isNotBlank();
+                    assertThat(e.getSqlState()).isEqualTo("23505");
+                });
+    }
+
+    @Test
+    void shouldTranslateNotNullConstraintViolation() {
+        assertThatExceptionOfType(NotNullConstraintViolationException.class)
+                .isThrownBy(() -> jdbi.useHandle(handle -> handle.execute("""
+                        INSERT INTO "TEST_TABLE" ("NAME", "STATUS") VALUES (NULL, 'ACTIVE')""")))
+                .satisfies(e -> {
+                    assertThat(e.getTableName()).isEqualToIgnoringCase("TEST_TABLE");
+                    assertThat(e.getColumnName()).isEqualToIgnoringCase("NAME");
+                    assertThat(e.getSqlState()).isEqualTo("23502");
+                });
+    }
+
+    @Test
+    void shouldTranslateCheckConstraintViolation() {
+        assertThatExceptionOfType(CheckConstraintViolationException.class)
+                .isThrownBy(() -> jdbi.useHandle(handle -> handle.execute("""
+                        INSERT INTO "TEST_TABLE" ("NAME", "STATUS") VALUES ('bar', 'INVALID')""")))
+                .satisfies(e -> {
+                    assertThat(e.getTableName()).isEqualToIgnoringCase("TEST_TABLE");
+                    assertThat(e.getConstraintName()).isNotBlank();
+                    assertThat(e.getSqlState()).isEqualTo("23514");
+                });
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds JDBI support module for translating constraint violation exceptions.

Makes it easier to react to constraint violations. Only covers UNIQUE, NOT NULL, and CHECK constraints for now.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
