### PR TITLE
Fix singleton events not being labelled as such

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/event/InternalComponentIdentificationEvent.java
+++ b/apiserver/src/main/java/org/dependencytrack/event/InternalComponentIdentificationEvent.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.event;
 
-import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+import java.util.UUID;
 
 /**
  * Defines an event triggered when internal components should be identified in the entire portfolio.
@@ -26,9 +28,13 @@ import alpine.event.framework.Event;
  * @author nscuro
  * @since 3.7.0
  */
-public class InternalComponentIdentificationEvent implements Event {
+public final class InternalComponentIdentificationEvent extends SingletonCapableEvent {
+
+    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("57096d18-fdad-41c7-a59e-925ce7dc3d0e");
 
     public InternalComponentIdentificationEvent() {
+        setChainIdentifier(CHAIN_IDENTIFIER);
+        setSingleton(true);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/event/VulnerabilityMetricsUpdateEvent.java
+++ b/apiserver/src/main/java/org/dependencytrack/event/VulnerabilityMetricsUpdateEvent.java
@@ -19,11 +19,22 @@
 package org.dependencytrack.event;
 
 import alpine.event.framework.Event;
+import alpine.event.framework.SingletonCapableEvent;
+
+import java.util.UUID;
 
 /**
  * Defines an {@link Event} used to trigger vulnerability metrics updates.
  *
  * @since 4.6.0
  */
-public class VulnerabilityMetricsUpdateEvent implements Event {
+public final class VulnerabilityMetricsUpdateEvent extends SingletonCapableEvent {
+
+    private static final UUID CHAIN_IDENTIFIER = UUID.fromString("915e97b9-c18e-42e8-8a13-b8eddaff50bf");
+
+    public VulnerabilityMetricsUpdateEvent() {
+        setChainIdentifier(CHAIN_IDENTIFIER);
+        setSingleton(true);
+    }
+
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/5775

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2105

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
