### PR TITLE
Tweak /api/v2/components endpoint

### DIFF
--- a/api/src/main/openapi/paths/components.yaml
+++ b/api/src/main/openapi/paths/components.yaml
@@ -56,90 +56,94 @@ get:
   operationId: listComponents
   summary: List all components
   description: |-
-    Retrieves a list of all components that have the specified component identity. This resource accepts coordinates (group, name, version) , `purl`, `cpe`, `swidTagId`, `project_uuid`, or `hash`.
-    
+    Retrieves a list of all components matching the provided filter criteria.
+
+    Text filters are case-insensitive.
+
     ### Sortable fields
-    
+
     Sorting is supported for the following fields:
-    
+
     * `name`
     * `version`
     * `group`
     * `purl`
     * `cpe`
-    * `swid_tag_id`
     * `last_inherited_risk_score`
-    
+
     Requires permission <strong>VIEW_PORTFOLIO</strong>
   tags:
-    - Components
+  - Components
   parameters:
-    - name: project_uuid
-      in: query
-      description: The UUID of the project to retrieve components for
-      schema:
-        type: string
-        format: uuid
-    - name: group
-      in: query
-      description: The group of the component
-      schema:
-        type: string
-    - name: name
-      in: query
-      description: The name of the component
-      schema:
-        type: string
-    - name: version
-      in: query
-      description: The version of the component
-      schema:
-        type: string
-    - name: purl
-      in: query
-      description: The PURL of the component
-      schema:
-        type: string
-    - name: cpe
-      in: query
-      description: The CPE of the component
-      schema:
-        type: string
-    - name: swid_tag_id
-      in: query
-      description: The SWID Tag ID of the component
-      schema:
-        type: string
-    - name: hash_type
-      in: query
-      description: The MD5, SHA1, SHA_256, SHA_384, SHA_512, SHA3_256, SHA3_384, SHA3_512, BLAKE2B_256, BLAKE2B_384, BLAKE2B_512, or BLAKE3 hash type of the component
-      schema:
-        type: string
-        enum:
-          - MD5
-          - SHA1
-          - SHA_256
-          - SHA_384
-          - SHA_512
-          - SHA3_256
-          - SHA3_384
-          - SHA3_512
-          - BLAKE2B_256
-          - BLAKE2B_384
-          - BLAKE2B_512
-          - BLAKE3
-    - name: hash
-      in: query
-      description: The hash value of the component
-      schema:
-        type: string
-    - $ref: "../components/parameters/pagination-limit.yaml"
-    - $ref: "../components/parameters/page-token.yaml"
-    - $ref: "../components/parameters/sort-direction.yaml"
-    - $ref: "../components/parameters/sort-by.yaml"
+  - name: group_contains
+    in: query
+    description: Filter by group (substring match)
+    schema:
+      type: string
+  - name: name_contains
+    in: query
+    description: Filter by name (substring match)
+    schema:
+      type: string
+  - name: version_contains
+    in: query
+    description: Filter by version (substring match)
+    schema:
+      type: string
+  - name: purl_prefix
+    in: query
+    description: |-
+      Filter by PURL (prefix match).
+      
+      Must be a valid PURL, with at least `pkg:<ecosystem>/<name>` populated.
+    schema:
+      type: string
+  - name: cpe
+    in: query
+    description: |-
+      Filter by CPE (exact match).
+      
+      Must be a valid CPE.
+    schema:
+      type: string
+  - name: swid_tag_id_contains
+    in: query
+    description: Filter by SWID Tag ID (substring match)
+    schema:
+      type: string
+  - name: hash_type
+    in: query
+    description: The hash type to filter by
+    schema:
+      type: string
+      enum:
+      - MD5
+      - SHA1
+      - SHA_256
+      - SHA_384
+      - SHA_512
+      - SHA3_256
+      - SHA3_384
+      - SHA3_512
+      - BLAKE2B_256
+      - BLAKE2B_384
+      - BLAKE2B_512
+      - BLAKE3
+  - name: hash
+    in: query
+    description: |-
+      Filter by hash value (exact match).
+      
+      Requires `hash_type` to be set.
+    schema:
+      type: string
+  - $ref: "../components/parameters/pagination-limit.yaml"
+  - $ref: "../components/parameters/page-token.yaml"
+  - $ref: "../components/parameters/sort-direction.yaml"
+  - $ref: "../components/parameters/sort-by.yaml"
   responses:
     "200":
-      description: A list of all components for a given identity
+      description: A list of components matching the provided filters
       content:
         application/json:
           schema:
@@ -150,13 +154,11 @@ get:
         application/problem+json:
           schema:
             anyOf:
-              - $ref: "../components/schemas/json-schema-validation-problem-details.yaml"
-              - $ref: "../components/schemas/problem-details.yaml"
+            - $ref: "../components/schemas/json-schema-validation-problem-details.yaml"
+            - $ref: "../components/schemas/problem-details.yaml"
     "401":
       $ref: "../components/responses/generic-unauthorized-error.yaml"
     "403":
       $ref: "../components/responses/generic-forbidden-error.yaml"
-    "404":
-      $ref: "../components/responses/generic-not-found-error.yaml"
     default:
       $ref: "../components/responses/generic-error.yaml"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ComponentDao.java
@@ -249,7 +249,7 @@ public interface ComponentDao extends SqlObject, PaginationSupport {
             queryParams.put("componentPurl", componentPurl);
         }
         if (componentCpe != null) {
-            whereConditions.add("LOWER(\"C\".\"CPE\") LIKE ('%' || LOWER(:componentCpe) || '%')");
+            whereConditions.add("LOWER(\"C\".\"CPE\") = LOWER(:componentCpe)");
             queryParams.put("componentCpe", componentCpe);
         }
         if (componentSwidTagId != null) {
@@ -298,7 +298,6 @@ public interface ComponentDao extends SqlObject, PaginationSupport {
             case "group" -> SortBy.GROUP;
             case "purl" -> SortBy.PURL;
             case "cpe" -> SortBy.CPE;
-            case "swid_tag_id" -> SortBy.SWIDTAGID;
             case "last_inherited_risk_score" -> SortBy.LAST_RISKSCORE;
             case null, default -> null;
         };
@@ -321,7 +320,6 @@ public interface ComponentDao extends SqlObject, PaginationSupport {
                 case SortBy.GROUP -> lastRow.getGroup();
                 case SortBy.PURL -> lastRow.getPurl();
                 case SortBy.CPE -> lastRow.getCpe();
-                case SortBy.SWIDTAGID -> lastRow.getSwidTagId();
                 case SortBy.LAST_RISKSCORE -> lastRow.getLastInheritedRiskScore();
                 case null -> lastRow.getName();
             };
@@ -450,7 +448,6 @@ public interface ComponentDao extends SqlObject, PaginationSupport {
         GROUP,
         PURL,
         CPE,
-        SWIDTAGID,
         LAST_RISKSCORE
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ComponentsResource.java
@@ -44,7 +44,6 @@ import org.dependencytrack.model.License;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.ComponentDao;
-import org.dependencytrack.persistence.jdbi.ProjectDao;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.util.InternalComponentIdentifier;
 import org.dependencytrack.util.PurlUtil;
@@ -109,23 +108,15 @@ public class ComponentsResource extends AbstractApiResource implements Component
 
     @Override
     @PermissionRequired(Permissions.Constants.VIEW_PORTFOLIO)
-    public Response listComponents(UUID projectUuid, String group, String name, String version, String purl, String cpe,
-                                   String swidTagId, String hashType, String hash, Integer limit, String pageToken, SortDirection sortDirection, String sortBy) {
+    public Response listComponents(String groupContains, String nameContains, String versionContains, String purlPrefix, String cpe,
+                                   String swidTagIdContains, String hashType, String hash, Integer limit, String pageToken, SortDirection sortDirection, String sortBy) {
         return inJdbiTransaction(getAlpineRequest(), handle -> {
-            Long projectId = null;
-            if (projectUuid != null) {
-                projectId = handle.attach(ProjectDao.class).getProjectId(projectUuid);
-                if (projectId == null) {
-                    throw new NotFoundException();
-                }
-                requireProjectAccess(handle, projectUuid);
-            }
             PackageURL packageURL = null;
-            if (purl != null) {
+            if (purlPrefix != null) {
                 try {
-                    packageURL = new PackageURL(StringUtils.trimToNull(purl));
+                    packageURL = new PackageURL(StringUtils.trimToNull(purlPrefix));
                 } catch (MalformedPackageURLException e) {
-                    throw new BadRequestException("Invalid package URL: %s".formatted(purl));
+                    throw new BadRequestException("Invalid package URL: %s".formatted(purlPrefix));
                 }
             }
             if (cpe != null) {
@@ -144,9 +135,9 @@ public class ComponentsResource extends AbstractApiResource implements Component
                 }
             }
             final Page<Component> componentsPage = handle.attach(ComponentDao.class)
-                    .listComponents(projectId, true, packageURL != null ? packageURL.canonicalize().toLowerCase() : null, StringUtils.trimToNull(cpe),
-                            StringUtils.trimToNull(swidTagId), StringUtils.trimToNull(group), StringUtils.trimToNull(name),
-                            StringUtils.trimToNull(version), hashTypeEnum, StringUtils.trimToNull(hash), limit, pageToken, sortBy, mapSortDirection(sortDirection));
+                    .listComponents(null, true, packageURL != null ? packageURL.canonicalize().toLowerCase() : null, StringUtils.trimToNull(cpe),
+                            StringUtils.trimToNull(swidTagIdContains), StringUtils.trimToNull(groupContains), StringUtils.trimToNull(nameContains),
+                            StringUtils.trimToNull(versionContains), hashTypeEnum, StringUtils.trimToNull(hash), limit, pageToken, sortBy, mapSortDirection(sortDirection));
 
             final var response = ListComponentsResponse.builder()
                     .items(componentsPage.items().stream()

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ComponentsResourceTest.java
@@ -31,8 +31,6 @@ import org.dependencytrack.model.Project;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.util.UUID;
-
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -302,9 +300,9 @@ public class ComponentsResourceTest extends ResourceTest {
     public void listComponentsWithCoordinatesTest() {
         prepareComponents();
         Response response = jersey.target("/components")
-                .queryParam("group", "B")
-                .queryParam("name", "B")
-                .queryParam("version", "versionB")
+                .queryParam("group_contains", "B")
+                .queryParam("name_contains", "B")
+                .queryParam("version_contains", "versionB")
                 .queryParam("limit", 2)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -341,7 +339,7 @@ public class ComponentsResourceTest extends ResourceTest {
     public void listComponentsWithPurlTest() {
         prepareComponents();
         Response response = jersey.target("/components")
-                .queryParam("purl", "pkg:maven/groupB/nameB@versionB")
+                .queryParam("purl_prefix", "pkg:maven/groupB/nameB@versionB")
                 .queryParam("limit", 2)
                 .request()
                 .header(X_API_KEY, apiKey)
@@ -424,62 +422,12 @@ public class ComponentsResourceTest extends ResourceTest {
     }
 
     @Test
-    public void listComponentsWithProjectTest() {
-        prepareComponents();
-        Response response = jersey.target("/components")
-                .queryParam("project_uuid", qm.getProject("projectA", "1.0").getUuid())
-                .queryParam("limit", 2)
-                .request()
-                .header(X_API_KEY, apiKey)
-                .get();
-        assertThat(response.getStatus()).isEqualTo(200);
-        final JsonObject responseJson = parseJsonObject(response);
-        assertThatJson(responseJson.toString()).isEqualTo(/* language=JSON */ """
-                {
-                  "items" : [ {
-                        "name": "nameA",
-                        "version": "versionA",
-                        "group": "groupA",
-                        "cpe": "cpe:2.3:a:groupA:nameA:versionA:*:*:*:*:*:*:*",
-                        "purl":"pkg:maven/groupA/nameA@versionA?foo=bar",
-                        "internal": false,
-                        "uuid": "${json-unit.any-string}",
-                        "project": {
-                            "name": "projectA",
-                            "version": "1.0",
-                            "uuid": "${json-unit.any-string}"
-                        }
-                      }
-                  ],
-                  "total": {
-                    "count": 1,
-                    "type": "EXACT"
-                  }
-                }
-                """);
-    }
-
-    @Test
-    public void listComponentsWithProjectWhenProjectDoesNotExistTest() {
-        prepareComponents();
-        Response response = jersey.target("/components")
-                .queryParam("project_uuid", UUID.randomUUID())
-                .queryParam("limit", 2)
-                .request()
-                .header(X_API_KEY, apiKey)
-                .get();
-        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_NOT_FOUND);
-        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isNull();
-        assertThat(getPlainTextBody(response)).contains("Not Found");
-    }
-
-    @Test
     public void listComponentsAclTest() {
         enablePortfolioAccessControl();
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT);
         prepareComponents();
         Response response = jersey.target("/components")
-                .queryParam("name", "name")
+                .queryParam("name_contains", "name")
                 .queryParam("limit", 2)
                 .request()
                 .header(X_API_KEY, apiKey)


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Tweaks /api/v2/components endpoint as follows:

* Encodes matching semantics in query parameter names to make them explicit.
* Removes the `project_uuid` parameter. We already have the `/api/v2/projects/<uuid>/components` endpoint for this.
* Change cpe filter from "contains" to "equals" semantics. We validate that the provided value is a valid CPE, and a partial CPE will fail to parse. Neither "contains" nor "prefix" matching makes sense there.
* Updates API description to mention that CPE and PURL must be valid, and that `hash_type` is required when `hash` is provided.
* Removes sorting by SWID Tag ID. There's no index on that column, and SWID usage has not been widespread enough to justify committing to support this yet.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to #1867 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/hyades-frontend/pull/489

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
