### PR TITLE
Port : Enable source filtering in SARIF format for `/finding/project/{UUID}`

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -219,7 +219,10 @@ public interface FindingDao {
                AND c."PROJECT_ID" = a."PROJECT_ID"
               INNER JOIN "PROJECT" AS p
                 ON c."PROJECT_ID" = p."ID"
-             WHERE c."PROJECT_ID" = :projectId
+            WHERE c."PROJECT_ID" = :projectId
+            <#if source>
+               AND v."SOURCE" = :source
+            </#if>
             <#if !includeSuppressed>
                AND a."SUPPRESSED" IS DISTINCT FROM TRUE
             </#if>
@@ -243,15 +246,17 @@ public interface FindingDao {
             @AllowApiOrdering.Column(name = "attribution.id", queryName = "fa.\"ID\""),
             @AllowApiOrdering.Column(name = "attribution.attributedOn", queryName = "fa.\"ATTRIBUTED_ON\"")
     })
+    @DefineNamedBindings
     @RegisterConstructorMapper(FindingRow.class)
     List<FindingRow> getFindingsByProject(
             @Bind long projectId,
             @Define boolean includeInactive,
             @Define boolean includeSuppressed,
-            @Bind Boolean hasAnalysis);
+            @Bind Boolean hasAnalysis,
+            @Bind String source);
 
     default List<Finding> getFindings(final long projectId, final boolean includeSuppressed) {
-        List<FindingRow> findingRows = getFindingsByProject(projectId, /* includeInactive */ false, includeSuppressed, null);
+        List<FindingRow> findingRows = getFindingsByProject(projectId, /* includeInactive */ false, includeSuppressed, null, null);
         List<Finding> findings = findingRows.stream().map(Finding::new).toList();
         return mapComponentLatestVersion(findings);
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -153,6 +153,9 @@ public class FindingResource extends AbstractApiResource {
                         handle.attach(FindingDao.class).getFindingsByProject(project.getId(), /* includeInactive */ false, suppressed, hasAnalysis));
                 final long totalCount = findingRows.isEmpty() ? 0 : findingRows.getFirst().totalCount();
                 List<Finding> findings = findingRows.stream().map(Finding::new).toList();
+                if (source != null) {
+                    findings = findings.stream().filter(finding -> source.equals(finding.getVulnerability().get("source"))).collect(Collectors.toList());
+                }
                 findings = mapComponentLatestVersion(findings);
                 if (acceptHeader != null && acceptHeader.contains(MEDIA_TYPE_SARIF_JSON)) {
                     try {
@@ -163,9 +166,6 @@ public class FindingResource extends AbstractApiResource {
                         LOGGER.error(ioException.getMessage(), ioException);
                         return Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity("An error occurred while generating SARIF file").build();
                     }
-                }
-                if (source != null) {
-                    findings = findings.stream().filter(finding -> source.name().equals(finding.getVulnerability().get("source"))).collect(Collectors.toList());
                 }
                 return Response.ok(findings).header(TOTAL_COUNT_HEADER, totalCount).build();
             } else {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -150,12 +150,10 @@ public class FindingResource extends AbstractApiResource {
             if (project != null) {
                 requireAccess(qm, project);
                 List<FindingDao.FindingRow> findingRows = withJdbiHandle(getAlpineRequest(), handle ->
-                        handle.attach(FindingDao.class).getFindingsByProject(project.getId(), /* includeInactive */ false, suppressed, hasAnalysis));
+                        handle.attach(FindingDao.class).getFindingsByProject(
+                                project.getId(), false, suppressed, hasAnalysis, source != null ? source.name() : null));
                 final long totalCount = findingRows.isEmpty() ? 0 : findingRows.getFirst().totalCount();
                 List<Finding> findings = findingRows.stream().map(Finding::new).toList();
-                if (source != null) {
-                    findings = findings.stream().filter(finding -> source.equals(finding.getVulnerability().get("source"))).collect(Collectors.toList());
-                }
                 findings = mapComponentLatestVersion(findings);
                 if (acceptHeader != null && acceptHeader.contains(MEDIA_TYPE_SARIF_JSON)) {
                     try {

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -26,7 +26,6 @@ import alpine.model.Team;
 import alpine.server.filters.ApiFilter;
 import alpine.server.filters.AuthenticationFeature;
 import alpine.server.filters.AuthorizationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
 import jakarta.ws.rs.client.Entity;
@@ -35,7 +34,6 @@ import jakarta.ws.rs.core.Response;
 import org.dependencytrack.JerseyTestExtension;
 import org.dependencytrack.ResourceTest;
 import org.dependencytrack.auth.Permissions;
-import org.dependencytrack.common.Mappers;
 import org.dependencytrack.dex.engine.api.DexEngine;
 import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
 import org.dependencytrack.model.Analysis;
@@ -56,21 +54,25 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.dependencytrack.resources.v1.FindingResource.MEDIA_TYPE_SARIF_JSON;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -80,6 +82,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static wiremock.org.apache.commons.io.IOUtils.resourceToString;
 
 public class FindingResourceTest extends ResourceTest {
 
@@ -1209,8 +1212,9 @@ public class FindingResourceTest extends ResourceTest {
         Assertions.assertEquals("Vuln-2", json.getJsonObject(0).getJsonObject("vulnerability").getString("vulnId"));
     }
 
-    @Test
-    public void getSARIFFindingsByProjectTest() throws Exception {
+    @ParameterizedTest
+    @MethodSource("getSARIFFindingsByProjectTestParameters")
+    public void getSARIFFindingsByProjectTest(String query, String expectedResponsePath) throws Exception {
         initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
 
         Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
@@ -1221,17 +1225,22 @@ public class FindingResourceTest extends ResourceTest {
         c1.setPurl("pkg:maven/org.acme/component1@1.1.4?type=jar");
         c2.setPurl("pkg:maven/com.xyz/component2@2.78.123?type=jar");
 
-        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL, "Vuln Title 1", "This is a description", null, 80);
-        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH, "Vuln Title 2", "   Yet another description but with surrounding whitespaces   ", "", 46);
-        Vulnerability v3 = createVulnerability("Vuln-3", Severity.LOW, "Vuln Title 3", "A description-with-hyphens-(and parentheses)", "  Recommendation with whitespaces  ", 23);
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL, "Vuln Title 1", "This is a description", null, 80, Vulnerability.Source.INTERNAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.HIGH, "Vuln Title 2", "   Yet another description but with surrounding whitespaces   ", "", 46, Vulnerability.Source.INTERNAL);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.LOW, "Vuln Title 3", "A description-with-hyphens-(and parentheses)", "  Recommendation with whitespaces  ", 23, Vulnerability.Source.INTERNAL);
+        Vulnerability v4 = createVulnerability("Vuln-4", Severity.MEDIUM, "Vuln Title 4", "This is a vulnerability that has GITHUB Advisory as a source", null, 20, Vulnerability.Source.GITHUB);
 
-        // Note: Same vulnerability added to multiple components to test whether "rules" field doesn't contain duplicates
         qm.addVulnerability(v1, c1, "none");
         qm.addVulnerability(v2, c1, "none");
         qm.addVulnerability(v3, c1, "none");
         qm.addVulnerability(v3, c2, "none");
+        qm.addVulnerability(v4, c2, "none");
 
-        Response response = jersey.target(V1_FINDING + "/project/" + project.getUuid().toString()).request()
+        var target = jersey.target(V1_FINDING + "/project/" + project.getUuid().toString());
+        if (query != null) {
+            target = target.queryParam("source", query);
+        }
+        Response response = target.request()
                 .header(HttpHeaders.ACCEPT, MEDIA_TYPE_SARIF_JSON)
                 .header(X_API_KEY, apiKey)
                 .get(Response.class);
@@ -1239,155 +1248,13 @@ public class FindingResourceTest extends ResourceTest {
         assertEquals(200, response.getStatus(), 0);
         assertEquals(MEDIA_TYPE_SARIF_JSON, response.getHeaderString(HttpHeaders.CONTENT_TYPE));
         final String jsonResponse = getPlainTextBody(response);
-        JsonNode resultArray = Mappers.jsonMapper().readTree(jsonResponse).get("runs").get(0).get("results");
-
-        assertThatJson(jsonResponse)
-                .withMatcher("version", equalTo(new About().getVersion()))
-                .withMatcher("fullName", equalTo("OWASP Dependency-Track - " + new About().getVersion()));
-
-        assertThat(resultArray).hasSize(4);
-        assertThat(resultArray).satisfiesExactlyInAnyOrder(
-                vuln1 -> assertThatJson(vuln1).isEqualTo("""
-                        {
-                          "ruleId": "Vuln-1",
-                          "message": {
-                            "text": "This is a description"
-                          },
-                          "locations": [
-                            {
-                              "logicalLocations": [
-                                {
-                                  "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                }
-                              ]
-                            }
-                          ],
-                          "level": "error",
-                          "properties": {
-                            "name": "Component 1",
-                            "group": "org.acme",
-                            "version": "1.1.4",
-                            "source": "INTERNAL",
-                            "cwes": [
-                                {
-                                    "cweId": "80",
-                                    "name": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)"
-                                }
-                            ],
-                            "cvssV3BaseScore": "",
-                            "epssScore": "",
-                            "epssPercentile": "",
-                            "severityRank": "0",
-                            "recommendation": ""
-                          }
-                        }
-                """),
-                vuln2 -> assertThatJson(vuln2).isEqualTo("""
-                        {
-                           "ruleId": "Vuln-2",
-                           "message": {
-                             "text": "Yet another description but with surrounding whitespaces"
-                           },
-                           "locations": [
-                             {
-                               "logicalLocations": [
-                                 {
-                                   "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                 }
-                               ]
-                             }
-                           ],
-                           "level": "error",
-                           "properties": {
-                             "name": "Component 1",
-                             "group": "org.acme",
-                             "version": "1.1.4",
-                             "source": "INTERNAL",
-                             "cwes": [
-                                {
-                                    "cweId": "46",
-                                    "name": "Path Equivalence: 'filename ' (Trailing Space)"
-                                }
-                             ],
-                             "cvssV3BaseScore": "",
-                             "epssScore": "",
-                             "epssPercentile": "",
-                             "severityRank": "1",
-                             "recommendation": ""
-                           }
-                        }
-                """),
-                vuln3 -> assertThatJson(vuln3).isEqualTo("""
-                        {
-                           "ruleId": "Vuln-3",
-                           "message": {
-                             "text": "A description-with-hyphens-(and parentheses)"
-                           },
-                           "locations": [
-                             {
-                               "logicalLocations": [
-                                 {
-                                   "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar"
-                                 }
-                               ]
-                             }
-                           ],
-                           "level": "note",
-                           "properties": {
-                             "name": "Component 1",
-                             "group": "org.acme",
-                             "version": "1.1.4",
-                             "source": "INTERNAL",
-                             "cwes": [
-                                {
-                                    "cweId": "23",
-                                    "name": "Relative Path Traversal"
-                                }
-                             ],
-                             "cvssV3BaseScore": "",
-                             "epssScore": "",
-                             "epssPercentile": "",
-                             "severityRank": "3",
-                             "recommendation": "Recommendation with whitespaces"
-                           }
-                        }
-                """),
-                vuln3 -> assertThatJson(vuln3).isEqualTo("""
-                        {
-                           "ruleId": "Vuln-3",
-                           "message": {
-                             "text": "A description-with-hyphens-(and parentheses)"
-                           },
-                           "locations": [
-                             {
-                               "logicalLocations": [
-                                 {
-                                   "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar"
-                                 }
-                               ]
-                             }
-                           ],
-                           "level": "note",
-                           "properties": {
-                             "name": "Component 2",
-                             "group": "com.xyz",
-                             "version": "2.78.123",
-                             "source": "INTERNAL",
-                             "cwes": [
-                                {
-                                    "cweId": "23",
-                                    "name": "Relative Path Traversal"
-                                }
-                             ],
-                             "cvssV3BaseScore": "",
-                             "epssScore": "",
-                             "epssPercentile": "",
-                             "severityRank": "3",
-                             "recommendation": "Recommendation with whitespaces"
-                           }
-                        }
-                """)
-        );
+        final String version = new About().getVersion();
+        final String fullName = "OWASP Dependency-Track - " + version;
+        String expectedTemplate = resourceToString(expectedResponsePath, StandardCharsets.UTF_8);
+        String expected = expectedTemplate
+                .replace("{{VERSION}}", version)
+                .replace("{{FULL_NAME}}", fullName);
+        assertThatJson(jsonResponse).isEqualTo(expected);
     }
 
     @Test
@@ -1513,6 +1380,13 @@ public class FindingResourceTest extends ResourceTest {
 
     }
 
+    private static Stream<Arguments> getSARIFFindingsByProjectTestParameters() {
+        return Stream.of(
+                Arguments.of("INTERNAL", "/unit/sarif/expected-internal.sarif.json"),
+                Arguments.of(null, "/unit/sarif/expected-all.sarif.json")
+        );
+    }
+
     private Component createComponent(Project project, String name, String version) {
         Component component = new Component();
         component.setProject(project);
@@ -1530,10 +1404,10 @@ public class FindingResourceTest extends ResourceTest {
         return qm.createVulnerability(vulnerability, false);
     }
 
-    private Vulnerability createVulnerability(String vulnId, Severity severity, String title, String description, String recommendation, Integer cweId) {
+    private Vulnerability createVulnerability(String vulnId, Severity severity, String title, String description, String recommendation, Integer cweId, Vulnerability.Source source) {
         Vulnerability vulnerability = new Vulnerability();
         vulnerability.setVulnId(vulnId);
-        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSource(source);
         vulnerability.setSeverity(severity);
         vulnerability.setTitle(title);
         vulnerability.setDescription(description);

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
@@ -318,6 +318,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
                                 projectId,
                                 /* includeInactive */ false,
                                 /* includeSuppressed */ false,
+                                null,
                                 null));
 
         List<FindingRow> findings = findingsSupplier.get();
@@ -1188,7 +1189,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
         final long projectId = project.getId();
         final List<FindingDao.FindingRow> findings = withJdbiHandle(
                 handle -> handle.attach(FindingDao.class)
-                        .getFindingsByProject(projectId, false, false, null));
+                        .getFindingsByProject(projectId, false, false, null, null));
         assertThat(findings).hasSize(1);
 
         assertThat(getAllAliasGroups()).satisfiesExactly(group ->

--- a/apiserver/src/test/resources/unit/sarif/expected-all.sarif.json
+++ b/apiserver/src/test/resources/unit/sarif/expected-all.sarif.json
@@ -1,0 +1,189 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "OWASP Dependency-Track",
+          "fullName": "{{FULL_NAME}}",
+          "version": "{{VERSION}}",
+          "informationUri": "https://dependencytrack.org/",
+          "rules": [
+            {
+              "id": "Vuln-1",
+              "name": "Vuln-1",
+              "shortDescription": { "text": "Vuln-1" },
+              "fullDescription": { "text": "This is a description" }
+            },
+            {
+              "id": "Vuln-2",
+              "name": "Vuln-2",
+              "shortDescription": { "text": "Vuln-2" },
+              "fullDescription": { "text": "Yet another description but with surrounding whitespaces" }
+            },
+            {
+              "id": "Vuln-3",
+              "name": "Vuln-3",
+              "shortDescription": { "text": "Vuln-3" },
+              "fullDescription": { "text": "A description-with-hyphens-(and parentheses)" }
+            },
+            {
+              "id": "Vuln-4",
+              "name": "Vuln-4",
+              "shortDescription": { "text": "Vuln-4" },
+              "fullDescription": { "text": "This is a vulnerability that has GITHUB Advisory as a source" }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Vuln-1",
+          "message": { "text": "This is a description" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar" }
+              ]
+            }
+          ],
+          "level": "error",
+          "properties": {
+            "name": "Component 1",
+            "group": "org.acme",
+            "version": "1.1.4",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "80",
+                "name": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "0",
+            "recommendation": ""
+          }
+        },
+        {
+          "ruleId": "Vuln-2",
+          "message": { "text": "Yet another description but with surrounding whitespaces" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar" }
+              ]
+            }
+          ],
+          "level": "error",
+          "properties": {
+            "name": "Component 1",
+            "group": "org.acme",
+            "version": "1.1.4",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "46",
+                "name": "Path Equivalence: 'filename ' (Trailing Space)"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "1",
+            "recommendation": ""
+          }
+        },
+        {
+          "ruleId": "Vuln-3",
+          "message": { "text": "A description-with-hyphens-(and parentheses)" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar" }
+              ]
+            }
+          ],
+          "level": "note",
+          "properties": {
+            "name": "Component 1",
+            "group": "org.acme",
+            "version": "1.1.4",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "23",
+                "name": "Relative Path Traversal"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "3",
+            "recommendation": "Recommendation with whitespaces"
+          }
+        },
+        {
+          "ruleId": "Vuln-3",
+          "message": { "text": "A description-with-hyphens-(and parentheses)" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar" }
+              ]
+            }
+          ],
+          "level": "note",
+          "properties": {
+            "name": "Component 2",
+            "group": "com.xyz",
+            "version": "2.78.123",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "23",
+                "name": "Relative Path Traversal"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "3",
+            "recommendation": "Recommendation with whitespaces"
+          }
+        },
+        {
+          "ruleId": "Vuln-4",
+          "message": { "text": "This is a vulnerability that has GITHUB Advisory as a source" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar" }
+              ]
+            }
+          ],
+          "level": "warning",
+          "properties": {
+            "name": "Component 2",
+            "group": "com.xyz",
+            "version": "2.78.123",
+            "source": "GITHUB",
+            "cwes": [
+              {
+                "cweId": "20",
+                "name": "Improper Input Validation"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "2",
+            "recommendation": ""
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/apiserver/src/test/resources/unit/sarif/expected-internal.sarif.json
+++ b/apiserver/src/test/resources/unit/sarif/expected-internal.sarif.json
@@ -1,0 +1,154 @@
+{
+  "version": "2.1.0",
+  "$schema": "https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0.json",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "OWASP Dependency-Track",
+          "fullName": "{{FULL_NAME}}",
+          "version": "{{VERSION}}",
+          "informationUri": "https://dependencytrack.org/",
+          "rules": [
+            {
+              "id": "Vuln-1",
+              "name": "Vuln-1",
+              "shortDescription": { "text": "Vuln-1" },
+              "fullDescription": { "text": "This is a description" }
+            },
+            {
+              "id": "Vuln-2",
+              "name": "Vuln-2",
+              "shortDescription": { "text": "Vuln-2" },
+              "fullDescription": { "text": "Yet another description but with surrounding whitespaces" }
+            },
+            {
+              "id": "Vuln-3",
+              "name": "Vuln-3",
+              "shortDescription": { "text": "Vuln-3" },
+              "fullDescription": { "text": "A description-with-hyphens-(and parentheses)" }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "Vuln-1",
+          "message": { "text": "This is a description" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar" }
+              ]
+            }
+          ],
+          "level": "error",
+          "properties": {
+            "name": "Component 1",
+            "group": "org.acme",
+            "version": "1.1.4",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "80",
+                "name": "Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "0",
+            "recommendation": ""
+          }
+        },
+        {
+          "ruleId": "Vuln-2",
+          "message": { "text": "Yet another description but with surrounding whitespaces" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar" }
+              ]
+            }
+          ],
+          "level": "error",
+          "properties": {
+            "name": "Component 1",
+            "group": "org.acme",
+            "version": "1.1.4",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "46",
+                "name": "Path Equivalence: 'filename ' (Trailing Space)"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "1",
+            "recommendation": ""
+          }
+        },
+        {
+          "ruleId": "Vuln-3",
+          "message": { "text": "A description-with-hyphens-(and parentheses)" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/org.acme/component1@1.1.4?type=jar" }
+              ]
+            }
+          ],
+          "level": "note",
+          "properties": {
+            "name": "Component 1",
+            "group": "org.acme",
+            "version": "1.1.4",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "23",
+                "name": "Relative Path Traversal"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "3",
+            "recommendation": "Recommendation with whitespaces"
+          }
+        },
+        {
+          "ruleId": "Vuln-3",
+          "message": { "text": "A description-with-hyphens-(and parentheses)" },
+          "locations": [
+            {
+              "logicalLocations": [
+                { "fullyQualifiedName": "pkg:maven/com.xyz/component2@2.78.123?type=jar" }
+              ]
+            }
+          ],
+          "level": "note",
+          "properties": {
+            "name": "Component 2",
+            "group": "com.xyz",
+            "version": "2.78.123",
+            "source": "INTERNAL",
+            "cwes": [
+              {
+                "cweId": "23",
+                "name": "Relative Path Traversal"
+              }
+            ],
+            "cvssV3BaseScore": "",
+            "epssScore": "",
+            "epssPercentile": "",
+            "severityRank": "3",
+            "recommendation": "Recommendation with whitespaces"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### Description

Enable missing source filtering for SARIF format in resource `\finding\project\{uuid}`

### Addressed Issue

Relates to https://github.com/DependencyTrack/hyades/issues/2105
Ports https://github.com/DependencyTrack/dependency-track/pull/4949

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
