### PR TITLE
Collect dex metrics for pod autoscaling

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
@@ -21,6 +21,7 @@ package org.dependencytrack.dex.engine;
 import io.github.resilience4j.core.IntervalFunction;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -53,6 +54,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
     private final String name;
     private final long minPollIntervalMillis;
     private final IntervalFunction pollBackoffFunction;
+    private final int maxConcurrency;
     private final Semaphore semaphore;
     private final MeterRegistry meterRegistry;
     private final Lock statusLock;
@@ -79,6 +81,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
         this.pollBackoffFunction = requireNonNull(pollBackoffFunction, "pollBackoffFunction must not be null");
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry must not be null");
         this.statusLock = new ReentrantLock();
+        this.maxConcurrency = maxConcurrency;
         this.semaphore = new Semaphore(maxConcurrency);
         this.logger = LoggerFactory.getLogger(getClass());
     }
@@ -126,6 +129,15 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 .builder("dt.dex.engine.task.worker.process.latency")
                 .tags(commonMeterTags)
                 .withRegistry(meterRegistry);
+        Gauge
+                .builder(
+                        "dt.dex.engine.task.worker.concurrency.utilization",
+                        this,
+                        worker -> 1.0 - ((double) worker.semaphore.availablePermits() / worker.maxConcurrency))
+                .description("Fraction (0-1) of the worker's concurrency slots currently in use")
+                .tags(commonMeterTags)
+                .tag("name", name)
+                .register(meterRegistry);
 
         pollThread.start();
 

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineMetricsCollector.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineMetricsCollector.java
@@ -23,12 +23,14 @@ import io.micrometer.core.instrument.MultiGauge;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.mapper.reflect.ConstructorMapper;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,6 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 final class DexEngineMetricsCollector implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DexEngineMetricsCollector.class);
+    private static final int ACTIVITY_TASK_QUEUE_BACKLOG_COUNT_CAP = 10_000;
 
     private final Jdbi jdbi;
     private final Duration initialDelay;
@@ -47,6 +50,8 @@ final class DexEngineMetricsCollector implements Closeable {
     private final MultiGauge workflowTaskQueueDepthGauge;
     private final MultiGauge activityTaskQueueCapacityGauge;
     private final MultiGauge activityTaskQueueDepthGauge;
+    private final MultiGauge activityTaskQueueBacklogGauge;
+    private final MultiGauge activityTaskQueueBacklogAgeGauge;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private @Nullable ScheduledExecutorService executor;
 
@@ -73,6 +78,15 @@ final class DexEngineMetricsCollector implements Closeable {
         this.activityTaskQueueDepthGauge = MultiGauge
                 .builder("dt.dex.engine.activity.task.queue.depth")
                 .description("Depth of activity task queues by name")
+                .register(meterRegistry);
+        this.activityTaskQueueBacklogGauge = MultiGauge
+                .builder("dt.dex.engine.activity.task.queue.backlog")
+                .description("Approximate count of unqueued, ready-to-schedule activity tasks per queue (capped at %d)".formatted(ACTIVITY_TASK_QUEUE_BACKLOG_COUNT_CAP))
+                .register(meterRegistry);
+        this.activityTaskQueueBacklogAgeGauge = MultiGauge
+                .builder("dt.dex.engine.activity.task.queue.backlog.age")
+                .description("Age of the oldest unqueued, ready-to-schedule activity task per queue")
+                .baseUnit("seconds")
                 .register(meterRegistry);
     }
 
@@ -122,6 +136,7 @@ final class DexEngineMetricsCollector implements Closeable {
         collectRunMetrics();
         collectWorkflowTaskQueueMetrics();
         collectActivityTaskQueueMetrics();
+        collectActivityTaskQueueBacklogMetrics();
     }
 
     private void collectRunMetrics() {
@@ -200,6 +215,60 @@ final class DexEngineMetricsCollector implements Closeable {
                                 rs.getLong(2)))
                         .list());
         activityTaskQueueDepthGauge.register(activityTaskQueueDepthRows, /* overwrite */ true);
+    }
+
+    public record TaskQueueBacklogRow(
+            String queueName,
+            long backlog,
+            @Nullable Duration age) {
+    }
+
+    private void collectActivityTaskQueueBacklogMetrics() {
+        final List<TaskQueueBacklogRow> rows = jdbi.withHandle(handle -> handle
+                .createQuery("""
+                        select tq.name as queue_name
+                             , coalesce((
+                                 select count(*)
+                                   from (
+                                     select 1
+                                       from dex_activity_task
+                                      where queue_name = tq.name
+                                        and status != 'QUEUED'
+                                        and visible_from <= now()
+                                      limit :cap
+                                   ) as capped
+                               ), 0) as backlog
+                             , now() - (
+                                 select min(visible_from)
+                                   from dex_activity_task
+                                  where queue_name = tq.name
+                                    and status != 'QUEUED'
+                                    and visible_from <= now()
+                               ) as age
+                          from dex_activity_task_queue as tq
+                         where tq.status = 'ACTIVE'
+                        """)
+                .bind("cap", ACTIVITY_TASK_QUEUE_BACKLOG_COUNT_CAP)
+                .map(ConstructorMapper.of(TaskQueueBacklogRow.class))
+                .list());
+
+        // Drop queues with no eligible work, so that drained queues stop producing metrics.
+        final var backlogRows = new ArrayList<MultiGauge.Row<Number>>(rows.size());
+        final var ageRows = new ArrayList<MultiGauge.Row<Number>>(rows.size());
+        for (final TaskQueueBacklogRow row : rows) {
+            if (row.backlog() == 0 && row.age() == null) {
+                continue;
+            }
+
+            final Tags tags = Tags.of("queueName", row.queueName());
+            backlogRows.add(MultiGauge.Row.of(tags, row.backlog()));
+            if (row.age() != null) {
+                ageRows.add(MultiGauge.Row.of(tags, row.age().toMillis() / 1000.0));
+            }
+        }
+
+        activityTaskQueueBacklogGauge.register(backlogRows, /* overwrite */ true);
+        activityTaskQueueBacklogAgeGauge.register(ageRows, /* overwrite */ true);
     }
 
 }

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/AbstractTaskWorkerTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/AbstractTaskWorkerTest.java
@@ -1,0 +1,158 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+import io.github.resilience4j.core.IntervalFunction;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.dependencytrack.dex.api.RetryPolicy;
+import org.dependencytrack.dex.engine.persistence.model.PolledActivityTask;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+class AbstractTaskWorkerTest {
+
+    private MeterRegistry meterRegistry;
+    private TestWorker worker;
+
+    @BeforeEach
+    void beforeEach() {
+        meterRegistry = new SimpleMeterRegistry();
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (worker != null) {
+            worker.close();
+        }
+    }
+
+    @Test
+    void shouldExposeConcurrencyUtilizationGauge() throws Exception {
+        final var processGate = new CountDownLatch(1);
+        final var processStarted = new CountDownLatch(2);
+        worker = new TestWorker("test", 4, meterRegistry, processGate, processStarted);
+        worker.start();
+
+        assertThat(meterRegistry.get("dt.dex.engine.task.worker.concurrency.utilization")
+                .tag("workerType", "TestWorker")
+                .tag("name", "test")
+                .gauge().value()).isEqualTo(0.0);
+
+        worker.queueTwoTasks();
+
+        assertThat(processStarted.await(5, TimeUnit.SECONDS)).isTrue();
+
+        await("Utilization climbs to 0.5")
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(meterRegistry.get("dt.dex.engine.task.worker.concurrency.utilization")
+                        .tag("workerType", "TestWorker")
+                        .tag("name", "test")
+                        .gauge().value()).isEqualTo(0.5));
+
+        processGate.countDown();
+
+        await("Utilization returns to 0")
+                .atMost(Duration.ofSeconds(5))
+                .untilAsserted(() -> assertThat(meterRegistry.get("dt.dex.engine.task.worker.concurrency.utilization")
+                        .tag("workerType", "TestWorker")
+                        .tag("name", "test")
+                        .gauge().value()).isEqualTo(0.0));
+    }
+
+    private static final class TestWorker extends AbstractTaskWorker<ActivityTask> {
+
+        private final CountDownLatch processGate;
+        private final CountDownLatch processStarted;
+        private final AtomicInteger pollsRemaining = new AtomicInteger(0);
+
+        TestWorker(
+                String name,
+                int maxConcurrency,
+                MeterRegistry meterRegistry,
+                CountDownLatch processGate,
+                CountDownLatch processStarted) {
+            super(
+                    name,
+                    Duration.ofMillis(10),
+                    IntervalFunction.of(Duration.ofMillis(10)),
+                    maxConcurrency,
+                    meterRegistry);
+            this.processGate = processGate;
+            this.processStarted = processStarted;
+        }
+
+        void queueTwoTasks() {
+            pollsRemaining.set(2);
+            nudge();
+        }
+
+        @Override
+        List<ActivityTask> poll(final int limit) {
+            final int toEmit = Math.min(limit, pollsRemaining.getAndSet(0));
+            if (toEmit <= 0) {
+                return List.of();
+            }
+
+            return IntStream.range(0, toEmit)
+                    .mapToObj(i -> ActivityTask.of(new PolledActivityTask(
+                            UUID.randomUUID(),
+                            i,
+                            "noop",
+                            "queue",
+                            0,
+                            null,
+                            RetryPolicy.ofDefault().toProto(),
+                            1,
+                            Instant.now().plusSeconds(60),
+                            0)))
+                    .toList();
+        }
+
+        @Override
+        void process(final ActivityTask task) {
+            processStarted.countDown();
+
+            try {
+                processGate.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        void abandon(final ActivityTask task) {
+        }
+
+    }
+
+}

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineMetricsCollectorTest.java
@@ -33,6 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.awaitility.Awaitility.await;
 
 @Testcontainers
@@ -242,6 +243,89 @@ class DexEngineMetricsCollectorTest {
     }
 
     @Test
+    void shouldCollectActivityBacklog() {
+        jdbi.useHandle(handle -> {
+            handle.execute("select dex_create_workflow_task_queue('default', cast(100 as smallint))");
+            handle.execute("select dex_create_activity_task_queue('act-queue-a', cast(30 as smallint))");
+            handle.execute("select dex_create_activity_task_queue('act-queue-b', cast(60 as smallint))");
+            handle.execute("select dex_create_activity_task_queue('act-queue-empty', cast(10 as smallint))");
+
+            handle.execute("""
+                    insert into dex_workflow_run(id, workflow_name, workflow_version, task_queue_name, status, created_at)
+                    values ('a0000000-0000-0000-0000-000000000001', 'wf-a', 1, 'default', 'RUNNING', now())
+                         , ('a0000000-0000-0000-0000-000000000002', 'wf-a', 1, 'default', 'RUNNING', now())
+                    """);
+            
+            handle.execute("""
+                    insert into dex_activity_task(queue_name, workflow_run_id, created_event_id, activity_name, priority, retry_policy, status, visible_from, created_at)
+                    values ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 1, 'act-a', 0, ''::bytea, 'CREATED', now() - interval '1 second', now())
+                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 2, 'act-a', 0, ''::bytea, 'CREATED', now() - interval '2 seconds', now())
+                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 3, 'act-a', 0, ''::bytea, 'CREATED', now() + interval '1 hour', now())
+                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000002', 1, 'act-a', 0, ''::bytea, 'QUEUED', now(), now())
+                         , ('act-queue-b', 'a0000000-0000-0000-0000-000000000002', 2, 'act-b', 0, ''::bytea, 'CREATED', now(), now())
+                    """);
+        });
+
+        try (final var collector = new DexEngineMetricsCollector(
+                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+            collector.start();
+
+            await("Collection")
+                    .atMost(Duration.ofSeconds(5))
+                    .ignoreException(MeterNotFoundException.class)
+                    .untilAsserted(() -> {
+                        assertThat(meterRegistry.get("dt.dex.engine.activity.task.queue.backlog")
+                                .tag("queueName", "act-queue-a")
+                                .gauge().value()).isEqualTo(2.0);
+                        assertThat(meterRegistry.get("dt.dex.engine.activity.task.queue.backlog")
+                                .tag("queueName", "act-queue-b")
+                                .gauge().value()).isEqualTo(1.0);
+                        assertThat(meterRegistry.find("dt.dex.engine.activity.task.queue.backlog")
+                                .tag("queueName", "act-queue-empty")
+                                .gauge()).isNull();
+                    });
+        }
+    }
+
+    @Test
+    void shouldCollectActivityBacklogAge() {
+        jdbi.useHandle(handle -> {
+            handle.execute("select dex_create_workflow_task_queue('default', cast(100 as smallint))");
+            handle.execute("select dex_create_activity_task_queue('act-queue-a', cast(30 as smallint))");
+            handle.execute("select dex_create_activity_task_queue('act-queue-b', cast(60 as smallint))");
+
+            handle.execute("""
+                    insert into dex_workflow_run(id, workflow_name, workflow_version, task_queue_name, status, created_at)
+                    values ('a0000000-0000-0000-0000-000000000001', 'wf-a', 1, 'default', 'RUNNING', now())
+                    """);
+
+            handle.execute("""
+                    insert into dex_activity_task(queue_name, workflow_run_id, created_event_id, activity_name, priority, retry_policy, status, visible_from, created_at)
+                    values ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 1, 'act-a', 0, ''::bytea, 'CREATED', now() - interval '5 seconds', now())
+                         , ('act-queue-a', 'a0000000-0000-0000-0000-000000000001', 2, 'act-a', 0, ''::bytea, 'CREATED', now() - interval '1 second', now())
+                         , ('act-queue-b', 'a0000000-0000-0000-0000-000000000001', 3, 'act-b', 0, ''::bytea, 'CREATED', now() - interval '2 seconds', now())
+                    """);
+        });
+
+        try (final var collector = new DexEngineMetricsCollector(
+                jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
+            collector.start();
+
+            await("Collection")
+                    .atMost(Duration.ofSeconds(5))
+                    .ignoreException(MeterNotFoundException.class)
+                    .untilAsserted(() -> {
+                        assertThat(meterRegistry.get("dt.dex.engine.activity.task.queue.backlog.age")
+                                .tag("queueName", "act-queue-a")
+                                .gauge().value()).isCloseTo(5.0, within(2.0));
+                        assertThat(meterRegistry.get("dt.dex.engine.activity.task.queue.backlog.age")
+                                .tag("queueName", "act-queue-b")
+                                .gauge().value()).isCloseTo(2.0, within(2.0));
+                    });
+        }
+    }
+
+    @Test
     void shouldHandleEmptyDatabase() {
         try (final var collector = new DexEngineMetricsCollector(
                 jdbi, Duration.ZERO, Duration.ofMillis(50), meterRegistry)) {
@@ -255,6 +339,8 @@ class DexEngineMetricsCollectorTest {
                         assertThat(meterRegistry.find("dt.dex.engine.workflow.runs.current").gauge()).isNull();
                         assertThat(meterRegistry.find("dt.dex.engine.workflow.task.queue.depth").gauge()).isNull();
                         assertThat(meterRegistry.find("dt.dex.engine.activity.task.queue.depth").gauge()).isNull();
+                        assertThat(meterRegistry.find("dt.dex.engine.activity.task.queue.backlog").gauge()).isNull();
+                        assertThat(meterRegistry.find("dt.dex.engine.activity.task.queue.backlog.age").gauge()).isNull();
                     });
         }
     }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

The existing queue depth metric is not a good autoscaling signal, because it's bounded by the respective queue's capacity. It does not include tasks that were not queued yet by schedulers.

Thus, this change adds 3 new metrics:

* `dt.dex.engine.activity.task.queue.backlog`: Number of activity tasks that are not yet scheduled but eligible for it. Capped at 10k to avoid expensive COUNT queries at scale, while still being a useful signal.
* `dt.dex.engine.activity.task.queue.backlog.age`: Age of the oldest task in the backlog.
* `dt.dex.engine.task.worker.concurrency.utilization`: Fraction of utilized worker threads.

Both backlog metrics can be used as signals to scale up, whereas worker utilization can be used as signal to scale down (i.e. low utilization = no need for more replicas).

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

I intentionally limited this to activity tasks for now, because workflow tasks are extremely cheap and unlikely to be a bottleneck worth scaling for. It's also more expensive to determine backlog size for workflows, so I deferred this until it becomes an actual requirement.

Docs PR: https://github.com/DependencyTrack/docs/pull/72

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- [x] This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
