### PR TITLE
Add circuit breakers for dex buffers

### DIFF
--- a/dex/engine/pom.xml
+++ b/dex/engine/pom.xml
@@ -146,7 +146,15 @@
 
         <dependency>
             <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-circuitbreaker</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.resilience4j</groupId>
+            <artifactId>resilience4j-micrometer</artifactId>
         </dependency>
 
         <dependency>

--- a/dex/engine/src/main/java/module-info.java
+++ b/dex/engine/src/main/java/module-info.java
@@ -31,7 +31,9 @@ module org.dependencytrack.dex.engine {
     requires com.github.benmanes.caffeine;
     requires com.google.protobuf.util;
     requires com.google.protobuf;
+    requires io.github.resilience4j.circuitbreaker;
     requires io.github.resilience4j.core;
+    requires io.github.resilience4j.micrometer;
     requires java.sql;
     requires micrometer.core;
     requires org.jdbi.v3.core;

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/AbstractTaskWorker.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
@@ -57,6 +58,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
     private final int maxConcurrency;
     private final Semaphore semaphore;
     private final MeterRegistry meterRegistry;
+    private final BooleanSupplier downstreamAcceptsWork;
     private final Lock statusLock;
     final Logger logger;
 
@@ -66,6 +68,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
     private @Nullable ExecutorService taskExecutor;
     private @Nullable Timer pollLatencyTimer;
     private @Nullable Counter pollsCounter;
+    private @Nullable Counter backpressureSkipsCounter;
     private @Nullable MeterProvider<DistributionSummary> polledTasksDistribution;
     private @Nullable MeterProvider<Counter> processedCounter;
     private @Nullable MeterProvider<Timer> processLatencyTimer;
@@ -75,11 +78,13 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
             final Duration minPollInterval,
             final IntervalFunction pollBackoffFunction,
             final int maxConcurrency,
-            final MeterRegistry meterRegistry) {
+            final MeterRegistry meterRegistry,
+            final BooleanSupplier downstreamAcceptsWork) {
         this.name = name;
         this.minPollIntervalMillis = requireNonNull(minPollInterval, "minPollInterval must not be null").toMillis();
         this.pollBackoffFunction = requireNonNull(pollBackoffFunction, "pollBackoffFunction must not be null");
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry must not be null");
+        this.downstreamAcceptsWork = requireNonNull(downstreamAcceptsWork, "downstreamAcceptsWork must not be null");
         this.statusLock = new ReentrantLock();
         this.maxConcurrency = maxConcurrency;
         this.semaphore = new Semaphore(maxConcurrency);
@@ -115,6 +120,10 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 .register(meterRegistry);
         pollsCounter = Counter
                 .builder("dt.dex.engine.task.worker.polls")
+                .tags(commonMeterTags)
+                .register(meterRegistry);
+        backpressureSkipsCounter = Counter
+                .builder("dt.dex.engine.task.worker.poll.skipped.backpressure")
                 .tags(commonMeterTags)
                 .register(meterRegistry);
         polledTasksDistribution = DistributionSummary
@@ -204,6 +213,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
         long nextPollDueInMillis;
         int pollsWithoutResults = 0;
         int consecutiveErrors = 0;
+        int consecutiveBackpressureSkips = 0;
 
         while (!status.isStoppingOrStopped() && !Thread.currentThread().isInterrupted()) {
             try {
@@ -213,16 +223,19 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 }
 
                 // Start backing off after 2 poll attempts that did not yield any results,
-                // OR if errors occurred previously. It doesn't make sense to keep polling
-                // at high frequency if the system sits idle or is experiencing issues.
-                if (pollsWithoutResults < 3 && consecutiveErrors == 0) {
+                // OR if errors occurred previously, OR if downstream is unhealthy. It doesn't
+                // make sense to keep polling at high frequency if the system sits idle, is
+                // experiencing issues, or cannot process results.
+                if (pollsWithoutResults < 3 && consecutiveErrors == 0 && consecutiveBackpressureSkips == 0) {
                     nowMillis = System.currentTimeMillis();
                     nextPollAtMillis = lastPolledAtMillis + minPollIntervalMillis;
                     nextPollDueInMillis = nextPollAtMillis > nowMillis
                             ? nextPollAtMillis - nowMillis
                             : 0;
                 } else {
-                    final int backoffAttempts = Math.max(pollsWithoutResults - 2, consecutiveErrors);
+                    final int backoffAttempts = Math.max(
+                            Math.max(pollsWithoutResults - 2, consecutiveErrors),
+                            consecutiveBackpressureSkips);
                     nextPollDueInMillis = Math.max(
                             pollBackoffFunction.apply(backoffAttempts),
                             minPollIntervalMillis);
@@ -264,6 +277,14 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                     continue;
                 }
 
+                if (!downstreamAcceptsWork.getAsBoolean()) {
+                    logger.debug("Skipping poll: downstream is not accepting work");
+                    backpressureSkipsCounter.increment();
+                    consecutiveBackpressureSkips++;
+                    lastPolledAtMillis = System.currentTimeMillis();
+                    continue;
+                }
+
                 logger.debug("Polling for up to {} tasks", tasksToPoll);
                 lastPolledAtMillis = System.currentTimeMillis();
                 pollsCounter.increment();
@@ -275,6 +296,8 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 } finally {
                     pollLatencySample.stop(pollLatencyTimer);
                 }
+
+                consecutiveBackpressureSkips = 0;
 
                 if (polledTasks.isEmpty()) {
                     pollsWithoutResults++;
@@ -322,6 +345,7 @@ abstract class AbstractTaskWorker<T extends Task> implements TaskWorker {
                 }
             } catch (Throwable t) {
                 consecutiveErrors++;
+                consecutiveBackpressureSkips = 0;
                 logger.error("Unexpected error occurred while polling for tasks (attempt {})", consecutiveErrors, t);
             }
         }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -60,8 +61,9 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
             final MetadataRegistry metadataRegistry,
             final String queueName,
             final int maxConcurrency,
-            final MeterRegistry meterRegistry) {
-        super(name, minPollInterval, pollBackoffIntervalFunction, maxConcurrency, meterRegistry);
+            final MeterRegistry meterRegistry,
+            final BooleanSupplier downstreamAcceptsWork) {
+        super(name, minPollInterval, pollBackoffIntervalFunction, maxConcurrency, meterRegistry, downstreamAcceptsWork);
         this.engine = requireNonNull(engine, "engine must not be null");
         this.metadataRegistry = requireNonNull(metadataRegistry, "metadataRegistry must not be null");
         this.queueName = requireNonNull(queueName, "queueName must not be null");

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -21,6 +21,10 @@ package org.dependencytrack.dex.engine;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.protobuf.util.Timestamps;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import io.github.resilience4j.core.IntervalFunction;
+import io.github.resilience4j.micrometer.tagged.TaggedCircuitBreakerMetrics;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.MeterProvider;
@@ -75,6 +79,7 @@ import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowEvents;
 import org.dependencytrack.dex.engine.persistence.model.PolledWorkflowTask;
 import org.dependencytrack.dex.engine.persistence.request.GetWorkflowRunHistoryRequest;
 import org.dependencytrack.dex.engine.support.Buffer;
+import org.dependencytrack.dex.engine.support.CircuitBreakerStateTransitionLogger;
 import org.dependencytrack.dex.proto.event.v1.ActivityTaskCompleted;
 import org.dependencytrack.dex.proto.event.v1.ActivityTaskFailed;
 import org.dependencytrack.dex.proto.event.v1.ChildRunFailed;
@@ -164,6 +169,7 @@ final class DexEngineImpl implements DexEngine {
     private @Nullable Buffer<ExternalEvent> externalEventBuffer;
     private @Nullable Buffer<TaskEvent> taskEventBuffer;
     private @Nullable Buffer<ActivityTaskHeartbeat> activityTaskHeartbeatBuffer;
+    private @Nullable CircuitBreakerRegistry bufferFlushCircuitBreakerRegistry;
     private @Nullable MaintenanceWorker maintenanceWorker;
     private @Nullable Cache<WorkflowRunHistoryCacheKey, CachedWorkflowRunHistory> runHistoryCache;
 
@@ -268,13 +274,47 @@ final class DexEngineImpl implements DexEngine {
             LOGGER.debug("Not starting task schedulers because leader election is disabled");
         }
 
+        LOGGER.debug("Initializing buffer flush circuit breaker registry");
+        bufferFlushCircuitBreakerRegistry = CircuitBreakerRegistry.of(
+                // NB: Config is hardcoded for now because exposing it significantly
+                // increases config surface. We can always add that later if necessary.
+                CircuitBreakerConfig.custom()
+                        .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                        // A sliding window of 20 calls is ~2s of history assuming a ~100ms flush interval,
+                        // which keeps detection responsive without flipping on a single hiccup.
+                        .slidingWindowSize(20)
+                        // Calculate failure rate only after at least 10 calls.
+                        // Avoids opening on cold starts before the window has settled.
+                        .minimumNumberOfCalls(10)
+                        // Transition to open state when at least 50% of calls failed.
+                        .failureRateThreshold(50.0f)
+                        // Calls slower than this are considered slow.
+                        // 5s is ~50x a healthy flush, and should be sufficient padding
+                        // to account for GC pauses or comparable blips.
+                        .slowCallDurationThreshold(Duration.ofSeconds(5))
+                        // Transition to open state when at least 80% of calls were slow.
+                        .slowCallRateThreshold(80.0f)
+                        .permittedNumberOfCallsInHalfOpenState(1)
+                        .waitIntervalFunctionInOpenState(
+                                IntervalFunction.ofExponentialRandomBackoff(
+                                        /* initialInterval */ Duration.ofSeconds(1),
+                                        /* multiplier */ 2.0,
+                                        /* randomizationFactor */ 0.3,
+                                        /* maxInterval */ Duration.ofSeconds(30)))
+                        .build());
+        TaggedCircuitBreakerMetrics
+                .ofCircuitBreakerRegistry(bufferFlushCircuitBreakerRegistry)
+                .bindTo(config.metrics().meterRegistry());
+        CircuitBreakerStateTransitionLogger.attach(bufferFlushCircuitBreakerRegistry);
+
         LOGGER.debug("Starting external event buffer");
         externalEventBuffer = new Buffer<>(
                 "external-event",
                 this::flushExternalEvents,
                 config.externalEventBuffer().flushInterval(),
                 config.externalEventBuffer().maxBatchSize(),
-                config.metrics().meterRegistry());
+                config.metrics().meterRegistry(),
+                bufferFlushCircuitBreakerRegistry);
         externalEventBuffer.start();
 
         // The buffer's flush interval should be long enough to allow
@@ -289,7 +329,8 @@ final class DexEngineImpl implements DexEngine {
                 this::flushTaskEvents,
                 config.taskEventBuffer().flushInterval(),
                 config.taskEventBuffer().maxBatchSize(),
-                config.metrics().meterRegistry());
+                config.metrics().meterRegistry(),
+                bufferFlushCircuitBreakerRegistry);
         taskEventBuffer.start();
 
         LOGGER.debug("Starting activity task heartbeat buffer");
@@ -298,7 +339,8 @@ final class DexEngineImpl implements DexEngine {
                 this::processActivityTaskHeartbeats,
                 config.activityTaskHeartbeatBuffer().flushInterval(),
                 config.activityTaskHeartbeatBuffer().maxBatchSize(),
-                config.metrics().meterRegistry());
+                config.metrics().meterRegistry(),
+                bufferFlushCircuitBreakerRegistry);
         activityTaskHeartbeatBuffer.start();
 
         if (config.leaderElection().isEnabled()) {
@@ -421,6 +463,10 @@ final class DexEngineImpl implements DexEngine {
             isUp &= taskEventBuffer.status() == Buffer.Status.RUNNING;
             responseBuilder.withData("buffer:" + taskEventBuffer.name(), taskEventBuffer.status().name());
         }
+        if (activityTaskHeartbeatBuffer != null) {
+            isUp &= activityTaskHeartbeatBuffer.status() == Buffer.Status.RUNNING;
+            responseBuilder.withData("buffer:" + activityTaskHeartbeatBuffer.name(), activityTaskHeartbeatBuffer.status().name());
+        }
 
         for (final Map.Entry<String, TaskWorker> entry : taskWorkerByName.entrySet()) {
             isUp &= entry.getValue().status() == TaskWorker.Status.RUNNING;
@@ -514,7 +560,9 @@ final class DexEngineImpl implements DexEngine {
                 metadataRegistry,
                 options.queueName(),
                 options.maxConcurrency(),
-                config.metrics().meterRegistry());
+                config.metrics().meterRegistry(),
+                () -> (taskEventBuffer == null || taskEventBuffer.acceptsWork())
+                        && (activityTaskHeartbeatBuffer == null || activityTaskHeartbeatBuffer.acceptsWork()));
 
         if (taskWorkerByName.putIfAbsent("activity/" + options.name(), worker) != null) {
             throw new IllegalStateException(
@@ -541,7 +589,8 @@ final class DexEngineImpl implements DexEngine {
                 options.minPollInterval(),
                 options.pollBackoffFunction(),
                 options.maxConcurrency(),
-                config.metrics().meterRegistry());
+                config.metrics().meterRegistry(),
+                () -> taskEventBuffer == null || taskEventBuffer.acceptsWork());
 
         if (taskWorkerByName.putIfAbsent("workflow/" + options.name(), worker) != null) {
             throw new IllegalStateException(
@@ -1489,58 +1538,58 @@ final class DexEngineImpl implements DexEngine {
         final Map<ActivityTaskId, TaskLock> lockByTaskId;
         try {
             lockByTaskId = jdbi.inTransaction(handle -> {
-            final Update update = handle.createUpdate("""
-                    update dex_activity_task as task
-                       set locked_until = locked_until + t.lock_timeout
-                         , lock_version = task.lock_version + 1
-                         , updated_at = now()
-                      from unnest(:queueNames, :workflowRunIds, :createdEventIds, :lockTimeouts, :lockVersions)
-                        as t(queue_name, workflow_run_id, created_event_id, lock_timeout, lock_version)
-                     where task.queue_name = t.queue_name
-                       and task.workflow_run_id = t.workflow_run_id
-                       and task.created_event_id = t.created_event_id
-                       and task.locked_by = :engineInstanceId
-                       and task.lock_version = t.lock_version
-                    returning task.queue_name
-                            , task.workflow_run_id
-                            , task.created_event_id
-                            , task.locked_until
-                            , task.lock_version
-                    """);
+                final Update update = handle.createUpdate("""
+                        update dex_activity_task as task
+                           set locked_until = locked_until + t.lock_timeout
+                             , lock_version = task.lock_version + 1
+                             , updated_at = now()
+                          from unnest(:queueNames, :workflowRunIds, :createdEventIds, :lockTimeouts, :lockVersions)
+                            as t(queue_name, workflow_run_id, created_event_id, lock_timeout, lock_version)
+                         where task.queue_name = t.queue_name
+                           and task.workflow_run_id = t.workflow_run_id
+                           and task.created_event_id = t.created_event_id
+                           and task.locked_by = :engineInstanceId
+                           and task.lock_version = t.lock_version
+                        returning task.queue_name
+                                , task.workflow_run_id
+                                , task.created_event_id
+                                , task.locked_until
+                                , task.lock_version
+                        """);
 
-            final var queueNames = new String[heartbeats.size()];
-            final var workflowRunIds = new UUID[heartbeats.size()];
-            final var createdEventIds = new int[heartbeats.size()];
-            final var lockTimeouts = new Duration[heartbeats.size()];
-            final var lockVersions = new int[heartbeats.size()];
+                final var queueNames = new String[heartbeats.size()];
+                final var workflowRunIds = new UUID[heartbeats.size()];
+                final var createdEventIds = new int[heartbeats.size()];
+                final var lockTimeouts = new Duration[heartbeats.size()];
+                final var lockVersions = new int[heartbeats.size()];
 
-            int i = 0;
-            for (final ActivityTaskHeartbeat heartbeat : heartbeats) {
-                queueNames[i] = heartbeat.taskId().queueName();
-                workflowRunIds[i] = heartbeat.taskId().workflowRunId();
-                createdEventIds[i] = heartbeat.taskId().createdEventId();
-                lockTimeouts[i] = heartbeat.lockTimeout();
-                lockVersions[i] = heartbeat.lock().version();
-                i++;
-            }
+                int i = 0;
+                for (final ActivityTaskHeartbeat heartbeat : heartbeats) {
+                    queueNames[i] = heartbeat.taskId().queueName();
+                    workflowRunIds[i] = heartbeat.taskId().workflowRunId();
+                    createdEventIds[i] = heartbeat.taskId().createdEventId();
+                    lockTimeouts[i] = heartbeat.lockTimeout();
+                    lockVersions[i] = heartbeat.lock().version();
+                    i++;
+                }
 
-            return update
-                    .bind("engineInstanceId", config.instanceId())
-                    .bind("queueNames", queueNames)
-                    .bind("workflowRunIds", workflowRunIds)
-                    .bind("createdEventIds", createdEventIds)
-                    .bind("lockTimeouts", lockTimeouts)
-                    .bind("lockVersions", lockVersions)
-                    .executeAndReturnGeneratedKeys("locked_until")
-                    .map((rs, ctx) -> Map.entry(
-                            new ActivityTaskId(
-                                    rs.getString("queue_name"),
-                                    rs.getObject("workflow_run_id", UUID.class),
-                                    rs.getInt("created_event_id")),
-                            new TaskLock(
-                                    ctx.findColumnMapperFor(Instant.class).orElseThrow().map(rs, "locked_until", ctx),
-                                    rs.getInt("lock_version"))))
-                    .collectToMap(Map.Entry::getKey, Map.Entry::getValue);
+                return update
+                        .bind("engineInstanceId", config.instanceId())
+                        .bind("queueNames", queueNames)
+                        .bind("workflowRunIds", workflowRunIds)
+                        .bind("createdEventIds", createdEventIds)
+                        .bind("lockTimeouts", lockTimeouts)
+                        .bind("lockVersions", lockVersions)
+                        .executeAndReturnGeneratedKeys("locked_until")
+                        .map((rs, ctx) -> Map.entry(
+                                new ActivityTaskId(
+                                        rs.getString("queue_name"),
+                                        rs.getObject("workflow_run_id", UUID.class),
+                                        rs.getInt("created_event_id")),
+                                new TaskLock(
+                                        ctx.findColumnMapperFor(Instant.class).orElseThrow().map(rs, "locked_until", ctx),
+                                        rs.getInt("lock_version"))))
+                        .collectToMap(Map.Entry::getKey, Map.Entry::getValue);
             });
         } catch (RuntimeException e) {
             for (final ActivityTaskHeartbeat heartbeat : heartbeats) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
@@ -33,6 +33,7 @@ import org.slf4j.MDC;
 import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.function.BooleanSupplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -51,8 +52,9 @@ final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
             final Duration minPollInterval,
             final IntervalFunction pollBackoffIntervalFunction,
             final int maxConcurrency,
-            final MeterRegistry meterRegistry) {
-        super(name, minPollInterval, pollBackoffIntervalFunction, maxConcurrency, meterRegistry);
+            final MeterRegistry meterRegistry,
+            final BooleanSupplier downstreamAcceptsWork) {
+        super(name, minPollInterval, pollBackoffIntervalFunction, maxConcurrency, meterRegistry, downstreamAcceptsWork);
         this.engine = requireNonNull(engine, "engine must not be null");
         this.metadataRegistry = requireNonNull(metadataRegistry, "metadataRegistry must not be null");
         this.queueName = requireNonNull(queueName, "queueName must not be null");

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
@@ -18,6 +18,8 @@
  */
 package org.dependencytrack.dex.engine.support;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Gauge;
@@ -41,6 +43,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+
+import static io.github.resilience4j.circuitbreaker.CallNotPermittedException.createCallNotPermittedException;
 
 public final class Buffer<T> implements Closeable {
 
@@ -84,6 +88,7 @@ public final class Buffer<T> implements Closeable {
     private final ReentrantLock flushLock;
     private final ReentrantLock statusLock;
     private final MeterRegistry meterRegistry;
+    private final CircuitBreaker circuitBreaker;
     private volatile Status status = Status.CREATED;
     private @Nullable DistributionSummary batchSizeDistribution;
     private @Nullable Timer itemWaitLatencyTimer;
@@ -95,8 +100,10 @@ public final class Buffer<T> implements Closeable {
             Consumer<List<T>> batchConsumer,
             Duration flushInterval,
             int maxBatchSize,
-            MeterRegistry meterRegistry) {
-        this(name, batchConsumer, flushInterval, maxBatchSize, Duration.ofSeconds(5), meterRegistry);
+            MeterRegistry meterRegistry,
+            CircuitBreakerRegistry circuitBreakerRegistry) {
+        this(name, batchConsumer, flushInterval, maxBatchSize, Duration.ofSeconds(5),
+                meterRegistry, circuitBreakerRegistry);
     }
 
     Buffer(
@@ -105,7 +112,8 @@ public final class Buffer<T> implements Closeable {
             Duration flushInterval,
             int maxBatchSize,
             Duration itemsQueueTimeout,
-            MeterRegistry meterRegistry) {
+            MeterRegistry meterRegistry,
+            CircuitBreakerRegistry circuitBreakerRegistry) {
         this.name = name;
         this.batchConsumer = batchConsumer;
         this.maxBatchSize = maxBatchSize;
@@ -126,6 +134,7 @@ public final class Buffer<T> implements Closeable {
         this.flushLock = new ReentrantLock();
         this.statusLock = new ReentrantLock();
         this.meterRegistry = meterRegistry;
+        this.circuitBreaker = circuitBreakerRegistry.circuitBreaker("dt.dex.engine.buffer." + name);
     }
 
     public String name() {
@@ -134,6 +143,14 @@ public final class Buffer<T> implements Closeable {
 
     public Status status() {
         return status;
+    }
+
+    public boolean acceptsWork() {
+        // NB: In the future we might want to include itemsQueue depth here.
+        // A queue at capacity won't accept new items, so calls to #add() may
+        // time out.
+        return status == Status.RUNNING
+                && circuitBreaker.getState() != CircuitBreaker.State.OPEN;
     }
 
     public void start() {
@@ -263,18 +280,55 @@ public final class Buffer<T> implements Closeable {
         }
 
         try {
-            if (itemsQueue.isEmpty()) {
+            // NB: tryAcquirePermission drives state transitions (e.g. OPEN -> HALF_OPEN),
+            // so it must be called on every tick to enable recovery, including when the
+            // queue is empty. Otherwise, once workers back off via acceptsWork():
+            //   1. no items arrive
+            //   2. no permission is ever attempted
+            //   3. the breaker stays OPEN indefinitely
+            //   4. workers never resume polling
+            // When permission is denied, we still drain up to maxBatchSize and fail
+            // those futures fast with CallNotPermittedException, so producers don't sit on
+            // Buffer#add until timeout and the queue doesn't grow unboundedly while the breaker is open.
+            final boolean permitted = circuitBreaker.tryAcquirePermission();
+            itemsQueue.drainTo(currentBatch, maxBatchSize);
+
+            if (currentBatch.isEmpty()) {
+                if (permitted) {
+                    // We acquired a permission but have no work to drive a probe.
+                    // Release so the next tick with work can acquire instead.
+                    circuitBreaker.releasePermission();
+                }
                 LOGGER.debug("{}: Buffer is empty; Nothing to flush", name);
                 return;
             }
 
-            itemsQueue.drainTo(currentBatch, maxBatchSize);
-            batchSizeDistribution.record(currentBatch.size());
+            if (!permitted) {
+                if (status == Status.RUNNING) {
+                    LOGGER.debug("{}: Circuit breaker rejected flush", name);
+                }
+                final long nowNanos = System.nanoTime();
 
+                for (final BufferedItem<T> item : currentBatch) {
+                    item.future().completeExceptionally(
+                            createCallNotPermittedException(circuitBreaker));
+                    itemWaitLatencyTimer.record(
+                            nowNanos - item.addedAtNanos(),
+                            TimeUnit.NANOSECONDS);
+                }
+
+                currentBatch.clear();
+                return;
+            }
+
+            batchSizeDistribution.record(currentBatch.size());
             LOGGER.debug("{}: Flushing batch of {} items", name, currentBatch.size());
             final Timer.Sample flushLatencySample = Timer.start();
+            final long startNanos = System.nanoTime();
             try {
-                batchConsumer.accept(currentBatch.stream().map(BufferedItem::item).collect(Collectors.toList()));
+                final List<T> batchItems = currentBatch.stream().map(BufferedItem::item).collect(Collectors.toList());
+                batchConsumer.accept(batchItems);
+                circuitBreaker.onSuccess(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS);
 
                 final long nowNanos = System.nanoTime();
                 for (final BufferedItem<T> item : currentBatch) {
@@ -284,6 +338,8 @@ public final class Buffer<T> implements Closeable {
                             TimeUnit.NANOSECONDS);
                 }
             } catch (Throwable e) {
+                circuitBreaker.onError(System.nanoTime() - startNanos, TimeUnit.NANOSECONDS, e);
+
                 final long nowNanos = System.nanoTime();
                 for (final BufferedItem<T> item : currentBatch) {
                     item.future().completeExceptionally(e);

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/CircuitBreakerStateTransitionLogger.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/CircuitBreakerStateTransitionLogger.java
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine.support;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class CircuitBreakerStateTransitionLogger {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CircuitBreakerStateTransitionLogger.class);
+
+    private CircuitBreakerStateTransitionLogger() {
+    }
+
+    public static void attach(CircuitBreakerRegistry registry) {
+        registry.getEventPublisher().onEntryAdded(
+                entryEvent -> onBreakerAdded(entryEvent.getAddedEntry()));
+        registry.getEventPublisher().onEntryReplaced(
+                entryEvent -> onBreakerAdded(entryEvent.getNewEntry()));
+    }
+
+    private static void onBreakerAdded(CircuitBreaker breaker) {
+        breaker.getEventPublisher().onStateTransition(transitionEvent -> {
+            final CircuitBreaker.Metrics metrics = breaker.getMetrics();
+            switch (transitionEvent.getStateTransition().getToState()) {
+                case OPEN -> LOGGER.warn(
+                        "Circuit breaker {} opened (failureRate={}%, slowCallRate={}%, calls={})",
+                        breaker.getName(),
+                        metrics.getFailureRate(),
+                        metrics.getSlowCallRate(),
+                        metrics.getNumberOfBufferedCalls());
+                case HALF_OPEN -> LOGGER.info(
+                        "Circuit breaker {} is half-open; probing recovery",
+                        breaker.getName());
+                case CLOSED -> LOGGER.info(
+                        "Circuit breaker {} closed; downstream healthy",
+                        breaker.getName());
+                default -> {
+                }
+            }
+        });
+    }
+
+}

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/AbstractTaskWorkerTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/AbstractTaskWorkerTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
@@ -57,10 +58,34 @@ class AbstractTaskWorkerTest {
     }
 
     @Test
+    void shouldSkipPollWhenDownstreamDoesNotAcceptWork() throws Exception {
+        final var downstreamAccepts = new AtomicBoolean(false);
+        final var processGate = new CountDownLatch(1);
+        final var processStarted = new CountDownLatch(1);
+        worker = new TestWorker("test", 1, meterRegistry, processGate, processStarted, downstreamAccepts::get);
+        worker.start();
+
+        worker.queueTwoTasks();
+
+        await("Backpressure skips increment")
+                .atMost(Duration.ofSeconds(2))
+                .untilAsserted(() -> assertThat(meterRegistry.get("dt.dex.engine.task.worker.poll.skipped.backpressure")
+                        .tag("workerType", "TestWorker")
+                        .counter().count()).isGreaterThan(0.0));
+
+        assertThat(processStarted.getCount()).isEqualTo(1);
+
+        downstreamAccepts.set(true);
+
+        assertThat(processStarted.await(5, TimeUnit.SECONDS)).isTrue();
+        processGate.countDown();
+    }
+
+    @Test
     void shouldExposeConcurrencyUtilizationGauge() throws Exception {
         final var processGate = new CountDownLatch(1);
         final var processStarted = new CountDownLatch(2);
-        worker = new TestWorker("test", 4, meterRegistry, processGate, processStarted);
+        worker = new TestWorker("test", 4, meterRegistry, processGate, processStarted, () -> true);
         worker.start();
 
         assertThat(meterRegistry.get("dt.dex.engine.task.worker.concurrency.utilization")
@@ -100,13 +125,15 @@ class AbstractTaskWorkerTest {
                 int maxConcurrency,
                 MeterRegistry meterRegistry,
                 CountDownLatch processGate,
-                CountDownLatch processStarted) {
+                CountDownLatch processStarted,
+                java.util.function.BooleanSupplier downstreamAcceptsWork) {
             super(
                     name,
                     Duration.ofMillis(10),
                     IntervalFunction.of(Duration.ofMillis(10)),
                     maxConcurrency,
-                    meterRegistry);
+                    meterRegistry,
+                    downstreamAcceptsWork);
             this.processGate = processGate;
             this.processStarted = processStarted;
         }

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -1917,6 +1917,7 @@ class DexEngineImplTest {
             assertThat(response.getData().get()).containsExactlyInAnyOrderEntriesOf(
                     Map.ofEntries(
                             Map.entry("internalStatus", "RUNNING"),
+                            Map.entry("buffer:activity-task-heartbeat", "RUNNING"),
                             Map.entry("buffer:external-event", "RUNNING"),
                             Map.entry("buffer:task-event", "RUNNING")));
         }

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/support/BufferTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/support/BufferTest.java
@@ -18,6 +18,9 @@
  */
 package org.dependencytrack.dex.engine.support;
 
+import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.Test;
@@ -27,11 +30,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
 
 class BufferTest {
 
@@ -44,7 +50,8 @@ class BufferTest {
                 flushedItems::addAll,
                 Duration.ofMillis(10),
                 /* maxBatchSize */ 10,
-                new SimpleMeterRegistry());
+                new SimpleMeterRegistry(),
+                CircuitBreakerRegistry.ofDefaults());
 
         try (buffer) {
             buffer.start();
@@ -66,7 +73,8 @@ class BufferTest {
                 batchConsumer,
                 Duration.ZERO,
                 /* maxBatchSize */ 10,
-                new SimpleMeterRegistry());
+                new SimpleMeterRegistry(),
+                CircuitBreakerRegistry.ofDefaults());
 
         try (buffer) {
             assertThatExceptionOfType(IllegalStateException.class)
@@ -85,7 +93,8 @@ class BufferTest {
                 Duration.ofMillis(50),
                 /* maxBatchSize */ 2,
                 Duration.ofSeconds(5),
-                new SimpleMeterRegistry());
+                new SimpleMeterRegistry(),
+                CircuitBreakerRegistry.ofDefaults());
 
         try (buffer) {
             buffer.start();
@@ -94,6 +103,152 @@ class BufferTest {
             buffer.add("bar").get(100, TimeUnit.MILLISECONDS);
 
             assertThat(flushedBatches).containsExactly(List.of("foo", "bar"));
+        }
+    }
+
+    @Test
+    void shouldOpenCircuitBreakerAfterRepeatedFailures() throws Exception {
+        final var flushAttempts = new AtomicInteger();
+        final Consumer<List<String>> batchConsumer = batch -> {
+            flushAttempts.incrementAndGet();
+            throw new RuntimeException("downstream broken");
+        };
+
+        final var registry = CircuitBreakerRegistry.of(
+                CircuitBreakerConfig.custom()
+                        .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                        .slidingWindowSize(3)
+                        .minimumNumberOfCalls(3)
+                        .failureRateThreshold(50.0f)
+                        .waitDurationInOpenState(Duration.ofMinutes(1))
+                        .build());
+
+        final var buffer = new Buffer<>(
+                "test",
+                batchConsumer,
+                Duration.ofMillis(10),
+                /* maxBatchSize */ 1,
+                Duration.ofMillis(100),
+                new SimpleMeterRegistry(),
+                registry);
+
+        try (buffer) {
+            buffer.start();
+
+            for (int i = 0; i < 3; i++) {
+                final CompletableFuture<Void> future = buffer.add("item-" + i);
+                assertThatExceptionOfType(ExecutionException.class)
+                        .isThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS));
+            }
+
+            await().atMost(Duration.ofSeconds(1)).until(() -> !buffer.acceptsWork());
+
+            final int attemptsWhenOpened = flushAttempts.get();
+            await("No further flush attempts while breaker is open")
+                    .during(Duration.ofMillis(200))
+                    .atMost(Duration.ofMillis(500))
+                    .untilAsserted(() -> assertThat(flushAttempts.get()).isEqualTo(attemptsWhenOpened));
+        }
+    }
+
+    @Test
+    void shouldRecoverFromOpenStateOnSuccessfulProbe() throws Exception {
+        final var shouldFail = new java.util.concurrent.atomic.AtomicBoolean(true);
+        final var flushedBatches = new ArrayBlockingQueue<List<String>>(10);
+        final Consumer<List<String>> batchConsumer = batch -> {
+            if (shouldFail.get()) {
+                throw new RuntimeException("downstream broken");
+            }
+            flushedBatches.add(List.copyOf(batch));
+        };
+
+        final var registry = CircuitBreakerRegistry.of(
+                CircuitBreakerConfig.custom()
+                        .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                        .slidingWindowSize(2)
+                        .minimumNumberOfCalls(2)
+                        .failureRateThreshold(50.0f)
+                        .waitDurationInOpenState(Duration.ofMillis(200))
+                        .permittedNumberOfCallsInHalfOpenState(1)
+                        .build());
+
+        final var buffer = new Buffer<>(
+                "test",
+                batchConsumer,
+                Duration.ofMillis(20),
+                /* maxBatchSize */ 1,
+                Duration.ofMillis(100),
+                new SimpleMeterRegistry(),
+                registry);
+
+        try (buffer) {
+            buffer.start();
+
+            for (int i = 0; i < 2; i++) {
+                final CompletableFuture<Void> future = buffer.add("fail-" + i);
+                assertThatExceptionOfType(ExecutionException.class)
+                        .isThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS));
+            }
+
+            await().atMost(Duration.ofSeconds(1)).until(() -> !buffer.acceptsWork());
+
+            shouldFail.set(false);
+
+            await().atMost(Duration.ofSeconds(5))
+                    .pollInterval(Duration.ofMillis(50))
+                    .until(() -> {
+                        try {
+                            buffer.add("recovery").get(200, TimeUnit.MILLISECONDS);
+                            return true;
+                        } catch (Exception e) {
+                            return false;
+                        }
+                    });
+
+            assertThat(flushedBatches).contains(List.of("recovery"));
+            assertThat(buffer.acceptsWork()).isTrue();
+        }
+    }
+
+    @Test
+    void addShouldFailFastWhileBreakerIsOpen() throws Exception {
+        final Consumer<List<String>> batchConsumer = batch -> {
+            throw new RuntimeException("downstream broken");
+        };
+
+        final var registry = CircuitBreakerRegistry.of(
+                CircuitBreakerConfig.custom()
+                        .slidingWindowType(CircuitBreakerConfig.SlidingWindowType.COUNT_BASED)
+                        .slidingWindowSize(2)
+                        .minimumNumberOfCalls(2)
+                        .failureRateThreshold(50.0f)
+                        .waitDurationInOpenState(Duration.ofMinutes(1))
+                        .build());
+
+        final var buffer = new Buffer<>(
+                "test",
+                batchConsumer,
+                Duration.ofMillis(10),
+                /* maxBatchSize */ 1,
+                /* itemsQueueTimeout */ Duration.ofMillis(100),
+                new SimpleMeterRegistry(),
+                registry);
+
+        try (buffer) {
+            buffer.start();
+
+            for (int i = 0; i < 2; i++) {
+                final CompletableFuture<Void> future = buffer.add("fail-" + i);
+                assertThatExceptionOfType(ExecutionException.class)
+                        .isThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS));
+            }
+
+            await().atMost(Duration.ofSeconds(1)).until(() -> !buffer.acceptsWork());
+
+            final CompletableFuture<Void> future = buffer.add("rejected");
+            assertThatExceptionOfType(ExecutionException.class)
+                    .isThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS))
+                    .withCauseInstanceOf(CallNotPermittedException.class);
         }
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds circuit breakers for dex buffers.

Enables us to apply backpressure to workers, i.e. to stop polling when task even buffer is experiencing continuous failures. Also covers slow buffer flushes, although with a much more permissive budget.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
