### PR TITLE
Remove size-based cache eviction policy

### DIFF
--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -229,23 +229,11 @@ dt.cache.provider.database.maintenance.interval-ms=300000
 # @type:     integer
 dt.cache."vuln-analyzer.oss-index.results".ttl-ms=43200000
 
-# Defines the maximum number of entries in the OSS Index result cache.
-#
-# @category: Cache
-# @type:     integer
-dt.cache."vuln-analyzer.oss-index.results".max-size=30000
-
 # Defines the TTL in milliseconds for Snyk result cache entries.
 #
 # @category: Cache
 # @type:     integer
 dt.cache."vuln-analyzer.snyk.results".ttl-ms=43200000
-
-# Defines the maximum number of entries in the Snyk result cache.
-#
-# @category: Cache
-# @type:     integer
-dt.cache."vuln-analyzer.snyk.results".max-size=30000
 
 # Defines the TTL in milliseconds for Maven package metadata resolver response cache entries.
 #

--- a/cache/api/src/main/java/org/dependencytrack/cache/api/CacheConfig.java
+++ b/cache/api/src/main/java/org/dependencytrack/cache/api/CacheConfig.java
@@ -44,10 +44,4 @@ public final class CacheConfig {
                 .orElse(Duration.ofHours(1));
     }
 
-    public int maxSize() {
-        return config
-                .getOptionalValue("dt.cache.\"%s\".max-size".formatted(this.name), int.class)
-                .orElse(10000);
-    }
-
 }

--- a/cache/api/src/test/java/org/dependencytrack/cache/api/CacheConfigTest.java
+++ b/cache/api/src/test/java/org/dependencytrack/cache/api/CacheConfigTest.java
@@ -46,24 +46,4 @@ class CacheConfigTest {
         assertThat(cacheConfig.ttl()).hasHours(1);
     }
 
-    @Test
-    void maxSizeShouldReturnConfiguredValue() {
-        final var config = new SmallRyeConfigBuilder()
-                .withDefaultValue("dt.cache.\"foo.bar\".max-size", "123")
-                .build();
-
-        final var cacheConfig = new CacheConfig(config, "foo.bar");
-
-        assertThat(cacheConfig.maxSize()).isEqualTo(123);
-    }
-
-    @Test
-    void maxSizeShouldReturnDefaultWhenPropertyIsNotDefined() {
-        final var config = new SmallRyeConfigBuilder().build();
-
-        final var cacheConfig = new CacheConfig(config, "foo.bar");
-
-        assertThat(cacheConfig.maxSize()).isEqualTo(10000);
-    }
-
 }

--- a/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCache.java
+++ b/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCache.java
@@ -39,7 +39,6 @@ import java.util.function.Function;
 final class DatabaseCache implements Cache {
 
     private final String name;
-    private final int maxSize;
     private final Duration ttl;
     private final DataSource dataSource;
     private final AtomicLong hitCount = new AtomicLong();
@@ -49,11 +48,9 @@ final class DatabaseCache implements Cache {
 
     DatabaseCache(
             String name,
-            int maxSize,
             Duration ttl,
             DataSource dataSource) {
         this.name = name;
-        this.maxSize = maxSize;
         this.ttl = ttl;
         this.dataSource = dataSource;
     }
@@ -129,7 +126,6 @@ final class DatabaseCache implements Cache {
                      VALUES (?, ?, ?, NOW() + (INTERVAL '1 millisecond' * ?))
                      ON CONFLICT ("CACHE_NAME", "KEY") DO UPDATE
                      SET "VALUE" = EXCLUDED."VALUE"
-                       , "CREATED_AT" = EXCLUDED."CREATED_AT"
                        , "EXPIRES_AT" = EXCLUDED."EXPIRES_AT"
                      """)) {
             ps.setString(1, this.name);
@@ -168,7 +164,6 @@ final class DatabaseCache implements Cache {
                          AS t(cache_name, key, value)
                      ON CONFLICT ("CACHE_NAME", "KEY") DO UPDATE
                      SET "VALUE" = EXCLUDED."VALUE"
-                       , "CREATED_AT" = EXCLUDED."CREATED_AT"
                        , "EXPIRES_AT" = EXCLUDED."EXPIRES_AT"
                      """)) {
             ps.setLong(1, ttl.toMillis());
@@ -218,10 +213,6 @@ final class DatabaseCache implements Cache {
 
     String name() {
         return name;
-    }
-
-    int maxSize() {
-        return maxSize;
     }
 
     long hitCount() {

--- a/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorker.java
+++ b/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorker.java
@@ -29,7 +29,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -91,14 +90,6 @@ final class DatabaseCacheMaintenanceWorker implements Closeable {
     void performMaintenance() throws SQLException {
         LOGGER.debug("Starting cache maintenance");
 
-        final var cacheNames = new ArrayList<String>(cacheByName.size());
-        final var maxSizes = new ArrayList<Integer>(cacheByName.size());
-
-        for (final var entry : cacheByName.entrySet()) {
-            cacheNames.add(entry.getKey());
-            maxSizes.add(entry.getValue().maxSize());
-        }
-
         try (final Connection connection = dataSource.getConnection();
              final PreparedStatement expireQuery = connection.prepareStatement("""
                      WITH cte_expired AS (
@@ -112,68 +103,15 @@ final class DatabaseCacheMaintenanceWorker implements Closeable {
                        FROM cte_expired
                       GROUP BY "CACHE_NAME"
                      """);
-             final PreparedStatement maxSizeQuery = connection.prepareStatement("""
-                     WITH
-                     cte_input AS (
-                       SELECT cache_name
-                            , max_size
-                         FROM UNNEST(?, ?)
-                           AS t(cache_name, max_size)
-                     )
-                     , cte_ranked AS (
-                       SELECT ce."CACHE_NAME"
-                            , ce."KEY"
-                            , ROW_NUMBER() OVER (PARTITION BY ce."CACHE_NAME" ORDER BY ce."CREATED_AT" DESC) AS rn
-                            , i.max_size
-                         FROM "CACHE_ENTRY" AS ce
-                        INNER JOIN cte_input AS i
-                           ON i.cache_name = ce."CACHE_NAME"
-                     )
-                     , cte_deleted AS (
-                       DELETE
-                         FROM "CACHE_ENTRY"
-                        WHERE ("CACHE_NAME", "KEY") IN (
-                          SELECT "CACHE_NAME"
-                               , "KEY"
-                            FROM cte_ranked
-                           WHERE cte_ranked.rn > cte_ranked.max_size
-                        )
-                       RETURNING "CACHE_NAME"
-                     )
-                     SELECT "CACHE_NAME"
-                          , COUNT(*)
-                       FROM cte_deleted
-                      GROUP BY "CACHE_NAME"
-                     """)) {
-            try (final ResultSet rs = expireQuery.executeQuery()) {
-                while (rs.next()) {
-                    final String cacheName = rs.getString(1);
-                    final int entriesEvicted = rs.getInt(2);
-                    LOGGER.debug("Deleted {} expired entries for cache '{}'", entriesEvicted, cacheName);
+             final ResultSet rs = expireQuery.executeQuery()) {
+            while (rs.next()) {
+                final String cacheName = rs.getString(1);
+                final int entriesEvicted = rs.getInt(2);
+                LOGGER.debug("Deleted {} expired entries for cache '{}'", entriesEvicted, cacheName);
 
-                    final DatabaseCache cache = cacheByName.get(cacheName);
-                    if (cache != null) {
-                        cache.onEntriesEvicted(entriesEvicted);
-                    }
-                }
-            }
-
-            if (maxSizes.isEmpty()) {
-                return;
-            }
-
-            maxSizeQuery.setArray(1, connection.createArrayOf("TEXT", cacheNames.toArray(String[]::new)));
-            maxSizeQuery.setArray(2, connection.createArrayOf("INT", maxSizes.toArray(Integer[]::new)));
-            try (final ResultSet rs = maxSizeQuery.executeQuery()) {
-                while (rs.next()) {
-                    final String cacheName = rs.getString(1);
-                    final int entriesEvicted = rs.getInt(2);
-                    LOGGER.debug("Deleted {} entries exceeding the max size for cache '{}'", entriesEvicted, cacheName);
-
-                    final DatabaseCache cache = cacheByName.get(cacheName);
-                    if (cache != null) {
-                        cache.onEntriesEvicted(entriesEvicted);
-                    }
+                final DatabaseCache cache = cacheByName.get(cacheName);
+                if (cache != null) {
+                    cache.onEntriesEvicted(entriesEvicted);
                 }
             }
         }

--- a/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheManager.java
+++ b/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheManager.java
@@ -72,7 +72,7 @@ final class DatabaseCacheManager implements CacheManager {
         LOGGER.debug("Creating cache '{}'", name);
 
         final var cacheConfig = new CacheConfig(config, name);
-        final var cache = new DatabaseCache(name, cacheConfig.maxSize(), cacheConfig.ttl(), dataSource);
+        final var cache = new DatabaseCache(name, cacheConfig.ttl(), dataSource);
         maintenanceWorker.registerCache(cache);
 
         new DatabaseCacheMeterBinder(cache, name)

--- a/cache/provider-database/src/test/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorkerTest.java
+++ b/cache/provider-database/src/test/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorkerTest.java
@@ -86,9 +86,9 @@ class DatabaseCacheMaintenanceWorkerTest {
 
     @Test
     void performMaintenanceShouldDeleteExpiredEntries() throws Exception {
-        insertEntry("cache-a", "expired1", "v1", Instant.now().minusSeconds(60), Instant.now().minusSeconds(10));
-        insertEntry("cache-a", "expired2", "v2", Instant.now().minusSeconds(60), Instant.now().minusSeconds(5));
-        insertEntry("cache-a", "valid", "v3", Instant.now().minusSeconds(60), Instant.now().plusSeconds(3600));
+        insertEntry("cache-a", "expired1", "v1", Instant.now().minusSeconds(10));
+        insertEntry("cache-a", "expired2", "v2", Instant.now().minusSeconds(5));
+        insertEntry("cache-a", "valid", "v3", Instant.now().plusSeconds(3600));
 
         try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
             worker.performMaintenance();
@@ -100,7 +100,7 @@ class DatabaseCacheMaintenanceWorkerTest {
 
     @Test
     void performMaintenanceShouldDeleteExpiredEntriesFromUnregisteredCaches() throws Exception {
-        insertEntry("unregistered", "key1", "v1", Instant.now().minusSeconds(60), Instant.now().minusSeconds(10));
+        insertEntry("unregistered", "key1", "v1", Instant.now().minusSeconds(10));
 
         try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
             worker.performMaintenance();
@@ -110,33 +110,10 @@ class DatabaseCacheMaintenanceWorkerTest {
     }
 
     @Test
-    void performMaintenanceShouldDeleteEntriesExceedingMaxSize() throws Exception {
-        for (int i = 1; i <= 5; i++) {
-            insertEntry("cache-a", "key" + i, "v" + i,
-                    Instant.now().minusSeconds(60 - i),
-                    Instant.now().plusSeconds(3600));
-        }
-
-        final var cache = new DatabaseCache("cache-a", 3, Duration.ofHours(1), dataSource);
-
-        try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
-            worker.registerCache(cache);
-            worker.performMaintenance();
-
-            assertThat(countEntries("cache-a")).isEqualTo(3);
-            assertThat(entryExists("cache-a", "key1")).isFalse();
-            assertThat(entryExists("cache-a", "key2")).isFalse();
-            assertThat(entryExists("cache-a", "key3")).isTrue();
-            assertThat(entryExists("cache-a", "key4")).isTrue();
-            assertThat(entryExists("cache-a", "key5")).isTrue();
-        }
-    }
-
-    @Test
     void performMaintenanceShouldIncrementEvictionCountForExpiredEntries() throws Exception {
-        insertEntry("cache-a", "expired", "v1", Instant.now().minusSeconds(60), Instant.now().minusSeconds(10));
+        insertEntry("cache-a", "expired", "v1", Instant.now().minusSeconds(10));
 
-        final var cache = new DatabaseCache("cache-a", 10000, Duration.ofHours(1), dataSource);
+        final var cache = new DatabaseCache("cache-a", Duration.ofHours(1), dataSource);
 
         try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
             worker.registerCache(cache);
@@ -147,34 +124,15 @@ class DatabaseCacheMaintenanceWorkerTest {
     }
 
     @Test
-    void performMaintenanceShouldIncrementEvictionCountForMaxSizeEvictions() throws Exception {
-        for (int i = 1; i <= 5; i++) {
-            insertEntry("cache-a", "key" + i, "v" + i,
-                    Instant.now().minusSeconds(60 - i),
-                    Instant.now().plusSeconds(3600));
-        }
-
-        final var cache = new DatabaseCache("cache-a", 2, Duration.ofHours(1), dataSource);
-
-        try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
-            worker.registerCache(cache);
-            worker.performMaintenance();
-
-            assertThat(cache.evictionCount()).isEqualTo(3);
-        }
-    }
-
-    @Test
     void performMaintenanceShouldHandleMultipleCaches() throws Exception {
-        insertEntry("cache-a", "key1", "v1", Instant.now().minusSeconds(10), Instant.now().plusSeconds(3600));
-        insertEntry("cache-a", "key2", "v2", Instant.now().minusSeconds(20), Instant.now().plusSeconds(3600));
-        insertEntry("cache-a", "key3", "v3", Instant.now().minusSeconds(30), Instant.now().plusSeconds(3600));
+        insertEntry("cache-a", "expired", "v1", Instant.now().minusSeconds(10));
+        insertEntry("cache-a", "valid", "v2", Instant.now().plusSeconds(3600));
 
-        insertEntry("cache-b", "key1", "v1", Instant.now().minusSeconds(10), Instant.now().plusSeconds(3600));
-        insertEntry("cache-b", "key2", "v2", Instant.now().minusSeconds(20), Instant.now().plusSeconds(3600));
+        insertEntry("cache-b", "expired1", "v1", Instant.now().minusSeconds(10));
+        insertEntry("cache-b", "expired2", "v2", Instant.now().minusSeconds(5));
 
-        final var cacheA = new DatabaseCache("cache-a", 1, Duration.ofHours(1), dataSource);
-        final var cacheB = new DatabaseCache("cache-b", 1, Duration.ofHours(1), dataSource);
+        final var cacheA = new DatabaseCache("cache-a", Duration.ofHours(1), dataSource);
+        final var cacheB = new DatabaseCache("cache-b", Duration.ofHours(1), dataSource);
 
         try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
             worker.registerCache(cacheA);
@@ -182,25 +140,9 @@ class DatabaseCacheMaintenanceWorkerTest {
             worker.performMaintenance();
 
             assertThat(countEntries("cache-a")).isEqualTo(1);
-            assertThat(countEntries("cache-b")).isEqualTo(1);
-            assertThat(cacheA.evictionCount()).isEqualTo(2);
-            assertThat(cacheB.evictionCount()).isEqualTo(1);
-        }
-    }
-
-    @Test
-    void performMaintenanceShouldNotDeleteEntriesWithinMaxSize() throws Exception {
-        insertEntry("cache-a", "key1", "v1", Instant.now().minusSeconds(10), Instant.now().plusSeconds(3600));
-        insertEntry("cache-a", "key2", "v2", Instant.now().minusSeconds(20), Instant.now().plusSeconds(3600));
-
-        final var cache = new DatabaseCache("cache-a", 10, Duration.ofHours(1), dataSource);
-
-        try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
-            worker.registerCache(cache);
-            worker.performMaintenance();
-
-            assertThat(countEntries("cache-a")).isEqualTo(2);
-            assertThat(cache.evictionCount()).isZero();
+            assertThat(countEntries("cache-b")).isZero();
+            assertThat(cacheA.evictionCount()).isEqualTo(1);
+            assertThat(cacheB.evictionCount()).isEqualTo(2);
         }
     }
 
@@ -208,18 +150,16 @@ class DatabaseCacheMaintenanceWorkerTest {
             String cacheName,
             String key,
             String value,
-            Instant createdAt,
             Instant expiresAt) throws Exception {
         try (final Connection connection = dataSource.getConnection();
              final PreparedStatement ps = connection.prepareStatement("""
-                     INSERT INTO "CACHE_ENTRY" ("CACHE_NAME", "KEY", "VALUE", "CREATED_AT", "EXPIRES_AT")
-                     VALUES (?, ?, ?, ?, ?)
+                     INSERT INTO "CACHE_ENTRY" ("CACHE_NAME", "KEY", "VALUE", "EXPIRES_AT")
+                     VALUES (?, ?, ?, ?)
                      """)) {
             ps.setString(1, cacheName);
             ps.setString(2, key);
             ps.setBytes(3, value.getBytes());
-            ps.setTimestamp(4, Timestamp.from(createdAt));
-            ps.setTimestamp(5, Timestamp.from(expiresAt));
+            ps.setTimestamp(4, Timestamp.from(expiresAt));
             ps.executeUpdate();
         }
     }

--- a/cache/provider-memory/src/main/java/org/dependencytrack/cache/memory/MemoryCacheManager.java
+++ b/cache/provider-memory/src/main/java/org/dependencytrack/cache/memory/MemoryCacheManager.java
@@ -64,7 +64,6 @@ final class MemoryCacheManager implements CacheManager {
         final com.github.benmanes.caffeine.cache.Cache<String, Optional<byte[]>> caffeineCache =
                 Caffeine.newBuilder()
                         .expireAfterWrite(cacheConfig.ttl())
-                        .maximumSize(cacheConfig.maxSize())
                         .build();
 
         return new MemoryCache(caffeineCache);

--- a/migration/src/main/resources/migration/changelog-v5.7.0.xml
+++ b/migration/src/main/resources/migration/changelog-v5.7.0.xml
@@ -2011,4 +2011,14 @@
             CHECK ("SCOPE" IS NULL OR "SCOPE"::TEXT = ANY(ARRAY['REQUIRED', 'OPTIONAL', 'EXCLUDED']));
         </sql>
     </changeSet>
+
+    <changeSet id="v5.7.0-84" author="nscuro">
+        <!--
+            Size-based eviction for the database cache provider was removed
+            in favor of TTL-only eviction. Drop the supporting index and the
+            CREATED_AT column that is no longer needed.
+        -->
+        <dropIndex tableName="CACHE_ENTRY" indexName="CACHE_ENTRY_NAME_CREATED_AT_DESC_IDX"/>
+        <dropColumn tableName="CACHE_ENTRY" columnName="CREATED_AT"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes size-based cache eviction policy.

The primary use case for our cache is to cache responses / data from upstream services, including package repositories and external analyzers. Having a size-based eviction policy risks organizations unknowingly growing their portfolios past the default max sizes, which in turn leads to ineffective caching due to premature evictions.

In that sense, the size-based eviction policy is actually harmful.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
