### PR TITLE
Encode page tokens with CBOR

### DIFF
--- a/common/pagination/pom.xml
+++ b/common/pagination/pom.xml
@@ -42,8 +42,8 @@
         </dependency>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
         </dependency>
 
         <dependency>

--- a/common/pagination/src/main/java/module-info.java
+++ b/common/pagination/src/main/java/module-info.java
@@ -24,6 +24,7 @@ module org.dependencytrack.common.pagination {
     exports org.dependencytrack.common.pagination;
 
     requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.dataformat.cbor;
 
     requires transitive org.jspecify;
 }

--- a/common/pagination/src/main/java/org/dependencytrack/common/pagination/InvalidPageTokenException.java
+++ b/common/pagination/src/main/java/org/dependencytrack/common/pagination/InvalidPageTokenException.java
@@ -23,7 +23,11 @@ package org.dependencytrack.common.pagination;
  */
 public final class InvalidPageTokenException extends IllegalArgumentException {
 
-    public InvalidPageTokenException(Throwable cause) {
+    InvalidPageTokenException(String message) {
+        super(message);
+    }
+
+    InvalidPageTokenException(Throwable cause) {
         super(cause);
     }
 

--- a/common/pagination/src/main/java/org/dependencytrack/common/pagination/SimplePageTokenEncoder.java
+++ b/common/pagination/src/main/java/org/dependencytrack/common/pagination/SimplePageTokenEncoder.java
@@ -18,11 +18,14 @@
  */
 package org.dependencytrack.common.pagination;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.cbor.CBORFactory;
+import com.fasterxml.jackson.dataformat.cbor.databind.CBORMapper;
 import org.jspecify.annotations.Nullable;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 /**
@@ -30,7 +33,23 @@ import java.util.Base64;
  */
 public final class SimplePageTokenEncoder implements PageTokenEncoder {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final int MAX_ENCODED_LENGTH = 8192;
+    private static final ObjectMapper OBJECT_MAPPER = new CBORMapper(
+            CBORFactory
+                    .builder()
+                    .streamReadConstraints(
+                            StreamReadConstraints.builder()
+                                    .maxStringLength(1024)
+                                    .maxNumberLength(20)
+                                    .maxNestingDepth(4)
+                                    .maxDocumentLength(4096)
+                                    .build())
+                    .build())
+            .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+
+    public SimplePageTokenEncoder() {
+
+    }
 
     @Override
     public @Nullable String encode(@Nullable PageToken pageToken) {
@@ -39,8 +58,14 @@ public final class SimplePageTokenEncoder implements PageTokenEncoder {
         }
 
         try {
-            final String pageTokenJson = objectMapper.writeValueAsString(pageToken);
-            return Base64.getUrlEncoder().encodeToString(pageTokenJson.getBytes(StandardCharsets.UTF_8));
+            final byte[] pageTokenBytes = OBJECT_MAPPER.writeValueAsBytes(pageToken);
+            final String encoded = Base64.getUrlEncoder().encodeToString(pageTokenBytes);
+            if (encoded.length() > MAX_ENCODED_LENGTH) {
+                throw new IllegalStateException(
+                        "Encoded token of size %d exceeds maximum size %d".formatted(
+                                encoded.length(), MAX_ENCODED_LENGTH));
+            }
+            return encoded;
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -51,10 +76,15 @@ public final class SimplePageTokenEncoder implements PageTokenEncoder {
         if (encoded == null) {
             return null;
         }
+        if (encoded.length() > MAX_ENCODED_LENGTH) {
+            throw new InvalidPageTokenException(
+                    "Token of size %d exceeds maximum size %d".formatted(
+                            encoded.length(), MAX_ENCODED_LENGTH));
+        }
 
         try {
-            final byte[] pageTokenJson = Base64.getUrlDecoder().decode(encoded);
-            return objectMapper.readValue(pageTokenJson, pageTokenClass);
+            final byte[] pageTokenBytes = Base64.getUrlDecoder().decode(encoded);
+            return OBJECT_MAPPER.readValue(pageTokenBytes, pageTokenClass);
         } catch (IOException | IllegalArgumentException e) {
             throw new InvalidPageTokenException(e);
         }

--- a/common/pagination/src/test/java/org/dependencytrack/common/pagination/SimplePageTokenEncoderTest.java
+++ b/common/pagination/src/test/java/org/dependencytrack/common/pagination/SimplePageTokenEncoderTest.java
@@ -33,6 +33,7 @@ class SimplePageTokenEncoderTest {
     public static class TestPageToken implements PageToken {
 
         public int offset;
+        public String value;
 
     }
 
@@ -72,6 +73,25 @@ class SimplePageTokenEncoderTest {
 
         assertThatExceptionOfType(InvalidPageTokenException.class)
                 .isThrownBy(() -> encoder.decode(encoded, TestPageToken.class));
+    }
+
+    @Test
+    void encodeShouldThrowWhenEncodedExceedsMaximumLength() {
+        final var token = new TestPageToken();
+        token.value = "A".repeat(7000);
+
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(() -> encoder.encode(token))
+                .withMessageContaining("exceeds maximum size");
+    }
+
+    @Test
+    void decodeShouldThrowWhenEncodedExceedsMaximumLength() {
+        final String encoded = "A".repeat(8193);
+
+        assertThatExceptionOfType(InvalidPageTokenException.class)
+                .isThrownBy(() -> encoder.decode(encoded, TestPageToken.class))
+                .withMessageContaining("exceeds maximum size");
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Encodes page tokens with CBOR.

CBOR is more compact than JSON which leads to smaller page tokens. And as a binary format it's not human-readable, which strengthens the opaqueness API contract. Note that it's still decodable though.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
