### PR TITLE
Add vulnerability references to Finding model

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Finding.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Finding.java
@@ -70,6 +70,7 @@ public class Finding implements Serializable {
         optValue(vulnerability, "subtitle", findingRow.vulnSubtitle());
         optValue(vulnerability, "description", findingRow.vulnDescription());
         optValue(vulnerability, "recommendation", findingRow.vulnRecommendation());
+        optValue(vulnerability, "references", findingRow.vulnReferences());
         if (findingRow.vulnSeverity() != null) {
             final Severity severity = findingRow.vulnSeverity();
             optValue(vulnerability, "severity", severity.name());

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -61,6 +61,7 @@ public interface FindingDao {
             String vulnSubtitle,
             String vulnDescription,
             String vulnRecommendation,
+            String vulnReferences,
             Instant vulnPublished,
             Severity vulnSeverity,
             List<Integer> cwes,
@@ -127,6 +128,7 @@ public interface FindingDao {
                  , v."SUBTITLE" AS "vulnSubtitle"
                  , v."DESCRIPTION" AS "vulnDescription"
                  , v."RECOMMENDATION" AS "vulnRecommendation"
+                 , v."REFERENCES" AS "vulnReferences"
                  , v."PUBLISHED" AS "vulnPublished"
                  , CASE
                      WHEN a."SEVERITY" IS NOT NULL
@@ -279,6 +281,7 @@ public interface FindingDao {
                  , v."SUBTITLE" AS "vulnSubtitle"
                  , v."DESCRIPTION" AS "vulnDescription"
                  , v."RECOMMENDATION" AS "vulnRecommendation"
+                 , v."REFERENCES" AS "vulnReferences"
                  , v."PUBLISHED" AS "vulnPublished"
                  , CASE
                      WHEN a."SEVERITY" IS NOT NULL

--- a/apiserver/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -82,7 +82,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
         final var findingRow1 = new FindingDao.FindingRow(project.getUuid(), UUID.randomUUID(), project.getName(), project.getVersion(),
                 "component-name-1", null, "component-version", null, null, true,
                 UUID.randomUUID(), Vulnerability.Source.GITHUB, "vuln-vulnId-1", "vuln-title", "vuln-subtitle", "vuln-description",
-                "vuln-recommendation", Instant.now(), Severity.CRITICAL, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(8.4),
+                "vuln-recommendation", "vuln-references", Instant.now(), Severity.CRITICAL, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", "cvssV4-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", null, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
                 "oss-index", Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true, 1);
@@ -111,7 +111,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
         final var findingRow2 = new FindingDao.FindingRow(project.getUuid(), UUID.randomUUID(), project.getName(), project.getVersion(),
                 "component-name-2", null, "component-version", null, null, true,
                 UUID.randomUUID(), Vulnerability.Source.NVD, "vuln-vulnId-2", "vuln-title", "vuln-subtitle", "vuln-description",
-                "vuln-recommendation", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(8.4),
+                "vuln-recommendation", "vuln-references", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", "cvssV4vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", List.of(alias, other), BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
                 "internal", Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true, 1);
@@ -159,6 +159,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                                 "subtitle": "vuln-subtitle",
                                 "description": "vuln-description",
                                 "recommendation": "vuln-recommendation",
+                                "references": "vuln-references",
                                 "severity": "CRITICAL",
                                 "severityRank": 0,
                                 "cvssV2BaseScore": 7.2,
@@ -204,6 +205,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                                 "subtitle": "vuln-subtitle",
                                 "description": "vuln-description",
                                 "recommendation": "vuln-recommendation",
+                                "references": "vuln-references",
                                 "severity": "HIGH",
                                 "severityRank": 1,
                                 "cvssV2BaseScore": 7.2,

--- a/apiserver/src/test/java/org/dependencytrack/model/FindingTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/FindingTest.java
@@ -114,7 +114,7 @@ public class FindingTest extends PersistenceCapableTest {
         FindingDao.FindingRow findingRow = new FindingDao.FindingRow(project.getUuid(), UUID.randomUUID(), project.getName(), project.getVersion(),
                 "component-name", "component-group", "component-version", "pkg:maven/foo/bar@1.2.3", "component-cpe",
                 true, UUID.randomUUID(), Vulnerability.Source.GITHUB, "vuln-vulnId", "vuln-title", "vuln-subtitle", "vuln-description",
-                "vuln-recommendation", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(8.4),
+                "vuln-recommendation", "vuln-references", Instant.now(), Severity.HIGH, null, BigDecimal.valueOf(7.2), BigDecimal.valueOf(8.4), BigDecimal.valueOf(8.4),
                 "cvssV2-vector", "cvssV3-vector", "cvssV4-vector", BigDecimal.valueOf(1.25), BigDecimal.valueOf(1.75), BigDecimal.valueOf(1.3),
                 "owasp-vector", null, BigDecimal.valueOf(0.5), BigDecimal.valueOf(0.9),
                 "internal", Instant.now(), null, null, AnalysisState.NOT_AFFECTED, true, 1);


### PR DESCRIPTION
CVSS and OWASP RR vectors already mapped.

### Description

This PR enhances the `Finding` model to include vulnerability `references` in API responses and the Finding Packaging Format (FPF) export. It specifically adds external references.
Publish date and CVSS vectors are already mapped into `Finding`.

### Addressed Issue

Relates to https://github.com/DependencyTrack/hyades/issues/2105
Ports https://github.com/DependencyTrack/dependency-track/pull/5844

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
