### PR TITLE
Port : Add EPSS score support for GitHub Advisory (GHSA) vulnerabilities

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
@@ -35,6 +35,7 @@ import org.cyclonedx.proto.v1_6.VulnerabilityAffectedVersions;
 import org.cyclonedx.proto.v1_6.VulnerabilityAffects;
 import org.cyclonedx.proto.v1_6.VulnerabilityRating;
 import org.cyclonedx.proto.v1_6.VulnerabilityReference;
+import org.dependencytrack.model.Epss;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
@@ -77,6 +78,8 @@ public final class BovModelConverter {
     private static final Logger LOGGER = LoggerFactory.getLogger(BovModelConverter.class);
     private static final Pattern EFFECTIVELY_ZERO_PATTERN = Pattern.compile("^0(\\.0)*$");
     static final String TITLE_PROPERTY_NAME = "dependency-track:vuln:title";
+    static final String EPSS_SCORE_PROPERTY_NAME = "dependency-track:vuln:epss:score";
+    static final String EPSS_PERCENTILE_PROPERTY_NAME = "dependency-track:vuln:epss:percentile";
 
     private BovModelConverter() {
     }
@@ -94,11 +97,37 @@ public final class BovModelConverter {
             vuln.setSource(extractSource(cdxVuln.getId(), cdxVuln.getSource()));
         }
         vuln.setVulnId(cdxVuln.getId());
-        if (cdxVuln.getPropertiesCount() != 0) {
-            var titleProperty = cdxVuln.getProperties(0);
-            if (titleProperty.getName().equals(TITLE_PROPERTY_NAME) && titleProperty.hasValue()) {
-                vuln.setTitle(StringUtils.abbreviate(titleProperty.getValue(), 255));
+        var epssScore = (BigDecimal) null;
+        var epssPercentile = (BigDecimal) null;
+        for (final var property : cdxVuln.getPropertiesList()) {
+            if (!property.hasValue()) {
+                continue;
             }
+            switch (property.getName()) {
+                case TITLE_PROPERTY_NAME ->
+                        vuln.setTitle(StringUtils.abbreviate(property.getValue(), 255));
+                case EPSS_SCORE_PROPERTY_NAME -> {
+                    try {
+                        epssScore = BigDecimal.valueOf(Double.parseDouble(property.getValue()));
+                    } catch (NumberFormatException e) {
+                        LOGGER.warn("Failed to parse EPSS score value '{}'; Skipping", property.getValue(), e);
+                    }
+                }
+                case EPSS_PERCENTILE_PROPERTY_NAME -> {
+                    try {
+                        epssPercentile = BigDecimal.valueOf(Double.parseDouble(property.getValue()));
+                    } catch (NumberFormatException e) {
+                        LOGGER.warn("Failed to parse EPSS percentile value '{}'; Skipping", property.getValue(), e);
+                    }
+                }
+            }
+        }
+        if (epssScore != null || epssPercentile != null) {
+            final var epss = new Epss();
+            epss.setCve(cdxVuln.getId());
+            epss.setScore(epssScore);
+            epss.setPercentile(epssPercentile);
+            vuln.setEpss(epss);
         }
         if (cdxVuln.hasDescription()) {
             vuln.setDescription(cdxVuln.getDescription());
@@ -245,8 +274,6 @@ public final class BovModelConverter {
                     .map(alias -> convert(cdxVuln, alias)).toList());
         }
 
-        // EPSS is an additional enrichment that no scanner currently provides.
-        // TODO: Add mapping of EPSS score and percentile when needed.
 
         return vuln;
     }

--- a/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
@@ -508,6 +508,27 @@ class BovModelConverterTest {
                     });
         }
 
+        @Test
+        void testConvertEpssProperty() {
+            final Bom bovInput = Bom.newBuilder().addVulnerabilities(
+                    org.cyclonedx.proto.v1_6.Vulnerability.newBuilder()
+                            .setId("CVE-2021-44228")
+                            .setSource(Source.newBuilder().setName("NVD").build())
+                            .addProperties(Property.newBuilder()
+                                    .setName(BovModelConverter.EPSS_SCORE_PROPERTY_NAME)
+                                    .setValue("3.4").build())
+                            .addProperties(Property.newBuilder()
+                                    .setName(BovModelConverter.EPSS_PERCENTILE_PROPERTY_NAME)
+                                    .setValue("1.23").build())
+                            .build()).build();
+
+            final Vulnerability vuln = BovModelConverter.convert(bovInput, bovInput.getVulnerabilities(0), true);
+            assertThat(vuln.getVulnId()).isEqualTo("CVE-2021-44228");
+            assertThat(vuln.getSource()).isEqualTo(Vulnerability.Source.NVD.name());
+            assertThat(vuln.getEpssScore()).isEqualTo(BigDecimal.valueOf(3.4));
+            assertThat(vuln.getEpssPercentile()).isEqualTo(BigDecimal.valueOf(1.23));
+        }
+
         private static Bom createBovWithVersionRange(String versionRange) {
             final var component = org.cyclonedx.proto.v1_6.Component.newBuilder()
                     .setBomRef("test-component")

--- a/vuln-data-source/github/src/main/java/org/dependencytrack/vulndatasource/github/ModelConverter.java
+++ b/vuln-data-source/github/src/main/java/org/dependencytrack/vulndatasource/github/ModelConverter.java
@@ -23,6 +23,7 @@ import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
 import com.google.protobuf.util.Timestamps;
 import io.github.jeremylong.openvulnerability.client.ghsa.CWEs;
+import io.github.jeremylong.openvulnerability.client.ghsa.Epss;
 import io.github.jeremylong.openvulnerability.client.ghsa.Identifier;
 import io.github.jeremylong.openvulnerability.client.ghsa.Package;
 import io.github.jeremylong.openvulnerability.client.ghsa.SecurityAdvisory;
@@ -74,6 +75,8 @@ final class ModelConverter {
     private static final Logger LOGGER = LoggerFactory.getLogger(ModelConverter.class);
     private static final Source SOURCE = Source.newBuilder().setName("GITHUB").build();
     private static final String TITLE_PROPERTY_NAME = "dependency-track:vuln:title";
+    private static final String EPSS_SCORE_PROPERTY_NAME = "dependency-track:vuln:epss_score";
+    private static final String EPSS_PERCENTILE_PROPERTY_NAME = "dependency-track:vuln:epss_percentile";
 
     private ModelConverter() {
     }
@@ -112,6 +115,29 @@ final class ModelConverter {
                 .map(Instant::toEpochMilli)
                 .map(Timestamps::fromMillis)
                 .ifPresent(vulnBuilder::setRejected);
+
+        if (advisory.getEpss() != null) {
+            final Epss epss = advisory.getEpss();
+            // GitHub's GraphQL API (https://docs.github.com/en/graphql/reference/objects#securityadvisoryepss):
+            //   "percentage" = exploitation probability (EPSS score, 0.0-1.0)
+            //   "percentile" = relative rank compared to other CVEs (0.0-1.0)
+            //
+            // NOTE: the open-vulnerability-clients library Javadoc has these two fields documented
+            // with swapped semantics — trust the live API values, not the Javadoc.
+            // Verified against real API responses, e.g. GHSA-57j2-w4cx-62h2 (CVE-2020-36518):
+            //   percentage=0.00514 (0.514% exploitation probability)
+            //   percentile=0.66009 (ranked above 66% of all CVEs)
+            Optional.ofNullable(epss.getPercentage()).ifPresent(value ->
+                vulnBuilder.addProperties(Property.newBuilder()
+                        .setName(EPSS_SCORE_PROPERTY_NAME)
+                        .setValue(value.toString())
+                        .build()));
+            Optional.ofNullable(epss.getPercentile()).ifPresent(value ->
+                vulnBuilder.addProperties(Property.newBuilder()
+                        .setName(EPSS_PERCENTILE_PROPERTY_NAME)
+                        .setValue(value.toString())
+                        .build()));
+        }
 
         final var componentByPurl = new HashMap<String, Component>();
         final var vulnAffectsBuilderByBomRef = new HashMap<String, VulnerabilityAffects.Builder>();

--- a/vuln-data-source/github/src/test/java/org/dependencytrack/vulndatasource/github/ModelConverterTest.java
+++ b/vuln-data-source/github/src/test/java/org/dependencytrack/vulndatasource/github/ModelConverterTest.java
@@ -303,4 +303,56 @@ class ModelConverterTest {
                          }
                         """);
     }
+
+    @Test
+    void shouldConvertEpss() throws IOException {
+
+        //given
+        var securityAdvisory = MAPPER.readValue(getClass().getResource("/advisory-04.json"), SecurityAdvisory.class);
+
+        Bom bom = ModelConverter.convert(securityAdvisory, true);
+
+        assertThatJson(JsonFormat.printer().print(bom))
+                .when(Option.IGNORING_ARRAY_ORDER)
+                .isEqualTo("""
+                        {
+                           "components": [{
+                             "bomRef": "9407f313-a355-3a52-a697-ab76c6641d89",
+                             "purl": "pkg:nuget/bootstrap"
+                           }],
+                           "vulnerabilities": [{
+                             "id": "GHSA-fxwm-579q-49qq",
+                             "source": {
+                               "name": "GITHUB"
+                             },
+                             "ratings": [{
+                               "method": "SCORE_METHOD_OTHER",
+                               "severity": "SEVERITY_CRITICAL",
+                               "source": {
+                                 "name": "GITHUB"
+                               }
+                             }],
+                             "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
+                             "published": "2026-02-22T20:54:40Z",
+                             "updated": "2026-12-03T14:54:43Z",
+                             "affects": [{
+                               "ref": "9407f313-a355-3a52-a697-ab76c6641d89",
+                               "versions": [{
+                                 "range": "vers:nuget/>=4.0.0|<4.3.1"
+                               }]
+                             }],
+                             "properties": [{
+                               "name": "dependency-track:vuln:title",
+                               "value": "Critical severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass"
+                             }, {
+                                "name":"dependency-track:vuln:epss_score",
+                                "value":"9.0"
+                             }, {
+                                "name":"dependency-track:vuln:epss_percentile",
+                                "value":"9.9"
+                             }]
+                           }]
+                         }
+                        """);
+    }
 }

--- a/vuln-data-source/github/src/test/resources/advisory-04.json
+++ b/vuln-data-source/github/src/test/resources/advisory-04.json
@@ -1,0 +1,55 @@
+{
+  "databaseId": 1275,
+  "description": "In Bootstrap 4 before 4.3.1 and Bootstrap 3 before 3.4.1, XSS is possible in the tooltip or popover data-template attribute. For more information, see: https://blog.getbootstrap.com/2019/02/13/bootstrap-4-3-1-and-3-4-1/",
+  "ghsaId": "GHSA-fxwm-579q-49qq",
+  "id": "MDE2OlNlY3VyaXR5QWR2aXNvcnlHSFNBLWZ4d20tNTc5cS00OXFx",
+  "identifiers": [
+    {
+      "type": "GHSA",
+      "value": "GHSA-fxwm-579q-49qq"
+    }
+  ],
+  "notificationsPermalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq/dependabot",
+  "origin": "UNSPECIFIED",
+  "permalink": "https://github.com/advisories/GHSA-fxwm-579q-49qq",
+  "publishedAt": "2026-02-22T20:54:40Z",
+  "severity": "CRITICAL",
+  "summary": "Critical severity vulnerability that affects Bootstrap.Less, bootstrap, and bootstrap.sass",
+  "updatedAt": "2026-12-03T14:54:43Z",
+  "vulnerabilities": {
+    "edges": [
+      {
+        "node": {
+          "severity": "MODERATE",
+          "updatedAt": "2026-02-22T20:53:04Z",
+          "firstPatchedVersion": {
+            "identifier": "4.3.1"
+          },
+          "vulnerableVersionRange": ">= 4.0.0, < 4.3.1",
+          "package": {
+            "ecosystem": "NUGET",
+            "name": "bootstrap"
+          }
+        }
+      }
+    ],
+    "totalCount": 1,
+    "pageInfo": {
+      "hasNextPage": false,
+      "endCursor": "Y3Vyc29yOnYyOpK5MjAxOS0wMi0yMlQyMTo1MzowNCswMTowMM0H6w=="
+    }
+  },
+  "epss": {
+    "percentage": 9.0,
+    "percentile": 9.9
+  },
+  "cwes": {
+    "edges": [],
+    "totalCount": 0,
+    "pageInfo": {
+      "hasNextPage": false,
+      "endCursor": null
+    }
+  },
+  "withdrawnAt": null
+}


### PR DESCRIPTION
### Description

Add EPSS score support for GitHub Advisory (GHSA) vulnerabilities.

### Addressed Issue

Fixes https://github.com/DependencyTrack/hyades/issues/2105
Ports https://github.com/DependencyTrack/dependency-track/pull/5829

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
