### PR TITLE
Improve efficiency of vuln data source mirroring

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -151,7 +151,6 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      */
     public Vulnerability getVulnerabilityByVulnId(String source, String vulnId, boolean includeVulnerableSoftware) {
         final Query<Vulnerability> query = pm.newQuery(Vulnerability.class, "source == :source && vulnId == :vulnId");
-        query.getFetchPlan().addGroup(Vulnerability.FetchGroup.COMPONENTS.name());
         if (includeVulnerableSoftware) {
             query.getFetchPlan().addGroup(Vulnerability.FetchGroup.VULNERABLE_SOFTWARE.name());
         }

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -41,6 +41,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jdo.Query;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -185,10 +186,11 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             qm.runInTransaction(() -> {
                 for (final Vulnerability vuln : vulns) {
                     LOGGER.debug("Synchronizing vulnerability {}", vuln.getVulnId());
-                    final Vulnerability existingVuln = qm.getVulnerabilityByVulnId(vuln.getSource(), vuln.getVulnId());
+                    final Vulnerability existingVuln = getExistingVuln(qm, vuln.getSource(), vuln.getVulnId());
                     final Vulnerability persistentVuln = existingVuln == null
                             ? qm.createVulnerability(vuln)
                             : qm.updateVulnerability(existingVuln, vuln);
+
                     final List<VulnerableSoftware> vsList = vsListByVulnId.get(persistentVuln.getVulnId());
                     qm.synchronizeVulnerableSoftware(persistentVuln, vsList, source);
                 }
@@ -202,6 +204,22 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
         for (final Bom bov : bovs) {
             dataSource.markProcessed(bov);
+        }
+    }
+
+    private static @Nullable Vulnerability getExistingVuln(
+            QueryManager qm,
+            String source,
+            String vulnId) {
+        final Query<Vulnerability> query = qm.getPersistenceManager().newQuery(
+                Vulnerability.class, "source == :source && vulnId == :vulnId");
+        query.getFetchPlan().addGroup(Vulnerability.FetchGroup.VULNERABLE_SOFTWARE.name());
+        query.setParameters(source, vulnId);
+        query.setRange(0, 1);
+        try {
+            return query.executeUnique();
+        } finally {
+            query.closeAll();
         }
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves efficiency of vuln data source mirroring.

* Don't load components assigned to a vulnerability. This data is not needed in this context.
* Pre-fetch associated VulnerableSoftware records as they're needed for synchronization.

Separately, removes the eager fetching of components for all callers of the global `getVulnerabilityByVulnId` method. No caller needs that data, and it's unnecessarily expensive.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
