### PR TITLE
Fix potentially wrong version being used for CPE comparison

### DIFF
--- a/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
+++ b/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
@@ -714,6 +714,108 @@ class InternalVulnAnalyzerTest {
                 .containsExactlyInAnyOrder("CVE-2022-00001", "GHSA-0000-0000-0001");
     }
 
+    @Test
+    void shouldUseCpeVersionNotComponentVersionForCpeMatching() throws Exception {
+        jdbi.useTransaction(handle -> {
+            final long vulnDbId = createVulnerability(handle, "CVE-2023-00001", "NVD");
+            createCpeVulnerableSoftware(
+                    handle,
+                    "cpe:2.3:o:st:stm32l4_firmware:-:*:*:*:*:*:*:*",
+                    WITHOUT_RANGE,
+                    vulnDbId);
+        });
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("stm32l4_firmware")
+                        .setVersion("1.2.3")
+                        .setCpe("cpe:2.3:o:st:stm32l4_firmware:-:*:*:*:*:*:*:*")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThat(vdr.getVulnerabilitiesList()).hasSize(1);
+        assertThat(vdr.getVulnerabilitiesList().getFirst().getId()).isEqualTo("CVE-2023-00001");
+    }
+
+    @Test
+    void shouldNotMatchWhenCpeVersionOutsideRangeEvenIfComponentVersionInRange() throws Exception {
+        jdbi.useTransaction(handle -> {
+            final long vulnDbId = createVulnerability(handle, "CVE-2023-00002", "NVD");
+            createCpeVulnerableSoftware(
+                    handle,
+                    "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                    Range.withRange().havingStartIncluding("1.0.0").havingEndExcluding("2.0.0"),
+                    vulnDbId);
+        });
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("product")
+                        .setVersion("1.5.0")
+                        .setCpe("cpe:2.3:a:vendor:product:5.0:*:*:*:*:*:*:*")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThat(vdr.getVulnerabilitiesList()).isEmpty();
+    }
+
+    @Test
+    void shouldUsePurlVersionNotComponentVersionForPurlMatching() throws Exception {
+        jdbi.useTransaction(handle -> {
+            final long vulnDbId = createVulnerability(handle, "CVE-2023-00003", "NVD");
+            createPurlVulnerableSoftware(
+                    handle,
+                    "pkg:maven/com.example/lib",
+                    Range.withRange().havingEndExcluding("1.0.1"),
+                    vulnDbId);
+        });
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("lib")
+                        .setVersion("1.0-SNAPSHOT")
+                        .setPurl("pkg:maven/com.example/lib@1.0.0")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThat(vdr.getVulnerabilitiesList()).hasSize(1);
+        assertThat(vdr.getVulnerabilitiesList().getFirst().getId()).isEqualTo("CVE-2023-00003");
+    }
+
+    @Test
+    void shouldNotMatchWhenPurlHasNoVersion() throws Exception {
+        jdbi.useTransaction(handle -> {
+            final long vulnDbId = createVulnerability(handle, "CVE-2023-00005", "NVD");
+            createPurlVulnerableSoftware(
+                    handle,
+                    "pkg:maven/com.example/lib",
+                    Range.withRange().havingEndExcluding("2.0.0"),
+                    vulnDbId);
+        });
+
+        final var bom = Bom.newBuilder()
+                .addComponents(Component.newBuilder()
+                        .setBomRef("1")
+                        .setName("lib")
+                        .setVersion("1.0.0")
+                        .setPurl("pkg:maven/com.example/lib")
+                        .build())
+                .build();
+
+        final Bom vdr = analyzer.analyze(bom);
+
+        assertThat(vdr.getVulnerabilitiesList()).isEmpty();
+    }
+
     public record Range(String startIncluding, String startExcluding, String endIncluding, String endExcluding) {
 
         public static Range withRange() {

--- a/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
+++ b/vuln-analysis/internal/src/test/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzerTest.java
@@ -780,7 +780,7 @@ class InternalVulnAnalyzerTest {
                 .addComponents(Component.newBuilder()
                         .setBomRef("1")
                         .setName("lib")
-                        .setVersion("1.0-SNAPSHOT")
+                        .setVersion("2.0.0")
                         .setPurl("pkg:maven/com.example/lib@1.0.0")
                         .build())
                 .build();


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/5962

Note that the new analyzer implementation does not suffer from the original bug. This port thus only includes the tests that document the desired behaviour.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2154

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
