### PR TITLE
Port : Make OIDC group mapping PUT idempotent

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/OidcResource.java
@@ -281,12 +281,13 @@ public class OidcResource extends AbstractApiResource {
                     return Response.status(Response.Status.NOT_FOUND).entity("A group with the specified UUID could not be found.").build();
                 }
 
-                if (!qm.isOidcGroupMapped(team, group)) {
+                final MappedOidcGroup existingMapping = qm.getMappedOidcGroup(team, group);
+                if (existingMapping == null) {
                     final MappedOidcGroup mappedOidcGroup = qm.createMappedOidcGroup(team, group);
                     super.logSecurityEvent(LOGGER, SecurityMarkers.SECURITY_AUDIT, "Mapping created for group " + group.getName() + " and team " + team.getName());
                     return Response.ok(mappedOidcGroup).build();
                 } else {
-                    return Response.status(Response.Status.CONFLICT).entity("A mapping for the same team and group already exists.").build();
+                    return Response.ok(existingMapping).build();
                 }
             });
         }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/OidcResourceAuthenticatedTest.java
@@ -284,7 +284,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
     }
 
     @Test
-    public void addMappingShouldIndicateConflictWhenMappingAlreadyExists() {
+    public void putMappingShouldBeIdempotent() {
         initializeWithPermissions(Permissions.ACCESS_MANAGEMENT_CREATE);
 
         final Team team = qm.createTeam("teamName");
@@ -298,7 +298,7 @@ public class OidcResourceAuthenticatedTest extends ResourceTest {
                 .header(X_API_KEY, apiKey)
                 .put(Entity.entity(request, MediaType.APPLICATION_JSON));
 
-        assertThat(response.getStatus()).isEqualTo(409);
+        assertThat(response.getStatus()).isEqualTo(200);
     }
 
     @Test


### PR DESCRIPTION
### Description

Make PUT `api/oidc/mapping` idempotent as it should be

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/4966
https://github.com/DependencyTrack/hyades/issues/2105

### Checklist

- [ ] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
