### PR TITLE
Port : Only return tags directly associated with a policy

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/TagQueryManager.java
@@ -39,16 +39,17 @@ import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class TagQueryManager extends QueryManager implements IQueryManager {
 
@@ -587,25 +588,11 @@ public class TagQueryManager extends QueryManager implements IQueryManager {
 
     @Override
     public PaginatedResult getTagsForPolicy(String policyUuid) {
-
         LOGGER.debug("Retrieving tags under policy {}", policyUuid);
-
-        Policy policy = getObjectByUuid(Policy.class, policyUuid);
-        List<Project> projects = policy.getProjects();
-
-        final Stream<Tag> tags;
-        if (projects != null && !projects.isEmpty()) {
-            tags = projects.stream()
-                    .map(Project::getTags)
-                    .flatMap(Set::stream)
-                    .distinct();
-        } else {
-            tags = pm.newQuery(Tag.class).executeList().stream();
-        }
-
-        List<Tag> tagsToShow = tags.sorted(TAG_COMPARATOR).toList();
-
-        return (new PaginatedResult()).objects(tagsToShow).total(tagsToShow.size());
+        final var policy = getObjectByUuid(Policy.class, policyUuid);
+        final var tags = Optional.ofNullable(policy.getTags())
+                .orElse(Collections.emptySet()).stream().sorted(TAG_COMPARATOR).toList();
+        return (new PaginatedResult()).objects(tags).total(tags.size());
     }
 
     /**

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -1530,11 +1531,24 @@ class TagResourceTest extends ResourceTest {
                 .get();
 
         Assertions.assertEquals(200, response.getStatus());
-        Assertions.assertEquals(String.valueOf(4), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assertions.assertNotNull(json);
-        Assertions.assertEquals(4, json.size());
-        Assertions.assertEquals("tag 2", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals(0, json.size());
+
+        policy.setTags(Set.of(qm.getTagByName("Tag 1"), qm.getTagByName("Tag 4")));
+        response = jersey.target(V1_TAG + "/policy/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        Assertions.assertEquals(200, response.getStatus());
+        Assertions.assertEquals(String.valueOf(2), response.getHeaderString(TOTAL_COUNT_HEADER));
+        json = parseJsonArray(response);
+        Assertions.assertNotNull(json);
+        Assertions.assertEquals(2, json.size());
+        Assertions.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals("tag 4", json.getJsonObject(1).getString("name"));
     }
 
     @Test
@@ -1556,11 +1570,10 @@ class TagResourceTest extends ResourceTest {
                 .get();
 
         Assertions.assertEquals(200, response.getStatus());
-        Assertions.assertEquals(String.valueOf(3), response.getHeaderString(TOTAL_COUNT_HEADER));
+        Assertions.assertEquals(String.valueOf(0), response.getHeaderString(TOTAL_COUNT_HEADER));
         JsonArray json = parseJsonArray(response);
         Assertions.assertNotNull(json);
-        Assertions.assertEquals(3, json.size());
-        Assertions.assertEquals("tag 1", json.getJsonObject(0).getString("name"));
+        Assertions.assertEquals(0, json.size());
     }
 
     @Test


### PR DESCRIPTION
### Description

Changes `/tag/policy/$policy_uuid` to return only tags of the policy itself, independent of whether a project is associated.

### Addressed Issue

https://github.com/DependencyTrack/hyades/issues/2105
Ports https://github.com/DependencyTrack/dependency-track/pull/5314

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
