### PR TITLE
Added MDC keys for logging of update/create/delete/clone projects

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -74,6 +74,7 @@ import org.jdbi.v3.core.Handle;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.jdo.FetchGroup;
 import java.security.Principal;
@@ -90,6 +91,9 @@ import java.util.function.Function;
 
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_NAME;
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_VERSION;
 import static org.dependencytrack.notification.api.NotificationFactory.createProjectCreatedNotification;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.createLocalJdbi;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
@@ -598,7 +602,12 @@ public class ProjectResource extends AbstractApiResource {
                 return project;
             });
 
-            LOGGER.info("Project {} created by {}", createdProject, super.getPrincipal().getName());
+            try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, createdProject.getUuid().toString());
+                 var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, createdProject.getName());
+                 var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, createdProject.getVersion())) {
+
+                LOGGER.info("Project {} created by {}", createdProject, super.getPrincipal().getName());
+            }
             return Response.status(Response.Status.CREATED).entity(createdProject).build();
         }
     }
@@ -706,7 +715,12 @@ public class ProjectResource extends AbstractApiResource {
                 }
             });
 
-            LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
+            try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, updatedProject.getUuid().toString());
+                 var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, updatedProject.getName());
+                 var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, updatedProject.getVersion())){
+
+                LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
+            }
             return Response.ok(updatedProject).build();
         } catch (RuntimeException e) {
             if (isUniqueConstraintViolation(e)) {
@@ -866,7 +880,12 @@ public class ProjectResource extends AbstractApiResource {
                 return Response.notModified().build();
             }
 
-            LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
+            try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, updatedProject.getUuid().toString());
+                 var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, updatedProject.getName());
+                 var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, updatedProject.getVersion())){
+
+                LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
+            }
             return Response.ok(updatedProject).build();
         }
     }
@@ -936,7 +955,12 @@ public class ProjectResource extends AbstractApiResource {
                 }
                 requireAccess(qm, project);
 
-                LOGGER.info("Project {} deletion request by {}", project, super.getPrincipal().getName());
+                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
+                     var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
+                     var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
+
+                    LOGGER.info("Project {} deletion request by {}", project, super.getPrincipal().getName());
+                }
 
                 try (final Handle jdbiHandle = createLocalJdbi(qm).open()) {
                     final var projectDao = jdbiHandle.attach(ProjectDao.class);
@@ -1032,7 +1056,12 @@ public class ProjectResource extends AbstractApiResource {
                     }
                 }
 
-                LOGGER.info("Project {} is being cloned by {}", sourceProject, super.getPrincipal().getName());
+                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, sourceProject.getUuid().toString());
+                     var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, sourceProject.getName());
+                     var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, sourceProject.getVersion())){
+
+                    LOGGER.info("Project {} is being cloned by {}", sourceProject, super.getPrincipal().getName());
+                }
             });
 
             final UUID sourceProjectUuid = UUID.fromString(jsonRequest.getProject());

--- a/apiserver/src/main/java/org/dependencytrack/tasks/VexUploadProcessingTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/VexUploadProcessingTask.java
@@ -26,7 +26,6 @@ import org.dependencytrack.event.VexUploadEvent;
 import org.dependencytrack.model.ConfigPropertyConstants;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vex;
-import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.notification.JdoNotificationEmitter;
 import org.dependencytrack.notification.NotificationModelConverter;
 import org.dependencytrack.parser.cyclonedx.CycloneDXVexImporter;
@@ -34,10 +33,11 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.util.CompressUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import java.util.Date;
-import java.util.List;
 
+import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
 import static org.dependencytrack.notification.api.NotificationFactory.createVexConsumedNotification;
 import static org.dependencytrack.notification.api.NotificationFactory.createVexProcessedNotification;
 
@@ -58,50 +58,51 @@ public class VexUploadProcessingTask implements Subscriber {
         if (e instanceof VexUploadEvent) {
             final VexUploadEvent event = (VexUploadEvent) e;
             final byte[] vexBytes = CompressUtil.optionallyDecompress(event.getVex());
-            try(final QueryManager qm = new QueryManager()) {
+            try (final QueryManager qm = new QueryManager()) {
                 final Project project = qm.getObjectByUuid(Project.class, event.getProjectUuid());
-                final List<Vulnerability> vulnerabilities;
+                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString())) {
 
-                final Vex vex = new Vex();
-                vex.setProject(project);
-                vex.setImported(new Date());
+                    final Vex vex = new Vex();
+                    vex.setProject(project);
+                    vex.setImported(new Date());
 
-                if (BomParserFactory.looksLikeCycloneDX(vexBytes)) {
-                    if (qm.isEnabled(ConfigPropertyConstants.ACCEPT_ARTIFACT_CYCLONEDX)) {
-                        LOGGER.info("Processing CycloneDX VEX uploaded to project: {}", event.getProjectUuid());
-                        vex.setVexFormat(Vex.Format.CYCLONEDX);
-                        final Parser parser = BomParserFactory.createParser(vexBytes);
-                        final org.cyclonedx.model.Bom cycloneDxBom = parser.parse(vexBytes);
-                        vex.setSpecVersion(cycloneDxBom.getSpecVersion());
-                        vex.setVexVersion(cycloneDxBom.getVersion());
-                        vex.setSerialNumber(cycloneDxBom.getSerialNumber());
-                        final CycloneDXVexImporter vexImporter = new CycloneDXVexImporter();
-                        vexImporter.applyVex(qm, cycloneDxBom, project);
-                        LOGGER.info("Completed processing of CycloneDX VEX for project: {}", event.getProjectUuid());
+                    if (BomParserFactory.looksLikeCycloneDX(vexBytes)) {
+                        if (qm.isEnabled(ConfigPropertyConstants.ACCEPT_ARTIFACT_CYCLONEDX)) {
+                            LOGGER.info("Processing CycloneDX VEX uploaded.");
+                            vex.setVexFormat(Vex.Format.CYCLONEDX);
+                            final Parser parser = BomParserFactory.createParser(vexBytes);
+                            final org.cyclonedx.model.Bom cycloneDxBom = parser.parse(vexBytes);
+                            vex.setSpecVersion(cycloneDxBom.getSpecVersion());
+                            vex.setVexVersion(cycloneDxBom.getVersion());
+                            vex.setSerialNumber(cycloneDxBom.getSerialNumber());
+                            final CycloneDXVexImporter vexImporter = new CycloneDXVexImporter();
+                            vexImporter.applyVex(qm, cycloneDxBom, project);
+                            LOGGER.info("Completed processing of CycloneDX VEX");
+                        } else {
+                            LOGGER.warn("A CycloneDX VEX was uploaded but accepting CycloneDX format is disabled. Aborting");
+                            return;
+                        }
+                        // TODO: Add support for CSAF
                     } else {
-                        LOGGER.warn("A CycloneDX VEX was uploaded but accepting CycloneDX format is disabled. Aborting");
+                        LOGGER.warn("The VEX uploaded is not in a supported format. Supported formats include CycloneDX XML and JSON");
                         return;
                     }
-                    // TODO: Add support for CSAF
-                } else {
-                    LOGGER.warn("The VEX uploaded is not in a supported format. Supported formats include CycloneDX XML and JSON");
-                    return;
+
+                    final var notificationEmitter = new JdoNotificationEmitter(qm);
+
+                    notificationEmitter.emit(
+                            createVexConsumedNotification(
+                                    NotificationModelConverter.convert(project),
+                                    NotificationModelConverter.convert(vex)));
+                    qm.persist(vex);
+
+                    notificationEmitter.emit(
+                            createVexProcessedNotification(
+                                    NotificationModelConverter.convert(project),
+                                    NotificationModelConverter.convert(vex)));
+                } catch (Exception ex) {
+                    LOGGER.error("Error while processing vex", ex);
                 }
-
-                final var notificationEmitter = new JdoNotificationEmitter(qm);
-
-                notificationEmitter.emit(
-                        createVexConsumedNotification(
-                                NotificationModelConverter.convert(project),
-                                NotificationModelConverter.convert(vex)));
-                qm.persist(vex);
-
-                notificationEmitter.emit(
-                        createVexProcessedNotification(
-                                NotificationModelConverter.convert(project),
-                                NotificationModelConverter.convert(vex)));
-            } catch (Exception ex) {
-                LOGGER.error("Error while processing vex", ex);
             }
         }
     }


### PR DESCRIPTION
### Description

Added MDC within ProjectResource.java to be able to include the project UUID in log messages. UUID is now included in the log messages for creating/cloning/updating/deleting a project, to be able to identify a project unambiguously even through changes of name/version of the project.

### Addressed Issue

Ports https://github.com/DependencyTrack/dependency-track/pull/5500
Ports https://github.com/DependencyTrack/dependency-track/pull/5615
https://github.com/DependencyTrack/hyades/issues/2105

### Checklist

- [x] I have read and understand the [contributing guidelines]
- [ ] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
