### PR TITLE
Fix PURL-specific version matching being bypassed for components with CPE

### DIFF
--- a/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
+++ b/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
@@ -22,6 +22,7 @@ import com.github.packageurl.PackageURL;
 import io.smallrye.config.SmallRyeConfigBuilder;
 import org.cyclonedx.proto.v1_7.Bom;
 import org.cyclonedx.proto.v1_7.Component;
+import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.migration.MigrationExecutor;
 import org.dependencytrack.plugin.api.MutableServiceRegistry;
@@ -35,6 +36,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -484,7 +486,7 @@ class InternalVulnAnalyzerTest {
                 String targetCpe) throws Exception {
             jdbi.useTransaction(handle -> {
                 final long vulnDbId = createVulnerability(handle);
-                createVulnerableSoftware(handle, sourceCpe, sourceRange, vulnDbId);
+                createCpeVulnerableSoftware(handle, sourceCpe, sourceRange, vulnDbId);
             });
 
             final var bom = Bom.newBuilder()
@@ -503,69 +505,6 @@ class InternalVulnAnalyzerTest {
             } else {
                 assertThat(vdr.getVulnerabilitiesList()).isEmpty();
             }
-        }
-
-        private void createVulnerableSoftware(Handle handle, String cpe23, Range range, long vulnDbId) throws Exception {
-            final Cpe cpe = CpeParser.parse(cpe23);
-
-            final long vsId = handle
-                    .createUpdate("""
-                            INSERT INTO "VULNERABLESOFTWARE" (
-                              "CPE23"
-                            , "PART"
-                            , "VENDOR"
-                            , "PRODUCT"
-                            , "VERSION"
-                            , "UPDATE"
-                            , "EDITION"
-                            , "LANGUAGE"
-                            , "SWEDITION"
-                            , "TARGETSW"
-                            , "TARGETHW"
-                            , "OTHER"
-                            , "VERSIONSTARTINCLUDING"
-                            , "VERSIONSTARTEXCLUDING"
-                            , "VERSIONENDEXCLUDING"
-                            , "VERSIONENDINCLUDING"
-                            , "VULNERABLE"
-                            , "UUID"
-                            ) VALUES (
-                              :cpe23
-                            , LOWER(:cpe.part.abbreviation)
-                            , LOWER(:cpe.vendor)
-                            , LOWER(:cpe.product)
-                            , :cpe.version
-                            , :cpe.update
-                            , :cpe.edition
-                            , :cpe.language
-                            , :cpe.swEdition
-                            , :cpe.targetSw
-                            , :cpe.targetHw
-                            , :cpe.other
-                            , :range.startIncluding
-                            , :range.startExcluding
-                            , :range.endExcluding
-                            , :range.endIncluding
-                            , TRUE
-                            , GEN_RANDOM_UUID()
-                            )
-                            RETURNING "ID"
-                            """)
-                    .bind("cpe23", cpe23)
-                    .bindBean("cpe", cpe)
-                    .bindMethods("range", range)
-                    .executeAndReturnGeneratedKeys()
-                    .mapTo(Long.class)
-                    .one();
-
-            handle
-                    .createUpdate("""
-                            INSERT INTO "VULNERABLESOFTWARE_VULNERABILITIES" ("VULNERABILITY_ID", "VULNERABLESOFTWARE_ID")
-                            VALUES (:vulnId, :vsId)
-                            """)
-                    .bind("vulnId", vulnDbId)
-                    .bind("vsId", vsId)
-                    .execute();
         }
 
     }
@@ -595,7 +534,7 @@ class InternalVulnAnalyzerTest {
                 String targetPurlString) throws Exception {
             jdbi.useTransaction(handle -> {
                 final long vulnDbId = createVulnerability(handle);
-                createVulnerableSoftware(handle, sourcePurlString, sourceRange, vulnDbId);
+                createPurlVulnerableSoftware(handle, sourcePurlString, sourceRange, vulnDbId);
             });
 
             final var bom = Bom.newBuilder()
@@ -614,55 +553,6 @@ class InternalVulnAnalyzerTest {
             } else {
                 assertThat(vdr.getVulnerabilitiesList()).isEmpty();
             }
-        }
-
-        private void createVulnerableSoftware(Handle handle, String purlStr, Range range, long vulnDbId) throws Exception {
-            final var purl = new PackageURL(purlStr);
-
-            final long vsId = handle
-                    .createUpdate("""
-                            INSERT INTO "VULNERABLESOFTWARE" (
-                              "PURL"
-                            , "PURL_TYPE"
-                            , "PURL_NAMESPACE"
-                            , "PURL_NAME"
-                            , "VERSION"
-                            , "VERSIONSTARTINCLUDING"
-                            , "VERSIONSTARTEXCLUDING"
-                            , "VERSIONENDEXCLUDING"
-                            , "VERSIONENDINCLUDING"
-                            , "VULNERABLE"
-                            , "UUID"
-                            ) VALUES (
-                              :purlStr
-                            , :purl.type
-                            , :purl.namespace
-                            , :purl.name
-                            , :purl.version
-                            , :range.startIncluding
-                            , :range.startExcluding
-                            , :range.endExcluding
-                            , :range.endIncluding
-                            , TRUE
-                            , GEN_RANDOM_UUID()
-                            )
-                            RETURNING "ID"
-                            """)
-                    .bind("purlStr", purlStr)
-                    .bindBean("purl", purl)
-                    .bindMethods("range", range)
-                    .executeAndReturnGeneratedKeys()
-                    .mapTo(Long.class)
-                    .one();
-
-            handle
-                    .createUpdate("""
-                            INSERT INTO "VULNERABLESOFTWARE_VULNERABILITIES" ("VULNERABILITY_ID", "VULNERABLESOFTWARE_ID")
-                            VALUES (:vulnId, :vsId)
-                            """)
-                    .bind("vulnId", vulnDbId)
-                    .bind("vsId", vsId)
-                    .execute();
         }
 
     }
@@ -739,7 +629,7 @@ class InternalVulnAnalyzerTest {
                 String targetPurlString) throws Exception {
             jdbi.useTransaction(handle -> {
                 final long vulnDbId = createVulnerability(handle);
-                createVulnerableSoftware(handle, sourcePurlString, sourceRange, vulnDbId);
+                createPurlVulnerableSoftware(handle, sourcePurlString, sourceRange, vulnDbId);
             });
 
             final var bom = Bom.newBuilder()
@@ -760,67 +650,66 @@ class InternalVulnAnalyzerTest {
             }
         }
 
-        private void createVulnerableSoftware(Handle handle, String purlStr, Range range, long vulnDbId) throws Exception {
-            final var purl = new PackageURL(purlStr);
-
-            final long vsId = handle
-                    .createUpdate("""
-                            INSERT INTO "VULNERABLESOFTWARE" (
-                              "PURL"
-                            , "PURL_TYPE"
-                            , "PURL_NAMESPACE"
-                            , "PURL_NAME"
-                            , "VERSION"
-                            , "VERSIONSTARTINCLUDING"
-                            , "VERSIONSTARTEXCLUDING"
-                            , "VERSIONENDEXCLUDING"
-                            , "VERSIONENDINCLUDING"
-                            , "VULNERABLE"
-                            , "UUID"
-                            ) VALUES (
-                              :purlStr
-                            , :purl.type
-                            , :purl.namespace
-                            , :purl.name
-                            , :purl.version
-                            , :range.startIncluding
-                            , :range.startExcluding
-                            , :range.endExcluding
-                            , :range.endIncluding
-                            , TRUE
-                            , GEN_RANDOM_UUID()
-                            )
-                            RETURNING "ID"
-                            """)
-                    .bind("purlStr", purlStr)
-                    .bindBean("purl", purl)
-                    .bindMethods("range", range)
-                    .executeAndReturnGeneratedKeys()
-                    .mapTo(Long.class)
-                    .one();
-
-            handle
-                    .createUpdate("""
-                            INSERT INTO "VULNERABLESOFTWARE_VULNERABILITIES" ("VULNERABILITY_ID", "VULNERABLESOFTWARE_ID")
-                            VALUES (:vulnId, :vsId)
-                            """)
-                    .bind("vulnId", vulnDbId)
-                    .bind("vsId", vsId)
-                    .execute();
-        }
-
     }
 
-    private long createVulnerability(Handle handle) {
-        return handle
-                .createUpdate("""
-                        INSERT INTO "VULNERABILITY" ("VULNID", "SOURCE", "UUID")
-                        VALUES ('CVE-123', 'NVD', GEN_RANDOM_UUID())
-                        RETURNING "ID"
-                        """)
-                .executeAndReturnGeneratedKeys()
-                .mapTo(Long.class)
-                .one();
+    @Test
+    void shouldNotSkipPurlAnalysisWhenCpeIsInvalid() throws Exception {
+        jdbi.useTransaction(handle -> {
+            final long vulnDbId = createVulnerability(handle, "GHSA-0000-0000-0001", "GITHUB");
+            createPurlVulnerableSoftware(
+                    handle,
+                    "pkg:maven/com.fasterxml.jackson.core/jackson-databind",
+                    Range.withRange().havingEndExcluding("2.13.1"),
+                    vulnDbId);
+        });
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("jackson-databind")
+                        .setCpe("cpe:invalid")
+                        .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThat(vdr.getVulnerabilitiesList()).hasSize(1);
+        assertThat(vdr.getVulnerabilitiesList().getFirst().getId()).isEqualTo("GHSA-0000-0000-0001");
+    }
+
+    @Test
+    void shouldMatchOnBothCpeAndPurlWhenComponentHasBoth() throws Exception {
+        jdbi.useTransaction(handle -> {
+            final long cveVulnDbId = createVulnerability(handle, "CVE-2022-00001", "NVD");
+            createCpeVulnerableSoftware(
+                    handle,
+                    "cpe:2.3:a:fasterxml:jackson-databind:2.13.0:*:*:*:*:*:*:*",
+                    WITHOUT_RANGE,
+                    cveVulnDbId);
+
+            final long ghsaVulnDbId = createVulnerability(handle, "GHSA-0000-0000-0001", "GITHUB");
+            createPurlVulnerableSoftware(
+                    handle,
+                    "pkg:maven/com.fasterxml.jackson.core/jackson-databind",
+                    Range.withRange().havingEndExcluding("2.13.1"),
+                    ghsaVulnDbId);
+        });
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("jackson-databind")
+                        .setCpe("cpe:2.3:a:fasterxml:jackson-databind:2.13.0:*:*:*:*:*:*:*")
+                        .setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.13.0")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThat(vdr.getVulnerabilitiesList())
+                .extracting(Vulnerability::getId)
+                .containsExactlyInAnyOrder("CVE-2022-00001", "GHSA-0000-0000-0001");
     }
 
     public record Range(String startIncluding, String startExcluding, String endIncluding, String endExcluding) {
@@ -845,6 +734,136 @@ class InternalVulnAnalyzerTest {
             return new Range(this.startIncluding, this.startExcluding, this.endIncluding, endExcluding);
         }
 
+    }
+
+    private long createVulnerability(Handle handle) {
+        return createVulnerability(handle, "CVE-123", "NVD");
+    }
+
+    private long createVulnerability(Handle handle, String vulnId, String source) {
+        return handle
+                .createUpdate("""
+                        INSERT INTO "VULNERABILITY" ("VULNID", "SOURCE", "UUID")
+                        VALUES (:vulnId, :source, GEN_RANDOM_UUID())
+                        RETURNING "ID"
+                        """)
+                .bind("vulnId", vulnId)
+                .bind("source", source)
+                .executeAndReturnGeneratedKeys()
+                .mapTo(Long.class)
+                .one();
+    }
+
+    private static void createCpeVulnerableSoftware(Handle handle, String cpe23, Range range, long vulnDbId) throws Exception {
+        final Cpe cpe = CpeParser.parse(cpe23);
+
+        final long vsId = handle
+                .createUpdate("""
+                        INSERT INTO "VULNERABLESOFTWARE" (
+                          "CPE23"
+                        , "PART"
+                        , "VENDOR"
+                        , "PRODUCT"
+                        , "VERSION"
+                        , "UPDATE"
+                        , "EDITION"
+                        , "LANGUAGE"
+                        , "SWEDITION"
+                        , "TARGETSW"
+                        , "TARGETHW"
+                        , "OTHER"
+                        , "VERSIONSTARTINCLUDING"
+                        , "VERSIONSTARTEXCLUDING"
+                        , "VERSIONENDEXCLUDING"
+                        , "VERSIONENDINCLUDING"
+                        , "VULNERABLE"
+                        , "UUID"
+                        ) VALUES (
+                          :cpe23
+                        , LOWER(:cpe.part.abbreviation)
+                        , LOWER(:cpe.vendor)
+                        , LOWER(:cpe.product)
+                        , :cpe.version
+                        , :cpe.update
+                        , :cpe.edition
+                        , :cpe.language
+                        , :cpe.swEdition
+                        , :cpe.targetSw
+                        , :cpe.targetHw
+                        , :cpe.other
+                        , :range.startIncluding
+                        , :range.startExcluding
+                        , :range.endExcluding
+                        , :range.endIncluding
+                        , TRUE
+                        , GEN_RANDOM_UUID()
+                        )
+                        RETURNING "ID"
+                        """)
+                .bind("cpe23", cpe23)
+                .bindBean("cpe", cpe)
+                .bindMethods("range", range)
+                .executeAndReturnGeneratedKeys()
+                .mapTo(Long.class)
+                .one();
+
+        handle
+                .createUpdate("""
+                        INSERT INTO "VULNERABLESOFTWARE_VULNERABILITIES" ("VULNERABILITY_ID", "VULNERABLESOFTWARE_ID")
+                        VALUES (:vulnId, :vsId)
+                        """)
+                .bind("vulnId", vulnDbId)
+                .bind("vsId", vsId)
+                .execute();
+    }
+
+    private static void createPurlVulnerableSoftware(Handle handle, String purlStr, Range range, long vulnDbId) throws Exception {
+        final var purl = new PackageURL(purlStr);
+
+        final long vsId = handle
+                .createUpdate("""
+                        INSERT INTO "VULNERABLESOFTWARE" (
+                          "PURL"
+                        , "PURL_TYPE"
+                        , "PURL_NAMESPACE"
+                        , "PURL_NAME"
+                        , "VERSION"
+                        , "VERSIONSTARTINCLUDING"
+                        , "VERSIONSTARTEXCLUDING"
+                        , "VERSIONENDEXCLUDING"
+                        , "VERSIONENDINCLUDING"
+                        , "VULNERABLE"
+                        , "UUID"
+                        ) VALUES (
+                          :purlStr
+                        , :purl.type
+                        , :purl.namespace
+                        , :purl.name
+                        , :purl.version
+                        , :range.startIncluding
+                        , :range.startExcluding
+                        , :range.endExcluding
+                        , :range.endIncluding
+                        , TRUE
+                        , GEN_RANDOM_UUID()
+                        )
+                        RETURNING "ID"
+                        """)
+                .bind("purlStr", purlStr)
+                .bindBean("purl", purl)
+                .bindMethods("range", range)
+                .executeAndReturnGeneratedKeys()
+                .mapTo(Long.class)
+                .one();
+
+        handle
+                .createUpdate("""
+                        INSERT INTO "VULNERABLESOFTWARE_VULNERABILITIES" ("VULNERABILITY_ID", "VULNERABLESOFTWARE_ID")
+                        VALUES (:vulnId, :vsId)
+                        """)
+                .bind("vulnId", vulnDbId)
+                .bind("vsId", vsId)
+                .execute();
     }
 
 }


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/5959

Only ports the test because the bug itself did not exist in this implementation.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2154

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
