### PR TITLE
Log retry details on dex activity failures

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -20,14 +20,18 @@ package org.dependencytrack.dex.engine;
 
 import io.github.resilience4j.core.IntervalFunction;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.dependencytrack.dex.api.RetryPolicy;
+import org.dependencytrack.dex.api.failure.ApplicationFailureException;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskAbandonedEvent;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskCompletedEvent;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskFailedEvent;
 import org.dependencytrack.dex.engine.persistence.command.PollActivityTaskCommand;
 import org.dependencytrack.dex.proto.payload.v1.Payload;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.MDC;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ExecutionException;
@@ -107,12 +111,20 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 final Payload result = activityMetadata.resultConverter().convertToPayload(activityResult);
                 engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
             } catch (ExecutionException e) {
-                if (e.getCause() instanceof InterruptedException) {
+                final Throwable cause = e.getCause();
+                if (cause instanceof InterruptedException) {
                     logger.debug("Activity was interrupted; Abandoning task");
                     abandon(task);
                 } else {
-                    logger.warn("Failed to execute activity", e.getCause());
-                    engine.onTaskEvent(new ActivityTaskFailedEvent(task, e.getCause()));
+                    final Instant retryAt = computeRetryAt(task, cause);
+                    if (retryAt == null) {
+                        logger.warn("Activity failed terminally after {} attempt(s)", task.attempt(), cause);
+                    } else {
+                        logger.warn(
+                                "Activity failed; Next retry due at {} (attempt {}/{})",
+                                retryAt, task.attempt() + 1, task.retryPolicy().maxAttempts(), cause);
+                    }
+                    engine.onTaskEvent(new ActivityTaskFailedEvent(task, cause, retryAt));
                 }
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for activity execution to complete; Abandoning task");
@@ -141,4 +153,35 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
         }
         super.close();
     }
+
+    private static @Nullable Instant computeRetryAt(ActivityTask task, Throwable cause) {
+        final RetryPolicy retryPolicy = task.retryPolicy();
+        final boolean isTerminal =
+                cause instanceof ApplicationFailureException afe
+                        && afe.isTerminal();
+        if (isTerminal || retryPolicy.maxAttempts() <= task.attempt()) {
+            return null;
+        }
+
+        final Duration retryAfter =
+                cause instanceof ApplicationFailureException afe
+                        ? afe.retryAfter()
+                        : null;
+
+        final Duration retryDelay;
+        if (retryAfter != null) {
+            retryDelay = retryAfter;
+        } else {
+            final var intervalFunc =
+                    IntervalFunction.ofExponentialRandomBackoff(
+                            retryPolicy.initialDelay(),
+                            retryPolicy.delayMultiplier(),
+                            retryPolicy.delayRandomizationFactor(),
+                            retryPolicy.maxDelay());
+            retryDelay = Duration.ofMillis(intervalFunc.apply(task.attempt() + 1));
+        }
+
+        return Instant.now().plus(retryDelay);
+    }
+
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -21,7 +21,6 @@ package org.dependencytrack.dex.engine;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.protobuf.util.Timestamps;
-import io.github.resilience4j.core.IntervalFunction;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.MeterProvider;
@@ -30,9 +29,7 @@ import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.common.pagination.PageIterator;
 import org.dependencytrack.dex.api.Activity;
-import org.dependencytrack.dex.api.RetryPolicy;
 import org.dependencytrack.dex.api.Workflow;
-import org.dependencytrack.dex.api.failure.ApplicationFailureException;
 import org.dependencytrack.dex.api.failure.InternalFailureException;
 import org.dependencytrack.dex.api.payload.PayloadConverter;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskAbandonedEvent;
@@ -1400,16 +1397,7 @@ final class DexEngineImpl implements DexEngine {
 
         for (final ActivityTaskFailedEvent event : events) {
             final ActivityTask task = event.task();
-            final RetryPolicy retryPolicy = event.task().retryPolicy();
-
-            final boolean isTerminal =
-                    event.exception() instanceof ApplicationFailureException afe
-                            && afe.isTerminal();
-            final boolean hasExceededMaxAttempts =
-                    retryPolicy.maxAttempts() > 0
-                            && retryPolicy.maxAttempts() <= task.attempt();
-
-            if (isTerminal || hasExceededMaxAttempts) {
+            if (event.retryAt() == null) {
                 tasksToDelete.add(task);
 
                 workflowMessageByTaskId.put(
@@ -1426,18 +1414,7 @@ final class DexEngineImpl implements DexEngine {
                                                 .build())
                                         .build()));
             } else {
-                final Duration retryAfter =
-                        event.exception() instanceof ApplicationFailureException afe
-                                ? afe.retryAfter()
-                                : null;
-                final Duration retryDelay = retryAfter == null
-                        ? getRetryDelay(retryPolicy, task.attempt() + 1)
-                        : retryAfter;
-                final Instant retryAt = event.timestamp().plus(retryDelay);
-
-                retriesToSchedule.add(
-                        new ScheduleActivityTaskRetryCommand(
-                                event.task(), retryAt));
+                retriesToSchedule.add(new ScheduleActivityTaskRetryCommand(task, event.retryAt()));
             }
         }
 
@@ -1706,15 +1683,6 @@ final class DexEngineImpl implements DexEngine {
 
         throw new IllegalStateException(
                 "Engine must be in state any of %s, but is %s".formatted(expectedStatuses, this.status));
-    }
-
-    private static Duration getRetryDelay(RetryPolicy retryPolicy, int attempt) {
-        final var intervalFunc = IntervalFunction.ofExponentialRandomBackoff(
-                retryPolicy.initialDelay(),
-                retryPolicy.delayMultiplier(),
-                retryPolicy.delayRandomizationFactor(),
-                retryPolicy.maxDelay());
-        return Duration.ofMillis(intervalFunc.apply(attempt));
     }
 
 }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskEvent.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskEvent.java
@@ -49,10 +49,11 @@ sealed interface TaskEvent {
     record ActivityTaskFailedEvent(
             ActivityTask task,
             Throwable exception,
+            @Nullable Instant retryAt,
             Instant timestamp) implements TaskEvent {
 
-        ActivityTaskFailedEvent(ActivityTask task, Throwable exception) {
-            this(task, exception, Instant.now());
+        ActivityTaskFailedEvent(ActivityTask task, Throwable exception, @Nullable Instant retryAt) {
+            this(task, exception, retryAt, Instant.now());
         }
 
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Logs retry details on dex activity failures.

Instead of just logging "activity failed", also log whether it will be retried, and when. This required moving the retry decision from the engine directly into the task worker.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
