### PR TITLE
Resolve EPSS through alias groups at query time

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Epss.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Epss.java
@@ -18,40 +18,18 @@
  */
 package org.dependencytrack.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import javax.jdo.annotations.Column;
-import javax.jdo.annotations.IdGeneratorStrategy;
-import javax.jdo.annotations.PersistenceCapable;
-import javax.jdo.annotations.Persistent;
-import javax.jdo.annotations.PrimaryKey;
-import jakarta.validation.constraints.NotBlank;
 import java.io.Serializable;
 import java.math.BigDecimal;
 
 import static java.util.Objects.requireNonNull;
 
-@PersistenceCapable
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Epss implements Serializable {
 
-    @PrimaryKey
-    @Persistent(valueStrategy = IdGeneratorStrategy.NATIVE)
-    @JsonIgnore
-    private long id;
-
-    @Persistent
-    @Column(name = "CVE", allowsNull = "false")
-    @NotBlank
     private String cve;
-
-    @Persistent
-    @Column(name = "SCORE", scale = 5)
     private BigDecimal score;
-
-    @Persistent
-    @Column(name = "PERCENTILE", scale = 5)
     private BigDecimal percentile;
 
     public Epss() {
@@ -59,16 +37,8 @@ public class Epss implements Serializable {
 
     public Epss(final String cve, final BigDecimal score, final BigDecimal percentile) {
         this.cve = requireNonNull(cve, "cve must not be null");
-        this.score = requireNonNull(score, "score must not be null");
-        this.percentile = requireNonNull(percentile, "percentile must not be null");
-    }
-
-    public long getId() {
-        return id;
-    }
-
-    public void setId(long id) {
-        this.id = id;
+        this.score = score;
+        this.percentile = percentile;
     }
 
     public String getCve() {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/EpssQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/EpssQueryManager.java
@@ -19,46 +19,134 @@
 package org.dependencytrack.persistence;
 
 import org.dependencytrack.model.Epss;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityKey;
+import org.jspecify.annotations.Nullable;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 final class EpssQueryManager extends QueryManager implements IQueryManager {
 
-    /**
-     * Constructs a new QueryManager.
-     *
-     * @param pm a PersistenceManager object
-     */
     EpssQueryManager(final PersistenceManager pm) {
         super(pm);
     }
 
-    /**
-     * Returns a Epss record by its CVE id.
-     * @param cveId the CVE id of the record
-     * @return the matching Epss object, or null if not found
-     */
-    public Epss getEpssByCveId(String cveId) {
-        final Query<Epss> query = pm.newQuery(Epss.class, "cve == :cveId");
-        query.setRange(0, 1);
-        return singleResult(query.execute(cveId));
+    public @Nullable Epss getEffectiveEpssForVuln(String source, String vulnId) {
+        final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                SELECT "CVE"
+                     , "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE ? = 'NVD'
+                       AND ee."CVE" = ?
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE ? != 'NVD'
+                       AND va."SOURCE" = ?
+                       AND va."VULN_ID" = ?
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+                """);
+        query.setParameters(source, vulnId, source, source, vulnId);
+        return executeAndCloseResultUnique(query, Epss.class);
     }
 
-    /**
-     * Returns a map of Epss records matching list of CVE ids.
-     *
-     * @param cveIds List of CVE ids to match
-     * @return the map of CVE ids and Epss records
-     */
-    public Map<String, Epss> getEpssForCveIds(List<String> cveIds) {
-        final Query<Epss> query = pm.newQuery(Epss.class);
-        query.setFilter(":cveList.contains(cve)");
-        return ((List<Epss>) query.execute(cveIds)).stream()
-                .collect(Collectors.toMap(Epss::getCve, Function.identity()));
+    public record EffectiveEpssRow(
+            String vulnSource,
+            String vulnId,
+            String cve,
+            BigDecimal score,
+            BigDecimal percentile) {
     }
+
+    public Map<VulnerabilityKey, Epss> getEffectiveEpssForVulns(Collection<VulnerabilityKey> keys) {
+        if (keys.isEmpty()) {
+            return Map.of();
+        }
+
+        final var sources = new String[keys.size()];
+        final var vulnIds = new String[keys.size()];
+
+        int i = 0;
+        for (final VulnerabilityKey key : keys) {
+            sources[i] = key.source().name();
+            vulnIds[i] = key.vulnId();
+            i++;
+        }
+
+        final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                SELECT t."VULN_SOURCE" AS "vulnSource"
+                     , t."VULN_ID" AS "vulnId"
+                     , best."CVE" AS "cve"
+                     , best."SCORE" AS "score"
+                     , best."PERCENTILE" AS "percentile"
+                  FROM UNNEST(?, ?)
+                    AS t("VULN_SOURCE", "VULN_ID")
+                  LEFT JOIN LATERAL (
+                    SELECT "CVE"
+                         , "SCORE"
+                         , "PERCENTILE"
+                      FROM (
+                        SELECT ee."CVE"
+                             , ee."SCORE"
+                             , ee."PERCENTILE"
+                          FROM "EPSS" AS ee
+                         WHERE t."VULN_SOURCE" = 'NVD'
+                           AND ee."CVE" = t."VULN_ID"
+                        UNION ALL
+                        SELECT ee."CVE"
+                             , ee."SCORE"
+                             , ee."PERCENTILE"
+                          FROM "VULNERABILITY_ALIAS" AS va
+                         INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                            ON cve_a."GROUP_ID" = va."GROUP_ID"
+                           AND cve_a."SOURCE" = 'NVD'
+                         INNER JOIN "EPSS" AS ee
+                            ON ee."CVE" = cve_a."VULN_ID"
+                         WHERE t."VULN_SOURCE" != 'NVD'
+                           AND va."SOURCE" = t."VULN_SOURCE"
+                           AND va."VULN_ID" = t."VULN_ID"
+                      ) candidates
+                     ORDER BY "SCORE" DESC NULLS LAST
+                            , "PERCENTILE" DESC NULLS LAST
+                            , "CVE"
+                     LIMIT 1
+                  ) AS best ON TRUE
+                 WHERE best."CVE" IS NOT NULL
+                """);
+        query.setParameters(sources, vulnIds);
+        final List<EffectiveEpssRow> rows = executeAndCloseResultList(query, EffectiveEpssRow.class);
+
+        final var result = new HashMap<VulnerabilityKey, Epss>(rows.size());
+        for (final EffectiveEpssRow row : rows) {
+            final var key = new VulnerabilityKey(
+                    row.vulnId(),
+                    Vulnerability.Source.valueOf(row.vulnSource()));
+            result.put(key, new Epss(row.cve(), row.score(), row.percentile()));
+        }
+
+        return result;
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -64,6 +64,7 @@ import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.ViolationAnalysis;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
+import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.notification.NotificationLevel;
@@ -1212,12 +1213,12 @@ public class QueryManager extends AlpineQueryManager {
         return getComponentQueryManager().getComponentsByPurl(purl);
     }
 
-    public Epss getEpssByCveId(String cveId) {
-        return getEpssQueryManager().getEpssByCveId(cveId);
+    public Epss getEffectiveEpssForVuln(String source, String vulnId) {
+        return getEpssQueryManager().getEffectiveEpssForVuln(source, vulnId);
     }
 
-    public Map<String, Epss> getEpssForCveIds(List<String> cveIds) {
-        return getEpssQueryManager().getEpssForCveIds(cveIds);
+    public Map<VulnerabilityKey, Epss> getEffectiveEpssForVulns(Collection<VulnerabilityKey> keys) {
+        return getEpssQueryManager().getEffectiveEpssForVulns(keys);
     }
 
     public Set<Tag> resolveTags(final Collection<Tag> tags) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -30,6 +30,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Tag;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityAlias;
+import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao.AffectedProjectCountRow;
@@ -158,7 +159,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         final Vulnerability vulnerability = singleResult(query.execute(source, vulnId));
         if (vulnerability != null) {
             vulnerability.setAliases(getVulnerabilityAliases(vulnerability));
-            vulnerability.setEpss(getEpssByCveId(vulnerability.getVulnId()));
+            vulnerability.setEpss(getEffectiveEpssForVuln(vulnerability.getSource(), vulnerability.getVulnId()));
         }
         return vulnerability;
     }
@@ -303,8 +304,8 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         } else {
             result = execute(query);
         }
-        Map<String, Epss> matchedEpssList = getEpssForCveIds(
-                result.getList(Vulnerability.class).stream().map(Vulnerability::getVulnId).distinct().toList());
+        final Map<VulnerabilityKey, Epss> matchedEpss = getEffectiveEpssForVulns(
+                result.getList(Vulnerability.class).stream().map(VulnerabilityKey::of).distinct().toList());
         final Map<Long, AffectedProjectCountRow> affectedProjectCountRows = withJdbiHandle(
                 this.request,
                 jdbiHandle -> jdbiHandle.attach(VulnerabilityDao.class).getAffectedProjectCount(
@@ -319,7 +320,7 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
                 vulnerability.setAffectedInactiveProjectCount(affectedProjects.totalProjectCount() - affectedProjects.activeProjectCount());
             }
             vulnerability.setAliases(getVulnerabilityAliases(vulnerability));
-            vulnerability.setEpss(matchedEpssList.get(vulnerability.getVulnId()));
+            vulnerability.setEpss(matchedEpss.get(VulnerabilityKey.of(vulnerability)));
         }
         return result;
     }
@@ -361,12 +362,12 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
         final String filter = includeSuppressed ? "components.contains(:component)" : "components.contains(:component)" + generateExcludeSuppressed(component.getProject(), component);
         final Query<Vulnerability> query = pm.newQuery(Vulnerability.class, filter);
         final List<Vulnerability> vulnerabilities = (List<Vulnerability>)query.execute(component);
-        Map<String, Epss> matchedEpssList = getEpssForCveIds(
-                vulnerabilities.stream().map(vuln -> vuln.getVulnId()).distinct().toList());
+        final Map<VulnerabilityKey, Epss> matchedEpss = getEffectiveEpssForVulns(
+                vulnerabilities.stream().map(VulnerabilityKey::of).distinct().toList());
         for (final Vulnerability vulnerability: vulnerabilities) {
             //vulnerability.setAffectedProjectCount(this.getProjects(vulnerability).size());
             vulnerability.setAliases(getVulnerabilityAliases(vulnerability));
-            vulnerability.setEpss(matchedEpssList.get(vulnerability.getVulnId()));
+            vulnerability.setEpss(matchedEpss.get(VulnerabilityKey.of(vulnerability)));
         }
         return vulnerabilities;
     }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -201,8 +201,36 @@ public interface FindingDao {
                 ON c."ID" = cv."COMPONENT_ID"
              INNER JOIN "VULNERABILITY" AS v
                 ON cv."VULNERABILITY_ID" = v."ID"
-              LEFT JOIN "EPSS" AS e
-                ON v."VULNID" = e."CVE"
+              LEFT JOIN LATERAL (
+                SELECT "CVE"
+                     , "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE v."SOURCE" = 'NVD'
+                       AND ee."CVE" = v."VULNID"
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE v."SOURCE" != 'NVD'
+                       AND va."SOURCE" = v."SOURCE"
+                       AND va."VULN_ID" = v."VULNID"
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+              ) AS e ON TRUE
              INNER JOIN LATERAL (
                SELECT *
                  FROM "FINDINGATTRIBUTION" AS fa
@@ -360,8 +388,36 @@ public interface FindingDao {
                 ON c."ID" = cv."COMPONENT_ID"
              INNER JOIN "VULNERABILITY" AS v
                 ON cv."VULNERABILITY_ID" = v."ID"
-             LEFT JOIN "EPSS" AS ep
-                ON v."VULNID" = ep."CVE"
+             LEFT JOIN LATERAL (
+                SELECT "CVE"
+                     , "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE v."SOURCE" = 'NVD'
+                       AND ee."CVE" = v."VULNID"
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE v."SOURCE" != 'NVD'
+                       AND va."SOURCE" = v."SOURCE"
+                       AND va."VULN_ID" = v."VULNID"
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+             ) AS ep ON TRUE
              INNER JOIN LATERAL (
                SELECT *
                  FROM "FINDINGATTRIBUTION" AS fa
@@ -485,8 +541,36 @@ public interface FindingDao {
                        , fa."ID"
                 LIMIT 1
              ) AS fa ON TRUE
-              LEFT JOIN "EPSS" AS ep
-                ON ep."CVE" = v."VULNID"
+              LEFT JOIN LATERAL (
+                SELECT "CVE"
+                     , "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE v."SOURCE" = 'NVD'
+                       AND ee."CVE" = v."VULNID"
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE v."SOURCE" != 'NVD'
+                       AND va."SOURCE" = v."SOURCE"
+                       AND va."VULN_ID" = v."VULNID"
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+              ) AS ep ON TRUE
               LEFT JOIN "ANALYSIS" AS a
                 ON c."ID" = a."COMPONENT_ID"
                AND v."ID" = a."VULNERABILITY_ID"

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -90,8 +90,34 @@ public interface VulnerabilityDao {
                         WHERE "TAG"."ID" = "VULNERABILITIES_TAGS"."TAG_ID"
                     ) AS "vulnTagsJson"
               FROM "VULNERABILITY" AS "V"
-              LEFT JOIN "EPSS"
-                ON "V"."VULNID" = "EPSS"."CVE"
+              LEFT JOIN LATERAL (
+                SELECT "CVE", "SCORE", "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE "V"."SOURCE" = 'NVD'
+                       AND ee."CVE" = "V"."VULNID"
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE "V"."SOURCE" != 'NVD'
+                       AND va."SOURCE" = "V"."SOURCE"
+                       AND va."VULN_ID" = "V"."VULNID"
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+              ) AS "EPSS" ON TRUE
              WHERE 1 = 1
             <#if uuid>
                AND "V"."UUID" = :uuid
@@ -288,8 +314,36 @@ public interface VulnerabilityDao {
               LEFT JOIN "ANALYSIS"
             	ON "V"."ID" = "ANALYSIS"."VULNERABILITY_ID"
                AND "COMPONENT"."PROJECT_ID" = "ANALYSIS"."PROJECT_ID"
-              LEFT JOIN "EPSS"
-            	ON "V"."VULNID" = "EPSS"."CVE"
+              LEFT JOIN LATERAL (
+                SELECT "CVE"
+                     , "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE "V"."SOURCE" = 'NVD'
+                       AND ee."CVE" = "V"."VULNID"
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE "V"."SOURCE" != 'NVD'
+                       AND va."SOURCE" = "V"."SOURCE"
+                       AND va."VULN_ID" = "V"."VULNID"
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+              ) AS "EPSS" ON TRUE
              WHERE TRUE
             <#if !includeSuppressed>
                AND "ANALYSIS"."SUPPRESSED" IS DISTINCT FROM TRUE
@@ -405,8 +459,36 @@ public interface VulnerabilityDao {
                 ON "V"."ID" = "COMPONENTS_VULNERABILITIES"."VULNERABILITY_ID"
              INNER JOIN "COMPONENT"
                 ON "COMPONENTS_VULNERABILITIES"."COMPONENT_ID" = "COMPONENT"."ID"
-              LEFT JOIN "EPSS"
-                ON "V"."VULNID" = "EPSS"."CVE"
+              LEFT JOIN LATERAL (
+                SELECT "CVE"
+                     , "SCORE"
+                     , "PERCENTILE"
+                  FROM (
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "EPSS" AS ee
+                     WHERE "V"."SOURCE" = 'NVD'
+                       AND ee."CVE" = "V"."VULNID"
+                    UNION ALL
+                    SELECT ee."CVE"
+                         , ee."SCORE"
+                         , ee."PERCENTILE"
+                      FROM "VULNERABILITY_ALIAS" AS va
+                     INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                        ON cve_a."GROUP_ID" = va."GROUP_ID"
+                       AND cve_a."SOURCE" = 'NVD'
+                     INNER JOIN "EPSS" AS ee
+                        ON ee."CVE" = cve_a."VULN_ID"
+                     WHERE "V"."SOURCE" != 'NVD'
+                       AND va."SOURCE" = "V"."SOURCE"
+                       AND va."VULN_ID" = "V"."VULNID"
+                  ) candidates
+                 ORDER BY "SCORE" DESC NULLS LAST
+                        , "PERCENTILE" DESC NULLS LAST
+                        , "CVE"
+                 LIMIT 1
+              ) AS "EPSS" ON TRUE
               LEFT JOIN "ANALYSIS"
                 ON "V"."ID" = "ANALYSIS"."VULNERABILITY_ID"
                AND "COMPONENT"."ID" = "ANALYSIS"."COMPONENT_ID"

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/persistence/CelPolicyDao.java
@@ -306,8 +306,36 @@ public final class CelPolicyDao {
                          INNER JOIN "COMPONENT" AS c
                             ON c."ID" = cv."COMPONENT_ID"
                         <#if shouldFetchEpss!false>
-                          LEFT JOIN "EPSS" AS ep
-                            ON v."VULNID" = ep."CVE"
+                          LEFT JOIN LATERAL (
+                            SELECT "CVE"
+                                 , "SCORE"
+                                 , "PERCENTILE"
+                              FROM (
+                                SELECT ee."CVE"
+                                     , ee."SCORE"
+                                     , ee."PERCENTILE"
+                                  FROM "EPSS" AS ee
+                                 WHERE v."SOURCE" = 'NVD'
+                                   AND ee."CVE" = v."VULNID"
+                                UNION ALL
+                                SELECT ee."CVE"
+                                     , ee."SCORE"
+                                     , ee."PERCENTILE"
+                                  FROM "VULNERABILITY_ALIAS" AS va
+                                 INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                                    ON cve_a."GROUP_ID" = va."GROUP_ID"
+                                   AND cve_a."SOURCE" = 'NVD'
+                                 INNER JOIN "EPSS" AS ee
+                                    ON ee."CVE" = cve_a."VULN_ID"
+                                 WHERE v."SOURCE" != 'NVD'
+                                   AND va."SOURCE" = v."SOURCE"
+                                   AND va."VULN_ID" = v."VULNID"
+                              ) candidates
+                             ORDER BY "SCORE" DESC NULLS LAST
+                                    , "PERCENTILE" DESC NULLS LAST
+                                    , "CVE"
+                             LIMIT 1
+                          ) AS ep ON TRUE
                         </#if>
                          WHERE c."PROJECT_ID" = :projectId
                            AND EXISTS (
@@ -700,8 +728,36 @@ public final class CelPolicyDao {
                         </#if>
                           FROM "VULNERABILITY" AS v
                         <#if needsEpss!false>
-                          LEFT JOIN "EPSS" AS ep
-                            ON v."VULNID" = ep."CVE"
+                          LEFT JOIN LATERAL (
+                            SELECT "CVE"
+                                 , "SCORE"
+                                 , "PERCENTILE"
+                              FROM (
+                                SELECT ee."CVE"
+                                     , ee."SCORE"
+                                     , ee."PERCENTILE"
+                                  FROM "EPSS" AS ee
+                                 WHERE v."SOURCE" = 'NVD'
+                                   AND ee."CVE" = v."VULNID"
+                                UNION ALL
+                                SELECT ee."CVE"
+                                     , ee."SCORE"
+                                     , ee."PERCENTILE"
+                                  FROM "VULNERABILITY_ALIAS" AS va
+                                 INNER JOIN "VULNERABILITY_ALIAS" AS cve_a
+                                    ON cve_a."GROUP_ID" = va."GROUP_ID"
+                                   AND cve_a."SOURCE" = 'NVD'
+                                 INNER JOIN "EPSS" AS ee
+                                    ON ee."CVE" = cve_a."VULN_ID"
+                                 WHERE v."SOURCE" != 'NVD'
+                                   AND va."SOURCE" = v."SOURCE"
+                                   AND va."VULN_ID" = v."VULNID"
+                              ) candidates
+                             ORDER BY "SCORE" DESC NULLS LAST
+                                    , "PERCENTILE" DESC NULLS LAST
+                                    , "CVE"
+                             LIMIT 1
+                          ) AS ep ON TRUE
                         </#if>
                          WHERE v."ID" = ANY(:ids)
                         """)

--- a/apiserver/src/main/resources/META-INF/persistence.xml
+++ b/apiserver/src/main/resources/META-INF/persistence.xml
@@ -38,7 +38,6 @@
     <class>org.dependencytrack.model.Component</class>
     <class>org.dependencytrack.model.ComponentOccurrence</class>
     <class>org.dependencytrack.model.ComponentProperty</class>
-    <class>org.dependencytrack.model.Epss</class>
     <class>org.dependencytrack.model.FindingAttribution</class>
     <class>org.dependencytrack.model.License</class>
     <class>org.dependencytrack.model.LicenseGroup</class>

--- a/apiserver/src/test/java/org/dependencytrack/persistence/EpssQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/EpssQueryManagerTest.java
@@ -20,57 +20,127 @@ package org.dependencytrack.persistence;
 
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Epss;
+import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.model.VulnerabilityKey;
+import org.dependencytrack.persistence.jdbi.EpssDao;
+import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 
-public class EpssQueryManagerTest extends PersistenceCapableTest {
+class EpssQueryManagerTest extends PersistenceCapableTest {
 
     @Test
-    public void testGetEpssByCveId() {
-        Epss epss = new Epss();
-        epss.setCve("CVE-000");
-        epss.setScore(BigDecimal.valueOf(0.01));
-        epss.setPercentile(BigDecimal.valueOf(0.02));
-        qm.persist(epss);
+    void shouldReturnDirectEpssForCveSourcedVuln() {
+        persistEpss("CVE-000", "0.01", "0.02");
 
-        assertThat(qm.getEpssByCveId("CVE-000")).satisfies(
-                epssRecord -> {
-                    assertThat(epssRecord.getScore()).isEqualByComparingTo("0.01");
-                    assertThat(epssRecord.getPercentile()).isEqualByComparingTo("0.02");
-                }
-        );
+        assertThat(qm.getEffectiveEpssForVuln(Vulnerability.Source.NVD.name(), "CVE-000"))
+                .isNotNull()
+                .satisfies(e -> {
+                    assertThat(e.getCve()).isEqualTo("CVE-000");
+                    assertThat(e.getScore()).isEqualByComparingTo("0.01");
+                    assertThat(e.getPercentile()).isEqualByComparingTo("0.02");
+                });
     }
 
     @Test
-    public void testShouldReturnNullIfEpssDoesNotExist() {
-        assertThat(qm.getEpssByCveId("CVE-999")).isNull();
+    void shouldReturnNullWhenVulnHasNoCveAndNoAlias() {
+        assertThat(qm.getEffectiveEpssForVuln(Vulnerability.Source.GITHUB.name(), "GHSA-xxxx-yyyy-zzzz")).isNull();
+        assertThat(qm.getEffectiveEpssForVuln(Vulnerability.Source.NVD.name(), "CVE-MISSING")).isNull();
     }
 
     @Test
-    public void testGetEpssForCveIds() {
-        Epss epss1 = new Epss();
-        epss1.setCve("CVE-000");
-        epss1.setScore(BigDecimal.valueOf(0.01));
-        epss1.setPercentile(BigDecimal.valueOf(0.02));
-        Epss epss2 = new Epss();
-        epss2.setCve("CVE-999");
-        epss2.setScore(BigDecimal.valueOf(0.08));
-        epss2.setPercentile(BigDecimal.valueOf(0.09));
-        qm.persist(List.of(epss1, epss2));
+    void shouldReturnEpssForAliasedVuln() {
+        persistEpss("CVE-100", "0.42", "0.88");
+        linkAliases(
+                new VulnerabilityKey("CVE-100", "NVD"),
+                Set.of(new VulnerabilityKey("GHSA-aaaa-bbbb-cccc", "GITHUB")));
 
-        assertThat(qm.getEpssForCveIds(List.of("CVE-000", "CVE-999"))).satisfies(
-                epssRecords -> {
-                    var value = epssRecords.get("CVE-000");
-                    assertThat(value.getScore()).isEqualByComparingTo("0.01");
-                    assertThat(value.getPercentile()).isEqualByComparingTo("0.02");
-                    value = epssRecords.get("CVE-999");
-                    assertThat(value.getScore()).isEqualByComparingTo("0.08");
-                    assertThat(value.getPercentile()).isEqualByComparingTo("0.09");
-                }
-        );
+        assertThat(qm.getEffectiveEpssForVuln(Vulnerability.Source.GITHUB.name(), "GHSA-aaaa-bbbb-cccc"))
+                .isNotNull()
+                .satisfies(e -> {
+                    assertThat(e.getCve()).isEqualTo("CVE-100");
+                    assertThat(e.getScore()).isEqualByComparingTo("0.42");
+                    assertThat(e.getPercentile()).isEqualByComparingTo("0.88");
+                });
+    }
+
+    @Test
+    void shouldReturnMostImpactfulEpssWhenAliasedToMultipleCves() {
+        persistEpss("CVE-200", "0.10", "0.20");
+        persistEpss("CVE-201", "0.90", "0.50");
+        persistEpss("CVE-202", "0.30", "0.40");
+        linkAliases(
+                new VulnerabilityKey("CVE-200", "NVD"),
+                Set.of(
+                        new VulnerabilityKey("CVE-201", "NVD"),
+                        new VulnerabilityKey("CVE-202", "NVD"),
+                        new VulnerabilityKey("GHSA-multi-cve-test", "GITHUB")));
+
+        assertThat(qm.getEffectiveEpssForVuln(Vulnerability.Source.GITHUB.name(), "GHSA-multi-cve-test"))
+                .isNotNull()
+                .satisfies(e -> {
+                    assertThat(e.getCve()).isEqualTo("CVE-201");
+                    assertThat(e.getScore()).isEqualByComparingTo("0.90");
+                });
+    }
+
+    @Test
+    void shouldBreakScoreTiesByPercentileThenByCveAscending() {
+        persistEpss("CVE-301", "0.50", "0.20");
+        persistEpss("CVE-302", "0.50", "0.80");
+        persistEpss("CVE-303", "0.50", "0.80");
+        linkAliases(
+                new VulnerabilityKey("CVE-301", "NVD"),
+                Set.of(
+                        new VulnerabilityKey("CVE-302", "NVD"),
+                        new VulnerabilityKey("CVE-303", "NVD"),
+                        new VulnerabilityKey("GHSA-tie-test", "GITHUB")));
+
+        assertThat(qm.getEffectiveEpssForVuln(Vulnerability.Source.GITHUB.name(), "GHSA-tie-test"))
+                .isNotNull()
+                .satisfies(e -> assertThat(e.getCve()).isEqualTo("CVE-302"));
+    }
+
+    @Test
+    void shouldReturnBatchKeyedBySourceAndVulnId() {
+        persistEpss("CVE-400", "0.10", "0.10");
+        persistEpss("CVE-401", "0.20", "0.20");
+        linkAliases(
+                new VulnerabilityKey("CVE-401", "NVD"),
+                Set.of(new VulnerabilityKey("GHSA-batch-test", "GITHUB")));
+
+        final var result = qm.getEffectiveEpssForVulns(List.of(
+                new VulnerabilityKey("CVE-400", "NVD"),
+                new VulnerabilityKey("GHSA-batch-test", "GITHUB"),
+                new VulnerabilityKey("GHSA-missing", "GITHUB")));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(new VulnerabilityKey("CVE-400", "NVD"))).satisfies(e ->
+                assertThat(e.getScore()).isEqualByComparingTo("0.10"));
+        assertThat(result.get(new VulnerabilityKey("GHSA-batch-test", "GITHUB"))).satisfies(e ->
+                assertThat(e.getCve()).isEqualTo("CVE-401"));
+    }
+
+    @Test
+    void shouldReturnEmptyMapForEmptyBatch() {
+        assertThat(qm.getEffectiveEpssForVulns(List.of())).isEmpty();
+    }
+
+    private void persistEpss(final String cve, final String score, final String percentile) {
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss(cve, new BigDecimal(score), new BigDecimal(percentile)))));
+    }
+
+    private void linkAliases(final VulnerabilityKey vulnKey, final Set<VulnerabilityKey> aliasKeys) {
+        useJdbiTransaction(handle -> new VulnerabilityAliasDao(handle)
+                .syncAssertions("test", Map.of(vulnKey, aliasKeys)));
     }
 }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
@@ -27,6 +27,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityKey;
+import org.dependencytrack.persistence.jdbi.EpssDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -38,6 +39,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 
 public class VulnerabilityQueryManagerTest extends PersistenceCapableTest {
@@ -60,17 +62,16 @@ public class VulnerabilityQueryManagerTest extends PersistenceCapableTest {
             vulnB.setSeverity(Severity.HIGH);
             qm.persist(List.of(vulnA, vulnB));
 
-            var epss = new Epss();
-            epss.setCve(vulnA.getVulnId());
-            epss.setScore(BigDecimal.valueOf(1.2));
-            epss.setPercentile(BigDecimal.valueOf(3.4));
-            qm.persist(epss);
+            useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                    .createOrUpdateAll(List.of(new Epss(
+                            "CVE-2024-0001", BigDecimal.valueOf(1.2), BigDecimal.valueOf(3.4)))));
 
             useJdbiTransaction(handle -> new VulnerabilityAliasDao(handle)
                     .syncAssertions(
                             "TEST",
                             new VulnerabilityKey("INT-001", Vulnerability.Source.INTERNAL),
                             Set.of(
+                                    new VulnerabilityKey("CVE-2024-0001", Vulnerability.Source.NVD),
                                     new VulnerabilityKey("GO-1000", Vulnerability.Source.OSV),
                                     new VulnerabilityKey("SNYK-1000", Vulnerability.Source.SNYK))));
 

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/CelPolicyEngineTest.java
@@ -42,6 +42,7 @@ import org.dependencytrack.model.ViolationAnalysisState;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityKey;
 import org.dependencytrack.persistence.command.MakeViolationAnalysisCommand;
+import org.dependencytrack.persistence.jdbi.EpssDao;
 import org.dependencytrack.persistence.jdbi.PackageArtifactMetadataDao;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
@@ -257,11 +258,9 @@ class CelPolicyEngineTest extends PersistenceCapableTest {
                                 new VulnerabilityKey("SONATYPE-001", Vulnerability.Source.OSSINDEX),
                                 new VulnerabilityKey("VULNDB-001", Vulnerability.Source.VULNDB))));
 
-        final var epss = new Epss();
-        epss.setCve("CVE-001");
-        epss.setScore(BigDecimal.valueOf(0.6));
-        epss.setPercentile(BigDecimal.valueOf(0.2));
-        qm.persist(epss);
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss(
+                        "CVE-001", BigDecimal.valueOf(0.6), BigDecimal.valueOf(0.2)))));
 
         final Policy policy = qm.createPolicy("policy", Policy.Operator.ALL, Policy.ViolationState.INFO);
         qm.createPolicyCondition(policy, PolicyCondition.Subject.EXPRESSION, PolicyCondition.Operator.MATCHES, """

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/compat/EpssConditionTest.java
@@ -26,11 +26,13 @@ import org.dependencytrack.model.PolicyCondition;
 import org.dependencytrack.model.PolicyCondition.Operator;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Vulnerability;
+import org.dependencytrack.persistence.jdbi.EpssDao;
 import org.dependencytrack.policy.cel.CelPolicyEngine;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.PolicyCondition.Operator.MATCHES;
@@ -40,6 +42,7 @@ import static org.dependencytrack.model.PolicyCondition.Operator.NUMERIC_GREATER
 import static org.dependencytrack.model.PolicyCondition.Operator.NUMERIC_LESSER_THAN_OR_EQUAL;
 import static org.dependencytrack.model.PolicyCondition.Operator.NUMERIC_LESS_THAN;
 import static org.dependencytrack.model.PolicyCondition.Operator.NUMERIC_NOT_EQUAL;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 
 public class EpssConditionTest extends PersistenceCapableTest {
 
@@ -109,10 +112,11 @@ public class EpssConditionTest extends PersistenceCapableTest {
 
         qm.addVulnerability(vuln, component, "internal");
 
-        final var epss = new Epss();
-        epss.setCve("CVE-123");
-        epss.setScore(vulnEpssScore != null ? BigDecimal.valueOf(vulnEpssScore) : null);
-        qm.persist(epss);
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss(
+                        "CVE-123",
+                        vulnEpssScore != null ? BigDecimal.valueOf(vulnEpssScore) : null,
+                        null))));
 
         new CelPolicyEngine().evaluateProject(project.getUuid());
         if (expectViolation) {

--- a/apiserver/src/test/java/org/dependencytrack/policy/cel/persistence/CelPolicyDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/policy/cel/persistence/CelPolicyDaoTest.java
@@ -38,6 +38,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerabilityKey;
+import org.dependencytrack.persistence.jdbi.EpssDao;
 import org.dependencytrack.persistence.jdbi.PackageArtifactMetadataDao;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityAliasDao;
@@ -284,11 +285,9 @@ public class CelPolicyDaoTest extends PersistenceCapableTest {
                         new VulnerabilityKey("CVE-001", Vulnerability.Source.NVD),
                         Set.of(new VulnerabilityKey("GHSA-001", Vulnerability.Source.GITHUB))));
 
-        final var epss = new Epss();
-        epss.setCve("CVE-001");
-        epss.setScore(BigDecimal.valueOf(0.6));
-        epss.setPercentile(BigDecimal.valueOf(0.2));
-        qm.persist(epss);
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss(
+                        "CVE-001", BigDecimal.valueOf(0.6), BigDecimal.valueOf(0.2)))));
 
         final var requirements = new HashSetValuedHashMap<CelType, String>();
         requirements.putAll(TYPE_VULNERABILITY, org.dependencytrack.proto.policy.v1.Vulnerability.getDescriptor().getFields().stream()

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -47,6 +47,7 @@ import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
+import org.dependencytrack.persistence.jdbi.EpssDao;
 import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
@@ -1467,15 +1468,13 @@ public class FindingResourceTest extends ResourceTest {
     private Vulnerability createVulnerabilityWithEpss(String vulnId, Severity severity, BigDecimal epssScore) {
         Vulnerability vulnerability = new Vulnerability();
         vulnerability.setVulnId(vulnId);
-        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSource(Vulnerability.Source.NVD);
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
         vulnerability = qm.createVulnerability(vulnerability);
 
-        var epss = new Epss();
-        epss.setCve(vulnId);
-        epss.setScore(epssScore);
-        qm.persist(epss);
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss(vulnId, epssScore, null))));
 
         return vulnerability;
     }
@@ -1483,15 +1482,13 @@ public class FindingResourceTest extends ResourceTest {
     private Vulnerability createVulnerabilityWithEpssPercentile(String vulnId, Severity severity, BigDecimal epssPercentile) {
         Vulnerability vulnerability = new Vulnerability();
         vulnerability.setVulnId(vulnId);
-        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSource(Vulnerability.Source.NVD);
         vulnerability.setSeverity(severity);
         vulnerability.setCwes(List.of(80, 666));
         vulnerability = qm.createVulnerability(vulnerability);
 
-        var epss = new Epss();
-        epss.setCve(vulnId);
-        epss.setPercentile(epssPercentile);
-        qm.persist(epss);
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss(vulnId, null, epssPercentile))));
 
         return vulnerability;
     }

--- a/apiserver/src/test/java/org/dependencytrack/tasks/EpssMirrorTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/EpssMirrorTaskTest.java
@@ -22,6 +22,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.event.EpssMirrorEvent;
 import org.dependencytrack.model.Epss;
+import org.dependencytrack.persistence.jdbi.EpssDao;
+import org.jdbi.v3.core.mapper.reflect.BeanMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -40,6 +42,8 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_EPSS_ENABLED;
 import static org.dependencytrack.model.ConfigPropertyConstants.VULNERABILITY_SOURCE_EPSS_FEEDS_URL;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 class EpssMirrorTaskTest extends PersistenceCapableTest {
 
@@ -96,12 +100,12 @@ class EpssMirrorTaskTest extends PersistenceCapableTest {
 
         // Create an existing EPSS record for CVE-1999-0001.
         // It must be updated as part of the mirroring operation.
-        qm.persist(new Epss("CVE-1999-0001", BigDecimal.ONE, BigDecimal.ZERO));
+        useJdbiHandle(handle -> handle.attach(EpssDao.class)
+                .createOrUpdateAll(List.of(new Epss("CVE-1999-0001", BigDecimal.ONE, BigDecimal.ZERO))));
 
         new EpssMirrorTask(httpClient).inform(new EpssMirrorEvent());
 
-        qm.getPersistenceManager().evictAll();
-        final List<Epss> epssRecords = qm.getPersistenceManager().newQuery(Epss.class).executeList();
+        final List<Epss> epssRecords = findAllEpss();
 
         assertThat(epssRecords).satisfiesExactlyInAnyOrder(
                 epssRecord -> {
@@ -152,8 +156,7 @@ class EpssMirrorTaskTest extends PersistenceCapableTest {
 
         new EpssMirrorTask(httpClient).inform(new EpssMirrorEvent());
 
-        final List<Epss> epssRecords = qm.getPersistenceManager().newQuery(Epss.class).executeList();
-        assertThat(epssRecords).isEmpty();
+        assertThat(findAllEpss()).isEmpty();
     }
 
     @Test
@@ -173,8 +176,18 @@ class EpssMirrorTaskTest extends PersistenceCapableTest {
 
         new EpssMirrorTask(httpClient).inform(new EpssMirrorEvent());
 
-        final List<Epss> epssRecords = qm.getPersistenceManager().newQuery(Epss.class).executeList();
-        assertThat(epssRecords).isEmpty();
+        assertThat(findAllEpss()).isEmpty();
+    }
+
+    private static List<Epss> findAllEpss() {
+        return withJdbiHandle(handle -> handle.createQuery("""
+                        SELECT "CVE" AS "cve"
+                             , "SCORE" AS "score"
+                             , "PERCENTILE" AS "percentile"
+                          FROM "EPSS"
+                        """)
+                .map(BeanMapper.of(Epss.class))
+                .list());
     }
 
 }

--- a/docs/adr/022-read-time-epss-resolution-via-alias.md
+++ b/docs/adr/022-read-time-epss-resolution-via-alias.md
@@ -1,0 +1,97 @@
+| Status   | Date       | Author(s)                            |
+|:---------|:-----------|:-------------------------------------|
+| Accepted | 2026-05-11 | [@nscuro](https://github.com/nscuro) |
+
+## Context
+
+[EPSS][epss] is a CVE-level signal published daily by [FIRST][first-org].
+It is stored in a dedicated `EPSS` table keyed by CVE ID. 
+The FIRST mirror is the sole writer. The table has no provenance column.
+
+Some vulnerability data sources publish EPSS values of their own, scoped to the
+identifiers they own. Accepting those values would mean a second writer competes for
+the same CVE-keyed rows. Without provenance there is no way to attribute or prioritise
+either value, so the last writer wins per source and per cycle. Coverage is also
+asymmetric: any non-authoritative source covers only the subset of CVEs it tracks.
+
+The alias schema (see [ADR-014][adr-014]) already groups equivalent vulnerability identifiers
+across sources by shared group identifier, so a non-CVE vulnerability can be linked to its
+CVE sibling at query time. Sorting and filtering by EPSS happens in SQL today and must keep working.
+
+## Decision
+
+EPSS is owned by one authoritative source. We will keep the FIRST mirror as the
+sole writer and not accept EPSS values from any vulnerability data source.
+
+We will resolve EPSS at read time by joining through the alias group. A CVE-sourced
+vulnerability resolves directly. A non-CVE vulnerability inherits the EPSS of its CVE
+sibling. When the alias group contains multiple CVEs, the most impactful record is
+returned, ordered by score, then by percentile, then by CVE identifier.
+
+The resolution is expressed inline at each read site as a correlated `LEFT JOIN LATERAL`,
+parameterized by the caller's source and vulnerability identifier. The branch that does
+not match the caller's source still executes, but its predicate is unsatisfiable so it
+reduces to an empty index probe rather than a row-producing scan. Each call therefore
+performs effectively one index seek path. Sort and filter on score and percentile
+remain pure SQL.
+
+### Rejected alternatives
+
+#### SQL view
+
+A view that callers join by name is the intuitive design, but neither form we tried
+performs acceptably at realistic data volumes.
+
+A view that picks the per-group best record via a window function acts as a planner
+optimisation fence: PostgreSQL cannot fold it into the surrounding query, so every
+join materialises the full candidate set before the outer filter applies. This is the
+same mechanism that prevents predicate pushdown into `WITH ... AS MATERIALIZED`
+queries.[^pg-with]
+
+A reformulation without a window function is foldable into the parent query, but the
+planner still does not push the caller's `(source, vuln_id)` predicates into the
+relevant part of the resolution. The candidate set is materialised regardless.
+Disabling hash and merge joins to force per-row evaluation produces a worse plan,
+because the predicates surface as residual filters above the materialised set.
+
+The lateral form sidesteps the planner by writing the parameterisation explicitly into
+the query. Its cost scales with caller size, whereas the view's cost scales with size
+of the `EPSS` table.
+
+#### Provenance column on `EPSS` table
+
+Adding a `SOURCE` column to `EPSS` and changing the primary key to `(SOURCE, CVE)`
+would let multiple mirrors write without overwriting each other. Reads would pick a
+value via a fixed source priority (e.g. FIRST wins, others as fallback) or aggregate
+across sources.
+
+EPSS has a single methodology, owned by FIRST. Other sources that surface EPSS values
+republish FIRST's data. Storing both yields two copies of the same number with no
+independent signal, plus a priority policy that has to deal will mirror-lag
+discrepancies forever.
+
+Provenance also does not remove the alias join. A non-CVE vulnerability with no EPSS
+row of its own still needs to resolve through its CVE sibling, so the lateral
+resolution stays. Provenance would add a second mechanism on top of it rather than
+replace it.
+
+## Consequences
+
+Any vulnerability with a CVE alias gains EPSS coverage with no per-source ingest
+change. New data sources benefit automatically. The `EPSS` table schema is unchanged
+and no provenance migration is needed.
+
+Each call performs an index seek on `EPSS` directly (NVD source) or via
+`VULNERABILITY_ALIAS` and then `EPSS` (non-NVD source). All columns involved are
+indexed.
+
+The resolution snippet is duplicated across read sites. Acceptable, as the logic is
+stable and tied to this ADR.
+
+Vulnerabilities with no CVE alias receive no EPSS. This is acceptable because EPSS is
+defined per CVE.
+
+[adr-014]: ./014-new-alias-schema.md
+[epss]: https://www.first.org/epss/
+[first-org]: https://www.first.org/
+[^pg-with]: PostgreSQL docs, [WITH Queries](https://www.postgresql.org/docs/current/queries-with.html), §7.8.2.


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Resolves EPSS through alias groups at query time.

Effectively ports https://github.com/DependencyTrack/hyades-apiserver/pull/1993

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/2105
Supersedes https://github.com/DependencyTrack/hyades-apiserver/pull/1993

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

See included ADR.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- [x] This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
