### PR TITLE
Fix hasPermission check for detached User objects

### DIFF
--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AlpineQueryManager.java
@@ -783,32 +783,31 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
      * @since 1.0.0
      */
     public boolean hasPermission(final User user, String permissionName, boolean includeTeams) {
-        Query<Permission> query = pm.newQuery(Permission.class)
-                .filter("name == :permissionName && users.contains(user) && user.id == :userId")
-                .variables("alpine.model.User user")
-                .setParameters(permissionName, user.getId())
-                .range(0, 1)
-                .result("id");
-
-        return !executeAndCloseResultList(query, Long.class).isEmpty()
-                || (includeTeams && user.getTeams().stream()
-                .anyMatch(team -> hasPermission(team, permissionName)));
-    }
-
-    /**
-     * Determines if the specified Team has been assigned the specified permission.
-     * @param team the Team to query
-     * @param permissionName the name of the permission
-     * @return true if the team has the permission assigned, false if not
-     * @since 1.0.0
-     */
-    public boolean hasPermission(final Team team, String permissionName) {
-        final Query<Permission> query = pm.newQuery(Permission.class, "name == :permissionName && teams.contains(team) && team.id == :teamId");
-        query.declareVariables("alpine.model.Team team");
-        query.setParameters(permissionName, team.getId());
-        query.setRange(0, 1);
-        query.setResult("id");
-        return !executeAndCloseResultList(query, Long.class).isEmpty();
+        final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                SELECT EXISTS (
+                  SELECT 1
+                    FROM "USERS_PERMISSIONS" up
+                   INNER JOIN "PERMISSION" p
+                      ON p."ID" = up."PERMISSION_ID"
+                   WHERE up."USER_ID" = :userId
+                     AND p."NAME" = :permissionName
+                  UNION ALL
+                  SELECT 1
+                    FROM "USERS_TEAMS" ut
+                   INNER JOIN "TEAMS_PERMISSIONS" tp
+                      ON tp."TEAM_ID" = ut."TEAM_ID"
+                   INNER JOIN "PERMISSION" p
+                      ON p."ID" = tp."PERMISSION_ID"
+                   WHERE :includeTeams = TRUE
+                     AND ut."USER_ID" = :userId
+                     AND p."NAME" = :permissionName
+                )
+                """);
+        query.setNamedParameters(Map.of(
+                "userId", user.getId(),
+                "permissionName", permissionName,
+                "includeTeams", includeTeams));
+        return executeAndCloseResultUnique(query, Boolean.class);
     }
 
     /**
@@ -819,18 +818,22 @@ public class AlpineQueryManager extends AbstractAlpineQueryManager {
      * @since 1.1.1
      */
     public boolean hasPermission(final ApiKey apiKey, String permissionName) {
-        if (apiKey.getTeams() == null) {
-            return false;
-        }
-        for (final Team team: apiKey.getTeams()) {
-            final List<Permission> teamPermissions = getObjectById(Team.class, team.getId()).getPermissions();
-            for (final Permission permission: teamPermissions) {
-                if (permission.getName().equals(permissionName)) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
+                SELECT EXISTS (
+                  SELECT 1
+                    FROM "APIKEYS_TEAMS" at
+                   INNER JOIN "TEAMS_PERMISSIONS" tp
+                      ON tp."TEAM_ID" = at."TEAM_ID"
+                   INNER JOIN "PERMISSION" p
+                      ON p."ID" = tp."PERMISSION_ID"
+                   WHERE at."APIKEY_ID" = :apiKeyId
+                     AND p."NAME" = :permissionName
+                )
+                """);
+        query.setNamedParameters(Map.of(
+                "apiKeyId", apiKey.getId(),
+                "permissionName", permissionName));
+        return executeAndCloseResultUnique(query, Boolean.class);
     }
 
     /**

--- a/alpine/alpine-infra/src/test/java/alpine/persistence/AlpineQueryManagerTest.java
+++ b/alpine/alpine-infra/src/test/java/alpine/persistence/AlpineQueryManagerTest.java
@@ -1,0 +1,150 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package alpine.persistence;
+
+import alpine.model.ApiKey;
+import alpine.model.ManagedUser;
+import alpine.model.Permission;
+import alpine.model.Team;
+import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.jdo.JDOHelper;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AlpineQueryManagerTest {
+
+    private JDOPersistenceManagerFactory pmf;
+    private AlpineQueryManager qm;
+
+    @BeforeEach
+    void beforeEach() {
+        pmf = (JDOPersistenceManagerFactory) JDOHelper.getPersistenceManagerFactory(JdoProperties.unit(), "Alpine");
+        qm = new AlpineQueryManager(pmf.getPersistenceManager());
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (qm != null) {
+            qm.close();
+        }
+        if (pmf != null) {
+            pmf.close();
+        }
+    }
+
+    @Test
+    void shouldReturnTrueWhenUserHasDirectPermission() {
+        final ManagedUser user = qm.callInTransaction(() -> {
+            final Permission permission = qm.createPermission("FOO", null);
+            final ManagedUser createdUser = qm.createManagedUser("alice", "hash");
+            createdUser.setPermissions(List.of(permission));
+            return createdUser;
+        });
+
+        assertThat(qm.hasPermission(user, "FOO", false)).isTrue();
+        assertThat(qm.hasPermission(user, "FOO", true)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenTeamGrantsPermissionAndIncludeTeams() {
+        final ManagedUser user = qm.callInTransaction(() -> {
+            final Permission permission = qm.createPermission("FOO", null);
+            final Team team = qm.createTeam("team-a");
+            team.setPermissions(List.of(permission));
+            final ManagedUser createdUser = qm.createManagedUser("alice", "hash");
+            qm.addUserToTeam(createdUser, team);
+            return createdUser;
+        });
+
+        assertThat(qm.hasPermission(user, "FOO", true)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseWhenTeamGrantsPermissionButIncludeTeamsIsFalse() {
+        final ManagedUser user = qm.callInTransaction(() -> {
+            final Permission permission = qm.createPermission("FOO", null);
+            final Team team = qm.createTeam("team-a");
+            team.setPermissions(List.of(permission));
+            final ManagedUser createdUser = qm.createManagedUser("alice", "hash");
+            qm.addUserToTeam(createdUser, team);
+            return createdUser;
+        });
+
+        assertThat(qm.hasPermission(user, "FOO", false)).isFalse();
+    }
+
+    @Test
+    void shouldReturnTrueForTeamPermissionWhenUserIsDetached() {
+        qm.callInTransaction(() -> {
+            final Permission permission = qm.createPermission("FOO", null);
+            final Team team = qm.createTeam("team-a");
+            team.setPermissions(List.of(permission));
+            final ManagedUser createdUser = qm.createManagedUser("alice", "hash");
+            qm.addUserToTeam(createdUser, team);
+            return createdUser;
+        });
+
+        final ManagedUser detached = qm.getManagedUser("alice");
+        final long userId = detached.getId();
+        qm.close();
+
+        qm = new AlpineQueryManager(pmf.getPersistenceManager());
+        final var stub = new ManagedUser();
+        stub.setId(userId);
+
+        assertThat(qm.hasPermission(stub, "FOO", true)).isTrue();
+    }
+
+    @Test
+    void shouldReturnTrueWhenApiKeyTeamGrantsPermission() {
+        final ApiKey apiKey = qm.callInTransaction(() -> {
+            final Permission permission = qm.createPermission("FOO", null);
+            final Team team = qm.createTeam("team-a");
+            team.setPermissions(List.of(permission));
+            return qm.createApiKey(team);
+        });
+
+        assertThat(qm.hasPermission(apiKey, "FOO")).isTrue();
+        assertThat(qm.hasPermission(apiKey, "MISSING")).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenApiKeyHasNoTeams() {
+        final ApiKey apiKey = qm.callInTransaction(() -> {
+            final Team team = qm.createTeam("team-a");
+            return qm.createApiKey(team);
+        });
+
+        assertThat(qm.hasPermission(apiKey, "FOO")).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalseWhenPermissionDoesNotExist() {
+        final ManagedUser user = qm.callInTransaction(
+                () -> qm.createManagedUser("alice", "hash"));
+
+        assertThat(qm.hasPermission(user, "MISSING", true)).isFalse();
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `hasPermission` check for detached `User` objects.

The check implicitly relied on the given user object to be either:

* fully hydrated, including teams, or
* attached to a persistence context to enable lazy loading of teams

Since https://github.com/DependencyTrack/hyades-apiserver/pull/1898, that can no longer be the case.

Separately, it used wasteful N+1 patterns to check team permissions.

Replacing the check with a single SQL existence query solves both the correctness and the performance concern. Same pattern applied to the API key path for consistency.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
