### PR TITLE
Remove toggle to disable loading of extensions

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -1444,77 +1444,17 @@ dt.file-storage.local.directory=${dt.data.directory}/storage
 # @type:     integer
 # dt.file-storage.s3.write-timeout-ms=
 
-# Defines whether the console notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.console.enabled=true
-
-# Defines whether the email notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.email.enabled=true
-
 # Defines whether the email notification publisher is allowed to connect to local hosts.
 #
 # @category: Notification
 # @type:     boolean
 # dt.notification-publisher.email.allow-local-connections=false
 
-# Defines whether the Jira notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.jira.enabled=true
-
-# Defines whether the Kafka notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.kafka.enabled=true
-
 # Defines whether the Kafka notification publisher is allowed to connect to local hosts.
 #
 # @category: Notification
 # @type:     boolean
 # dt.notification-publisher.kafka.allow-local-connections=false
-
-# Defines whether the Mattermost notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.mattermost.enabled=true
-
-# Defines whether the Microsoft Teams notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.msteams.enabled=true
-
-# Defines whether the Slack notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.slack.enabled=true
-
-# Defines whether the WebEx notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.webex.enabled=true
-
-# Defines whether the Webhook notification publisher is enabled.
-#
-# @category: Notification
-# @type:     boolean
-# dt.notification-publisher.webhook.enabled=true
-
-# Defines whether the internal vulnerability analyzer is enabled.
-#
-# @category: Vulnerability Analysis
-# @type:     boolean
-# dt.vuln-analyzer.internal.enabled=true
 
 # Defines the name of the data source to be used by the internal vulnerability analyzer.
 # <br/><br/>

--- a/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/PluginManager.java
+++ b/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/PluginManager.java
@@ -391,14 +391,6 @@ public class PluginManager implements Closeable {
                         : null);
         configRegistryByExtensionIdentity.put(extensionIdentity, configRegistry);
 
-        final boolean isEnabled = configRegistry.getDeploymentConfig()
-                .getOptionalValue("enabled", boolean.class)
-                .orElse(true);
-        if (!isEnabled) {
-            LOGGER.debug("Extension is disabled; Skipping");
-            return;
-        }
-
         if (runtimeConfigSpec != null) {
             final RuntimeConfig defaultRuntimeConfig = runtimeConfigSpec.defaultConfig();
             if (defaultRuntimeConfig == null) {

--- a/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/PluginManagerTest.java
+++ b/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/PluginManagerTest.java
@@ -165,24 +165,6 @@ class PluginManagerTest extends AbstractDatabaseTest {
     }
 
     @Test
-    void testDisabledExtension() {
-        final var config = new SmallRyeConfigBuilder()
-                .withDefaultValue("dt.test.dummy.enabled", "false")
-                .build();
-
-        try (final var pluginManager = new PluginManager(
-                config, new NoopCacheManager(), secretName -> null,
-                jdbi, HttpClient.newHttpClient(),
-                List.of(TestExtensionPoint.class))) {
-            pluginManager.loadPlugins(List.of(new DummyPlugin()));
-
-            assertThatExceptionOfType(NoSuchExtensionException.class)
-                    .isThrownBy(() -> pluginManager.getExtension(TestExtensionPoint.class))
-                    .withMessage("No extension exists for the extension point 'test'");
-        }
-    }
-
-    @Test
     void testDefaultExtensionNotLoaded() {
         final var config = new SmallRyeConfigBuilder()
                 .withDefaultValue("dt.test.default-extension", "does.not.exist")


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes toggle to disable loading of extensions.

This was originally necessary because `FileStorage` was an extension point, and it didn't make sense to load the s3 provider when only the local provider was used. We have since moved all infra-level concerns *away* from the extension mechanism, so this use-case no longer exists.

Once we add support for loading extensions from external plugins, we'll need a similar mechanism, but most likely one with opt-in rather than opt-out semantics (i.e. operators decide explicitly what to load).

Until then, this toggle only adds unnecessary config surface.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
