### PR TITLE
Bump FPF version to 1.3

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/integrations/FindingPackagingFormat.java
+++ b/apiserver/src/main/java/org/dependencytrack/integrations/FindingPackagingFormat.java
@@ -46,7 +46,7 @@ public class FindingPackagingFormat {
     /**
      * FPF is versioned. If the format changes, the version needs to be bumped.
      */
-    private static final String FPF_VERSION = "1.2";
+    private static final String FPF_VERSION = "1.3";
     private static final String FIELD_APPLICATION = "application";
     private static final String FIELD_VERSION = "version";
     private static final String FIELD_TIMESTAMP = "timestamp";

--- a/apiserver/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/integrations/FindingPackagingFormatTest.java
@@ -58,7 +58,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .isEqualTo(/* language=JSON */ """
                         {
-                          "version": "1.2",
+                          "version": "1.3",
                           "meta": {
                             "application": "${json-unit.matches:appName}",
                             "version": "${json-unit.matches:appVersion}",
@@ -129,7 +129,7 @@ public class FindingPackagingFormatTest extends PersistenceCapableTest {
                 .withMatcher("projectUuid", equalTo(project.getUuid().toString()))
                 .isEqualTo(/* language=JSON */ """
                         {
-                          "version": "1.2",
+                          "version": "1.3",
                           "meta": {
                             "application": "${json-unit.any-string}",
                             "version": "${json-unit.any-string}",

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -337,7 +337,7 @@ public class FindingResourceTest extends ResourceTest {
         assertEquals("Acme Example", json.getJsonObject("project").getString("name"));
         assertEquals("1.0", json.getJsonObject("project").getString("version"));
         assertEquals(p1.getUuid().toString(), json.getJsonObject("project").getString("uuid"));
-        assertEquals("1.2", json.getString("version")); // FPF version
+        assertEquals("1.3", json.getString("version")); // FPF version
         JsonArray findings = json.getJsonArray("findings");
         assertThat(findings).satisfiesExactlyInAnyOrder(
                 jsonValue -> {

--- a/apiserver/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/DefectDojoUploadTaskTest.java
@@ -145,7 +145,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                         .withName("file")
                         .withBody(equalToJson("""
                                 {
-                                  "version": "1.2",
+                                  "version": "1.3",
                                   "meta": {
                                     "application": "Dependency-Track",
                                     "version": "${json-unit.any-string}",
@@ -283,7 +283,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                         .withName("file")
                         .withBody(equalToJson("""
                                 {
-                                  "version": "1.2",
+                                  "version": "1.3",
                                   "meta": {
                                     "application": "Dependency-Track",
                                     "version": "${json-unit.any-string}",
@@ -538,7 +538,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                         .withName("file")
                         .withBody(equalToJson("""
                                 {
-                                  "version": "1.2",
+                                  "version": "1.3",
                                   "meta": {
                                     "application": "Dependency-Track",
                                     "version": "${json-unit.any-string}",
@@ -691,7 +691,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                         .withName("file")
                         .withBody(equalToJson("""
                                 {
-                                  "version": "1.2",
+                                  "version": "1.3",
                                   "meta": {
                                     "application": "Dependency-Track",
                                     "version": "${json-unit.any-string}",
@@ -821,7 +821,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                         .withName("file")
                         .withBody(equalToJson("""
                                 {
-                                  "version": "1.2",
+                                  "version": "1.3",
                                   "meta": {
                                     "application": "Dependency-Track",
                                     "version": "${json-unit.any-string}",
@@ -916,7 +916,7 @@ class DefectDojoUploadTaskTest extends PersistenceCapableTest {
                         .withName("file")
                         .withBody(equalToJson("""
                                 {
-                                  "version": "1.2",
+                                  "version": "1.3",
                                   "meta": {
                                     "application": "Dependency-Track",
                                     "version": "${json-unit.any-string}",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/5885

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2105

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
