### PR TITLE
Remove unused UUID column from AFFECTEDVERSIONATTRIBUTION table

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/AffectedVersionAttribution.java
@@ -35,7 +35,6 @@ import javax.jdo.annotations.Unique;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * Model class for tracking the attribution of versions affected by a given {@link Vulnerability}.
@@ -90,11 +89,6 @@ public class AffectedVersionAttribution implements Serializable {
     @Column(name = "VULNERABLE_SOFTWARE", allowsNull = "false")
     @JsonIgnore
     private VulnerableSoftware vulnerableSoftware;
-
-    @Persistent(customValueStrategy = "uuid")
-    @Unique(name = "AFFECTEDVERSIONATTRIBUTION_UUID_IDX")
-    @Column(name = "UUID", sqlType = "UUID", allowsNull = "false")
-    private UUID uuid;
 
     public AffectedVersionAttribution() {
     }
@@ -153,14 +147,6 @@ public class AffectedVersionAttribution implements Serializable {
 
     public void setVulnerableSoftware(final VulnerableSoftware vulnerableSoftware) {
         this.vulnerableSoftware = vulnerableSoftware;
-    }
-
-    public UUID getUuid() {
-        return uuid;
-    }
-
-    public void setUuid(final UUID uuid) {
-        this.uuid = uuid;
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -141,11 +141,9 @@ public interface VulnerabilityDao {
                  , "VS"."VULNERABLE"
                  , "VS"."UUID"
                  , (SELECT JSONB_AGG(JSONB_BUILD_OBJECT(
-                             'id', "ID"
-                           , 'firstSeen', CAST(EXTRACT(EPOCH FROM "FIRST_SEEN") * 1000 AS BIGINT)
+                             'firstSeen', CAST(EXTRACT(EPOCH FROM "FIRST_SEEN") * 1000 AS BIGINT)
                            , 'lastSeen', CAST(EXTRACT(EPOCH FROM "LAST_SEEN") * 1000 AS BIGINT)
-                           , 'source', "SOURCE"
-                           , 'uuid', "UUID"))
+                           , 'source', "SOURCE"))
                       FROM "AFFECTEDVERSIONATTRIBUTION"
                      WHERE "VULNERABILITY" = "VSV"."VULNERABILITY_ID"
                        AND "VULNERABLE_SOFTWARE" = "VSV"."VULNERABLESOFTWARE_ID") AS "attributionsJson"

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -533,8 +533,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                 {
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}",
-                                  "source": "INTERNAL",
-                                  "uuid": "${json-unit.any-string}"
+                                  "source": "INTERNAL"
                                 }
                               ]
                             }
@@ -598,8 +597,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
                                 {
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}",
-                                  "source": "INTERNAL",
-                                  "uuid": "${json-unit.any-string}"
+                                  "source": "INTERNAL"
                                 }
                               ]
                             }
@@ -1136,7 +1134,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
                               "version": "1.2.3",
                               "affectedVersionAttributions": [
                                 {
-                                  "uuid": "${json-unit.any-string}",
                                   "source": "INTERNAL",
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}"
@@ -1151,7 +1148,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
                               "version": "3.2.1",
                               "affectedVersionAttributions": [
                                 {
-                                  "uuid": "${json-unit.any-string}",
                                   "source": "INTERNAL",
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}"
@@ -1210,7 +1206,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
                               "version": "1.2.3",
                               "affectedVersionAttributions": [
                                 {
-                                  "uuid": "${json-unit.any-string}",
                                   "source": "INTERNAL",
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}"
@@ -1225,7 +1220,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
                               "versionStartIncluding": "3.2.1",
                               "affectedVersionAttributions": [
                                 {
-                                  "uuid": "${json-unit.any-string}",
                                   "source": "INTERNAL",
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}"
@@ -1260,7 +1254,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
                               "version": "1.2.3",
                               "affectedVersionAttributions": [
                                 {
-                                  "uuid": "${json-unit.any-string}",
                                   "source": "INTERNAL",
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}"
@@ -1275,7 +1268,6 @@ public class VulnerabilityResourceTest extends ResourceTest {
                               "versionStartIncluding": "3.2.1",
                               "affectedVersionAttributions": [
                                 {
-                                  "uuid": "${json-unit.any-string}",
                                   "source": "INTERNAL",
                                   "firstSeen": "${json-unit.any-number}",
                                   "lastSeen": "${json-unit.any-number}"
@@ -1300,7 +1292,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         vuln.setSource(Vulnerability.Source.INTERNAL);
         vuln.setVulnerableSoftware(List.of(vs));
         vuln = qm.createVulnerability(vuln);
-        final AffectedVersionAttribution attribution = qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, vuln, vs));
+        qm.persist(new AffectedVersionAttribution(Vulnerability.Source.INTERNAL, vuln, vs));
 
         final Response response = jersey.target(V1_VULNERABILITY + "/" + vuln.getUuid()).request()
                 .header(X_API_KEY, apiKey)
@@ -1308,7 +1300,7 @@ public class VulnerabilityResourceTest extends ResourceTest {
         Assertions.assertEquals(204, response.getStatus());
         Assertions.assertNull(response.getHeaderString(TOTAL_COUNT_HEADER));
 
-        Assertions.assertNull(qm.getObjectByUuid(AffectedVersionAttribution.class, attribution.getUuid()));
+        assertThat(qm.getAffectedVersionAttribution(vuln, vs, Vulnerability.Source.INTERNAL)).isNull();
         Assertions.assertNotNull(qm.getObjectByUuid(VulnerableSoftware.class, vs.getUuid()));
         Assertions.assertNull(qm.getObjectByUuid(Vulnerability.class, vuln.getUuid()));
     }

--- a/migration/src/main/resources/org/dependencytrack/migration/V202605101718__drop_affectedversionattribution_uuid.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/V202605101718__drop_affectedversionattribution_uuid.sql
@@ -1,0 +1,5 @@
+-- Remove unused AFFECTEDVERSIONATTRIBUTION.UUID column.
+-- The associated unique index grows unproportionally large
+-- (i.e. multiple GBs) on deployments with multiple vuln data
+-- sources enabled.
+ALTER TABLE "AFFECTEDVERSIONATTRIBUTION" DROP COLUMN IF EXISTS "UUID";


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes unused UUID column from AFFECTEDVERSIONATTRIBUTION table.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See comment in migration script.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
