### PR TITLE
Implemented automatical assignment of severity "CRITICAL" for malicious packages from OSV.

### DIFF
--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
@@ -165,6 +165,10 @@ final class ModelConverter {
             severity = parseSeverity(osvAffectedArray);
         }
 
+        if (isOsvMalwareIdentifier(osv.getId())) {
+            severity = SEVERITY_CRITICAL;
+        }
+
         // CVSS ratings
         vulnerability.addAllRatings(parseCvssRatings(osv, severity));
 
@@ -506,6 +510,12 @@ final class ModelConverter {
             return SEVERITY_UNKNOWN;
         }
     }
+
+    
+    private static boolean isOsvMalwareIdentifier(final String osvId) {
+        return osvId != null && osvId.startsWith("MAL-");
+    }
+
 
     private static List<VulnerabilityRating> parseCvssRatings(Osv osv, Severity severity) {
         List<VulnerabilityRating> ratings = new ArrayList<>();

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/ModelConverterTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/ModelConverterTest.java
@@ -453,7 +453,7 @@ public class ModelConverterTest {
                               },
                               "ratings": [
                                 {
-                                  "severity": "SEVERITY_UNKNOWN"
+                                  "severity": "SEVERITY_CRITICAL"
                                 }
                               ],
                               "affects": [
@@ -468,8 +468,8 @@ public class ModelConverterTest {
                               ],
                               "properties": [
                                 {
-                                    "name": "internal:osv:ecosystem",
-                                    "value": "maven"
+                                  "name": "internal:osv:ecosystem",
+                                  "value": "maven"
                                 }]
                             }
                           ]


### PR DESCRIPTION
### Description
If a new entry downloaded from OSV starts its identifier with MAL, the severity "CRITICAL" will automatically be assigned to the entry. This assumes that no malicious package from OSV should contain a cvss rating. However, if there is one, it will overwrite the assigned "CRITICAL", to prevent unwanted masking of entries. 

### Addressed Issue
Closes https://github.com/DependencyTrack/hyades/issues/2144

### Additional Details
Would be good to add a remark to the documentation for hyades. 

### Checklist
- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
