### PR TITLE
Fix wasteful existence queries

### DIFF
--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -787,11 +787,11 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
                 .filter("name == :permissionName && users.contains(user) && user.id == :userId")
                 .variables("alpine.model.User user")
                 .setParameters(permissionName, user.getId())
-                .result("count(id)");
+                .range(0, 1)
+                .result("id");
 
-        final long count = query.executeResultUnique(Long.class);
-
-        return count > 0 || (includeTeams && user.getTeams().stream()
+        return !executeAndCloseResultList(query, Long.class).isEmpty()
+                || (includeTeams && user.getTeams().stream()
                 .anyMatch(team -> hasPermission(team, permissionName)));
     }
 
@@ -806,8 +806,9 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
         final Query<Permission> query = pm.newQuery(Permission.class, "name == :permissionName && teams.contains(team) && team.id == :teamId");
         query.declareVariables("alpine.model.Team team");
         query.setParameters(permissionName, team.getId());
-        query.setResult("count(id)");
-        return executeAndCloseResultUnique(query, Long.class) > 0;
+        query.setRange(0, 1);
+        query.setResult("id");
+        return !executeAndCloseResultList(query, Long.class).isEmpty();
     }
 
     /**

--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -785,12 +785,9 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
                     "name", name
             ));
         }
-        query.setResult("count(this)");
-        try {
-            return query.executeResultUnique(Long.class) > 0;
-        } finally {
-            query.closeAll();
-        }
+        query.setRange(0, 1);
+        query.setResult("id");
+        return !executeAndCloseResultList(query, Long.class).isEmpty();
     }
 
     private boolean isChildOf(Project project, UUID uuid) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -572,8 +572,9 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
                 "source", source,
                 "vuln", vulnerability,
                 "vs", vulnerableSoftware));
-        query.setResult("count(this)");
-        return executeAndCloseResultUnique(query, Long.class) > 0;
+        query.setRange(0, 1);
+        query.setResult("id");
+        return !executeAndCloseResultList(query, Long.class).isEmpty();
     }
 
     /**


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/5960

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2154

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
