### PR TITLE
Fix redundant VulnerableSoftware records being created from Ubuntu OSV advisories

### DIFF
--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
@@ -194,8 +194,9 @@ final class ModelConverter {
         final List<Affected> affected = osv.getAffected();
         if (affected != null && !affected.isEmpty()) {
             final var purlToBomRef = new HashMap<String, String>();
+            final boolean isMalware = isOsvMalwareIdentifier(id);
             for (final Affected entry : affected) {
-                final VulnerabilityAffects affects = convertAffected(id, entry, bom, purlToBomRef);
+                final VulnerabilityAffects affects = convertAffected(id, entry, bom, purlToBomRef, isMalware);
                 if (affects != null) {
                     vuln.addAffects(affects);
                 }
@@ -428,7 +429,8 @@ final class ModelConverter {
             @Nullable String vulnId,
             Affected entry,
             Bom.Builder bom,
-            Map<String, String> purlToBomRef) {
+            Map<String, String> purlToBomRef,
+            boolean isMalware) {
         final Package pkg = entry.getPackage();
         if (pkg == null) {
             return null;
@@ -458,7 +460,7 @@ final class ModelConverter {
 
         return VulnerabilityAffects.newBuilder()
                 .setRef(bomRef)
-                .addAllVersions(convertVersions(entry))
+                .addAllVersions(convertVersions(entry, isMalware))
                 .build();
     }
 
@@ -504,7 +506,7 @@ final class ModelConverter {
         return builder.build();
     }
 
-    private List<VulnerabilityAffectedVersions> convertVersions(Affected entry) {
+    private List<VulnerabilityAffectedVersions> convertVersions(Affected entry, boolean isMalware) {
         final List<Range> ranges = entry.getRanges();
         final var parsedRanges = new ArrayList<VulnerabilityAffectedVersions>();
         if (ranges != null) {
@@ -515,15 +517,27 @@ final class ModelConverter {
         }
 
         // OSV typically provides BOTH ranges (introduced/fixed events) and a redundant `versions` array
-        // expanded from those ranges. Consume the ranges by default, and fall back to discrete versions only
-        // when no usable range was parsed, or when only wildcard ranges (e.g. `>=0`) survived. The latter
-        // case mirrors advisories like https://osv-vulnerabilities.storage.googleapis.com/npm/MAL-2023-995.json,
-        // where the wildcard range alongside an exact version would otherwise produce false positives.
-        final boolean onlyWildcardRanges = !parsedRanges.isEmpty() && parsedRanges.stream()
-                .map(VulnerabilityAffectedVersions::getRange)
-                .allMatch(WILDCARD_VERS_PATTERN.asPredicate());
+        // expanded from those ranges. Consume the ranges by default, and fall back to discrete versions
+        // only when no usable range was parsed.
+        //
+        // For malware advisories (MAL-*), also fall back to discrete versions when only wildcard ranges
+        // (e.g. `>=0`) survived. Such records pair a wildcard range with a precise list of malicious
+        // versions and trusting the wildcard would flag every legitimate release as malware. See
+        // https://osv-vulnerabilities.storage.googleapis.com/npm/MAL-2023-995.json.
+        //
+        // Outside of malware, wildcard-only ranges are authoritative ("all versions affected"), even
+        // when the advisory enumerates known versions alongside them. This is common for unfixed distro
+        // CVEs, where Debian / Ubuntu list every historical release of a source package under
+        // `introduced=0`. Expanding those into per-version VulnerableSoftware records produces tens of
+        // thousands of redundant rows per advisory without adding matching information.
         final List<String> exactVersions = entry.getVersions();
-        if ((parsedRanges.isEmpty() || onlyWildcardRanges)
+        final boolean noUsableRange = parsedRanges.isEmpty();
+        final boolean malwareWildcardOnly = isMalware
+                && !parsedRanges.isEmpty()
+                && parsedRanges.stream()
+                        .map(VulnerabilityAffectedVersions::getRange)
+                        .allMatch(WILDCARD_VERS_PATTERN.asPredicate());
+        if ((noUsableRange || malwareWildcardOnly)
                 && exactVersions != null
                 && !exactVersions.isEmpty()) {
             final var fallback = new ArrayList<VulnerabilityAffectedVersions>(exactVersions.size());

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/ModelConverterTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/ModelConverterTest.java
@@ -515,6 +515,47 @@ class ModelConverterTest {
         }
 
         @Test
+        void shouldDiscardEnumeratedVersionsWhenWildcardRangeIsAuthoritative() throws IOException {
+            final var advisory = MAPPER.readValue(/* language=JSON */ """
+                    {
+                      "id": "UBUNTU-CVE-2024-99999",
+                      "affected": [
+                        {
+                          "package": {
+                            "name": "linux",
+                            "ecosystem": "Ubuntu:24.04:LTS",
+                            "purl": "pkg:deb/ubuntu/linux?arch=source&distro=noble"
+                          },
+                          "ranges": [
+                            {
+                              "type": "ECOSYSTEM",
+                              "events": [
+                                { "introduced": "0" }
+                              ]
+                            }
+                          ],
+                          "versions": [
+                            "6.8.0-31.31",
+                            "6.8.0-35.35",
+                            "6.8.0-39.39"
+                          ]
+                        }
+                      ]
+                    }
+                    """, Osv.class);
+
+            final Bom bov = new ModelConverter(MAPPER).convert(advisory, false, "Ubuntu");
+
+            assertThatBov(bov)
+                    .inPath("$.vulnerabilities[0].affects[0].versions")
+                    .isEqualTo(/* language=JSON */ """
+                            [
+                              { "range": "vers:deb/*" }
+                            ]
+                            """);
+        }
+
+        @Test
         void shouldResolveConflictingUpperBounds() throws IOException {
             final Bom bov = new ModelConverter(MAPPER).convert(
                     loadOsvAdvisory("osv-git-conflict-upper-bound-range.json"), false, DEFAULT_SOURCE_ECOSYSTEM);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes redundant VulnerableSoftware records being created from Ubuntu OSV advisories.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Ubuntu enumerates all matching versions in addition to wildcard ranges (i.e. introduced=0), see https://osv.dev/vulnerability/UBUNTU-CVE-2024-24864 for example.

This is redundant information for us, while also adding immense overhead.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
