### PR TITLE
Treat dex activity serialization failures as terminal

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -22,6 +22,7 @@ import io.github.resilience4j.core.IntervalFunction;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.dependencytrack.dex.api.RetryPolicy;
 import org.dependencytrack.dex.api.failure.ApplicationFailureException;
+import org.dependencytrack.dex.api.failure.TerminalApplicationFailureException;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskAbandonedEvent;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskCompletedEvent;
 import org.dependencytrack.dex.engine.TaskEvent.ActivityTaskFailedEvent;
@@ -94,7 +95,19 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
             }
 
             final var ctx = new ActivityContextImpl(engine, task, activityMetadata.lockTimeout());
-            final var arg = activityMetadata.argumentConverter().convertFromPayload(task.argument());
+
+            final Object arg;
+            try {
+                arg = activityMetadata.argumentConverter().convertFromPayload(task.argument());
+            } catch (RuntimeException e) {
+                logger.warn("Failed to deserialize activity argument; Failing task terminally", e);
+                engine.onTaskEvent(
+                        new ActivityTaskFailedEvent(
+                                task,
+                                new TerminalApplicationFailureException(e),
+                                /* retryAt */ null));
+                return;
+            }
 
             final Future<Object> future;
             try {
@@ -108,7 +121,18 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
 
             try {
                 final Object activityResult = future.get();
-                final Payload result = activityMetadata.resultConverter().convertToPayload(activityResult);
+                final Payload result;
+                try {
+                    result = activityMetadata.resultConverter().convertToPayload(activityResult);
+                } catch (RuntimeException e) {
+                    logger.warn("Failed to serialize activity result; Failing task terminally", e);
+                    engine.onTaskEvent(
+                            new ActivityTaskFailedEvent(
+                                    task,
+                                    new TerminalApplicationFailureException(e),
+                                    /* retryAt */ null));
+                    return;
+                }
                 engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
             } catch (ExecutionException e) {
                 final Throwable cause = e.getCause();

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -54,6 +54,7 @@ import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
 import org.dependencytrack.dex.engine.api.request.UpdateTaskQueueRequest;
 import org.dependencytrack.dex.engine.api.response.CreateWorkflowRunResponse;
 import org.dependencytrack.dex.proto.event.v1.WorkflowEvent;
+import org.dependencytrack.dex.proto.payload.v1.Payload;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
@@ -1056,6 +1057,115 @@ class DexEngineImplTest {
                 entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_STARTED),
                 entry -> {
                     assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.ACTIVITY_TASK_FAILED);
+                },
+                entry -> {
+                    assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_COMPLETED);
+                    assertThat(entry.getRunCompleted().getStatus()).isEqualTo(WORKFLOW_RUN_STATUS_FAILED);
+                },
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_COMPLETED));
+    }
+
+    @Test
+    void shouldFailActivityTerminallyOnArgumentDeserializationError() {
+        final PayloadConverter<String> throwingArgumentConverter = new PayloadConverter<>() {
+            @Override
+            public Payload convertToPayload(String value) {
+                return stringConverter().convertToPayload(value);
+            }
+
+            @Override
+            public String convertFromPayload(Payload payload) {
+                throw new RuntimeException("boom");
+            }
+        };
+
+        final var activityInvocations = new AtomicInteger(0);
+
+        registerWorkflow("test", (ctx, arg) -> {
+            ctx.callActivity("abc", ACTIVITY_TASK_QUEUE, "input", stringConverter(), stringConverter(), RetryPolicy.ofDefault()).await();
+            return null;
+        });
+        registerActivity("abc", throwingArgumentConverter, stringConverter(), (ctx, arg) -> {
+            activityInvocations.incrementAndGet();
+            return arg;
+        });
+        registerWorkflowWorker("workflow-worker", 1);
+        registerTaskWorker("activity-worker", 1);
+        engine.start();
+
+        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+        awaitRunStatus(runId, WorkflowRunStatus.FAILED);
+
+        assertThat(activityInvocations).hasValue(0);
+
+        final List<WorkflowEvent> historyEvents = engine
+                .listRunHistory(new ListWorkflowRunHistoryRequest(runId).withLimit(20))
+                .items()
+                .stream()
+                .map(WorkflowRunHistoryEntry::event)
+                .toList();
+        assertThat(historyEvents).satisfiesExactly(
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_STARTED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_CREATED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_STARTED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.ACTIVITY_TASK_CREATED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_COMPLETED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_STARTED),
+                entry -> {
+                    assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.ACTIVITY_TASK_FAILED);
+                    assertThat(entry.getActivityTaskFailed().getAttempts()).isEqualTo(1);
+                },
+                entry -> {
+                    assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_COMPLETED);
+                    assertThat(entry.getRunCompleted().getStatus()).isEqualTo(WORKFLOW_RUN_STATUS_FAILED);
+                },
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_COMPLETED));
+    }
+
+    @Test
+    void shouldFailActivityTerminallyOnResultSerializationError() {
+        final PayloadConverter<String> throwingResultConverter = new PayloadConverter<>() {
+            @Override
+            public Payload convertToPayload(String value) {
+                throw new RuntimeException("boom");
+            }
+
+            @Override
+            public String convertFromPayload(Payload payload) {
+                return stringConverter().convertFromPayload(payload);
+            }
+        };
+
+        registerWorkflow("test", (ctx, arg) -> {
+            ctx.callActivity("abc", ACTIVITY_TASK_QUEUE, null, voidConverter(), stringConverter(), RetryPolicy.ofDefault()).await();
+            return null;
+        });
+        registerActivity("abc", voidConverter(), throwingResultConverter, (ctx, arg) -> "result");
+        registerWorkflowWorker("workflow-worker", 1);
+        registerTaskWorker("activity-worker", 1);
+        engine.start();
+
+        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+        awaitRunStatus(runId, WorkflowRunStatus.FAILED);
+
+        final List<WorkflowEvent> historyEvents = engine
+                .listRunHistory(new ListWorkflowRunHistoryRequest(runId).withLimit(20))
+                .items()
+                .stream()
+                .map(WorkflowRunHistoryEntry::event)
+                .toList();
+        assertThat(historyEvents).satisfiesExactly(
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_STARTED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_CREATED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_STARTED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.ACTIVITY_TASK_CREATED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_COMPLETED),
+                entry -> assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.WORKFLOW_TASK_STARTED),
+                entry -> {
+                    assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.ACTIVITY_TASK_FAILED);
+                    assertThat(entry.getActivityTaskFailed().getAttempts()).isEqualTo(1);
                 },
                 entry -> {
                     assertThat(entry.getSubjectCase()).isEqualTo(WorkflowEvent.SubjectCase.RUN_COMPLETED);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Treats dex activity serialization failures as terminal.

Failure to deserialize arguments or serialize results was previously treated as non-terminal failure, that caused tasks to be abandoned, leaving them in a retry loop that would never resolve itself. Since activity arguments and results are deterministic, serialization failures are now immediately treated as terminal.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
