### PR TITLE
Deprecate `/api/v1/vulnerability/project/{uuid}` and add deprecation response filter

### DIFF
--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -101,6 +101,16 @@ info:
     created resource.
 
     Delete operations return `204 No Content` with no body.
+
+    ## Deprecations
+
+    Operations may be removed or replaced over time. When a response
+    carries the `X-API-Deprecated: true` header, the operation that
+    produced it is deprecated and may be removed in a future release.
+    Clients should check for this header on every response and surface
+    it (e.g. via a log warning) so that operators are aware of upcoming
+    breakages. The respective operation's description points out which
+    alternative operation(s) to use.
   version: 2.0.0
   contact:
     name: The Dependency-Track Authors

--- a/apiserver/src/main/java/org/dependencytrack/filters/DeprecationResponseFilter.java
+++ b/apiserver/src/main/java/org/dependencytrack/filters/DeprecationResponseFilter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.filters;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.ext.Provider;
+
+import java.lang.reflect.Method;
+
+/**
+ * @since 5.7.0
+ */
+@Provider
+@Priority(Priorities.HEADER_DECORATOR)
+public final class DeprecationResponseFilter implements ContainerResponseFilter {
+
+    private final ResourceInfo resourceInfo;
+
+    public DeprecationResponseFilter(@Context ResourceInfo resourceInfo) {
+        this.resourceInfo = resourceInfo;
+    }
+
+    @Override
+    public void filter(
+            ContainerRequestContext requestContext,
+            ContainerResponseContext responseContext) {
+        final Method method = resourceInfo.getResourceMethod();
+        if (method == null) {
+            return;
+        }
+
+        if (!method.isAnnotationPresent(Deprecated.class)
+                && !method.getDeclaringClass().isAnnotationPresent(Deprecated.class)) {
+            return;
+        }
+
+        responseContext.getHeaders().putSingle("X-API-Deprecated", "true");
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -133,10 +133,13 @@ public class VulnerabilityResource extends AbstractApiResource {
 
     @GET
     @Path("/project/{uuid}")
+    @Deprecated(since = "5.7.0", forRemoval = true)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(
             summary = "Returns a list of all vulnerabilities for a specific project",
-            description = "<p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>"
+            description = """
+                    <p>Requires permission <strong>VIEW_PORTFOLIO</strong></p>
+                    <p><strong>Deprecated</strong>! Use <code>/api/v1/finding/project/{uuid}</code> instead.</p>"""
     )
     @ApiResponses(value = {
             @ApiResponse(

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
@@ -30,6 +30,7 @@ import org.dependencytrack.cache.CacheManagerBinder;
 import org.dependencytrack.common.Mappers;
 import org.dependencytrack.dex.DexEngineBinder;
 import org.dependencytrack.filestorage.FileStorageBinder;
+import org.dependencytrack.filters.DeprecationResponseFilter;
 import org.dependencytrack.filters.JerseyMetricsApplicationEventListener;
 import org.dependencytrack.plugin.PluginManagerBinder;
 import org.dependencytrack.secret.SecretManagerBinder;
@@ -65,6 +66,7 @@ public final class ResourceConfig extends org.glassfish.jersey.server.ResourceCo
         register(ApiFilter.class);
         register(AuthenticationFeature.class);
         register(AuthorizationFeature.class);
+        register(DeprecationResponseFilter.class);
         register(HeaderFilter.class);
         register(JacksonFeature.withoutExceptionMappers());
         register(JerseyMetricsApplicationEventListener.class);

--- a/apiserver/src/main/resources/openapi-configuration.yaml
+++ b/apiserver/src/main/resources/openapi-configuration.yaml
@@ -2,7 +2,18 @@ openAPI:
   info:
     version: "${project.version}"
     title: OWASP Dependency-Track
-    description: REST API of OWASP Dependency-Track
+    description: |-
+      REST API of OWASP Dependency-Track
+
+      ## Deprecations
+
+      Operations may be removed or replaced over time. When a response
+      carries the `X-API-Deprecated: true` header, the operation that
+      produced it is deprecated and may be removed in a future release.
+      Clients should check for this header on every response and surface
+      it (e.g. via a log warning) so that operators are aware of
+      upcoming breakages. The respective operation's description points
+      out which alternative operation(s) to use.
     contact:
       name: The Dependency-Track Authors
       url: https://github.com/DependencyTrack/dependency-track

--- a/apiserver/src/test/java/org/dependencytrack/filters/DeprecationResponseFilterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/filters/DeprecationResponseFilterTest.java
@@ -1,0 +1,115 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.filters;
+
+import alpine.server.auth.AuthenticationNotRequired;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DeprecationResponseFilterTest {
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig()
+                    .register(DeprecationResponseFilter.class)
+                    .register(NotDeprecatedResource.class)
+                    .register(DeprecatedClassResource.class));
+
+    @Test
+    void shouldNotSetHeaderWhenMethodIsNotDeprecated() {
+        final Response response = jersey.target("/test/active").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("X-API-Deprecated")).isNull();
+    }
+
+    @Test
+    void shouldSetHeaderWhenMethodIsDeprecated() {
+        final Response response = jersey.target("/test/legacy").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("X-API-Deprecated")).isEqualTo("true");
+    }
+
+    @Test
+    void shouldSetHeaderWhenDeclaringClassIsDeprecated() {
+        final Response response = jersey.target("/old/anything").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString("X-API-Deprecated")).isEqualTo("true");
+    }
+
+    @Test
+    void shouldSetHeaderOnErrorResponseWhenMethodIsDeprecated() {
+        final Response response = jersey.target("/test/legacy-broken").request().get();
+
+        assertThat(response.getStatus()).isEqualTo(418);
+        assertThat(response.getHeaderString("X-API-Deprecated")).isEqualTo("true");
+    }
+
+    @Path("/test")
+    public static class NotDeprecatedResource {
+
+        @GET
+        @Path("/active")
+        @AuthenticationNotRequired
+        public Response active() {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/legacy")
+        @Deprecated
+        @AuthenticationNotRequired
+        public Response legacy() {
+            return Response.ok().build();
+        }
+
+        @GET
+        @Path("/legacy-broken")
+        @Deprecated
+        @AuthenticationNotRequired
+        public Response legacyBroken() {
+            throw new WebApplicationException(Response.status(418).build());
+        }
+
+    }
+
+    @Deprecated
+    @Path("/old")
+    public static class DeprecatedClassResource {
+
+        @GET
+        @Path("/anything")
+        @AuthenticationNotRequired
+        public Response anything() {
+            return Response.ok().build();
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Deprecate `/api/v1/vulnerability/project/{uuid}` and add deprecation response header

The endpoint examines inefficient behaviour that is not fixable without breaking changes:

* It's not paginated
* It includes a nested vulnerable component collection

The latter will crumble for even mid-sized portfolios. It should really be a separate endpoint with proper pagination.

Instead of somehow trying to fix it, deprecate it for removal and steer clients to the findings endpoints instead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~

[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
