### PR TITLE
Port : Validate description length for PUT /api/v1/project

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Project.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Project.java
@@ -193,6 +193,7 @@ public class Project implements Serializable {
     @Persistent
     @Column(name = "DESCRIPTION", jdbcType = "VARCHAR")
     @JsonDeserialize(using = TrimmedStringDeserializer.class)
+    @Size(max = 255)
     @Pattern(regexp = RegexSequence.Definition.PRINTABLE_CHARS, message = "The description may only contain printable characters")
     private String description;
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -80,6 +80,9 @@ import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -2070,16 +2073,21 @@ class ProjectResourceTest extends ResourceTest {
         assertThat(getPlainTextBody(response)).isEqualTo("An inactive Parent cannot be selected as parent");
     }
 
-    @Test
-    void createProjectEmptyTest() {
+    @ParameterizedTest
+    @MethodSource("projectValidationTestData")
+    void createProjectValidationTest(String testCase, String json, String expectedError) {
         initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_CREATE);
-        Project project = new Project();
-        project.setName(" ");
         Response response = jersey.target(V1_PROJECT)
                 .request()
                 .header(X_API_KEY, apiKey)
-                .put(Entity.entity(project, MediaType.APPLICATION_JSON));
-        Assertions.assertEquals(400, response.getStatus(), 0);
+                .put(Entity.json(json));
+        Assertions.assertEquals(400, response.getStatus(), "Test case: " + testCase);
+        Assertions.assertEquals(expectedError, parseJsonArray(response).getJsonObject(0).getString("message"), "Test case: " + testCase);
+    }
+
+    static Stream<Arguments> projectValidationTestData() {
+        return Stream.of(Arguments.of("Blank name", "{\"name\": \" \"}", "must not be blank"),
+                Arguments.of("Too long description", "{\"name\": \"Valid Project Name\", \"description\": \"" + "a".repeat(256) + "\"}", "size must be between 0 and 255"));
     }
 
     @Test


### PR DESCRIPTION
### Description

Add validation for project description to return corret HTTP 400 with appriopriate message instead of HTTP 500

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/5455
https://github.com/DependencyTrack/hyades/issues/2105

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://dependencytrack.github.io/hyades/latest/development/documentation/
[migration changelog]: https://dependencytrack.github.io/hyades/latest/development/database-migrations/
