### PR TITLE
Support package metadata resolution for GitHub PURLs with commit versions

### DIFF
--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolver.java
@@ -37,11 +37,13 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
 
 final class GithubPackageMetadataResolver implements PackageMetadataResolver {
 
+    private static final Pattern COMMIT_SHA_PATTERN = Pattern.compile("^[0-9a-fA-F]{7,40}$");
     private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
 
     private final ObjectMapper objectMapper;
@@ -72,13 +74,26 @@ final class GithubPackageMetadataResolver implements PackageMetadataResolver {
         final var resolvedAt = Instant.now();
 
         PackageArtifactMetadata artifactMetadata = null;
-        if (purl.getVersion() != null && purl.getVersion().equals(tagName)) {
-            artifactMetadata = extractArtifactMetadata(root, resolvedAt);
-        } else if (purl.getVersion() != null) {
-            final byte[] versionBody = fetchReleaseByTag(
-                    purl.getNamespace(), purl.getName(), purl.getVersion(), repository);
-            if (versionBody != null) {
-                artifactMetadata = extractArtifactMetadata(parseJson(versionBody), resolvedAt);
+        final String version = purl.getVersion();
+        if (version != null && version.equals(tagName)) {
+            artifactMetadata = extractReleaseArtifactMetadata(root, resolvedAt);
+        } else if (version != null) {
+            // NB: SHA-shaped versions are usually commits, but *can* also be hex-only release tags
+            // (e.g. "deadbeef"). Try the commit endpoint first, and on 404 fall through to the
+            // release-by-tag lookup, so legitimate hex tags still resolve.
+            if (COMMIT_SHA_PATTERN.matcher(version).matches()) {
+                final byte[] commitBody = fetchCommit(
+                        purl.getNamespace(), purl.getName(), version, repository);
+                if (commitBody != null) {
+                    artifactMetadata = extractCommitArtifactMetadata(parseJson(commitBody), resolvedAt);
+                }
+            }
+            if (artifactMetadata == null) {
+                final byte[] versionBody = fetchReleaseByTag(
+                        purl.getNamespace(), purl.getName(), version, repository);
+                if (versionBody != null) {
+                    artifactMetadata = extractReleaseArtifactMetadata(parseJson(versionBody), resolvedAt);
+                }
             }
         }
 
@@ -102,6 +117,15 @@ final class GithubPackageMetadataResolver implements PackageMetadataResolver {
         return fetch(url, repository);
     }
 
+    private byte @Nullable [] fetchCommit(
+            String owner,
+            String name,
+            String sha,
+            PackageRepository repository) throws InterruptedException {
+        final String url = UrlUtils.join(repository.url(), "repos", owner, name, "commits", sha);
+        return fetch(url, repository);
+    }
+
     private byte @Nullable [] fetch(String url, PackageRepository repository) throws InterruptedException {
         final HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(URI.create(url))
@@ -116,15 +140,33 @@ final class GithubPackageMetadataResolver implements PackageMetadataResolver {
         return cachingHttpClient.get(requestBuilder, repository);
     }
 
-    private static @Nullable PackageArtifactMetadata extractArtifactMetadata(JsonNode root, Instant resolvedAt) {
-        final String publishedAtStr = root.path("published_at").asText(null);
-        if (publishedAtStr == null) {
+    private static @Nullable PackageArtifactMetadata extractReleaseArtifactMetadata(JsonNode root, Instant resolvedAt) {
+        return parseArtifactDate(root.path("published_at").asText(null), resolvedAt);
+    }
+
+    private static @Nullable PackageArtifactMetadata extractCommitArtifactMetadata(JsonNode root, Instant resolvedAt) {
+        final JsonNode commit = root.path("commit");
+        if (commit.isMissingNode() || commit.isNull()) {
+            return null;
+        }
+
+        // NB: Prefer author date since it records when the code was authored.
+        // Committer date can be reset by rebase or cherry-pick, which is misleading.
+        String dateStr = commit.path("author").path("date").asText(null);
+        if (dateStr == null) {
+            dateStr = commit.path("committer").path("date").asText(null);
+        }
+
+        return parseArtifactDate(dateStr, resolvedAt);
+    }
+
+    private static @Nullable PackageArtifactMetadata parseArtifactDate(@Nullable String dateStr, Instant resolvedAt) {
+        if (dateStr == null) {
             return null;
         }
 
         try {
-            final Instant publishedAt = Instant.parse(publishedAtStr);
-            return new PackageArtifactMetadata(resolvedAt, publishedAt, Map.of());
+            return new PackageArtifactMetadata(resolvedAt, Instant.parse(dateStr), Map.of());
         } catch (DateTimeParseException e) {
             return null;
         }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverTest.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.pkgmetadata.resolution.github;
 
-import com.github.packageurl.PackageURLBuilder;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.dependencytrack.cache.api.CacheManager;
@@ -38,7 +37,9 @@ import java.net.http.HttpClient;
 import java.time.Instant;
 import java.util.Map;
 
+import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -88,7 +89,7 @@ class GithubPackageMetadataResolverTest {
                         }
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -115,7 +116,7 @@ class GithubPackageMetadataResolverTest {
                         }
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -147,7 +148,7 @@ class GithubPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/repos/acme/project/releases/tags/v1.3.0"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -172,7 +173,7 @@ class GithubPackageMetadataResolverTest {
                         }
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -196,7 +197,7 @@ class GithubPackageMetadataResolverTest {
                         }
                         """)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -207,12 +208,12 @@ class GithubPackageMetadataResolverTest {
         resolver.resolve(purl, repo);
 
         verify(getRequestedFor(urlPathEqualTo("/repos/acme/project/releases/latest"))
-                .withHeader("Authorization", com.github.tomakehurst.wiremock.client.WireMock.equalTo("Bearer ghp_testtoken123")));
+                .withHeader("Authorization", equalTo("Bearer ghp_testtoken123")));
     }
 
     @Test
     void shouldThrowWhenRepositoryIsNull() throws Exception {
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -228,7 +229,7 @@ class GithubPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/repos/acme/nonexistent/releases/latest"))
                 .willReturn(aResponse().withStatus(404)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("nonexistent")
@@ -246,7 +247,7 @@ class GithubPackageMetadataResolverTest {
         stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
                 .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "60")));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")
@@ -260,11 +261,291 @@ class GithubPackageMetadataResolverTest {
     }
 
     @Test
+    void shouldResolveCommitArtifactMetadataWhenVersionIsFullSha(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {
+                          "tag_name": "v1.5.0",
+                          "published_at": "2024-03-15T12:00:00Z"
+                        }
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/4359dee1b7bd29ee25bc78e358a1254a0277ee96"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {
+                          "sha": "4359dee1b7bd29ee25bc78e358a1254a0277ee96",
+                          "commit": {
+                            "author": {"date": "2024-01-05T09:00:00Z"},
+                            "committer": {"date": "2024-01-06T10:00:00Z"}
+                          }
+                        }
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("4359dee1b7bd29ee25bc78e358a1254a0277ee96")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("v1.5.0");
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-01-05T09:00:00Z"));
+
+        verify(0, getRequestedFor(urlPathEqualTo(
+                "/repos/acme/project/releases/tags/4359dee1b7bd29ee25bc78e358a1254a0277ee96")));
+    }
+
+    @Test
+    void shouldResolveCommitArtifactMetadataWhenVersionIsShortSha(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {
+                          "tag_name": "v1.5.0",
+                          "published_at": "2024-03-15T12:00:00Z"
+                        }
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/4359dee"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {
+                          "sha": "4359dee1b7bd29ee25bc78e358a1254a0277ee96",
+                          "commit": {
+                            "author": {"date": "2024-01-05T09:00:00Z"}
+                          }
+                        }
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("4359dee")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("v1.5.0");
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-01-05T09:00:00Z"));
+    }
+
+    @Test
+    void shouldFallBackToCommitterDateWhenAuthorDateMissing(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "v1.5.0", "published_at": "2024-03-15T12:00:00Z"}
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/4359dee1b7bd29ee25bc78e358a1254a0277ee96"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {
+                          "sha": "4359dee1b7bd29ee25bc78e358a1254a0277ee96",
+                          "commit": {
+                            "committer": {"date": "2024-01-06T10:00:00Z"}
+                          }
+                        }
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("4359dee1b7bd29ee25bc78e358a1254a0277ee96")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-01-06T10:00:00Z"));
+    }
+
+    @Test
+    void shouldReturnNullArtifactMetadataWhenAuthorAndCommitterDatesMissing(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "v1.5.0", "published_at": "2024-03-15T12:00:00Z"}
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/4359dee1b7bd29ee25bc78e358a1254a0277ee96"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {
+                          "sha": "4359dee1b7bd29ee25bc78e358a1254a0277ee96",
+                          "commit": {
+                            "author": null,
+                            "committer": null
+                          }
+                        }
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("4359dee1b7bd29ee25bc78e358a1254a0277ee96")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("v1.5.0");
+        assertThat(result.artifactMetadata()).isNull();
+    }
+
+    @Test
+    void shouldReturnNullArtifactMetadataWhenNeitherCommitNorTagFound(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "v1.5.0", "published_at": "2024-03-15T12:00:00Z"}
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/0000000"))
+                .willReturn(aResponse().withStatus(404)));
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/tags/0000000"))
+                .willReturn(aResponse().withStatus(404)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("0000000")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("v1.5.0");
+        assertThat(result.artifactMetadata()).isNull();
+    }
+
+    @Test
+    void shouldFallBackToReleaseTagWhenShaShapedVersionIsActuallyATag(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "v2.0.0", "published_at": "2024-06-01T00:00:00Z"}
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/deadbeef"))
+                .willReturn(aResponse().withStatus(404)));
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/tags/deadbeef"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "deadbeef", "published_at": "2024-04-01T00:00:00Z"}
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("deadbeef")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("v2.0.0");
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-04-01T00:00:00Z"));
+    }
+
+    @Test
+    void shouldNotTreatNonShaVersionAsCommit(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "v1.5.0", "published_at": "2024-03-15T12:00:00Z"}
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/tags/invalid-release"))
+                .willReturn(aResponse().withStatus(404)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("invalid-release")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("v1.5.0");
+        assertThat(result.artifactMetadata()).isNull();
+        verify(0, getRequestedFor(urlPathEqualTo("/repos/acme/project/commits/invalid-release")));
+    }
+
+    @Test
+    void shouldPreferReleaseTagMatchOverShaShape(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "abcdef1", "published_at": "2024-03-15T12:00:00Z"}
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("abcdef1")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo);
+
+        assertThat(result).isNotNull();
+        assertThat(result.latestVersion()).isEqualTo("abcdef1");
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-03-15T12:00:00Z"));
+        verify(0, getRequestedFor(urlPathEqualTo("/repos/acme/project/commits/abcdef1")));
+    }
+
+    @Test
+    void shouldSendAuthorizationHeaderOnCommitsEndpoint(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"tag_name": "v1.5.0", "published_at": "2024-03-15T12:00:00Z"}
+                        """)));
+
+        stubFor(get(urlPathEqualTo("/repos/acme/project/commits/4359dee1b7bd29ee25bc78e358a1254a0277ee96"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"sha": "4359dee1b7bd29ee25bc78e358a1254a0277ee96",
+                         "commit": {"committer": {"date": "2024-01-06T10:00:00Z"}}}
+                        """)));
+
+        final var purl = aPackageURL()
+                .withType("github")
+                .withNamespace("acme")
+                .withName("project")
+                .withVersion("4359dee1b7bd29ee25bc78e358a1254a0277ee96")
+                .build();
+
+        final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, "ghp_testtoken123");
+        resolver.resolve(purl, repo);
+
+        verify(getRequestedFor(urlPathEqualTo("/repos/acme/project/commits/4359dee1b7bd29ee25bc78e358a1254a0277ee96"))
+                .withHeader("Authorization", equalTo("Bearer ghp_testtoken123")));
+    }
+
+    @Test
     void shouldThrowRetryableExceptionOnServerError(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         stubFor(get(urlPathEqualTo("/repos/acme/project/releases/latest"))
                 .willReturn(aResponse().withStatus(503)));
 
-        final var purl = PackageURLBuilder.aPackageURL()
+        final var purl = aPackageURL()
                 .withType("github")
                 .withNamespace("acme")
                 .withName("project")


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Supports packagepkg metadata resolution for GitHub PURLs with commit versions.

Fixes a regression compared to v4 where package metadata was not resolved for PURLs of type `github` that use commit hashes as versions instead of tag names.

Also effectively ports https://github.com/DependencyTrack/dependency-track/pull/5265

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2105

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Note that, in contrast to v4, the resolved latest version does NOT depend on the version format of the PURL. This could cause latest versions to flip-flop if the portfolio contains multiple PURLs for the same package but with different versioning formats.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
