### PR TITLE
Fix findings API returning 500 when filtering by severity

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -608,6 +608,9 @@ public interface FindingDao {
             String[] filters = filter.split(",");
             for (int i = 0, length = filters.length; i < length; i++) {
                 queryFilter.append(column).append(" = :").append(paramName).append(i);
+                if (paramName.equals("severity")) {
+                    queryFilter.append("::SEVERITY");
+                }
                 params.put(paramName + i, filters[i].toUpperCase());
                 if (filters[i].equals("NOT_SET") && (paramName.equals("analysisStatus") || paramName.equals("vendorResponse"))) {
                     queryFilter.append(" OR ").append(column).append(" IS NULL");

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -780,6 +780,49 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @Test
+    public void getAllFindingsFilteredBySeverity() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        Project p1 = qm.createProject("Acme Example 1", null, "1.0", null, null, null, null, false);
+        Component c1 = createComponent(p1, "Component A", "1.0");
+        Vulnerability v1 = createVulnerability("Vuln-1", Severity.CRITICAL);
+        Vulnerability v2 = createVulnerability("Vuln-2", Severity.MEDIUM);
+        Vulnerability v3 = createVulnerability("Vuln-3", Severity.HIGH);
+        Date date = new Date();
+        v1.setPublished(date);
+        v2.setPublished(date);
+        v3.setPublished(date);
+        qm.addVulnerability(v1, c1, "none");
+        qm.addVulnerability(v2, c1, "none");
+        qm.addVulnerability(v3, c1, "none");
+
+        // Filter by single severity
+        Response response = jersey.target(V1_FINDING)
+                .queryParam("severity", "CRITICAL")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertEquals(200, response.getStatus(), 0);
+        assertEquals(String.valueOf(1), response.getHeaderString(TOTAL_COUNT_HEADER));
+        JsonArray json = parseJsonArray(response);
+        assertNotNull(json);
+        assertEquals(1, json.size());
+        assertEquals("CRITICAL", json.getJsonObject(0).getJsonObject("vulnerability").getString("severity"));
+
+        // Filter by multiple severities
+        response = jersey.target(V1_FINDING)
+                .queryParam("severity", "CRITICAL,HIGH")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertEquals(200, response.getStatus(), 0);
+        assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
+        json = parseJsonArray(response);
+        assertNotNull(json);
+        assertEquals(2, json.size());
+    }
+
+    @Test
     public void getAllFindingsWithAclEnabled() {
         Project p1 = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
         Project p1_child = qm.createProject("Acme Example Child", null, "1.0", null, p1, null, null, false);


### PR DESCRIPTION
### Description

`GET /api/v1/finding?severity=CRITICAL` returns 500 with `operator does not exist: severity = character varying`. This regression was introduce with the migration done in #1122. It converted the `SEVERITY` column to an enum, but `FindingDao.processArrayFilter` still binds filter values as plain varchar strings, making the API fail.
Casting the column to `TEXT` before comparison in `processArrayFilter` makes the function work for both enum and varchar columns.

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- [ ] ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [ ] ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
