### PR TITLE
Raise default DB connection pool size from 20 to 30

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1846,7 +1846,7 @@ dt.dex-engine.activity-worker.package-metadata-resolution.queue-name=package-met
 # @category: Durable Execution
 # @type:     integer
 # @required
-dt.dex-engine.activity-worker.package-metadata-resolution.max-concurrency=10
+dt.dex-engine.activity-worker.package-metadata-resolution.max-concurrency=3
 
 # Defines the time in milliseconds between flushes of the task event buffer.
 # <br/><br/>

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -180,7 +180,7 @@ dt.database.pool.enabled=true
 # @category:   Database
 # @deprecated: Since 5.7.0. Use dt.datasource.pool.max-size instead.
 # @type:       integer
-dt.database.pool.max.size=20
+dt.database.pool.max.size=30
 
 # This property controls the minimum number of idle connections in the pool.
 # This value should be equal to or less than dt.database.pool.max.size.
@@ -190,7 +190,7 @@ dt.database.pool.max.size=20
 # @category:   Database
 # @deprecated: Since 5.7.0. Use dt.datasource.pool.min-idle instead.
 # @type:       integer
-dt.database.pool.min.idle=10
+dt.database.pool.min.idle=15
 
 # This property controls the maximum amount of time that a connection is
 # allowed to sit idle in the pool.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Raises the default DB connection pool size from 20 to 30.

Also lowers the default max concurrency for package metadata resolution activities from 10 to 3. See commit message for rationale.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
