### PR TITLE
Resolve dex heartbeat futures exceptionally on transaction failure

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -1486,8 +1486,9 @@ final class DexEngineImpl implements DexEngine {
     }
 
     private void processActivityTaskHeartbeats(List<ActivityTaskHeartbeat> heartbeats) {
-        // TODO: Complete all futures exceptionally when transaction fails.
-        final Map<ActivityTaskId, TaskLock> lockByTaskId = jdbi.inTransaction(handle -> {
+        final Map<ActivityTaskId, TaskLock> lockByTaskId;
+        try {
+            lockByTaskId = jdbi.inTransaction(handle -> {
             final Update update = handle.createUpdate("""
                     update dex_activity_task as task
                        set locked_until = locked_until + t.lock_timeout
@@ -1540,7 +1541,13 @@ final class DexEngineImpl implements DexEngine {
                                     ctx.findColumnMapperFor(Instant.class).orElseThrow().map(rs, "locked_until", ctx),
                                     rs.getInt("lock_version"))))
                     .collectToMap(Map.Entry::getKey, Map.Entry::getValue);
-        });
+            });
+        } catch (RuntimeException e) {
+            for (final ActivityTaskHeartbeat heartbeat : heartbeats) {
+                heartbeat.future().completeExceptionally(e);
+            }
+            throw e;
+        }
 
         final Map<ActivityTaskId, CompletableFuture<TaskLock>> futureByTaskId = heartbeats.stream()
                 .collect(Collectors.toMap(


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Resolves heartbeat futures exceptionally on transaction failure.

Since all heartbeats are flushed atomically, resolving them more-or-less blindly is safe.

Prior to this fix, activities that had requested a heartbeat were left waiting forever for their futures to complete.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
