### PR TITLE
Drop unused VULNERABLESOFTWARE indexes

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/VulnerableSoftware.java
@@ -53,8 +53,6 @@ import java.util.UUID;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Index(name = "VULNERABLESOFTWARE_CPE23_VERSION_RANGE_IDX", members = {"cpe23", "versionEndExcluding", "versionEndIncluding", "versionStartExcluding", "versionStartIncluding"})
 @Index(name = "VULNERABLESOFTWARE_PART_VENDOR_PRODUCT_IDX", members = {"part", "vendor", "product"})
-@Index(name = "VULNERABLESOFTWARE_CPE_PURL_PARTS_IDX", members = {"part", "vendor", "product", "purlType", "purlNamespace", "purlName"})
-@Index(name = "VULNERABLESOFTWARE_PURL_VERSION_RANGE_IDX", members = {"purl", "versionEndExcluding", "versionEndIncluding", "versionStartExcluding", "versionStartIncluding"})
 public class VulnerableSoftware implements ICpe, Serializable {
 
     private static final long serialVersionUID = -3987946408457131098L;

--- a/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
@@ -548,7 +548,18 @@ public final class BovModelConverter {
                 vs.setPart(cpe.getPart().getAbbreviation());
                 vs.setVendor(cpe.getVendor());
                 vs.setProduct(cpe.getProduct());
-                vs.setVersion(version != null ? version : cpe.getVersion());
+                final String cpeVersion = cpe.getVersion();
+                if (version != null && !version.equals(cpeVersion)) {
+                    // NB: It doesn't make sense for CPE version and version to diverge
+                    // (e.g. "*" vs "1.2.3"). CPEs either have an explicit version,
+                    // or a wildcard with version ranges. This is a safeguard for a situation
+                    // that *should* never happen, unless the upstream reports bad data.
+                    LOGGER.warn("""
+                                    BOV for {} reports CPE '{}' (version: '{}') alongside a diverging
+                                    exact version '{}'; using the CPE's version.""",
+                            vulnId, affectedComponent.getCpe(), cpeVersion, version);
+                }
+                vs.setVersion(cpeVersion);
                 vs.setUpdate(cpe.getUpdate());
                 vs.setEdition(cpe.getEdition());
                 vs.setLanguage(cpe.getLanguage());

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -712,13 +712,12 @@ public class QueryManager extends AlpineQueryManager {
 
     public VulnerableSoftware getVulnerableSoftwareByCpe23(
             String cpe23,
-            String version,
             String versionEndExcluding,
             String versionEndIncluding,
             String versionStartExcluding,
             String versionStartIncluding) {
         return getVulnerableSoftwareQueryManager().getVulnerableSoftwareByCpe23(
-                cpe23, version, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding);
+                cpe23, versionEndExcluding, versionEndIncluding, versionStartExcluding, versionStartIncluding);
     }
 
     public VulnerableSoftware getVulnerableSoftwareByPurl(

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManager.java
@@ -68,7 +68,6 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
     @Override
     public VulnerableSoftware getVulnerableSoftwareByCpe23(
             String cpe23,
-            String version,
             String versionEndExcluding,
             String versionEndIncluding,
             String versionStartExcluding,
@@ -82,12 +81,6 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
         // cache. This method is called very frequently during NVD mirroring,
         // we should avoid the overhead of repeated re-compilation if possible.
         // See also: https://github.com/DependencyTrack/dependency-track/issues/2540
-        if (version != null) {
-            filter += " && version == :version";
-            parameters.put("version", version);
-        } else {
-            filter += " && version == null";
-        }
         if (versionEndExcluding != null) {
             filter += " && versionEndExcluding == :vee";
             parameters.put("vee", versionEndExcluding);
@@ -298,7 +291,6 @@ final class VulnerableSoftwareQueryManager extends QueryManager implements IQuer
                 if (vs.getCpe23() != null) {
                     existingVs = getVulnerableSoftwareByCpe23(
                             vs.getCpe23(),
-                            vs.getVersion(),
                             vs.getVersionEndExcluding(),
                             vs.getVersionEndIncluding(),
                             vs.getVersionStartExcluding(),

--- a/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
@@ -437,21 +437,19 @@ class BovModelConverterTest {
 
         @Test
         void shouldProduceTwoEntriesForRangeWithExactVersion() {
-            final Bom bov = createBovWithCpeAndVersionRange(
-                    "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
-                    "vers:generic/>5|<6|6.0.1");
+            final Bom bov = createBovWithVersionRange("vers:npm/>=1.0.0|<2.0.0|2.5.0");
             final List<VulnerableSoftware> vsList = BovModelConverter.extractVulnerableSoftware(bov);
 
             assertThat(vsList).satisfiesExactlyInAnyOrder(
                     vs -> {
-                        assertThat(vs.getVersion()).isEqualTo("*");
-                        assertThat(vs.getVersionStartIncluding()).isNull();
-                        assertThat(vs.getVersionStartExcluding()).isEqualTo("5");
+                        assertThat(vs.getVersion()).isNull();
+                        assertThat(vs.getVersionStartIncluding()).isEqualTo("1.0.0");
+                        assertThat(vs.getVersionStartExcluding()).isNull();
                         assertThat(vs.getVersionEndIncluding()).isNull();
-                        assertThat(vs.getVersionEndExcluding()).isEqualTo("6");
+                        assertThat(vs.getVersionEndExcluding()).isEqualTo("2.0.0");
                     },
                     vs -> {
-                        assertThat(vs.getVersion()).isEqualTo("6.0.1");
+                        assertThat(vs.getVersion()).isEqualTo("2.5.0");
                         assertThat(vs.getVersionStartIncluding()).isNull();
                         assertThat(vs.getVersionStartExcluding()).isNull();
                         assertThat(vs.getVersionEndIncluding()).isNull();

--- a/apiserver/src/test/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/VulnerableSoftwareQueryManagerTest.java
@@ -22,8 +22,8 @@ import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.AffectedVersionAttribution;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -238,7 +238,6 @@ public class VulnerableSoftwareQueryManagerTest extends PersistenceCapableTest {
 
         final VulnerableSoftware found = qm.getVulnerableSoftwareByCpe23(
                 "cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*",
-                null,
                 "1.1.0",
                 null,
                 null,
@@ -258,7 +257,6 @@ public class VulnerableSoftwareQueryManagerTest extends PersistenceCapableTest {
 
         final VulnerableSoftware found = qm.getVulnerableSoftwareByCpe23(
                 "cpe:2.3:a:acme:product:1.0.0:*:*:*:*:*:*:*",
-                null,
                 null,
                 null,
                 null,

--- a/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
@@ -986,42 +986,19 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
                     assertThat(vs.getPurlSubpath()).isNull();
                     assertThat(vs.getPurl()).isNull();
                 },
-                // vers:generic/0
+                // Exact-version constraints (vers:generic/0, vers:generic/1, and the 6.0.1
+                // exact part of vers:generic/>5|<6|6.0.1) collapse into a single CPE entry,
+                // because the CPE's version is always taken from the CPE itself ("*" here).
+                //
+                // Note that the constellations in this test are fabricated and do not represent
+                // real-world data. It thus merely documents behaviour.
                 vs -> {
                     assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
                     assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
                     assertThat(vs.getPart()).isEqualTo("a");
                     assertThat(vs.getVendor()).isEqualTo("thinkcmf");
                     assertThat(vs.getProduct()).isEqualTo("thinkcmf");
-                    assertThat(vs.getVersion()).isEqualTo("0");
-                    assertThat(vs.getUpdate()).isEqualTo("*");
-                    assertThat(vs.getEdition()).isEqualTo("*");
-                    assertThat(vs.getLanguage()).isEqualTo("*");
-                    assertThat(vs.getSwEdition()).isEqualTo("*");
-                    assertThat(vs.getTargetSw()).isEqualTo("*");
-                    assertThat(vs.getTargetHw()).isEqualTo("*");
-                    assertThat(vs.getOther()).isEqualTo("*");
-                    assertThat(vs.getVersionStartIncluding()).isNull();
-                    assertThat(vs.getVersionStartExcluding()).isNull();
-                    assertThat(vs.getVersionEndIncluding()).isNull();
-                    assertThat(vs.getVersionEndExcluding()).isNull();
-                    assertThat(vs.isVulnerable()).isTrue();
-                    assertThat(vs.getPurlType()).isNull();
-                    assertThat(vs.getPurlNamespace()).isNull();
-                    assertThat(vs.getPurlName()).isNull();
-                    assertThat(vs.getPurlVersion()).isNull();
-                    assertThat(vs.getPurlQualifiers()).isNull();
-                    assertThat(vs.getPurlSubpath()).isNull();
-                    assertThat(vs.getPurl()).isNull();
-                },
-                // vers:generic/1
-                vs -> {
-                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
-                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
-                    assertThat(vs.getPart()).isEqualTo("a");
-                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
-                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
-                    assertThat(vs.getVersion()).isEqualTo("1");
+                    assertThat(vs.getVersion()).isEqualTo("*");
                     assertThat(vs.getUpdate()).isEqualTo("*");
                     assertThat(vs.getEdition()).isEqualTo("*");
                     assertThat(vs.getLanguage()).isEqualTo("*");
@@ -1098,7 +1075,8 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
                     assertThat(vs.getPurlSubpath()).isNull();
                     assertThat(vs.getPurl()).isNull();
                 },
-                // vers:generic/>5|<6|6.0.1 - range part.
+                // Range part of vers:generic/>5|<6|6.0.1.
+                // The exact "6.0.1" part collapses into the shared exact-version CPE entry above.
                 vs -> {
                     assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
                     assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
@@ -1117,34 +1095,6 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
                     assertThat(vs.getVersionStartExcluding()).isEqualTo("5");
                     assertThat(vs.getVersionEndIncluding()).isNull();
                     assertThat(vs.getVersionEndExcluding()).isEqualTo("6");
-                    assertThat(vs.isVulnerable()).isTrue();
-                    assertThat(vs.getPurlType()).isNull();
-                    assertThat(vs.getPurlNamespace()).isNull();
-                    assertThat(vs.getPurlName()).isNull();
-                    assertThat(vs.getPurlVersion()).isNull();
-                    assertThat(vs.getPurlQualifiers()).isNull();
-                    assertThat(vs.getPurlSubpath()).isNull();
-                    assertThat(vs.getPurl()).isNull();
-                },
-                // vers:generic/>5|<6|6.0.1 - exact version part.
-                vs -> {
-                    assertThat(vs.getCpe22()).isEqualTo("cpe:/a:thinkcmf:thinkcmf");
-                    assertThat(vs.getCpe23()).isEqualTo("cpe:2.3:a:thinkcmf:thinkcmf:*:*:*:*:*:*:*:*");
-                    assertThat(vs.getPart()).isEqualTo("a");
-                    assertThat(vs.getVendor()).isEqualTo("thinkcmf");
-                    assertThat(vs.getProduct()).isEqualTo("thinkcmf");
-                    assertThat(vs.getVersion()).isEqualTo("6.0.1");
-                    assertThat(vs.getUpdate()).isEqualTo("*");
-                    assertThat(vs.getEdition()).isEqualTo("*");
-                    assertThat(vs.getLanguage()).isEqualTo("*");
-                    assertThat(vs.getSwEdition()).isEqualTo("*");
-                    assertThat(vs.getTargetSw()).isEqualTo("*");
-                    assertThat(vs.getTargetHw()).isEqualTo("*");
-                    assertThat(vs.getOther()).isEqualTo("*");
-                    assertThat(vs.getVersionStartIncluding()).isNull();
-                    assertThat(vs.getVersionStartExcluding()).isNull();
-                    assertThat(vs.getVersionEndIncluding()).isNull();
-                    assertThat(vs.getVersionEndExcluding()).isNull();
                     assertThat(vs.isVulnerable()).isTrue();
                     assertThat(vs.getPurlType()).isNull();
                     assertThat(vs.getPurlNamespace()).isNull();

--- a/migration/src/main/resources/org/dependencytrack/migration/V202605051201__drop_unused_vulnerablesoftware_indexes.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202605051201__drop_unused_vulnerablesoftware_indexes.sql
@@ -1,0 +1,7 @@
+-- Redundant: Superset of VULNERABLESOFTWARE_PART_VENDOR_PRODUCT_IDX.
+-- No query filters on CPE parts and PURL parts together, so the trailing PURL columns are never used.
+DROP INDEX IF EXISTS "VULNERABLESOFTWARE_CPE_PURL_PARTS_IDX";
+
+-- Unused: Indexes the legacy combined PURL column, but all PURL lookups go via
+-- the split PURL_TYPE / PURL_NAMESPACE / PURL_NAME columns.
+DROP INDEX IF EXISTS "VULNERABLESOFTWARE_PURL_VERSION_RANGE_IDX";


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Drops unused VULNERABLESOFTWARE indexes.

These are leftovers from v4 that are no longer relevant to our query patterns. We no longer query CPE and PURL data at once. We also no longer query by full PURLs, but only PURL parts.

Also fixes a source of inconsistencies, where the model allowed the CPE's version and the dedicated VERSION column to diverge. This doesn't make sense, and assuming both stay consistent allows us to run cheaper queries by omitting the VERSION column.

Identified while working on #2093.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [x] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
