### PR TITLE
Fix : Restrict `dockerignore` jar and handling of long filenames for distribution tar

### DIFF
--- a/apiserver/.dockerignore
+++ b/apiserver/.dockerignore
@@ -7,5 +7,5 @@ src/
 !src/main/docker/logback-json.xml
 target/
 !target/*.jar
-!target/**/*.jar
+!target/lib/*.jar
 /*.md

--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -768,6 +768,7 @@
                                     <goal>single</goal>
                                 </goals>
                                 <configuration>
+                                    <tarlongfilemode>posix</tarlongfilemode>
                                     <descriptors>
                                         <descriptor>src/main/assembly/dist.xml</descriptor>
                                     </descriptors>


### PR DESCRIPTION
### Description

1. Tighten `apiserver/.dockerignore` to only include JARs to limit what gets sent to Docker build context. 
2. Enable the assembly plugin to ensure proper handling of long filenames when creating the distribution tar.

### Addressed Issue

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- [ ] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- [ ] This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- [ ] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
