### PR TITLE
Implement OSV vuln analyzer

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -157,6 +157,11 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analyzer-osv</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>vuln-analyzer-snyk</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/coverage-report/pom.xml
+++ b/coverage-report/pom.xml
@@ -241,6 +241,12 @@
         </dependency>
         <dependency>
             <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analyzer-osv</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
             <artifactId>vuln-analyzer-snyk</artifactId>
             <version>${project.version}</version>
             <scope>provided</scope>

--- a/vuln-analysis/osv/pom.xml
+++ b/vuln-analysis/osv/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>vuln-analysis-parent</artifactId>
+        <version>5.7.0-alpha.3-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>vuln-analyzer-osv</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Vulnerability Analysis :: Analyzer :: OSV</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>plugin-testing</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.dependencytrack</groupId>
+            <artifactId>vuln-analysis-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jsonschema2pojo</groupId>
+                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/resources/org/dependencytrack/vulnanalysis/osv</sourceDirectory>
+                    <targetPackage>org.dependencytrack.vulnanalysis.osv</targetPackage>
+                    <generateBuilders>true</generateBuilders>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/OsvVulnAnalyzer.java
+++ b/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/OsvVulnAnalyzer.java
@@ -1,0 +1,282 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.osv;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import org.cyclonedx.proto.v1_6.Bom;
+import org.cyclonedx.proto.v1_6.Component;
+import org.cyclonedx.proto.v1_6.Property;
+import org.cyclonedx.proto.v1_6.Source;
+import org.cyclonedx.proto.v1_6.Vulnerability;
+import org.cyclonedx.proto.v1_6.VulnerabilityAffects;
+import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+
+final class OsvVulnAnalyzer implements VulnAnalyzer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OsvVulnAnalyzer.class);
+    private static final Source SOURCE_OSV = Source.newBuilder().setName("OSV").build();
+    private static final int QUERY_CACHE_BATCH_SIZE = 1000;
+    private static final int QUERY_BATCH_SIZE = 1000;
+
+    private final Cache resultsCache;
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final URI apiUrl;
+
+    OsvVulnAnalyzer(
+            Cache resultsCache,
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            URI apiUrl) {
+        this.resultsCache = resultsCache;
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.apiUrl = apiUrl;
+    }
+
+    @Override
+    public Bom analyze(Bom bom) throws InterruptedException {
+        final Map<String, Set<String>> bomRefsByPurl = collectAnalyzablePurls(bom);
+        if (bomRefsByPurl.isEmpty()) {
+            LOGGER.debug("No analyzable PURLs found; Skipping analysis");
+            return Bom.getDefaultInstance();
+        }
+
+        final Map<String, Set<String>> vulnIdsByPurl;
+        try {
+            vulnIdsByPurl = queryPurls(bomRefsByPurl.keySet());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        // TODO: Fetch vulnerability records: https://google.github.io/osv.dev/get-v1-vulns/
+
+        return assembleVdr(vulnIdsByPurl, bomRefsByPurl);
+    }
+
+    private Map<String, Set<String>> collectAnalyzablePurls(Bom bom) {
+        final var bomRefsByPurl = new LinkedHashMap<String, Set<String>>();
+
+        for (final Component component : bom.getComponentsList()) {
+            if (!component.hasBomRef() || !component.hasPurl()) {
+                continue;
+            }
+            if (component.getPropertiesCount() > 0
+                    && component.getPropertiesList().stream()
+                    .map(Property::getName)
+                    .anyMatch("dependencytrack:internal:is-internal-component"::equalsIgnoreCase)) {
+                continue;
+            }
+
+            try {
+                final var purl = new PackageURL(component.getPurl());
+                if (purl.getVersion() == null) {
+                    continue;
+                }
+
+                bomRefsByPurl
+                        .computeIfAbsent(purl.canonicalize(), k -> new HashSet<>())
+                        .add(component.getBomRef());
+            } catch (MalformedPackageURLException e) {
+                LOGGER.warn("Failed to parse PURL '{}'; Skipping", component.getPurl(), e);
+            }
+        }
+
+        return bomRefsByPurl;
+    }
+
+    private Map<String, Set<String>> queryPurls(Collection<String> purls) throws IOException, InterruptedException {
+        final var cachedVulnIdsByPurl = new HashMap<String, Set<String>>();
+        for (final var purlBatch : partition(List.copyOf(purls), QUERY_CACHE_BATCH_SIZE)) {
+            if (Thread.interrupted()) {
+                throw new InterruptedException("Interrupted before all cache lookups could complete");
+            }
+
+            final Map<String, byte[]> cachedBytesByPurl = resultsCache.getMany(Set.copyOf(purlBatch));
+            LOGGER.debug("Found cached results for {}/{} PURLs", cachedBytesByPurl.size(), purlBatch.size());
+
+            for (final var entry : cachedBytesByPurl.entrySet()) {
+                final String purl = entry.getKey();
+                final byte[] cachedBytes = entry.getValue();
+
+                if (cachedBytes == null) {
+                    cachedVulnIdsByPurl.put(purl, Set.of());
+                    continue;
+                }
+
+                try {
+                    final var vulnIds = objectMapper.readValue(cachedBytes, String[].class);
+                    cachedVulnIdsByPurl.put(purl, Set.of(vulnIds));
+                } catch (IOException e) {
+                    LOGGER.warn("Failed to deserialize cached component report for PURL '{}'; Will re-fetch", purl, e);
+                }
+            }
+        }
+
+        final var queryQueue = new LinkedBlockingQueue<>(
+                purls.stream()
+                        .filter(purl -> !cachedVulnIdsByPurl.containsKey(purl))
+                        .map(QueryBatchRequest.Query::new)
+                        .toList());
+
+        final var vulnIdsByPurl = new HashMap<String, Set<String>>(purls.size());
+        final var batch = new ArrayList<QueryBatchRequest.Query>(Math.min(queryQueue.size(), QUERY_BATCH_SIZE));
+
+        while (!queryQueue.isEmpty()) {
+            queryQueue.drainTo(batch, QUERY_BATCH_SIZE);
+
+            final QueryBatchResponse response = queryBatch(new QueryBatchRequest(batch));
+            for (int i = 0; i < batch.size(); i++) {
+                final QueryBatchRequest.Query query = batch.get(i);
+                final QueryBatchResponse.Result result = response.results().get(i);
+
+                final List<QueryBatchResponse.Vuln> vulns = response.results().get(i).vulns();
+                if (vulns != null && !vulns.isEmpty()) {
+                    vulnIdsByPurl
+                            .computeIfAbsent(query.pkg().purl(), k -> new HashSet<>())
+                            .addAll(vulns.stream().map(QueryBatchResponse.Vuln::id).toList());
+                } else {
+                    vulnIdsByPurl.putIfAbsent(query.pkg().purl(), Set.of());
+                }
+
+                if (result.nextPageToken() != null) {
+                    queryQueue.add(new QueryBatchRequest.Query(query.pkg(), result.nextPageToken()));
+                }
+            }
+
+            batch.clear();
+        }
+
+        final var entriesToCache = new HashMap<String, byte @Nullable []>(vulnIdsByPurl.size());
+        for (var entry : vulnIdsByPurl.entrySet()) {
+            final String purl = entry.getKey();
+            final Set<String> vulnIds = entry.getValue();
+
+            entriesToCache.put(
+                    purl,
+                    !vulnIds.isEmpty()
+                            ? objectMapper.writeValueAsBytes(vulnIds)
+                            : null);
+        }
+        resultsCache.putMany(entriesToCache);
+
+        vulnIdsByPurl.putAll(cachedVulnIdsByPurl);
+        return vulnIdsByPurl;
+    }
+
+    private QueryBatchResponse queryBatch(QueryBatchRequest request) throws IOException, InterruptedException {
+        final byte[] serializedRequest;
+        try {
+            serializedRequest = objectMapper.writeValueAsBytes(request);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        final var httpRequest = HttpRequest.newBuilder()
+                .uri(apiUrl.resolve("/v1/querybatch"))
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(10))
+                .POST(HttpRequest.BodyPublishers.ofByteArray(serializedRequest))
+                .build();
+
+        final HttpResponse<String> response = httpClient.send(
+                httpRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (response.statusCode() == 200) {
+            return objectMapper.readValue(response.body(), QueryBatchResponse.class);
+        }
+
+        throw new IOException("OSV API request failed with status " + response.statusCode());
+    }
+
+    private Bom assembleVdr(
+            Map<String, Set<String>> vulnIdsByPurl,
+            Map<String, Set<String>> bomRefsByPurl) {
+        final var vulnBuilderByVulnId = new HashMap<String, Vulnerability.Builder>();
+
+        for (final var entry : vulnIdsByPurl.entrySet()) {
+            final String purl = entry.getKey();
+            final Set<String> vulnIds = entry.getValue();
+
+            final Set<String> bomRefs = bomRefsByPurl.get(purl);
+            if (bomRefs == null) {
+                LOGGER.warn("""
+                        Received vulnerabilities for PURL '{}', but no component \
+                        with this PURL was submitted for analysis""", purl);
+                continue;
+            }
+
+            for (final var vulnId : vulnIds) {
+                final Vulnerability.Builder vulnBuilder =
+                        vulnBuilderByVulnId.computeIfAbsent(
+                                vulnId,
+                                ignored -> Vulnerability.newBuilder().setId(vulnId).setSource(SOURCE_OSV));
+
+                for (final String bomRef : bomRefs) {
+                    vulnBuilder.addAffects(
+                            VulnerabilityAffects.newBuilder()
+                                    .setRef(bomRef)
+                                    .build());
+                }
+            }
+        }
+
+        return Bom
+                .newBuilder()
+                .addAllVulnerabilities(
+                        vulnBuilderByVulnId.values().stream()
+                                .map(Vulnerability.Builder::build)
+                                .toList())
+                .build();
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int batchSize) {
+        final var partitions = new ArrayList<List<T>>();
+        for (int i = 0; i < list.size(); i += batchSize) {
+            partitions.add(list.subList(i, Math.min(i + batchSize, list.size())));
+        }
+
+        return partitions;
+    }
+
+}

--- a/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/OsvVulnAnalyzerFactory.java
+++ b/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/OsvVulnAnalyzerFactory.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.osv;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.dependencytrack.cache.api.CacheManager;
+import org.dependencytrack.plugin.api.RuntimeConfigurable;
+import org.dependencytrack.plugin.api.ServiceRegistry;
+import org.dependencytrack.plugin.api.config.ConfigRegistry;
+import org.dependencytrack.plugin.api.config.InvalidRuntimeConfigException;
+import org.dependencytrack.plugin.api.config.RuntimeConfigSpec;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzer;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzerFactory;
+import org.dependencytrack.vulnanalysis.api.VulnAnalyzerRequirement;
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.EnumSet;
+
+import static java.util.Objects.requireNonNull;
+
+final class OsvVulnAnalyzerFactory implements VulnAnalyzerFactory, RuntimeConfigurable {
+
+    private @Nullable CacheManager cacheManager;
+    private @Nullable ConfigRegistry configRegistry;
+    private @Nullable HttpClient httpClient;
+    private @Nullable ObjectMapper objectMapper;
+
+    @Override
+    public String extensionName() {
+        return "osv";
+    }
+
+    @Override
+    public Class<? extends VulnAnalyzer> extensionClass() {
+        return OsvVulnAnalyzer.class;
+    }
+
+    @Override
+    public void init(ServiceRegistry serviceRegistry) {
+        cacheManager = serviceRegistry.require(CacheManager.class);
+        configRegistry = serviceRegistry.require(ConfigRegistry.class);
+        httpClient = serviceRegistry.require(HttpClient.class);
+        objectMapper = new ObjectMapper()
+                .setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
+                .registerModule(new JavaTimeModule());
+    }
+
+    @Override
+    public boolean isEnabled() {
+        requireNonNull(configRegistry);
+        return configRegistry.getRuntimeConfig(OsvVulnAnalyzerConfigV1.class).isEnabled();
+    }
+
+    @Override
+    public EnumSet<VulnAnalyzerRequirement> analyzerRequirements() {
+        return EnumSet.of(VulnAnalyzerRequirement.COMPONENT_PURL);
+    }
+
+    @Override
+    public RuntimeConfigSpec runtimeConfigSpec() {
+        return RuntimeConfigSpec.of(
+                new OsvVulnAnalyzerConfigV1()
+                        .withEnabled(true)
+                        .withApiUrl(URI.create("https://api.osv.dev")),
+                config -> {
+                    if (!config.isEnabled()) {
+                        return;
+                    }
+                    if (config.getApiUrl() == null) {
+                        throw new InvalidRuntimeConfigException("No API URL provided");
+                    }
+                });
+    }
+
+    @Override
+    public VulnAnalyzer create() {
+        requireNonNull(cacheManager);
+        requireNonNull(configRegistry);
+        requireNonNull(httpClient);
+        requireNonNull(objectMapper);
+
+        final var config = configRegistry.getRuntimeConfig(OsvVulnAnalyzerConfigV1.class);
+
+        return new OsvVulnAnalyzer(
+                cacheManager.getCache("results"),
+                httpClient,
+                objectMapper,
+                config.getApiUrl());
+    }
+
+}

--- a/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/OsvVulnAnalyzerPlugin.java
+++ b/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/OsvVulnAnalyzerPlugin.java
@@ -1,0 +1,35 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.osv;
+
+import org.dependencytrack.plugin.api.ExtensionFactory;
+import org.dependencytrack.plugin.api.ExtensionPoint;
+import org.dependencytrack.plugin.api.Plugin;
+
+import java.util.Collection;
+import java.util.List;
+
+public final class OsvVulnAnalyzerPlugin implements Plugin {
+
+    @Override
+    public Collection<? extends ExtensionFactory<? extends ExtensionPoint>> extensionFactories() {
+        return List.of(new OsvVulnAnalyzerFactory());
+    }
+
+}

--- a/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/QueryBatchRequest.java
+++ b/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/QueryBatchRequest.java
@@ -1,0 +1,39 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.osv;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+public record QueryBatchRequest(List<Query> queries) {
+
+    public record Query(@JsonProperty("package") Package pkg, @Nullable String pageToken) {
+
+        Query(String purl) {
+            this(new Package(purl), null);
+        }
+
+    }
+
+    public record Package(String purl) {
+    }
+
+}

--- a/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/QueryBatchResponse.java
+++ b/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/QueryBatchResponse.java
@@ -1,0 +1,34 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulnanalysis.osv;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.List;
+
+public record QueryBatchResponse(List<Result> results) {
+
+    public record Result(List<Vuln> vulns, @Nullable String nextPageToken) {
+    }
+
+    public record Vuln(String id, Instant modified) {
+    }
+
+}

--- a/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/package-info.java
+++ b/vuln-analysis/osv/src/main/java/org/dependencytrack/vulnanalysis/osv/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+@NullMarked
+package org.dependencytrack.vulnanalysis.osv;
+
+import org.jspecify.annotations.NullMarked;

--- a/vuln-analysis/osv/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
+++ b/vuln-analysis/osv/src/main/resources/META-INF/services/org.dependencytrack.plugin.api.Plugin
@@ -1,0 +1,1 @@
+org.dependencytrack.vulnanalysis.osv.OsvVulnAnalyzerPlugin

--- a/vuln-analysis/osv/src/main/resources/org/dependencytrack/vulnanalysis/osv/osv-vuln-analyzer-config-v1.schema.json
+++ b/vuln-analysis/osv/src/main/resources/org/dependencytrack/vulnanalysis/osv/osv-vuln-analyzer-config-v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dependencytrack.org/schemas/osv-vuln-analyzer-config-v1.schema.json",
+  "type": "object",
+  "javaInterfaces": [
+    "org.dependencytrack.plugin.api.config.RuntimeConfig"
+  ],
+  "properties": {
+    "enabled": {
+      "type": "boolean",
+      "title": "Enabled",
+      "description": "Whether the OSV vulnerability analyzer should be enabled.",
+      "existingJavaType": "boolean"
+    },
+    "aliasSyncEnabled": {
+      "type": "boolean",
+      "title": "Alias Synchronization Enabled",
+      "description": "Whether to include alias information in vulnerability data.",
+      "existingJavaType": "boolean"
+    },
+    "apiUrl": {
+      "type": "string",
+      "title": "API URL",
+      "description": "URL of OSS Index' REST API.",
+      "format": "uri",
+      "minLength": 1
+    }
+  },
+  "required": [
+    "enabled"
+  ]
+}

--- a/vuln-analysis/osv/src/test/resources/simplelogger.properties
+++ b/vuln-analysis/osv/src/test/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel=warn

--- a/vuln-analysis/pom.xml
+++ b/vuln-analysis/pom.xml
@@ -36,6 +36,7 @@
         <module>api</module>
         <module>internal</module>
         <module>oss-index</module>
+        <module>osv</module>
         <module>snyk</module>
         <module>trivy</module>
         <module>vuln-db</module>


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds a vulnerability analyzer that uses OSV's batch API. The analyzer is enabled by default, because:

* The internal analyzer relies on vulnerability datasource mirroring, which can take a rather long time for new instances.
* Only the NVD datasource is enabled by default.
* NVD does not provide PURL data, is behind on analysis, and generally not reliable anymore.
* OSS Index requires authentication and is about to enforce strict rate limiting.

The idea is that new users can use a fresh DT instance out of the box, without having to configure anything. They should be able to see vulnerabilities on their very first BOM upload.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
