### PR TITLE
Compute cache sizes during maintenance and serve cached values to meter registry

### DIFF
--- a/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCache.java
+++ b/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCache.java
@@ -45,6 +45,7 @@ final class DatabaseCache implements Cache {
     private final AtomicLong missCount = new AtomicLong();
     private final AtomicLong putCount = new AtomicLong();
     private final AtomicLong evictionCount = new AtomicLong();
+    private final AtomicLong cachedSize = new AtomicLong(-1L);
 
     DatabaseCache(
             String name,
@@ -235,21 +236,13 @@ final class DatabaseCache implements Cache {
         evictionCount.addAndGet(count);
     }
 
-    long size() {
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement ps = connection.prepareStatement("""
-                     SELECT COUNT(*)
-                       FROM "CACHE_ENTRY"
-                      WHERE "CACHE_NAME" = ?
-                        AND "EXPIRES_AT" > NOW()
-                     """)) {
-            ps.setString(1, this.name);
+    void onSizeRefreshed(long size) {
+        cachedSize.set(size);
+    }
 
-            final ResultSet rs = ps.executeQuery();
-            return rs.next() ? rs.getLong(1) : 0;
-        } catch (SQLException e) {
-            throw new IllegalStateException(e);
-        }
+    @Nullable Long size() {
+        final long size = cachedSize.get();
+        return size < 0 ? null : size;
     }
 
 }

--- a/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorker.java
+++ b/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorker.java
@@ -29,7 +29,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -90,20 +92,28 @@ final class DatabaseCacheMaintenanceWorker implements Closeable {
     void performMaintenance() throws SQLException {
         LOGGER.debug("Starting cache maintenance");
 
-        try (final Connection connection = dataSource.getConnection();
-             final PreparedStatement expireQuery = connection.prepareStatement("""
-                     WITH cte_expired AS (
-                       DELETE
-                         FROM "CACHE_ENTRY"
-                        WHERE "EXPIRES_AT" < NOW()
-                       RETURNING "CACHE_NAME"
-                     )
-                     SELECT "CACHE_NAME"
-                          , COUNT(*)
-                       FROM cte_expired
-                      GROUP BY "CACHE_NAME"
-                     """);
-             final ResultSet rs = expireQuery.executeQuery()) {
+        try (final Connection connection = dataSource.getConnection()) {
+            deleteExpiredEntries(connection);
+            refreshCachedSizes(connection);
+        }
+
+        LOGGER.debug("Cache maintenance completed");
+    }
+
+    private void deleteExpiredEntries(Connection connection) throws SQLException {
+        try (final PreparedStatement ps = connection.prepareStatement("""
+                WITH cte_expired AS (
+                  DELETE
+                    FROM "CACHE_ENTRY"
+                   WHERE "EXPIRES_AT" < NOW()
+                  RETURNING "CACHE_NAME"
+                )
+                SELECT "CACHE_NAME"
+                     , COUNT(*)
+                  FROM cte_expired
+                 GROUP BY "CACHE_NAME"
+                """);
+             final ResultSet rs = ps.executeQuery()) {
             while (rs.next()) {
                 final String cacheName = rs.getString(1);
                 final int entriesEvicted = rs.getInt(2);
@@ -115,8 +125,43 @@ final class DatabaseCacheMaintenanceWorker implements Closeable {
                 }
             }
         }
+    }
 
-        LOGGER.debug("Cache maintenance completed");
+    private void refreshCachedSizes(Connection connection) throws SQLException {
+        final Set<String> cachesWithoutEntries = new HashSet<>(cacheByName.keySet());
+
+        try (final PreparedStatement ps = connection.prepareStatement("""
+                SELECT "CACHE_NAME"
+                     , COUNT(*)
+                  FROM "CACHE_ENTRY"
+                 WHERE "CACHE_NAME" = ANY(?)
+                   AND "EXPIRES_AT" > NOW()
+                 GROUP BY "CACHE_NAME"
+                """)) {
+            ps.setArray(1, connection.createArrayOf("TEXT", cachesWithoutEntries.toArray(String[]::new)));
+
+            try (final ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    final String cacheName = rs.getString(1);
+                    final long size = rs.getLong(2);
+                    cachesWithoutEntries.remove(cacheName);
+
+                    final DatabaseCache cache = cacheByName.get(cacheName);
+                    if (cache != null) {
+                        cache.onSizeRefreshed(size);
+                    }
+                }
+            }
+        }
+
+        // Zero out caches that have no entries so stale sizes
+        // don't linger after full eviction.
+        for (final String cacheName : cachesWithoutEntries) {
+            final DatabaseCache cache = cacheByName.get(cacheName);
+            if (cache != null) {
+                cache.onSizeRefreshed(0L);
+            }
+        }
     }
 
     @Override

--- a/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheMeterBinder.java
+++ b/cache/provider-database/src/main/java/org/dependencytrack/cache/database/DatabaseCacheMeterBinder.java
@@ -34,10 +34,8 @@ final class DatabaseCacheMeterBinder extends CacheMeterBinder<DatabaseCache> {
 
     @Override
     protected Long size() {
-        return Optional
-                .ofNullable(getCache())
-                .map(DatabaseCache::size)
-                .orElse(0L);
+        final DatabaseCache cache = getCache();
+        return cache != null ? cache.size() : null;
     }
 
     @Override

--- a/cache/provider-database/src/test/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorkerTest.java
+++ b/cache/provider-database/src/test/java/org/dependencytrack/cache/database/DatabaseCacheMaintenanceWorkerTest.java
@@ -124,6 +124,51 @@ class DatabaseCacheMaintenanceWorkerTest {
     }
 
     @Test
+    void performMaintenanceShouldRefreshCachedSize() throws Exception {
+        insertEntry("cache-a", "expired", "v0", Instant.now().minusSeconds(10));
+        insertEntry("cache-a", "valid1", "v1", Instant.now().plusSeconds(3600));
+        insertEntry("cache-a", "valid2", "v2", Instant.now().plusSeconds(3600));
+        insertEntry("cache-b", "valid", "v3", Instant.now().plusSeconds(3600));
+
+        final var cacheA = new DatabaseCache("cache-a", Duration.ofHours(1), dataSource);
+        final var cacheB = new DatabaseCache("cache-b", Duration.ofHours(1), dataSource);
+
+        try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
+            worker.registerCache(cacheA);
+            worker.registerCache(cacheB);
+
+            assertThat(cacheA.size()).isNull();
+            assertThat(cacheB.size()).isNull();
+
+            worker.performMaintenance();
+
+            assertThat(cacheA.size()).isEqualTo(2);
+            assertThat(cacheB.size()).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void performMaintenanceShouldZeroOutCachedSizeWhenAllEntriesAreGone() throws Exception {
+        insertEntry("cache-a", "valid", "v1", Instant.now().plusSeconds(3600));
+
+        final var cacheA = new DatabaseCache("cache-a", Duration.ofHours(1), dataSource);
+
+        try (final var worker = new DatabaseCacheMaintenanceWorker(dataSource, Duration.ofMinutes(1), Duration.ofMinutes(5))) {
+            worker.registerCache(cacheA);
+            worker.performMaintenance();
+            assertThat(cacheA.size()).isEqualTo(1);
+
+            try (final Connection connection = dataSource.getConnection();
+                 final Statement statement = connection.createStatement()) {
+                statement.execute("DELETE FROM \"CACHE_ENTRY\" WHERE \"CACHE_NAME\" = 'cache-a'");
+            }
+
+            worker.performMaintenance();
+            assertThat(cacheA.size()).isZero();
+        }
+    }
+
+    @Test
     void performMaintenanceShouldHandleMultipleCaches() throws Exception {
         insertEntry("cache-a", "expired", "v1", Instant.now().minusSeconds(10));
         insertEntry("cache-a", "valid", "v2", Instant.now().plusSeconds(3600));


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Computes cache sizes during maintenance and serve cached values to meter registry.

Issuing potentially expensive COUNT queries for every registered cache, on every request for Prometheus metrics, does not scale well and is needlessly wasteful. Instead, compute the cache sizes in a single sweep as part of cache maintenance.

The size metrics are now no longer "real-time", but that is acceptable.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
