### PR TITLE
Only poll dex tasks for which a corresponding workflow or activity is registered

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/ActivityDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/ActivityDao.java
@@ -235,12 +235,14 @@ public final class ActivityDao extends AbstractDao {
                       as t(activity_name, lock_timeout)
                 ),
                 cte_poll as (
-                  select workflow_run_id
-                       , created_event_id
-                       , activity_name
+                  select dat.workflow_run_id
+                       , dat.created_event_id
+                       , dat.activity_name
                     from dex_activity_task as dat
                    inner join dex_activity_task_queue as queue
                       on queue.name = dat.queue_name
+                   inner join cte_poll_req
+                      on cte_poll_req.activity_name = dat.activity_name
                    where dat.queue_name = :queueName
                      and queue.status = 'ACTIVE'
                      and dat.status = 'QUEUED'

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
@@ -430,11 +430,19 @@ public final class WorkflowDao extends AbstractDao {
             int limit) {
         final Query query = jdbiHandle.createQuery("""
                 with
+                cte_poll_req as (
+                  select *
+                    from unnest(:workflowNames, :lockTimeouts)
+                      as t(workflow_name, lock_timeout)
+                ),
                 cte_poll as (
-                  select workflow_run_id
+                  select task.workflow_run_id
+                       , cte_poll_req.lock_timeout
                     from dex_workflow_task as task
                    inner join dex_workflow_task_queue as queue
                       on queue.name = task.queue_name
+                   inner join cte_poll_req
+                      on cte_poll_req.workflow_name = task.workflow_name
                    where task.queue_name = :queueName
                      and queue.status = 'ACTIVE'
                      and (
@@ -452,12 +460,7 @@ public final class WorkflowDao extends AbstractDao {
                 cte_locked as (
                   update dex_workflow_task as task
                      set locked_by = :engineInstanceId
-                       , locked_until = now() + (
-                           select t.lock_timeout
-                             from unnest(:workflowNames, :lockTimeouts) as t(workflow_name, lock_timeout)
-                            where t.workflow_name = task.workflow_name
-                            limit 1
-                         )
+                       , locked_until = now() + cte_poll.lock_timeout
                        , lock_version = lock_version + 1
                    from cte_poll
                   where task.queue_name = :queueName


### PR DESCRIPTION

### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Only polls dex tasks for which a corresponding workflow or activity is registered.

Tasks without corresponding registration were immediately abandoned in Java after polling, causing potential unnecessary churn. Only poll for tasks with active registrations to prevent that.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
