### PR TITLE
Fix vuln policy bundle sync ignoring nested files

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/SyncVulnPolicyBundleActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/vulnerability/SyncVulnPolicyBundleActivity.java
@@ -259,7 +259,12 @@ public final class SyncVulnPolicyBundleActivity implements Activity<SyncVulnPoli
             final var entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 final ZipEntry zipEntry = entries.nextElement();
-                if (!POLICY_FILE_NAME_PATTERN.matcher(zipEntry.getName()).matches()) {
+                if (zipEntry.isDirectory()) {
+                    continue;
+                }
+
+                final String fileName = Path.of(zipEntry.getName()).getFileName().toString();
+                if (!POLICY_FILE_NAME_PATTERN.matcher(fileName).matches()) {
                     LOGGER.debug("Skipping file '{}': Unexpected file name pattern", zipEntry.getName());
                     continue;
                 }

--- a/apiserver/src/test/java/org/dependencytrack/policy/vulnerability/SyncVulnPolicyBundleActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/vulnerability/SyncVulnPolicyBundleActivityTest.java
@@ -455,6 +455,34 @@ class SyncVulnPolicyBundleActivityTest extends PersistenceCapableTest {
                 .withHeader("Authorization", WireMock.equalTo("Basic dXNlcjpwYXNz")));
     }
 
+    @Test
+    void shouldProcessPoliciesInSubdirectories() throws Exception {
+        final UUID bundleUuid = UUID.randomUUID();
+        final Path bundlePath = Files.createTempFile(tempDir, "test-bundle-", ".zip");
+        try (final var fos = Files.newOutputStream(bundlePath);
+             final var zos = new java.util.zip.ZipOutputStream(fos)) {
+            zos.putNextEntry(new java.util.zip.ZipEntry("my-bundle/policy-0.yaml"));
+            zos.write(VALID_POLICY.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        }
+
+        wireMock.stubFor(WireMock.get("/bundle.zip")
+                .willReturn(WireMock.aResponse()
+                        .withStatus(200)
+                        .withBody(Files.readAllBytes(bundlePath))));
+
+        final var activity = createActivity(wireMock.baseUrl() + "/bundle.zip");
+        activity.execute(mock(ActivityContext.class), createActivityArg(bundleUuid));
+
+        final VulnPolicyBundleRow bundle = withJdbiHandle(
+                handle -> handle.attach(VulnerabilityPolicyDao.class).getBundleByUuid(bundleUuid));
+        assertThat(bundle).isNotNull();
+
+        final List<VulnPolicyIdentityRow> policies = withJdbiHandle(
+                handle -> handle.attach(VulnerabilityPolicyDao.class).getAllByBundleId(bundle.id()));
+        assertThat(policies).singleElement().satisfies(policy ->
+                assertThat(policy.name()).isEqualTo("Valid"));
+    }
+
     private static SyncVulnPolicyBundleActivity createActivity(String bundleUrl) {
         final Config config = new SmallRyeConfigBuilder()
                 .withDefaultValue("dt.vulnerability.policy.bundle.url", bundleUrl)


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes vuln policy bundle sync ignoring nested files.

The synchronization mechanism would consider files in nested directories as ineligible and skip them. This is a regression of the recent refactoring.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1975 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
