### PR TITLE
Consistently declare timestamp types as epoch millis in API v1 OpenAPI spec

### DIFF
--- a/apiserver/pom.xml
+++ b/apiserver/pom.xml
@@ -607,6 +607,13 @@
                 <groupId>io.swagger.core.v3</groupId>
                 <artifactId>swagger-maven-plugin-jakarta</artifactId>
                 <version>${lib.swagger.version}</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.dependencytrack</groupId>
+                        <artifactId>swagger-model-converters</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>resolve-openapi</id>

--- a/apiserver/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
@@ -67,12 +67,12 @@ public class AffectedVersionAttribution implements Serializable {
 
     @Persistent
     @Column(name = "FIRST_SEEN", allowsNull = "false")
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date firstSeen;
 
     @Persistent
     @Column(name = "LAST_SEEN", allowsNull = "false")
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date lastSeen;
 
     @Persistent

--- a/apiserver/src/main/java/org/dependencytrack/model/AnalysisComment.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/AnalysisComment.java
@@ -61,7 +61,7 @@ public class AnalysisComment implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "TIMESTAMP", allowsNull = "false")
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date timestamp;
 
     @Persistent(defaultFetchGroup = "true")

--- a/apiserver/src/main/java/org/dependencytrack/model/Bom.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Bom.java
@@ -76,7 +76,7 @@ public class Bom implements Serializable {
     @Persistent
     @Column(name = "IMPORTED", allowsNull = "false")
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date imported;
 
     @Persistent
@@ -109,7 +109,7 @@ public class Bom implements Serializable {
 
     @Persistent
     @Column(name = "GENERATED")
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date generated;
 
     public long getId() {

--- a/apiserver/src/main/java/org/dependencytrack/model/DependencyMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/DependencyMetrics.java
@@ -71,11 +71,11 @@ public class DependencyMetrics implements Serializable {
     private int policyViolationsOperationalUnaudited;
 
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date firstOccurrence;
 
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date lastOccurrence;
 
     public long getProjectId() {

--- a/apiserver/src/main/java/org/dependencytrack/model/FindingAttribution.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/FindingAttribution.java
@@ -55,7 +55,7 @@ public class FindingAttribution implements Serializable {
     @Persistent
     @Column(name = "ATTRIBUTED_ON", allowsNull = "false")
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date attributedOn;
 
     @Persistent

--- a/apiserver/src/main/java/org/dependencytrack/model/NotificationRule.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/NotificationRule.java
@@ -187,7 +187,7 @@ public class NotificationRule implements Serializable {
      */
     @Persistent
     @Column(name = "SCHEDULE_LAST_TRIGGERED_AT")
-    @Schema(type = "integer", format = "int64", accessMode = Schema.AccessMode.READ_ONLY, description = "When the schedule last triggered, as UNIX epoch timestamp in milliseconds")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "When the schedule last triggered, as UNIX epoch timestamp in milliseconds")
     private Date scheduleLastTriggeredAt;
 
     /**
@@ -195,7 +195,7 @@ public class NotificationRule implements Serializable {
      */
     @Persistent
     @Column(name = "SCHEDULE_NEXT_TRIGGER_AT")
-    @Schema(type = "integer", format = "int64", accessMode = Schema.AccessMode.READ_ONLY, description = "When the schedule triggers next, as UNIX epoch timestamp in milliseconds")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY, description = "When the schedule triggers next, as UNIX epoch timestamp in milliseconds")
     private Date scheduleNextTriggerAt;
 
     /**

--- a/apiserver/src/main/java/org/dependencytrack/model/PolicyViolation.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/PolicyViolation.java
@@ -86,7 +86,7 @@ public class PolicyViolation implements Serializable {
 
     @Persistent
     @Column(name = "TIMESTAMP", allowsNull = "false")
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date timestamp;
 
     @Persistent

--- a/apiserver/src/main/java/org/dependencytrack/model/PortfolioMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/PortfolioMetrics.java
@@ -69,11 +69,11 @@ public class PortfolioMetrics implements Serializable {
     private int policyViolationsOperationalUnaudited;
 
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date firstOccurrence;
 
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date lastOccurrence;
 
     public int getCritical() {

--- a/apiserver/src/main/java/org/dependencytrack/model/Project.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Project.java
@@ -276,7 +276,7 @@ public class Project implements Serializable {
     @Persistent
     @Index(name = "PROJECT_LASTBOMIMPORT_IDX")
     @Column(name = "LAST_BOM_IMPORTED")
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date lastBomImport;
 
     /**
@@ -297,13 +297,11 @@ public class Project implements Serializable {
 
     @Persistent
     @Column(name = "LAST_VULNERABILITY_ANALYSIS", allowsNull = "true")
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.NOT_REQUIRED, description = "UNIX epoch timestamp in milliseconds")
     private Date lastVulnerabilityAnalysis;
 
     @Persistent
     @Column(name = "INACTIVE_SINCE")
-    @Schema(accessMode = Schema.AccessMode.READ_ONLY,
-            type = "integer", format = "int64", description = "UNIX epoch timestamp in milliseconds")
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     private Date inactiveSince;
 
     @Persistent(table = "PROJECT_ACCESS_TEAMS")

--- a/apiserver/src/main/java/org/dependencytrack/model/ProjectMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ProjectMetrics.java
@@ -70,11 +70,11 @@ public class ProjectMetrics implements Serializable {
     private int policyViolationsOperationalUnaudited;
 
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date firstOccurrence;
 
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date lastOccurrence;
 
     public long getProjectId() {

--- a/apiserver/src/main/java/org/dependencytrack/model/RepositoryMetaComponent.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/RepositoryMetaComponent.java
@@ -19,7 +19,6 @@
 package org.dependencytrack.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.v3.oas.annotations.media.Schema;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Date;
@@ -31,7 +30,6 @@ public class RepositoryMetaComponent {
     private String namespace;
     private String name;
     private String latestVersion;
-    @Schema(type = "integer", format = "int64", description = "UNIX epoch timestamp in milliseconds")
     private Date lastCheck;
 
     public static @Nullable RepositoryMetaComponent of(PackageMetadata packageMetadata) {

--- a/apiserver/src/main/java/org/dependencytrack/model/Vex.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Vex.java
@@ -75,7 +75,7 @@ public class Vex implements Serializable {
     @Persistent
     @Column(name = "IMPORTED", allowsNull = "false")
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date imported;
 
     @Persistent

--- a/apiserver/src/main/java/org/dependencytrack/model/ViolationAnalysisComment.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/ViolationAnalysisComment.java
@@ -61,7 +61,7 @@ public class ViolationAnalysisComment implements Serializable {
     @Persistent(defaultFetchGroup = "true")
     @Column(name = "TIMESTAMP", allowsNull = "false")
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date timestamp;
 
     @Persistent(defaultFetchGroup = "true")

--- a/apiserver/src/main/java/org/dependencytrack/model/VulnerabilityMetrics.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/VulnerabilityMetrics.java
@@ -63,7 +63,7 @@ public class VulnerabilityMetrics implements Serializable {
     @Persistent
     @Column(name = "MEASURED_AT", allowsNull = "false")
     @NotNull
-    @Schema(type = "integer", format = "int64", requiredMode = Schema.RequiredMode.REQUIRED, description = "UNIX epoch timestamp in milliseconds")
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
     private Date measuredAt;
 
     public long getId() {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConciseProject.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/vo/ConciseProject.java
@@ -48,7 +48,7 @@ public record ConciseProject(
         @Schema(description = "Collection logic for aggregating child metrics") ProjectCollectionLogic collectionLogic,
         @Schema(description = "Tags associated with the project") List<Tag> tags,
         @Schema(description = "Teams associated with the project") List<Team> teams,
-        @Schema(description = "Timestamp of the last BOM import", type = "number", example = "1719499619599") Date lastBomImport,
+        @Schema(description = "Timestamp of the last BOM import") Date lastBomImport,
         @Schema(description = "Format of the last imported BOM") String lastBomImportFormat,
         @Schema(description = "Last observed risk score") Double lastRiskScore,
         @Schema(description = "Whether the project has children", requiredMode = Schema.RequiredMode.REQUIRED) boolean hasChildren,

--- a/apiserver/src/main/resources/openapi-configuration.yaml
+++ b/apiserver/src/main/resources/openapi-configuration.yaml
@@ -124,3 +124,5 @@ prettyPrint: true
 resourcePackages:
 - alpine.server.resources
 - org.dependencytrack.resources.v1
+modelConverterClasses:
+- org.dependencytrack.support.swagger.EpochMillisModelConverter

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <module>support/os-distro-metadata</module>
         <module>support/smallrye-config-secret-handler-file</module>
         <module>support/smallrye-config-source-memory</module>
+        <module>support/swagger-model-converters</module>
         <module>api</module>
         <module>alpine</module>
         <module>dex</module>

--- a/support/swagger-model-converters/pom.xml
+++ b/support/swagger-model-converters/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This file is part of Dependency-Track.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ Copyright (c) OWASP Foundation. All Rights Reserved.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.dependencytrack</groupId>
+        <artifactId>dependency-track-parent</artifactId>
+        <version>5.7.0-alpha.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>swagger-model-converters</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Support :: Swagger Model Converters</name>
+
+    <properties>
+        <project.parentBaseDir>${project.basedir}/../..</project.parentBaseDir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-core-jakarta</artifactId>
+            <version>${lib.swagger.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/support/swagger-model-converters/src/main/java/org/dependencytrack/support/swagger/EpochMillisModelConverter.java
+++ b/support/swagger-model-converters/src/main/java/org/dependencytrack/support/swagger/EpochMillisModelConverter.java
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.support.swagger;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.oas.models.media.Schema;
+import org.jspecify.annotations.Nullable;
+
+import java.lang.annotation.Annotation;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Iterator;
+
+/**
+ * Maps {@link Date}, {@link Instant}, {@link OffsetDateTime}, and {@link ZonedDateTime}
+ * types to {@code integer($int64)} in the generated OpenAPI spec,
+ * reflecting that Jackson serializes them as UNIX epoch milliseconds at
+ * runtime by default.
+ * <p>
+ * Conversion is skipped when the field carries a Jackson annotation that
+ * overrides the default serialization (e.g. {@code @JsonSerialize} or
+ * {@code @JsonFormat}).
+ */
+@SuppressWarnings("unused") // Invoked by Swagger Maven plugin.
+public final class EpochMillisModelConverter implements ModelConverter {
+
+    @Override
+    public @Nullable Schema<?> resolve(
+            AnnotatedType type,
+            ModelConverterContext context,
+            Iterator<ModelConverter> chain) {
+        final Schema<?> resolved = chain.hasNext()
+                ? chain.next().resolve(type, context, chain)
+                : null;
+        if (resolved == null || type == null || type.getType() == null) {
+            return resolved;
+        }
+
+        final JavaType javaType = Json.mapper().constructType(type.getType());
+        if (javaType == null
+                || !isTimestamp(javaType.getRawClass())
+                || hasSerializationOverride(type.getCtxAnnotations())) {
+            return resolved;
+        }
+
+        // Mutate the schema produced by the default resolver so that metadata
+        // contributed by @Schema (description, accessMode, example, nullable, ...)
+        // is preserved. Clear string-specific facets that don't apply to integers.
+        resolved.setType("integer");
+        resolved.setFormat("int64");
+        resolved.setPattern(null);
+        resolved.setMinLength(null);
+        resolved.setMaxLength(null);
+        if (resolved.getDescription() == null || resolved.getDescription().isBlank()) {
+            resolved.setDescription("UNIX epoch timestamp in milliseconds");
+        }
+
+        return resolved;
+    }
+
+    private static boolean isTimestamp(Class<?> rawClass) {
+        return Date.class.isAssignableFrom(rawClass)
+                || Instant.class.isAssignableFrom(rawClass)
+                || OffsetDateTime.class.isAssignableFrom(rawClass)
+                || ZonedDateTime.class.isAssignableFrom(rawClass);
+    }
+
+    private static boolean hasSerializationOverride(Annotation @Nullable [] annotations) {
+        if (annotations == null) {
+            return false;
+        }
+
+        for (final Annotation annotation : annotations) {
+            if (annotation instanceof JsonSerialize) {
+                return true;
+            }
+
+            if (annotation instanceof JsonFormat jsonFormat
+                    && jsonFormat.shape() == JsonFormat.Shape.STRING) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Consistently declares timestamp types as epoch millis in API v1 OpenAPI spec.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/2155

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Uses a Swagger's `ModelConverter` to apply this globally instead of spamming brittle annotations everywhere. Converter lives in a separate module to avoid polluting the API server's class path.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
