### PR TITLE
Prevent vuln data sources overriding each other's vulnerability data

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/VulnerabilityUpdatePolicy.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/VulnerabilityUpdatePolicy.java
@@ -30,12 +30,12 @@ import java.util.Map;
 /**
  * @since 5.7.0
  */
-final class VulnerabilityUpdatePolicy {
+public final class VulnerabilityUpdatePolicy {
 
     private final PluginManager pluginManager;
     private final Map<String, Boolean> isMirroringEnabledCache;
 
-    VulnerabilityUpdatePolicy(PluginManager pluginManager) {
+    public VulnerabilityUpdatePolicy(PluginManager pluginManager) {
         this.pluginManager = pluginManager;
         this.isMirroringEnabledCache = new HashMap<>();
     }
@@ -52,6 +52,30 @@ final class VulnerabilityUpdatePolicy {
         // corresponding VulnDataSource is absent or disabled.
         return !isMirroringEnabledCache.computeIfAbsent(
                 normalizedSource, this::isVulnDataSourceEnabled);
+    }
+
+    public boolean isUpdatableByDataSource(String vulnSource, String dataSourceName, boolean exists) {
+        final String normalizedVulnSource = vulnSource.toLowerCase(Locale.ROOT);
+        if ("internal".equals(normalizedVulnSource)) {
+            // Vulnerabilities from the internal source are
+            // categorically not updatable by any data source.
+            return false;
+        }
+
+        if (normalizedVulnSource.equals(dataSourceName.toLowerCase(Locale.ROOT))) {
+            // The data source is the authoritative source for this vulnerability.
+            return true;
+        }
+
+        if (!exists) {
+            // The vulnerability is not yet recorded locally. Allow a non-authoritative
+            // data source to fill the gap until the authoritative one catches up.
+            return true;
+        }
+
+        // Otherwise, allow only if no other enabled data source owns this source.
+        return !isMirroringEnabledCache.computeIfAbsent(
+                normalizedVulnSource, this::isVulnDataSourceEnabled);
     }
 
     private boolean isVulnDataSourceEnabled(String source) {

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -35,6 +35,7 @@ import org.dependencytrack.plugin.runtime.NoSuchExtensionException;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.proto.internal.workflow.v1.MirrorVulnDataSourceArg;
 import org.dependencytrack.util.VulnerabilityUtil;
+import org.dependencytrack.vulnanalysis.VulnerabilityUpdatePolicy;
 import org.dependencytrack.vulndatasource.api.VulnDataSource;
 import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
 import org.jspecify.annotations.Nullable;
@@ -99,6 +100,8 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
                     "Data source %s is not enabled".formatted(arg.getDataSourceName()));
         }
 
+        final var updatePolicy = new VulnerabilityUpdatePolicy(pluginManager);
+
         try (final VulnDataSource dataSource = dataSourceFactory.create()) {
             final var bovBatch = new ArrayList<Bom>(25);
             while (dataSource.hasNext()) {
@@ -111,7 +114,7 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
                 if (!bov.getVulnerabilities(0).hasRejected()) {
                     bovBatch.add(bov);
                     if (bovBatch.size() == 25) {
-                        processBatch(dataSource, bovBatch, source, arg.getDataSourceName());
+                        processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
                         bovBatch.clear();
                     }
                 } else {
@@ -124,7 +127,7 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
             if (!bovBatch.isEmpty()) {
                 ctx.maybeHeartbeat();
-                processBatch(dataSource, bovBatch, source, arg.getDataSourceName());
+                processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
                 bovBatch.clear();
             }
         }
@@ -136,7 +139,8 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             VulnDataSource dataSource,
             Collection<Bom> bovs,
             Vulnerability.Source source,
-            String dataSourceName) {
+            String dataSourceName,
+            VulnerabilityUpdatePolicy updatePolicy) {
         LOGGER.debug("Processing batch of {} BOVs", bovs.size());
 
         final var vulns = new ArrayList<Vulnerability>(bovs.size());
@@ -185,8 +189,16 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
             qm.runInTransaction(() -> {
                 for (final Vulnerability vuln : vulns) {
-                    LOGGER.debug("Synchronizing vulnerability {}", vuln.getVulnId());
                     final Vulnerability existingVuln = getExistingVuln(qm, vuln.getSource(), vuln.getVulnId());
+                    if (!updatePolicy.isUpdatableByDataSource(
+                            vuln.getSource(), dataSourceName, existingVuln != null)) {
+                        LOGGER.debug(
+                                "Skipping vulnerability {} from source {}: authoritative source is enabled",
+                                vuln.getVulnId(), vuln.getSource());
+                        continue;
+                    }
+
+                    LOGGER.debug("Synchronizing vulnerability {}", vuln.getVulnId());
                     final Vulnerability persistentVuln = existingVuln == null
                             ? qm.createVulnerability(vuln)
                             : qm.updateVulnerability(existingVuln, vuln);

--- a/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivityTest.java
@@ -59,6 +59,11 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
     }
 
     private PluginManager createPluginManager(String extensionName, VulnDataSource dataSource) {
+        return createPluginManager(List.of(
+                new TestVulnDataSourceFactory(extensionName, () -> dataSource)));
+    }
+
+    private PluginManager createPluginManager(List<VulnDataSourceFactory> factories) {
         pluginManager = new PluginManager(
                 new SmallRyeConfigBuilder().build(),
                 new NoopCacheManager(),
@@ -66,8 +71,7 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
                 JdbiFactory.createJdbi(),
                 HttpClient.newHttpClient(),
                 List.of(VulnDataSource.class));
-        pluginManager.loadPlugins(List.of(
-                () -> List.of(new TestVulnDataSourceFactory(extensionName, () -> dataSource))));
+        pluginManager.loadPlugins(List.of(() -> List.copyOf(factories)));
         return pluginManager;
     }
 
@@ -125,6 +129,139 @@ class MirrorVulnDataSourceActivityTest extends PersistenceCapableTest {
 
         assertThatExceptionOfType(TerminalApplicationFailureException.class)
                 .isThrownBy(() -> activity.execute(mock(ActivityContext.class), arg));
+    }
+
+    @Test
+    void shouldNotOverwriteExistingVulnWhenAuthoritativeMirrorEnabled() throws Exception {
+        final var existing = new Vulnerability();
+        existing.setVulnId("GHSA-fxwm-579q-49qq");
+        existing.setSource(Vulnerability.Source.GITHUB);
+        existing.setDescription("Authoritative GHSA description");
+        qm.createVulnerability(existing);
+
+        final var bovJson = """
+                {
+                  "vulnerabilities": [
+                    {
+                      "id": "GHSA-fxwm-579q-49qq",
+                      "source": { "name": "GITHUB" },
+                      "description": "Republished by OSV."
+                    }
+                  ]
+                }
+                """;
+
+        final Bom bov = generateBomFromJson(bovJson);
+
+        final var osvDataSourceMock = mock(VulnDataSource.class);
+        doReturn(true, false).when(osvDataSourceMock).hasNext();
+        doReturn(bov).when(osvDataSourceMock).next();
+
+        final var pluginManager = createPluginManager(List.of(
+                new TestVulnDataSourceFactory("osv", () -> osvDataSourceMock),
+                new TestVulnDataSourceFactory("github", () -> mock(VulnDataSource.class))));
+
+        final var activity = new MirrorVulnDataSourceActivity(pluginManager);
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder()
+                .setDataSourceName("osv").setSourceName("OSV").build());
+
+        verify(osvDataSourceMock).markProcessed(eq(bov));
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-fxwm-579q-49qq");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getDescription()).isEqualTo("Authoritative GHSA description");
+    }
+
+    @Test
+    void shouldCreateMissingVulnWhenAuthoritativeMirrorEnabled() throws Exception {
+        final var bovJson = """
+                {
+                  "vulnerabilities": [
+                    {
+                      "id": "GHSA-fxwm-579q-49qq",
+                      "source": { "name": "GITHUB" },
+                      "description": "Republished by OSV."
+                    }
+                  ]
+                }
+                """;
+
+        final Bom bov = generateBomFromJson(bovJson);
+
+        final var osvDataSourceMock = mock(VulnDataSource.class);
+        doReturn(true, false).when(osvDataSourceMock).hasNext();
+        doReturn(bov).when(osvDataSourceMock).next();
+
+        final var pluginManager = createPluginManager(List.of(
+                new TestVulnDataSourceFactory("osv", () -> osvDataSourceMock),
+                new TestVulnDataSourceFactory("github", () -> mock(VulnDataSource.class))));
+
+        final var activity = new MirrorVulnDataSourceActivity(pluginManager);
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder()
+                .setDataSourceName("osv").setSourceName("OSV").build());
+
+        verify(osvDataSourceMock).markProcessed(eq(bov));
+        final Vulnerability vuln = qm.getVulnerabilityByVulnId("GITHUB", "GHSA-fxwm-579q-49qq");
+        assertThat(vuln).isNotNull();
+        assertThat(vuln.getDescription()).isEqualTo("Republished by OSV.");
+    }
+
+    @Test
+    void shouldProcessBovWhenAuthoritativeMirrorAbsent() throws Exception {
+        final var bovJson = """
+                {
+                  "vulnerabilities": [
+                    {
+                      "id": "GHSA-fxwm-579q-49qq",
+                      "source": { "name": "GITHUB" },
+                      "description": "Republished by OSV."
+                    }
+                  ]
+                }
+                """;
+
+        final Bom bov = generateBomFromJson(bovJson);
+
+        final var osvDataSourceMock = mock(VulnDataSource.class);
+        doReturn(true, false).when(osvDataSourceMock).hasNext();
+        doReturn(bov).when(osvDataSourceMock).next();
+
+        final var pluginManager = createPluginManager(List.of(
+                new TestVulnDataSourceFactory("osv", () -> osvDataSourceMock)));
+
+        final var activity = new MirrorVulnDataSourceActivity(pluginManager);
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder()
+                .setDataSourceName("osv").setSourceName("OSV").build());
+
+        verify(osvDataSourceMock).markProcessed(eq(bov));
+        assertThat(qm.getVulnerabilityByVulnId("GITHUB", "GHSA-fxwm-579q-49qq")).isNotNull();
+    }
+
+    @Test
+    void shouldSkipBovFromInternalSource() throws Exception {
+        final var bovJson = """
+                {
+                  "vulnerabilities": [
+                    {
+                      "id": "INT-001",
+                      "source": { "name": "INTERNAL" },
+                      "description": "Should never be overwritten by a mirror."
+                    }
+                  ]
+                }
+                """;
+
+        final Bom bov = generateBomFromJson(bovJson);
+
+        final var osvDataSourceMock = mock(VulnDataSource.class);
+        doReturn(true, false).when(osvDataSourceMock).hasNext();
+        doReturn(bov).when(osvDataSourceMock).next();
+
+        final var activity = new MirrorVulnDataSourceActivity(createPluginManager("osv", osvDataSourceMock));
+        activity.execute(mock(ActivityContext.class), MirrorVulnDataSourceArg.newBuilder()
+                .setDataSourceName("osv").setSourceName("OSV").build());
+
+        verify(osvDataSourceMock).markProcessed(eq(bov));
+        assertThat(qm.getVulnerabilityByVulnId("INTERNAL", "INT-001")).isNull();
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Prevents vuln data sources overriding each other's vulnerability data.

Analogue to what we already do for analyzer result reconciliation, and what we did in v4. The main source of conflict usually is that both GitHub and OSV use GHSA identifiers. When both are enabled, GitHub should be treated as authoritative source, and OSV should not override GHSA data if it exists.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
