### PR TITLE
Port changes of pr 5264 from upstream dependency track

### DIFF
--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverTest.java
@@ -67,6 +67,27 @@ class NugetPackageMetadataResolverTest {
             }
             """;
 
+    private static final String NUGET_INDEX_PRERELEASE_ONLY_RESPONSE = /* language=JSON */ """
+            {
+              "items": [{
+                "items": [
+                  {
+                    "catalogEntry": {
+                      "version": "1.0.0-beta.1",
+                      "published": "2023-06-15T10:30:00Z"
+                    }
+                  },
+                  {
+                    "catalogEntry": {
+                      "version": "1.0.0-rc.1",
+                      "published": "2024-01-01T12:00:00Z"
+                    }
+                  }
+                ]
+              }]
+            }
+            """;
+
     private NugetPackageMetadataResolverFactory factory;
     private NugetPackageMetadataResolver resolver;
 
@@ -128,6 +149,25 @@ class NugetPackageMetadataResolverTest {
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
         assertThat(result.artifactMetadata()).isNull();
+    }
+
+    @Test
+    void shouldResolveLatestVersionWhenOnlyPrereleaseVersionsExist(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/v3/registration5-gz-semver2/mypackage/index.json"))
+                .willReturn(aResponse().withStatus(200).withBody(NUGET_INDEX_PRERELEASE_ONLY_RESPONSE)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("nuget")
+                .withName("MyPackage")
+                .withVersion("1.0.0-beta.1")
+                .build();
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("1.0.0-rc.1");
+        assertThat(result.artifactMetadata()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
### Description
Pull request ports changes from dependency track upstream: https://github.com/DependencyTrack/dependency-track/pull/5264/commits
<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

### Addressed Issue
https://github.com/DependencyTrack/hyades/issues/2105
<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
