### PR TITLE
Ensure user teams and permissions are loaded when authenticating via session token

### DIFF
--- a/alpine/alpine-server/src/main/java/alpine/server/auth/SessionTokenAuthenticationService.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/auth/SessionTokenAuthenticationService.java
@@ -73,7 +73,7 @@ public final class SessionTokenAuthenticationService implements AuthenticationSe
 
             this.tokenHash = hashedToken;
 
-            return session.getUser();
+            return qm.detach(session.getUser());
         }
     }
 

--- a/alpine/alpine-server/src/test/java/alpine/server/auth/SessionTokenAuthenticationServiceTest.java
+++ b/alpine/alpine-server/src/test/java/alpine/server/auth/SessionTokenAuthenticationServiceTest.java
@@ -19,6 +19,10 @@
 package alpine.server.auth;
 
 import alpine.model.ManagedUser;
+import alpine.model.OidcUser;
+import alpine.model.Permission;
+import alpine.model.Team;
+import alpine.model.User;
 import alpine.persistence.AlpineQueryManager;
 import alpine.server.persistence.PersistenceManagerFactory;
 import io.smallrye.config.SmallRyeConfigBuilder;
@@ -161,6 +165,43 @@ class SessionTokenAuthenticationServiceTest {
 
         assertThat(authService.isSpecified()).isTrue();
         assertThat(authService.authenticate()).isNull();
+    }
+
+    @Test
+    void shouldReturnDetachedUserWithTeamsAndPermissionsLoaded() throws Exception {
+        final String rawToken;
+        try (final var qm = new AlpineQueryManager()) {
+            final OidcUser user = qm.callInTransaction(() -> {
+                // NB: Use a non-ManagedUser here to ensure that DN
+                // correctly resolves the user type via discriminator column.
+                final OidcUser created = qm.createOidcUser("testuser");
+
+                final Team team = qm.createTeam("team-a");
+                qm.addUserToTeam(created, team);
+
+                final Permission permission = qm.createPermission("FOO", null);
+                created.setPermissions(List.of(permission));
+
+                return created;
+            });
+
+            rawToken = new SessionTokenService().createSession(user.getId());
+        }
+
+        final var request = mock(ContainerRequest.class);
+        when(request.getRequestHeader("Authorization")).thenReturn(List.of("Bearer " + rawToken));
+        final var authService = new SessionTokenAuthenticationService(request);
+
+        final Principal principal = authService.authenticate();
+        assertThat(principal).isInstanceOf(User.class);
+
+        final var user = (User) principal;
+        assertThat(user.getTeams())
+                .extracting(Team::getName)
+                .containsExactly("team-a");
+        assertThat(user.getPermissions())
+                .extracting(Permission::getName)
+                .containsExactly("FOO");
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ensures user teams and permissions are loaded when authenticating via session token.

For users of type != `ManagedUser`, DataNucleus would for some reason not load associated fields such as `teams`, which are unfortunately still required by downstream consumers.

Detaching the user object explicitly forces DN to load related fields.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
