### PR TITLE
Tweak vulnerability persistence logic

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -629,16 +629,12 @@ public class QueryManager extends AlpineQueryManager {
         return getPolicyQueryManager().createLicenseGroup(name);
     }
 
-    public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
-        return getVulnerabilityQueryManager().createVulnerability(vulnerability, commitIndex);
+    public Vulnerability createVulnerability(Vulnerability transientVuln) {
+        return getVulnerabilityQueryManager().createVulnerability(transientVuln);
     }
 
-    public Vulnerability updateVulnerability(Vulnerability transientVulnerability, boolean commitIndex) {
-        return getVulnerabilityQueryManager().updateVulnerability(transientVulnerability, commitIndex);
-    }
-
-    public Vulnerability synchronizeVulnerability(Vulnerability vulnerability, boolean commitIndex) {
-        return getVulnerabilityQueryManager().synchronizeVulnerability(vulnerability, commitIndex);
+    public Vulnerability updateVulnerability(Vulnerability persistentVuln, Vulnerability transientVuln) {
+        return getVulnerabilityQueryManager().updateVulnerability(persistentVuln, transientVuln);
     }
 
     public Vulnerability getVulnerabilityByVulnId(String source, String vulnId) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -51,6 +51,8 @@ import java.util.stream.Collectors;
 
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
+import static org.dependencytrack.util.PersistenceUtil.applyIfChanged;
+import static org.dependencytrack.util.PersistenceUtil.assertNonPersistent;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistent;
 import static org.dependencytrack.util.PersistenceUtil.assertPersistentAll;
 
@@ -75,80 +77,70 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
 
     /**
      * Creates a new Vulnerability.
-     * @param vulnerability the vulnerability to persist
-     * @param commitIndex specifies if the search index should be committed (an expensive operation)
+     *
+     * @param transientVuln the vulnerability to persist
      * @return a new vulnerability object
      */
-    public Vulnerability createVulnerability(Vulnerability vulnerability, boolean commitIndex) {
-        final Vulnerability result = persist(vulnerability);
-        return result;
+    public Vulnerability createVulnerability(Vulnerability transientVuln) {
+        assertNonPersistent(transientVuln, "transientVuln must not be persistent");
+
+        final var newVuln = new Vulnerability();
+        newVuln.setVulnId(transientVuln.getVulnId());
+        newVuln.setSource(transientVuln.getSource());
+
+        return callInTransaction(() -> {
+            final Vulnerability persistentVuln = persist(newVuln);
+            return updateVulnerability(persistentVuln, transientVuln);
+        });
     }
 
     /**
-     * Updates a vulnerability.
-     * @param transientVulnerability the vulnerability to update
-     * @param commitIndex specifies if the search index should be committed (an expensive operation)
-     * @return a Vulnerability object
+     * Updates a persistent {@link Vulnerability} in place from the given transient template.
+     * <p>
+     * Only scalar fields whose values differ are written, to avoid emitting redundant UPDATE
+     * columns. 1:N / N:M relationships are left untouched, as those have dedicated synchronization
+     * paths (e.g. {@link #synchronizeVulnerableSoftware(Vulnerability, List, Vulnerability.Source)}).
+     *
+     * @param persistentVuln the persistent {@link Vulnerability} to mutate
+     * @param transientVuln  the source of new values; must not be persistent
+     * @return the same {@code persistentVuln} instance, returned for fluent chaining
      */
-    public Vulnerability updateVulnerability(Vulnerability transientVulnerability, boolean commitIndex) {
-        final Vulnerability vulnerability;
-        if (transientVulnerability.getId() > 0) {
-            vulnerability = getObjectById(Vulnerability.class, transientVulnerability.getId());
-        } else {
-            vulnerability = getVulnerabilityByVulnId(transientVulnerability.getSource(), transientVulnerability.getVulnId());
-        }
-        if (vulnerability != null) {
-            vulnerability.setCreated(transientVulnerability.getCreated());
-            vulnerability.setPublished(transientVulnerability.getPublished());
-            vulnerability.setUpdated(transientVulnerability.getUpdated());
-            vulnerability.setVulnId(transientVulnerability.getVulnId());
-            vulnerability.setSource(transientVulnerability.getSource());
-            vulnerability.setCredits(transientVulnerability.getCredits());
-            vulnerability.setVulnerableVersions(transientVulnerability.getVulnerableVersions());
-            vulnerability.setPatchedVersions(transientVulnerability.getPatchedVersions());
-            vulnerability.setDescription(transientVulnerability.getDescription());
-            vulnerability.setDetail(transientVulnerability.getDetail());
-            vulnerability.setTitle(transientVulnerability.getTitle());
-            vulnerability.setSubTitle(transientVulnerability.getSubTitle());
-            vulnerability.setReferences(transientVulnerability.getReferences());
-            vulnerability.setRecommendation(transientVulnerability.getRecommendation());
-            vulnerability.setSeverity(transientVulnerability.getSeverity());
-            vulnerability.setCvssV2Vector(transientVulnerability.getCvssV2Vector());
-            vulnerability.setCvssV2BaseScore(transientVulnerability.getCvssV2BaseScore());
-            vulnerability.setCvssV2ImpactSubScore(transientVulnerability.getCvssV2ImpactSubScore());
-            vulnerability.setCvssV2ExploitabilitySubScore(transientVulnerability.getCvssV2ExploitabilitySubScore());
-            vulnerability.setCvssV3Vector(transientVulnerability.getCvssV3Vector());
-            vulnerability.setCvssV3BaseScore(transientVulnerability.getCvssV3BaseScore());
-            vulnerability.setCvssV3ImpactSubScore(transientVulnerability.getCvssV3ImpactSubScore());
-            vulnerability.setCvssV3ExploitabilitySubScore(transientVulnerability.getCvssV3ExploitabilitySubScore());
-            vulnerability.setOwaspRRLikelihoodScore(transientVulnerability.getOwaspRRLikelihoodScore());
-            vulnerability.setOwaspRRBusinessImpactScore(transientVulnerability.getOwaspRRBusinessImpactScore());
-            vulnerability.setOwaspRRTechnicalImpactScore(transientVulnerability.getOwaspRRTechnicalImpactScore());
-            vulnerability.setOwaspRRVector(transientVulnerability.getOwaspRRVector());
-            vulnerability.setCwes(transientVulnerability.getCwes());
-            if (transientVulnerability.getVulnerableSoftware() != null) {
-                vulnerability.setVulnerableSoftware(transientVulnerability.getVulnerableSoftware());
-            }
-            final Vulnerability result = persist(vulnerability);
-            return result;
-        }
-        return null;
-    }
+    public Vulnerability updateVulnerability(Vulnerability persistentVuln, Vulnerability transientVuln) {
+        assertPersistent(persistentVuln, "persistentVuln must be persistent");
+        assertNonPersistent(transientVuln, "transientVuln must not be persistent");
 
-    /**
-     * Synchronizes a vulnerability. Method first checkes to see if the vulnerability already
-     * exists and if so, updates the vulnerability. If the vulnerability does not already exist,
-     * this method will create a new vulnerability.
-     * @param vulnerability the vulnerability to synchronize
-     * @param commitIndex specifies if the search index should be committed (an expensive operation)
-     * @return a Vulnerability object
-     */
-    public Vulnerability synchronizeVulnerability(Vulnerability vulnerability, boolean commitIndex) {
-        Vulnerability result = updateVulnerability(vulnerability, commitIndex);
-        if (result == null) {
-            result = createVulnerability(vulnerability, commitIndex);
-        }
-        return result;
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCreated, persistentVuln::setCreated);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getPublished, persistentVuln::setPublished);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getUpdated, persistentVuln::setUpdated);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getVulnId, persistentVuln::setVulnId);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getSource, persistentVuln::setSource);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getFriendlyVulnId, persistentVuln::setFriendlyVulnId);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCredits, persistentVuln::setCredits);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getVulnerableVersions, persistentVuln::setVulnerableVersions);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getPatchedVersions, persistentVuln::setPatchedVersions);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getDescription, persistentVuln::setDescription);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getDetail, persistentVuln::setDetail);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getTitle, persistentVuln::setTitle);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getSubTitle, persistentVuln::setSubTitle);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getReferences, persistentVuln::setReferences);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getRecommendation, persistentVuln::setRecommendation);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getSeverity, persistentVuln::setSeverity);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV2Vector, persistentVuln::setCvssV2Vector);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV2BaseScore, persistentVuln::setCvssV2BaseScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV2ImpactSubScore, persistentVuln::setCvssV2ImpactSubScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV2ExploitabilitySubScore, persistentVuln::setCvssV2ExploitabilitySubScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV3Vector, persistentVuln::setCvssV3Vector);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV3BaseScore, persistentVuln::setCvssV3BaseScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV3ImpactSubScore, persistentVuln::setCvssV3ImpactSubScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV3ExploitabilitySubScore, persistentVuln::setCvssV3ExploitabilitySubScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV4Score, persistentVuln::setCvssV4Score);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCvssV4Vector, persistentVuln::setCvssV4Vector);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getOwaspRRLikelihoodScore, persistentVuln::setOwaspRRLikelihoodScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getOwaspRRBusinessImpactScore, persistentVuln::setOwaspRRBusinessImpactScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getOwaspRRTechnicalImpactScore, persistentVuln::setOwaspRRTechnicalImpactScore);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getOwaspRRVector, persistentVuln::setOwaspRRVector);
+        applyIfChanged(persistentVuln, transientVuln, Vulnerability::getCwes, persistentVuln::setCwes);
+        return persistentVuln;
     }
 
     /**

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/VulnerabilityResource.java
@@ -398,7 +398,7 @@ public class VulnerabilityResource extends AbstractApiResource {
                         }
                         recalculateScoresAndSeverityFromVectors(jsonVulnerability);
                         jsonVulnerability.setSource(Vulnerability.Source.INTERNAL);
-                        final Vulnerability persistentVuln = qm.createVulnerability(jsonVulnerability, true);
+                        final Vulnerability persistentVuln = qm.createVulnerability(jsonVulnerability);
                         qm.synchronizeVulnerableSoftware(persistentVuln, vsList, Vulnerability.Source.INTERNAL);
                         if (persistentVuln.getVulnerableSoftware() != null && !persistentVuln.getVulnerableSoftware().isEmpty()) {
                             persistentVuln.setAffectedComponents(persistentVuln.getVulnerableSoftware().stream()
@@ -487,7 +487,8 @@ public class VulnerabilityResource extends AbstractApiResource {
                         qm.bind(vulnerability, resolvedTags);
 
                         recalculateScoresAndSeverityFromVectors(jsonVuln);
-                        final Vulnerability persistentVuln = qm.updateVulnerability(jsonVuln, true);
+                        final Vulnerability persistentVuln = qm.updateVulnerability(vulnerability, jsonVuln);
+                        persistentVuln.setAliases(qm.getVulnerabilityAliases(persistentVuln));
                         qm.synchronizeVulnerableSoftware(persistentVuln, vsList, Vulnerability.Source.INTERNAL);
                         if (persistentVuln.getVulnerableSoftware() != null && !persistentVuln.getVulnerableSoftware().isEmpty()) {
                             persistentVuln.setAffectedComponents(persistentVuln.getVulnerableSoftware().stream()

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -175,7 +175,10 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             qm.runInTransaction(() -> {
                 for (final Vulnerability vuln : vulns) {
                     LOGGER.debug("Synchronizing vulnerability {}", vuln.getVulnId());
-                    final Vulnerability persistentVuln = qm.synchronizeVulnerability(vuln, false);
+                    final Vulnerability existingVuln = qm.getVulnerabilityByVulnId(vuln.getSource(), vuln.getVulnId());
+                    final Vulnerability persistentVuln = existingVuln == null
+                            ? qm.createVulnerability(vuln)
+                            : qm.updateVulnerability(existingVuln, vuln);
                     final List<VulnerableSoftware> vsList = vsListByVulnId.get(persistentVuln.getVulnId());
                     qm.synchronizeVulnerableSoftware(persistentVuln, vsList, source);
                 }

--- a/apiserver/src/test/java/org/dependencytrack/metrics/UpdatePortfolioMetricsWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/metrics/UpdatePortfolioMetricsWorkflowTest.java
@@ -163,7 +163,7 @@ class UpdatePortfolioMetricsWorkflowTest extends AbstractMetricsUpdateTaskTest {
         vuln.setVulnId("INTERNAL-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
 
         // Create a project with an unaudited vulnerability.
         var projectUnaudited = new Project();
@@ -398,7 +398,7 @@ class UpdatePortfolioMetricsWorkflowTest extends AbstractMetricsUpdateTaskTest {
         vuln.setVulnId("INTERNAL-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
 
         var regularProject = new Project();
         regularProject.setName("acme-app-regular");

--- a/apiserver/src/test/java/org/dependencytrack/metrics/UpdateProjectMetricsActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/metrics/UpdateProjectMetricsActivityTest.java
@@ -129,7 +129,7 @@ class UpdateProjectMetricsActivityTest extends AbstractMetricsUpdateTaskTest {
         vuln.setVulnId("INTERNAL-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
 
         // Create a component with an unaudited vulnerability.
         var componentUnaudited = new Component();

--- a/apiserver/src/test/java/org/dependencytrack/metrics/VulnerabilityMetricsUpdateTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/metrics/VulnerabilityMetricsUpdateTaskTest.java
@@ -55,7 +55,7 @@ public class VulnerabilityMetricsUpdateTaskTest extends AbstractMetricsUpdateTas
                 vuln.setSource(Vulnerability.Source.INTERNAL);
                 vuln.setSeverity(Severity.HIGH);
                 vuln.setCreated(Date.from(LocalDateTime.of(2020, 10, 1, 6, 6, 6).toInstant(ZoneOffset.UTC)));
-                qm.createVulnerability(vuln, false);
+                qm.createVulnerability(vuln);
             }
         }
 
@@ -92,7 +92,7 @@ public class VulnerabilityMetricsUpdateTaskTest extends AbstractMetricsUpdateTas
                 vuln.setSeverity(Severity.HIGH);
                 vuln.setCreated(Date.from(LocalDateTime.of(2020, 10, 1, 6, 6, 6).toInstant(ZoneOffset.UTC)));
                 vuln.setPublished(Date.from(LocalDateTime.of(2022, 10, 1, 6, 6, 6).toInstant(ZoneOffset.UTC)));
-                qm.createVulnerability(vuln, false);
+                qm.createVulnerability(vuln);
             }
         }
 
@@ -128,7 +128,7 @@ public class VulnerabilityMetricsUpdateTaskTest extends AbstractMetricsUpdateTas
                 vuln.setSource(Vulnerability.Source.INTERNAL);
                 vuln.setSeverity(Severity.HIGH);
                 vuln.setPublished(Date.from(LocalDateTime.of(2022, 10, 1, 6, 6, 6).toInstant(ZoneOffset.UTC)));
-                qm.createVulnerability(vuln, false);
+                qm.createVulnerability(vuln);
             }
         }
 

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
@@ -63,7 +63,7 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         unknownVexSourceVulnerability.setSource(Vulnerability.Source.NVD);
         unknownVexSourceVulnerability.setSeverity(Severity.HIGH);
         unknownVexSourceVulnerability.setComponents(List.of(component));
-        unknownVexSourceVulnerability = qm.createVulnerability(unknownVexSourceVulnerability, false);
+        unknownVexSourceVulnerability = qm.createVulnerability(unknownVexSourceVulnerability);
         qm.addVulnerability(unknownVexSourceVulnerability, component, "none");
 
         var mismatchVexSourceVulnerability = new Vulnerability();
@@ -71,7 +71,7 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         mismatchVexSourceVulnerability.setSource(Vulnerability.Source.NVD);
         mismatchVexSourceVulnerability.setSeverity(Severity.HIGH);
         mismatchVexSourceVulnerability.setComponents(List.of(component));
-        mismatchVexSourceVulnerability = qm.createVulnerability(mismatchVexSourceVulnerability, false);
+        mismatchVexSourceVulnerability = qm.createVulnerability(mismatchVexSourceVulnerability);
         qm.addVulnerability(mismatchVexSourceVulnerability, component, "none");
 
         var noVexSourceVulnerability = new Vulnerability();
@@ -79,7 +79,7 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
         noVexSourceVulnerability.setSource(Vulnerability.Source.GITHUB);
         noVexSourceVulnerability.setSeverity(Severity.HIGH);
         noVexSourceVulnerability.setComponents(List.of(component));
-        noVexSourceVulnerability = qm.createVulnerability(noVexSourceVulnerability, false);
+        noVexSourceVulnerability = qm.createVulnerability(noVexSourceVulnerability);
         qm.addVulnerability(noVexSourceVulnerability, component, "none");
 
         // Build vulnerabilities for each available and known vulnerability source
@@ -90,7 +90,7 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
             vulnerability.setSource(source);
             vulnerability.setSeverity(Severity.HIGH);
             vulnerability.setComponents(List.of(component));
-            vulnerability = qm.createVulnerability(vulnerability, false);
+            vulnerability = qm.createVulnerability(vulnerability);
             qm.addVulnerability(vulnerability, component, "none");
 
             var audit = new org.cyclonedx.model.vulnerability.Vulnerability();

--- a/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 
 public class VulnerabilityQueryManagerTest extends PersistenceCapableTest {
@@ -206,5 +207,95 @@ public class VulnerabilityQueryManagerTest extends PersistenceCapableTest {
             assertThat(taggedVulnerabilities).isNotNull();
             assertThat(taggedVulnerabilities.getTotal()).isEqualTo(2);
         }
+    }
+
+    @Nested
+    public class CreateUpdateTest {
+
+        @Test
+        public void shouldReturnDistinctPersistentInstanceWhenCreatingVulnerability() {
+            final var transientVuln = new Vulnerability();
+            transientVuln.setVulnId("CVE-2024-0001");
+            transientVuln.setSource(Vulnerability.Source.NVD);
+            transientVuln.setDescription("desc");
+            transientVuln.setSeverity(Severity.HIGH);
+
+            final Vulnerability persistent = qm.createVulnerability(transientVuln);
+
+            assertThat(persistent).isNotSameAs(transientVuln);
+            assertThat(persistent.getId()).isPositive();
+            assertThat(persistent.getUuid()).isNotNull();
+            assertThat(persistent.getVulnId()).isEqualTo("CVE-2024-0001");
+            assertThat(persistent.getSource()).isEqualTo("NVD");
+            assertThat(persistent.getDescription()).isEqualTo("desc");
+            assertThat(persistent.getSeverity()).isEqualTo(Severity.HIGH);
+
+            // Provided transient must remain unchanged.
+            assertThat(transientVuln.getId()).isZero();
+            assertThat(transientVuln.getUuid()).isNull();
+        }
+
+        @Test
+        public void shouldNotPropagateRelationshipFieldsWhenCreatingVulnerability() {
+            final var component = new Component();
+
+            final var transientVuln = new Vulnerability();
+            transientVuln.setVulnId("CVE-2024-0002");
+            transientVuln.setSource(Vulnerability.Source.NVD);
+            transientVuln.setComponents(List.of(component));
+
+            final Vulnerability persistent = qm.createVulnerability(transientVuln);
+
+            qm.getPersistenceManager().refresh(persistent);
+            assertThat(persistent.getComponents()).isNullOrEmpty();
+        }
+
+        @Test
+        public void shouldRejectPersistentInputWhenCreatingVulnerability() {
+            final var vuln = new Vulnerability();
+            vuln.setVulnId("CVE-2024-0003");
+            vuln.setSource(Vulnerability.Source.NVD);
+            qm.persist(vuln);
+
+            assertThat(vuln.getId()).isPositive();
+
+            assertThat(catchThrowable(() -> qm.createVulnerability(vuln)))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
+        @Test
+        public void shouldUpdatePersistentVulnerabilityInPlace() {
+            final var persistent = new Vulnerability();
+            persistent.setVulnId("CVE-2024-0004");
+            persistent.setSource(Vulnerability.Source.NVD);
+            persistent.setDescription("old");
+            qm.persist(persistent);
+
+            final var transientVuln = new Vulnerability();
+            transientVuln.setVulnId("CVE-2024-0004");
+            transientVuln.setSource(Vulnerability.Source.NVD);
+            transientVuln.setDescription("new");
+            transientVuln.setSeverity(Severity.CRITICAL);
+
+            qm.updateVulnerability(persistent, transientVuln);
+
+            assertThat(persistent.getDescription()).isEqualTo("new");
+            assertThat(persistent.getSeverity()).isEqualTo(Severity.CRITICAL);
+        }
+
+        @Test
+        public void shouldRejectNonPersistentTargetWhenUpdatingVulnerability() {
+            final var target = new Vulnerability();
+            target.setVulnId("CVE-2024-0005");
+            target.setSource(Vulnerability.Source.NVD);
+
+            final var transientVuln = new Vulnerability();
+            transientVuln.setVulnId("CVE-2024-0005");
+            transientVuln.setSource(Vulnerability.Source.NVD);
+
+            assertThat(catchThrowable(() -> qm.updateVulnerability(target, transientVuln)))
+                    .isInstanceOf(IllegalStateException.class);
+        }
+
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/AnalysisResourceTest.java
@@ -91,7 +91,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         qm.makeAnalysis(
                 new MakeAnalysisCommand(component, vulnerability)
@@ -146,7 +146,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
@@ -176,7 +176,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("component", component.getUuid())
@@ -205,7 +205,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", UUID.randomUUID())
@@ -236,7 +236,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
@@ -262,12 +262,12 @@ class AnalysisResourceTest extends ResourceTest {
         component.setVersion("1.0");
         component = qm.createComponent(component, false);
 
-        final var vulnerability = new Vulnerability();
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final Response response = jersey.target(V1_ANALYSIS)
                 .queryParam("project", project.getUuid())
@@ -367,7 +367,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
@@ -439,7 +439,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
@@ -505,7 +505,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
                 vulnerability.getUuid().toString(), null, null, null, null, null, null);
@@ -548,7 +548,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         qm.makeAnalysis(
                 new MakeAnalysisCommand(component, vulnerability)
@@ -632,7 +632,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         qm.makeAnalysis(
                 new MakeAnalysisCommand(component, vulnerability)
@@ -693,7 +693,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         qm.makeAnalysis(
                 new MakeAnalysisCommand(component, vulnerability)
@@ -766,7 +766,7 @@ class AnalysisResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), UUID.randomUUID().toString(),
                 vulnerability.getUuid().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
@@ -793,12 +793,12 @@ class AnalysisResourceTest extends ResourceTest {
         component.setVersion("1.0");
         component = qm.createComponent(component, false);
 
-        final var vulnerability = new Vulnerability();
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final var analysisRequest = new AnalysisRequest(project.getUuid().toString(), component.getUuid().toString(),
                 UUID.randomUUID().toString(), AnalysisState.NOT_AFFECTED, AnalysisJustification.CODE_NOT_REACHABLE,
@@ -831,12 +831,12 @@ class AnalysisResourceTest extends ResourceTest {
         component.setVersion("1.0");
         qm.createComponent(component, false);
 
-        final var vulnerability = new Vulnerability();
+        var vulnerability = new Vulnerability();
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
         vulnerability.setComponents(List.of(component));
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         qm.makeAnalysis(
                 new MakeAnalysisCommand(component, vulnerability)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -286,7 +286,7 @@ class BomResourceTest extends ResourceTest {
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         final var projectManufacturer = new OrganizationalEntity();
         projectManufacturer.setName("projectManufacturer");
@@ -601,7 +601,7 @@ class BomResourceTest extends ResourceTest {
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         var project = new Project();
         project.setName("acme-app");
@@ -819,7 +819,7 @@ class BomResourceTest extends ResourceTest {
         vulnerability.setVulnId("INT-001");
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         var project = new Project();
         project.setName("acme-app");

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -1445,7 +1445,7 @@ public class FindingResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
-        return qm.createVulnerability(vulnerability, false);
+        return qm.createVulnerability(vulnerability);
     }
 
     private Vulnerability createVulnerability(String vulnId, Severity severity, String title, String description, String recommendation, Integer cweId, Vulnerability.Source source) {
@@ -1457,7 +1457,7 @@ public class FindingResourceTest extends ResourceTest {
         vulnerability.setDescription(description);
         vulnerability.setRecommendation(recommendation);
         vulnerability.setCwes(List.of(cweId));
-        return qm.createVulnerability(vulnerability, false);
+        return qm.createVulnerability(vulnerability);
     }
 
     private Vulnerability createVulnerabilityWithEpss(String vulnId, Severity severity, BigDecimal epssScore) {
@@ -1466,7 +1466,7 @@ public class FindingResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         var epss = new Epss();
         epss.setCve(vulnId);
@@ -1482,7 +1482,7 @@ public class FindingResourceTest extends ResourceTest {
         vulnerability.setSource(Vulnerability.Source.INTERNAL);
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
-        vulnerability = qm.createVulnerability(vulnerability, false);
+        vulnerability = qm.createVulnerability(vulnerability);
 
         var epss = new Epss();
         epss.setCve(vulnId);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VexResourceTest.java
@@ -112,13 +112,13 @@ public class VexResourceTest extends ResourceTest {
         vulnA.setVulnId("INT-001");
         vulnA.setSource(Vulnerability.Source.INTERNAL);
         vulnA.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vulnA, false);
+        vulnA = qm.createVulnerability(vulnA);
 
         var vulnB = new Vulnerability();
         vulnB.setVulnId("INT-002");
         vulnB.setSource(Vulnerability.Source.INTERNAL);
         vulnB.setSeverity(Severity.LOW);
-        qm.createVulnerability(vulnB, false);
+        vulnB = qm.createVulnerability(vulnB);
 
         final var project = new Project();
         project.setName("acme-app");
@@ -543,7 +543,7 @@ public class VexResourceTest extends ResourceTest {
         vuln.setVulnId("INT-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         qm.addVulnerability(vuln, componentAWithVuln, "none");
         qm.makeAnalysis(
                 new MakeAnalysisCommand(componentAWithVuln, vuln)
@@ -652,7 +652,7 @@ public class VexResourceTest extends ResourceTest {
         vuln.setVulnId("INT-001");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         qm.addVulnerability(vuln, componentAWithVuln, "none");
         qm.makeAnalysis(
                 new MakeAnalysisCommand(componentAWithVuln, vuln)

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -134,7 +134,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("INT-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         qm.addVulnerability(vuln, component, "none");
 
         Response response = jersey
@@ -385,7 +385,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("INT-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         qm.addVulnerability(vuln, component, "none");
 
         Response response = jersey
@@ -712,7 +712,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("INT-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         qm.addVulnerability(vuln, component, "none");
 
         Response response = jersey
@@ -825,7 +825,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("INT-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setSeverity(Severity.HIGH);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         qm.addVulnerability(vuln, component, "none");
 
         Response response = jersey
@@ -972,7 +972,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("description", "Something is vulnerable")
@@ -997,7 +997,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-1")
                 .add("source", "INTERNAL")
@@ -1068,7 +1068,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         JsonObject payload = Json.createObjectBuilder()
                 .add("vulnId", "ACME-2")
                 .add("description", "Something is vulnerable")
@@ -1299,7 +1299,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setVulnerableSoftware(List.of(vs));
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         final AffectedVersionAttribution attribution = qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, vuln, vs));
 
         final Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid()).request()
@@ -1320,7 +1320,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Project project = qm.createProject("Acme Example", null, null, null, null, null, null, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -1358,7 +1358,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
@@ -1375,7 +1375,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Project project = qm.createProject("Acme Example", null, null, null, null, null, null, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -1413,7 +1413,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .post(Entity.entity(null, MediaType.APPLICATION_JSON));
@@ -1512,7 +1512,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Project project = qm.createProject("Acme Example", null, null, null, null, null, null, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -1550,7 +1550,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Response response = jersey.target(V1_VULNERABILITY + "/source/INTERNAL/vuln/ACME-1/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -1567,7 +1567,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Project project = qm.createProject("Acme Example", null, null, null, null, null, null, false);
         Component comp = new Component();
         comp.setProject(project);
@@ -1605,7 +1605,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setVulnId("ACME-1");
         vuln.setSource(Vulnerability.Source.INTERNAL);
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/component/" + UUID.randomUUID().toString()).request()
                 .header(X_API_KEY, apiKey)
                 .delete();
@@ -1705,11 +1705,11 @@ public class VulnerabilityResourceTest extends ResourceTest {
         final Component c1;
         final Component c2;
         final Component c3;
-        final Vulnerability v1;
-        final Vulnerability v2;
-        final Vulnerability v3;
-        final Vulnerability v4;
-        final Vulnerability v5;
+        Vulnerability v1;
+        Vulnerability v2;
+        Vulnerability v3;
+        Vulnerability v4;
+        Vulnerability v5;
         final VulnerableSoftware vs1;
 
         SampleData() {
@@ -1755,11 +1755,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
             v1.setCwes(List.of(123));
             v1.setTags(Set.of(tag));
 
-            vs1 = new VulnerableSoftware();
-            qm.persist(vs1);
-            qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, v1, vs1));
-            v1.setVulnerableSoftware(List.of(vs1));
-
             v2 = new Vulnerability();
             v2.setVulnId("INT-2");
             v2.setSource(Vulnerability.Source.INTERNAL);
@@ -1786,11 +1781,18 @@ public class VulnerabilityResourceTest extends ResourceTest {
             v5.setSeverity(Severity.CRITICAL);
             v5.setDescription("Description 5");
 
-            qm.createVulnerability(v1, false);
-            qm.createVulnerability(v2, false);
-            qm.createVulnerability(v3, false);
-            qm.createVulnerability(v4, false);
-            qm.createVulnerability(v5, false);
+            v1 = qm.createVulnerability(v1);
+            v2 = qm.createVulnerability(v2);
+            v3 = qm.createVulnerability(v3);
+            v4 = qm.createVulnerability(v4);
+            v5 = qm.createVulnerability(v5);
+            qm.bind(v1, Set.of(tag));
+
+            vs1 = new VulnerableSoftware();
+            qm.persist(vs1);
+            qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, v1, vs1));
+            v1.setVulnerableSoftware(List.of(vs1));
+
             qm.addVulnerability(v1, c1, "none");
             qm.addVulnerability(v2, c1, "none");
             qm.addVulnerability(v3, c1, "none");
@@ -1825,7 +1827,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setSource(Vulnerability.Source.INTERNAL);
         Tag existingTag = qm.createTag("old-tag");
         vuln.setTags(Set.of(existingTag));
-        vuln = qm.createVulnerability(vuln, false);
+        vuln = qm.createVulnerability(vuln);
 
         Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid().toString() + "/tags")
                 .request()


### PR DESCRIPTION




### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/5862

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2105

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

A few deviations:

* synchronizeVulnerability is removed entirely. Not necessary anymore.
* Diff tracking in updateVulnerability omitted because that was only needed to update the Lucene search index, which we no longer have.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
