### PR TITLE
Squash dex correctness bugs

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -635,8 +635,10 @@ final class DexEngineImpl implements DexEngine {
                 return Collections.emptyList();
             }
             if (createdRunIdByRequestId.size() != createWorkflowRunCommands.size()) {
+                // Drop messages targeting runs that were not created due to instance ID conflict.
+                // Keeping them would cause a foreign key violation when inserting into the inbox.
                 messagesToCreate.removeIf(
-                        command -> createdRunIdByRequestId.containsValue(command.recipientRunId()));
+                        message -> !createdRunIdByRequestId.containsValue(message.recipientRunId()));
             }
 
             handle.afterCommit(() -> {
@@ -957,7 +959,7 @@ final class DexEngineImpl implements DexEngine {
             }
 
             final var historyRequests = new ArrayList<GetWorkflowRunHistoryRequest>(polledTaskByRunId.size());
-            final var cachedHistoryByRunId = new HashMap<UUID, List<WorkflowEvent>>(polledTaskByRunId.size());
+            final var cachedHistoryByRunId = new HashMap<UUID, CachedWorkflowRunHistory>(polledTaskByRunId.size());
 
             // Try to populate event histories from cache first.
             for (final var entry : polledTaskByRunId.entrySet()) {
@@ -968,7 +970,7 @@ final class DexEngineImpl implements DexEngine {
                 if (cachedHistory == null) {
                     historyRequests.add(new GetWorkflowRunHistoryRequest(runId, -1));
                 } else {
-                    cachedHistoryByRunId.put(runId, cachedHistory.events());
+                    cachedHistoryByRunId.put(runId, cachedHistory);
                     historyRequests.add(new GetWorkflowRunHistoryRequest(runId, cachedHistory.maxSequenceNumber()));
                 }
             }
@@ -978,7 +980,10 @@ final class DexEngineImpl implements DexEngine {
             return polledTaskByRunId.values().stream()
                     .map(polledTask -> {
                         final PolledWorkflowEvents polledEvents = polledEventsByRunId.get(polledTask.runId());
-                        final List<WorkflowEvent> cachedHistoryEvents = cachedHistoryByRunId.get(polledTask.runId());
+                        final CachedWorkflowRunHistory cachedHistory = cachedHistoryByRunId.get(polledTask.runId());
+                        final List<WorkflowEvent> cachedHistoryEvents = cachedHistory != null
+                                ? cachedHistory.events()
+                                : null;
 
                         var historySize = polledEvents.history().size();
                         if (cachedHistoryEvents != null) {
@@ -991,13 +996,20 @@ final class DexEngineImpl implements DexEngine {
                         }
                         history.addAll(polledEvents.history());
 
+                        // Preserve the previously cached max sequence number when no new history events
+                        // were polled. Otherwise, the cache would be left with a non-empty event list but
+                        // a max of -1, causing the next poll to refetch the full history and double-apply
+                        // the already-cached events.
+                        final int maxSequenceNumber =
+                                polledEvents.history().isEmpty() && cachedHistory != null
+                                        ? cachedHistory.maxSequenceNumber()
+                                        : polledEvents.maxHistorySequenceNumber();
+
                         runHistoryCache.put(
                                 new WorkflowRunHistoryCacheKey(
                                         polledTask.runId(),
                                         polledTask.continuedAsNewGeneration()),
-                                new CachedWorkflowRunHistory(
-                                        history,
-                                        polledEvents.maxHistorySequenceNumber()));
+                                new CachedWorkflowRunHistory(history, maxSequenceNumber));
 
                         return WorkflowTask.of(
                                 polledTask,


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Squashes dex correctness bugs:

* Fixes inverted removeIf condition when removing inbox messages for workflow runs that were not created due to instance ID conflicts.
* Fixes duplicate RunCreated error from poisoned workflow history cache.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

When `pollWorkflowTasks` returned no new history rows for a run that already had cached events, the cache was rewritten with the existing events but a `maxSequenceNumber` of -1 (the default from `pollRunEvents` when no `WORKFLOW_RUN_HISTORY` rows are returned). The next poll then requested `offset=-1`, re-fetched the full history, and concatenated it onto the cached copy, thus duplicating every event.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
