### PR TITLE
Add repository bearer authentication

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/RepositoryResourceTest.java
@@ -205,7 +205,7 @@ public class RepositoryResourceTest extends ResourceTest {
     }
 
     @Test
-    public void createRepositoryTest() {
+    public void createRepositoryWithBasicAuthTest() {
         initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
 
         Response response = jersey
@@ -236,6 +236,41 @@ public class RepositoryResourceTest extends ResourceTest {
                   "authenticationRequired": true,
                   "username": "testuser",
                   "password": "testPassword",
+                  "uuid": "${json-unit.any-string}"
+                }
+                """);
+    }
+
+    @Test
+    public void createRepositoryWithBearerAuthTest() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_CREATE);
+
+        Response response = jersey
+                .target(V1_REPOSITORY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .put(Entity.entity(/* language=JSON */ """
+                        {
+                          "identifier": "test2",
+                          "url": "https://www.foobar2.com",
+                          "internal": true,
+                          "authenticationRequired": true,
+                          "password": "letoken",
+                          "enabled": true,
+                          "type": "MAVEN"
+                        }
+                        """, MediaType.APPLICATION_JSON));
+        assertThat(response.getStatus()).isEqualTo(201);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "MAVEN",
+                  "identifier": "test2",
+                  "url": "https://www.foobar2.com",
+                  "resolutionOrder": "${json-unit.any-number}",
+                  "enabled": true,
+                  "internal": true,
+                  "authenticationRequired": true,
+                  "password": "letoken",
                   "uuid": "${json-unit.any-string}"
                 }
                 """);

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
@@ -40,8 +40,10 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -134,12 +136,13 @@ final class CargoPackageMetadataResolver implements PackageMetadataResolver {
             throws InterruptedException {
         final String url = UrlUtils.join(repository.url(), "api", "v1", "crates", name);
 
-        final HttpRequest request = HttpRequest.newBuilder()
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Accept-Encoding", "gzip")
                 .timeout(REQUEST_TIMEOUT)
-                .GET()
-                .build();
+                .GET();
+        maybeApplyAuth(builder, repository);
+        final HttpRequest request = builder.build();
 
         final HttpResponse<InputStream> response;
         try {
@@ -193,6 +196,23 @@ final class CargoPackageMetadataResolver implements PackageMetadataResolver {
                 crateMetadata.latestVersion(),
                 crateMetadata.resolvedAt(),
                 artifactMetadata);
+    }
+
+    private static void maybeApplyAuth(HttpRequest.Builder builder, PackageRepository repository) {
+        if (repository.password() == null) {
+            return;
+        }
+
+        final String authHeaderValue;
+        if (repository.username() != null) {
+            final String credentials = repository.username() + ":" + repository.password();
+            authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(
+                    credentials.getBytes(StandardCharsets.UTF_8));
+        } else {
+            authHeaderValue = "Bearer " + repository.password();
+        }
+
+        builder.header("Authorization", authHeaderValue);
     }
 
     private byte[] serialize(Object value) {

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolver.java
@@ -419,13 +419,17 @@ final class ComposerPackageMetadataResolver implements PackageMetadataResolver {
                 .header("Accept-Encoding", "gzip")
                 .GET();
 
-        if (repository.username() != null && repository.password() != null
-                && UrlUtils.hasSameOrigin(url, repository.url())) {
-            final String credentials = repository.username() + ":" + repository.password();
-            builder.header(
-                    "Authorization",
-                    "Basic " + Base64.getEncoder().encodeToString(
-                            credentials.getBytes(StandardCharsets.UTF_8)));
+        if (repository.password() != null && UrlUtils.hasSameOrigin(url, repository.url())) {
+            final String authHeaderValue;
+            if (repository.username() != null) {
+                final String credentials = repository.username() + ":" + repository.password();
+                authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(
+                        credentials.getBytes(StandardCharsets.UTF_8));
+            } else {
+                authHeaderValue = "Bearer " + repository.password();
+            }
+
+            builder.header("Authorization", authHeaderValue);
         }
 
         final HttpResponse<InputStream> response;

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolver.java
@@ -40,9 +40,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.Base64;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -124,11 +126,12 @@ final class GemPackageMetadataResolver implements PackageMetadataResolver {
             throws InterruptedException {
         final String url = UrlUtils.join(repository.url(), "api", "v1", "versions", name + ".json");
 
-        final HttpRequest request = HttpRequest.newBuilder()
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(REQUEST_TIMEOUT)
-                .GET()
-                .build();
+                .GET();
+        maybeApplyAuth(builder, repository);
+        final HttpRequest request = builder.build();
 
         final HttpResponse<byte[]> response;
         try {
@@ -148,6 +151,20 @@ final class GemPackageMetadataResolver implements PackageMetadataResolver {
                     "Unexpected status code %d for %s".formatted(response.statusCode(), url)));
         }
         return response.body();
+    }
+
+    private static void maybeApplyAuth(HttpRequest.Builder builder, PackageRepository repository) {
+        // NB: Private gem mirrors (Gemstash, Gemfury, GitLab, Artifactory) use Basic auth.
+        // rubygems.org uses a raw API key header, but its read endpoints don't require auth.
+        if (repository.username() == null || repository.password() == null) {
+            return;
+        }
+
+        final String credentials = repository.username() + ":" + repository.password();
+        builder.header(
+                "Authorization",
+                "Basic " + Base64.getEncoder().encodeToString(
+                        credentials.getBytes(StandardCharsets.UTF_8)));
     }
 
     private JsonNode parseJson(byte[] body) {

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolver.java
@@ -38,9 +38,11 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
+import java.util.Base64;
 import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
@@ -116,11 +118,12 @@ final class GoModulesPackageMetadataResolver implements PackageMetadataResolver 
         final String[] moduleSegments = modulePath.split("/");
         final String url = UrlUtils.join(UrlUtils.join(repository.url(), moduleSegments), "@latest");
 
-        final HttpRequest request = HttpRequest.newBuilder()
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(REQUEST_TIMEOUT)
-                .GET()
-                .build();
+                .GET();
+        maybeApplyAuth(builder, repository);
+        final HttpRequest request = builder.build();
 
         final HttpResponse<byte[]> response;
         try {
@@ -150,11 +153,12 @@ final class GoModulesPackageMetadataResolver implements PackageMetadataResolver 
         final String url = UrlUtils.join(
                 UrlUtils.join(repository.url(), moduleSegments), "@v", version + ".info");
 
-        final HttpRequest request = HttpRequest.newBuilder()
+        final HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .timeout(REQUEST_TIMEOUT)
-                .GET()
-                .build();
+                .GET();
+        maybeApplyAuth(builder, repository);
+        final HttpRequest request = builder.build();
 
         final HttpResponse<byte[]> response;
         try {
@@ -170,6 +174,23 @@ final class GoModulesPackageMetadataResolver implements PackageMetadataResolver 
             return null;
         }
         return response.body();
+    }
+
+    private static void maybeApplyAuth(HttpRequest.Builder builder, PackageRepository repository) {
+        if (repository.password() == null) {
+            return;
+        }
+
+        final String authHeaderValue;
+        if (repository.username() != null) {
+            final String credentials = repository.username() + ":" + repository.password();
+            authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(
+                    credentials.getBytes(StandardCharsets.UTF_8));
+        } else {
+            authHeaderValue = "Bearer " + repository.password();
+        }
+
+        builder.header("Authorization", authHeaderValue);
     }
 
     private static @Nullable PackageArtifactMetadata extractArtifactMetadata(JsonNode root, Instant resolvedAt) {

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
@@ -290,16 +290,25 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
                 .uri(uri)
                 .method(method, HttpRequest.BodyPublishers.noBody())
                 .timeout(REQUEST_TIMEOUT);
+        maybeApplyAuth(builder, repository);
+        return builder.build();
+    }
 
-        if (repository.username() != null && repository.password() != null) {
-            final String credentials = repository.username() + ":" + repository.password();
-            builder.header(
-                    "Authorization",
-                    "Basic " + Base64.getEncoder().encodeToString(
-                            credentials.getBytes(StandardCharsets.UTF_8)));
+    private static void maybeApplyAuth(HttpRequest.Builder builder, PackageRepository repository) {
+        if (repository.password() == null) {
+            return;
         }
 
-        return builder.build();
+        final String authHeaderValue;
+        if (repository.username() != null) {
+            final String credentials = repository.username() + ":" + repository.password();
+            authHeaderValue = "Basic " + Base64.getEncoder().encodeToString(
+                    credentials.getBytes(StandardCharsets.UTF_8));
+        } else {
+            authHeaderValue = "Bearer " + repository.password();
+        }
+
+        builder.header("Authorization", authHeaderValue);
     }
 
     private static String formatArtifactFileName(PackageURL purl) {

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverTest.java
@@ -36,13 +36,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -313,6 +318,42 @@ class CargoPackageMetadataResolverTest {
         final PackageMetadata result = resolver.resolve(purl, repo);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldUseBasicAuthWhenUsernameAndPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"crate": {"newest_version": "1.0.0"}, "versions": []}
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("cargo").withName("serde").withVersion("1.0.0").build();
+
+        final var repo = new PackageRepository("crates", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        final String expected = "Basic " + Base64.getEncoder().encodeToString(
+                "user:secret".getBytes(StandardCharsets.UTF_8));
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/crates/serde"))
+                .withHeader("Authorization", equalTo(expected)));
+    }
+
+    @Test
+    void shouldUseBearerAuthWhenOnlyPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/crates/serde"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"crate": {"newest_version": "1.0.0"}, "versions": []}
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("cargo").withName("serde").withVersion("1.0.0").build();
+
+        final var repo = new PackageRepository("crates", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/crates/serde"))
+                .withHeader("Authorization", equalTo("Bearer token")));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverTest.java
@@ -39,10 +39,13 @@ import org.junit.jupiter.api.Test;
 
 import java.io.UncheckedIOException;
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
 
 import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -842,6 +845,50 @@ class ComposerPackageMetadataResolverTest {
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(UncheckedIOException.class)
                 .isThrownBy(() -> smallResolver.resolve(purl, repo));
+    }
+
+    @Test
+    void shouldUseBasicAuthWhenUsernameAndPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubJsonFile("/packages.json", "composer/packagist-v2-packages.json");
+        stubJsonFile("/p2/typo3/class-alias-loader.json", "composer/typo3-class-alias-loader.json");
+
+        final var purl = aPackageURL()
+                .withType("composer")
+                .withNamespace("typo3")
+                .withName("class-alias-loader")
+                .withVersion("v1.1.0")
+                .build();
+
+        final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        final String expected = "Basic " + Base64.getEncoder().encodeToString(
+                "user:secret".getBytes(StandardCharsets.UTF_8));
+        verify(getRequestedFor(urlPathEqualTo("/packages.json"))
+                .withHeader("Authorization", equalTo(expected)));
+        verify(getRequestedFor(urlPathEqualTo("/p2/typo3/class-alias-loader.json"))
+                .withHeader("Authorization", equalTo(expected)));
+    }
+
+    @Test
+    void shouldUseBearerAuthWhenOnlyPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubJsonFile("/packages.json", "composer/packagist-v2-packages.json");
+        stubJsonFile("/p2/typo3/class-alias-loader.json", "composer/typo3-class-alias-loader.json");
+
+        final var purl = aPackageURL()
+                .withType("composer")
+                .withNamespace("typo3")
+                .withName("class-alias-loader")
+                .withVersion("v1.1.0")
+                .build();
+
+        final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        verify(getRequestedFor(urlPathEqualTo("/packages.json"))
+                .withHeader("Authorization", equalTo("Bearer token")));
+        verify(getRequestedFor(urlPathEqualTo("/p2/typo3/class-alias-loader.json"))
+                .withHeader("Authorization", equalTo("Bearer token")));
     }
 
     private static void stubJsonFile(String path, String bodyFile) {

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverTest.java
@@ -35,13 +35,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -207,6 +212,28 @@ class GemPackageMetadataResolverTest {
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
                 .isThrownBy(() -> resolver.resolve(purl, repo));
+    }
+
+    @Test
+    void shouldUseBasicAuthWhenUsernameAndPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/api/v1/versions/rails.json"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        [{"number": "7.1.3", "created_at": "2024-01-15T10:30:00Z"}]
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("gem")
+                .withName("rails")
+                .withVersion("7.1.3")
+                .build();
+
+        final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        final String expected = "Basic " + Base64.getEncoder().encodeToString(
+                "user:secret".getBytes(StandardCharsets.UTF_8));
+        verify(getRequestedFor(urlPathEqualTo("/api/v1/versions/rails.json"))
+                .withHeader("Authorization", equalTo(expected)));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverTest.java
@@ -35,13 +35,18 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.Base64;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -194,6 +199,50 @@ class GoModulesPackageMetadataResolverTest {
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
                 .isThrownBy(() -> resolver.resolve(purl, repo));
+    }
+
+    @Test
+    void shouldUseBasicAuthWhenUsernameAndPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/golang.org/x/text/@latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"Version": "v1.0.0", "Time": "2024-01-01T00:00:00Z"}
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("golang")
+                .withNamespace("golang.org/x")
+                .withName("text")
+                .withVersion("v1.0.0")
+                .build();
+
+        final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        final String expected = "Basic " + Base64.getEncoder().encodeToString(
+                "user:secret".getBytes(StandardCharsets.UTF_8));
+        verify(getRequestedFor(urlPathEqualTo("/golang.org/x/text/@latest"))
+                .withHeader("Authorization", equalTo(expected)));
+    }
+
+    @Test
+    void shouldUseBearerAuthWhenOnlyPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/golang.org/x/text/@latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"Version": "v1.0.0", "Time": "2024-01-01T00:00:00Z"}
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("golang")
+                .withNamespace("golang.org/x")
+                .withName("text")
+                .withVersion("v1.0.0")
+                .build();
+
+        final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        verify(getRequestedFor(urlPathEqualTo("/golang.org/x/text/@latest"))
+                .withHeader("Authorization", equalTo("Bearer token")));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
@@ -39,11 +39,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.head;
@@ -482,6 +485,64 @@ class MavenPackageMetadataResolverTest {
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
         assertThat(result.artifactMetadata()).isNull();
+    }
+
+    @Test
+    void shouldUseBasicAuthWhenUsernameAndPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <versioning><latest>1.0.0</latest></versioning>
+                        </metadata>
+                        """)));
+        stubFor(head(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar"))
+                .willReturn(aResponse().withStatus(404)));
+        stubFor(get(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1"))
+                .willReturn(aResponse().withStatus(404)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .withVersion("1.0.0")
+                .build();
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        final String expected = "Basic " + Base64.getEncoder().encodeToString(
+                "user:secret".getBytes(StandardCharsets.UTF_8));
+        verify(getRequestedFor(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .withHeader("Authorization", equalTo(expected)));
+    }
+
+    @Test
+    void shouldUseBearerAuthWhenOnlyPasswordProvided(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <versioning><latest>1.0.0</latest></versioning>
+                        </metadata>
+                        """)));
+        stubFor(head(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar"))
+                .willReturn(aResponse().withStatus(404)));
+        stubFor(get(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1"))
+                .willReturn(aResponse().withStatus(404)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .withVersion("1.0.0")
+                .build();
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
+        assertThat(resolver.resolve(purl, repo)).isNotNull();
+
+        verify(getRequestedFor(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .withHeader("Authorization", equalTo("Bearer token")));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/4483

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2105

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Differs from the original change in that each resolver is responsible for setting auth headers itself. For some resolvers like that for Ruby Gems, bearer tokens are not supported.

Took the opportunity to add AuthN support for resolvers that were previously missing it, i.e. Cargo, Gem, Go modules.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
