### PR TITLE
Refactor maintenance tasks to handle large datasets better

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/metrics/VulnerabilityMetricsUpdateTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/metrics/VulnerabilityMetricsUpdateTask.java
@@ -20,7 +20,6 @@ package org.dependencytrack.metrics;
 
 import alpine.event.framework.Event;
 import alpine.event.framework.Subscriber;
-import net.javacrumbs.shedlock.core.LockingTaskExecutor;
 import org.dependencytrack.event.VulnerabilityMetricsUpdateEvent;
 import org.dependencytrack.model.VulnerabilityMetrics;
 import org.dependencytrack.persistence.QueryManager;
@@ -39,79 +38,84 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.dependencytrack.metrics.VulnerabilityMetricsUpdateTask.VulnerabilityDateCounters.queryForMetrics;
-import static org.dependencytrack.util.LockProvider.executeWithLock;
-import static org.dependencytrack.util.TaskUtil.getLockConfigForTask;
 
 /**
  * A {@link Subscriber} task that updates vulnerability metrics.
  *
  * @since 4.6.0
  */
-public class VulnerabilityMetricsUpdateTask implements Subscriber {
+public final class VulnerabilityMetricsUpdateTask implements Subscriber {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(VulnerabilityMetricsUpdateTask.class);
+    private static final long ADVISORY_LOCK_ID = 6491758203467129854L;
 
     @Override
-    public void inform(final Event e) {
-        if (e instanceof VulnerabilityMetricsUpdateEvent) {
-            try {
-                executeWithLock(
-                        getLockConfigForTask(VulnerabilityMetricsUpdateTask.class),
-                        (LockingTaskExecutor.Task) this::updateMetrics);
-            } catch (Throwable ex) {
-                LOGGER.error("Error in acquiring lock and executing vulnerability metrics update task", ex);
+    public void inform(Event e) {
+        if (!(e instanceof VulnerabilityMetricsUpdateEvent)) {
+            return;
+        }
+
+        try (final var qm = new QueryManager()) {
+            final boolean acquired = qm.callInTransaction(() -> {
+                if (!qm.tryAcquireAdvisoryLock(ADVISORY_LOCK_ID)) {
+                    return false;
+                }
+
+                updateMetrics(qm);
+                return true;
+            });
+            if (!acquired) {
+                LOGGER.debug("Advisory lock held by another instance; Skipping");
             }
+        } catch (Exception ex) {
+            LOGGER.error("Error executing vulnerability metrics update task", ex);
         }
     }
 
-    private void updateMetrics() throws Exception {
+    private void updateMetrics(QueryManager qm) throws Exception {
         LOGGER.info("Executing metrics update on vulnerability database");
         final long startTimeNs = System.nanoTime();
         final var measuredAt = new Date();
 
-        try (final var qm = new QueryManager()) {
-            final PersistenceManager pm = qm.getPersistenceManager();
-            /**
-             *
-             * The created field has priotiy over the published field, which is used as a fallback
-             * However, the created field is always empty (in my instances)
-             * But we leave this mechanism and field juggling in place for backwards compatibility,
-             * and for (future) analyzers/sources that might provide this field.
-             *
-             * BTW the queries to get these vulnerability counts are very fast,
-             * so strictly speaking there is no reason to create this extra table with metrics
-             *
-             */
+        final PersistenceManager pm = qm.getPersistenceManager();
+        /*
+         * The created field has priotiy over the published field, which is used as a fallback
+         * However, the created field is always empty (in my instances)
+         * But we leave this mechanism and field juggling in place for backwards compatibility,
+         * and for (future) analyzers/sources that might provide this field.
+         *
+         * BTW the queries to get these vulnerability counts are very fast,
+         * so strictly speaking there is no reason to create this extra table with metrics
+         */
 
-            // Get metrics by published date but only if created field is null
-            Collection<YearMonthMetric> published = queryForMetrics(pm, "published", "created");
+        // Get metrics by published date but only if created field is null
+        Collection<YearMonthMetric> published = queryForMetrics(pm, "published", "created");
 
-            // Get metrics by created date regardless of value of published field
-            Collection<YearMonthMetric> created = queryForMetrics(pm, "created", null);
+        // Get metrics by created date regardless of value of published field
+        Collection<YearMonthMetric> created = queryForMetrics(pm, "created", null);
 
-            // Merge flat lists
-            published.addAll(created);
+        // Merge flat lists
+        published.addAll(created);
 
-            // Collect into nested map so we can sum the counts
-            Map<Integer, Map<Integer, Long>> metrics = published.stream()
-                    .filter(ymm -> ymm.year != null)
-                    .collect(Collectors.groupingBy(ymm -> ymm.year,
-                            Collectors.groupingBy(ymm -> ymm.month, Collectors.summingLong(ymm -> ymm.count))));
+        // Collect into nested map so we can sum the counts
+        Map<Integer, Map<Integer, Long>> metrics = published.stream()
+                .filter(ymm -> ymm.year != null)
+                .collect(Collectors.groupingBy(ymm -> ymm.year,
+                        Collectors.groupingBy(ymm -> ymm.month, Collectors.summingLong(ymm -> ymm.count))));
 
-            // Flatten again, but now into VulnerabilityMetrics that can be persisted
-            Stream<VulnerabilityMetrics> monthlyStream = metrics.entrySet().stream()
-                    .flatMap(e -> e.getValue().entrySet().stream().map(
-                            v -> new VulnerabilityMetrics(e.getKey(), v.getKey(), v.getValue().intValue(), measuredAt)));
+        // Flatten again, but now into VulnerabilityMetrics that can be persisted
+        Stream<VulnerabilityMetrics> monthlyStream = metrics.entrySet().stream()
+                .flatMap(e -> e.getValue().entrySet().stream().map(
+                        v -> new VulnerabilityMetrics(e.getKey(), v.getKey(), v.getValue().intValue(), measuredAt)));
 
-            // Flatten another time, for the yearly counts
-            Stream<VulnerabilityMetrics> yearlyStream = metrics.entrySet().stream()
-                    .map(e -> new VulnerabilityMetrics(e.getKey(), null, e.getValue().values().stream().mapToInt(d -> d.intValue()).sum(), measuredAt));
+        // Flatten another time, for the yearly counts
+        Stream<VulnerabilityMetrics> yearlyStream = metrics.entrySet().stream()
+                .map(e -> new VulnerabilityMetrics(e.getKey(), null, e.getValue().values().stream().mapToInt(d -> d.intValue()).sum(), measuredAt));
 
-            qm.synchronizeVulnerabilityMetrics(Stream.concat(monthlyStream, yearlyStream).toList());
+        qm.synchronizeVulnerabilityMetrics(Stream.concat(monthlyStream, yearlyStream).toList());
 
-            LOGGER.info("Completed metrics update on vulnerability database in %s"
-                    .formatted(Duration.ofNanos(System.nanoTime() - startTimeNs)));
-        }
+        LOGGER.info("Completed metrics update on vulnerability database in %s"
+                .formatted(Duration.ofNanos(System.nanoTime() - startTimeNs)));
     }
 
     static final class VulnerabilityDateCounters {

--- a/apiserver/src/main/java/org/dependencytrack/notification/NotificationOutboxRelay.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/NotificationOutboxRelay.java
@@ -33,6 +33,7 @@ import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
 import org.dependencytrack.filestorage.api.FileStorage;
 import org.dependencytrack.filestorage.proto.v1.FileMetadata;
 import org.dependencytrack.notification.proto.v1.Notification;
+import org.dependencytrack.persistence.jdbi.AdvisoryLocks;
 import org.dependencytrack.persistence.jdbi.NotificationOutboxDao;
 import org.dependencytrack.proto.internal.workflow.v1.PublishNotificationWorkflowArg;
 import org.jdbi.v3.core.Handle;
@@ -224,7 +225,7 @@ final class NotificationOutboxRelay implements Closeable {
             // emitted. Work-stealing polling with FOR UPDATE SKIP LOCKED would mess with ordering.
             //
             // The lack of concurrency is in part mitigated by processing notifications in batches.
-            final boolean lockAcquired = tryAcquireAdvisoryLock(handle);
+            final boolean lockAcquired = AdvisoryLocks.tryAcquire(handle, ADVISORY_LOCK_ID);
             if (!lockAcquired) {
                 LOGGER.debug("Lock already acquired by another instance");
                 return RelayCycleOutcome.SKIPPED;
@@ -267,15 +268,6 @@ final class NotificationOutboxRelay implements Closeable {
 
             return RelayCycleOutcome.COMPLETED;
         });
-    }
-
-    private boolean tryAcquireAdvisoryLock(Handle handle) {
-        return handle.createQuery("""
-                        SELECT pg_try_advisory_xact_lock(:lockId)
-                        """)
-                .bind("lockId", ADVISORY_LOCK_ID)
-                .mapTo(boolean.class)
-                .one();
     }
 
     private void sendAll(Collection<NotificationRouter.Result> routerResults) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -162,6 +162,19 @@ public class QueryManager extends AlpineQueryManager {
     }
 
     /**
+     * @since 5.0.0
+     */
+    public boolean tryAcquireAdvisoryLock(long lockId) {
+        if (!pm.currentTransaction().isActive()) {
+            throw new IllegalStateException("Advisory locks can only be acquired within an active JDO transaction");
+        }
+
+        final Query<?> query = pm.newQuery(Query.SQL, "SELECT pg_try_advisory_xact_lock(?)");
+        query.setParameters(lockId);
+        return executeAndCloseResultUnique(query, Boolean.class);
+    }
+
+    /**
      * Override of {@link AbstractAlpineQueryManager#decorate(Query)} to modify the
      * method's behavior such that it always sorts by ID, in addition to whatever field
      * is requested to be sorted by via {@link #orderBy}.

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/AdvisoryLocks.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/AdvisoryLocks.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi;
+
+import org.jdbi.v3.core.Handle;
+
+/**
+ * @since 5.0.0
+ */
+public final class AdvisoryLocks {
+
+    private AdvisoryLocks() {
+    }
+
+    public static boolean tryAcquire(Handle handle, long lockId) {
+        if (!handle.isInTransaction()) {
+            throw new IllegalStateException("Advisory locks can only be acquired within a transaction");
+        }
+
+        return handle.createQuery("SELECT pg_try_advisory_xact_lock(:lockId)")
+                .bind("lockId", lockId)
+                .mapTo(boolean.class)
+                .one();
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/TagDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/TagDao.java
@@ -19,6 +19,7 @@
 package org.dependencytrack.persistence.jdbi;
 
 import org.jdbi.v3.sqlobject.SqlObject;
+import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 /**
@@ -29,19 +30,33 @@ public interface TagDao extends SqlObject {
     @SqlUpdate("""
             DELETE
               FROM "TAG"
-             WHERE NOT EXISTS(
-                 SELECT 1
-                   FROM "PROJECTS_TAGS"
-                  WHERE "PROJECTS_TAGS"."TAG_ID" = "TAG"."ID")
-               AND NOT EXISTS(
-                  SELECT 1
-                    FROM "POLICY_TAGS"
-                   WHERE "POLICY_TAGS"."TAG_ID" = "TAG"."ID")
-               AND NOT EXISTS(
-                  SELECT 1
-                    FROM "VULNERABILITIES_TAGS"
-                   WHERE "VULNERABILITIES_TAGS"."TAG_ID" = "TAG"."ID")
+             WHERE "ID" IN (
+               SELECT "ID"
+                 FROM "TAG" AS t
+                WHERE TRUE
+                  AND NOT EXISTS(
+                    SELECT 1
+                      FROM "NOTIFICATIONRULE_TAGS" AS nrt
+                     WHERE nrt."TAG_ID" = t."ID"
+                  )
+                  AND NOT EXISTS(
+                    SELECT 1
+                      FROM "PROJECTS_TAGS" AS prt
+                     WHERE prt."TAG_ID" = t."ID"
+                  )
+                  AND NOT EXISTS(
+                    SELECT 1
+                      FROM "POLICY_TAGS" AS pot
+                     WHERE pot."TAG_ID" = t."ID"
+                  )
+                  AND NOT EXISTS(
+                    SELECT 1
+                      FROM "VULNERABILITIES_TAGS" AS vt
+                     WHERE vt."TAG_ID" = t."ID"
+                  )
+                LIMIT :batchSize
+             )
             """)
-    int deleteUnused();
+    int deleteUnused(@Bind int batchSize);
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -573,12 +573,17 @@ public interface VulnerabilityDao {
     @SqlUpdate("""
             DELETE
               FROM "VULNERABLESOFTWARE"
-             WHERE NOT EXISTS(
-               SELECT 1
-                 FROM "VULNERABLESOFTWARE_VULNERABILITIES"
-                WHERE "VULNERABLESOFTWARE_ID" = "VULNERABLESOFTWARE"."ID")
+             WHERE "ID" IN (
+               SELECT "ID"
+                 FROM "VULNERABLESOFTWARE" AS "VS"
+                WHERE NOT EXISTS (
+                  SELECT 1
+                    FROM "VULNERABLESOFTWARE_VULNERABILITIES"
+                   WHERE "VULNERABLESOFTWARE_ID" = "VS"."ID")
+                LIMIT :batchSize
+             )
             """)
-    int deleteOrphanVulnerableSoftware();
+    int deleteOrphanVulnerableSoftware(@Bind int batchSize);
 
     @SqlUpdate("""
             DELETE

--- a/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/AbstractBatchingMaintenanceTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/AbstractBatchingMaintenanceTask.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.tasks.maintenance;
+
+import alpine.event.framework.Event;
+import alpine.event.framework.Subscriber;
+import org.dependencytrack.persistence.jdbi.AdvisoryLocks;
+import org.jdbi.v3.core.Handle;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToIntFunction;
+
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
+
+abstract class AbstractBatchingMaintenanceTask<E extends Event> implements Subscriber {
+
+    private final Class<E> eventType;
+    private final String taskName;
+    private final long advisoryLockId;
+    private final int maxIterations;
+    private final Logger logger;
+
+    AbstractBatchingMaintenanceTask(
+            Class<E> eventType,
+            String taskName,
+            long advisoryLockId,
+            int maxIterations) {
+        this.eventType = eventType;
+        this.taskName = taskName;
+        this.advisoryLockId = advisoryLockId;
+        this.maxIterations = maxIterations;
+        this.logger = LoggerFactory.getLogger(getClass());
+    }
+
+    @Override
+    public final void inform(Event event) {
+        if (!eventType.isInstance(event)) {
+            return;
+        }
+
+        final long startTimeNanos = System.nanoTime();
+        try {
+            logger.info("Starting {}", taskName);
+            final String summary = doRun();
+
+            logger.info(
+                    "Completed {} in {}ms: {}",
+                    taskName,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos),
+                    summary);
+        } catch (RuntimeException e) {
+            logger.error(
+                    "Failed to complete {} after {}ms",
+                    taskName,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTimeNanos),
+                    e);
+        }
+    }
+
+    abstract String doRun();
+
+    final int runBatched(int batchSize, ToIntFunction<Handle> batchFn) {
+        int totalProcessed = 0;
+        int iteration = 0;
+
+        while (iteration < maxIterations) {
+            final int processed = inJdbiTransaction(handle -> {
+                if (!AdvisoryLocks.tryAcquire(handle, advisoryLockId)) {
+                    return -1;
+                }
+
+                return batchFn.applyAsInt(handle);
+            });
+
+            if (processed < 0) {
+                logger.debug("Advisory lock held by another instance; Skipping remaining batches");
+                break;
+            }
+
+            iteration++;
+            totalProcessed += processed;
+            if (processed < batchSize) {
+                break;
+            }
+        }
+
+        if (iteration >= maxIterations) {
+            logger.warn("Reached safety cap of {} iterations; will resume on next run", maxIterations);
+        }
+
+        return totalProcessed;
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/PackageMetadataMaintenanceTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/PackageMetadataMaintenanceTask.java
@@ -18,87 +18,75 @@
  */
 package org.dependencytrack.tasks.maintenance;
 
-import alpine.event.framework.Event;
-import alpine.event.framework.Subscriber;
 import org.dependencytrack.event.maintenance.PackageMetadataMaintenanceEvent;
 import org.jdbi.v3.core.Handle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.time.Duration;
-
-import static net.javacrumbs.shedlock.core.LockAssert.assertLocked;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
-import static org.dependencytrack.util.LockProvider.executeWithLock;
-import static org.dependencytrack.util.TaskUtil.getLockConfigForTask;
 
 /**
  * @since 5.0.0
  */
-public class PackageMetadataMaintenanceTask implements Subscriber {
+public final class PackageMetadataMaintenanceTask
+        extends AbstractBatchingMaintenanceTask<PackageMetadataMaintenanceEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PackageMetadataMaintenanceTask.class);
+    private static final long ADVISORY_LOCK_ID = 3179468540126812349L;
+    private static final int BATCH_SIZE = 1000;
+    private static final int MAX_ITERATIONS = 1000;
+
+    public PackageMetadataMaintenanceTask() {
+        super(
+                PackageMetadataMaintenanceEvent.class,
+                "package metadata maintenance",
+                ADVISORY_LOCK_ID,
+                MAX_ITERATIONS);
+    }
 
     @Override
-    public void inform(final Event event) {
-        if (!(event instanceof PackageMetadataMaintenanceEvent)) {
-            return;
-        }
-
-        final long startTimeNs = System.nanoTime();
-        try (final Handle jdbiHandle = openJdbiHandle()) {
-            LOGGER.info("Starting component metadata maintenance");
-            final Statistics statistics = executeWithLock(
-                    getLockConfigForTask(PackageMetadataMaintenanceTask.class),
-                    () -> informLocked(jdbiHandle));
-            if (statistics == null) {
-                LOGGER.info("Task is locked by another instance; Skipping");
-                return;
-            }
-
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.info("Completed in %s: %s".formatted(taskDuration, statistics));
-        } catch (Throwable e) {
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.error("Failed to complete after %s".formatted(taskDuration), e);
-        }
+    protected String doRun() {
+        final int deletedArtifactMetadata = runBatched(
+                BATCH_SIZE, PackageMetadataMaintenanceTask::deleteOrphanedArtifactMetadata);
+        final int deletedPackageMetadata = runBatched(
+                BATCH_SIZE, PackageMetadataMaintenanceTask::deleteOrphanedPackageMetadata);
+        return "deleted %d orphan PACKAGE_ARTIFACT_METADATA rows, %d orphan PACKAGE_METADATA rows"
+                .formatted(deletedArtifactMetadata, deletedPackageMetadata);
     }
 
-    private record Statistics(
-            int deletedIntegrityMetadata,
-            int deletedRepositoryMetadata) {
-    }
-
-    private Statistics informLocked(final Handle jdbiHandle) {
-        assertLocked();
-
-        final int numDeletedPackageVersionMetadata = jdbiHandle
+    private static int deleteOrphanedArtifactMetadata(Handle handle) {
+        return handle
                 .createUpdate("""
                         DELETE
-                          FROM "PACKAGE_ARTIFACT_METADATA" AS pam
-                         WHERE NOT EXISTS (
-                           SELECT 1
-                             FROM "COMPONENT" AS c
-                            WHERE c."PURL" = pam."PURL"
-                         )
-                        """)
-                .execute();
-
-        final int numDeletedPackageMetadata = jdbiHandle
-                .createUpdate("""
-                        DELETE
-                          FROM "PACKAGE_METADATA" AS pm
-                         WHERE NOT EXISTS (
-                           SELECT 1
+                          FROM "PACKAGE_ARTIFACT_METADATA"
+                         WHERE "PURL" IN (
+                           SELECT "PURL"
                              FROM "PACKAGE_ARTIFACT_METADATA" AS pam
-                            WHERE pam."PACKAGE_PURL" = pm."PURL"
+                            WHERE NOT EXISTS (
+                              SELECT 1
+                                FROM "COMPONENT" AS c
+                               WHERE c."PURL" = pam."PURL"
+                            )
+                            LIMIT :batchSize
                          )
                         """)
+                .bind("batchSize", BATCH_SIZE)
                 .execute();
+    }
 
-        return new Statistics(
-                numDeletedPackageVersionMetadata,
-                numDeletedPackageMetadata);
+    private static int deleteOrphanedPackageMetadata(Handle handle) {
+        return handle
+                .createUpdate("""
+                        DELETE
+                          FROM "PACKAGE_METADATA"
+                         WHERE "PURL" IN (
+                           SELECT "PURL"
+                             FROM "PACKAGE_METADATA" AS pm
+                            WHERE NOT EXISTS (
+                              SELECT 1
+                                FROM "PACKAGE_ARTIFACT_METADATA" AS pam
+                               WHERE pam."PACKAGE_PURL" = pm."PURL"
+                            )
+                            LIMIT :batchSize
+                         )
+                        """)
+                .bind("batchSize", BATCH_SIZE)
+                .execute();
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/ProjectMaintenanceTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/ProjectMaintenanceTask.java
@@ -18,8 +18,6 @@
  */
 package org.dependencytrack.tasks.maintenance;
 
-import alpine.event.framework.Event;
-import alpine.event.framework.Subscriber;
 import org.dependencytrack.event.maintenance.ProjectMaintenanceEvent;
 import org.dependencytrack.persistence.jdbi.ConfigPropertyDao;
 import org.dependencytrack.persistence.jdbi.ProjectDao;
@@ -29,98 +27,87 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.Optional;
 
-import static net.javacrumbs.shedlock.core.LockAssert.assertLocked;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_PROJECTS_RETENTION_DAYS;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_PROJECTS_RETENTION_TYPE;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_PROJECTS_RETENTION_VERSIONS;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.inJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
-import static org.dependencytrack.util.LockProvider.executeWithLock;
-import static org.dependencytrack.util.TaskUtil.getLockConfigForTask;
 
-public class ProjectMaintenanceTask implements Subscriber {
+public final class ProjectMaintenanceTask extends AbstractBatchingMaintenanceTask<ProjectMaintenanceEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ProjectMaintenanceTask.class);
+    private static final long ADVISORY_LOCK_ID = 7102463598274163180L;
+    private static final int BATCH_SIZE = 100;
+    private static final int MAX_ITERATIONS = 1000;
+
+    public ProjectMaintenanceTask() {
+        super(
+                ProjectMaintenanceEvent.class,
+                "project maintenance",
+                ADVISORY_LOCK_ID,
+                MAX_ITERATIONS);
+    }
 
     @Override
-    public void inform(final Event event) {
-        if (!(event instanceof ProjectMaintenanceEvent)) {
-            return;
+    String doRun() {
+        final Optional<String> retentionType = withJdbiHandle(
+                handle -> handle
+                        .attach(ConfigPropertyDao.class)
+                        .getOptionalValue(MAINTENANCE_PROJECTS_RETENTION_TYPE, String.class));
+
+        if (retentionType.isEmpty() || retentionType.get().isEmpty()) {
+            return "inactive project deletion is disabled";
         }
 
-        final long startTimeNs = System.nanoTime();
-        try {
-            LOGGER.info("Starting project maintenance");
-            final Statistics statistics = executeWithLock(
-                    getLockConfigForTask(ProjectMaintenanceTask.class),
-                    () -> informLocked());
-            if (statistics == null) {
-                LOGGER.info("Task is locked by another instance; Skipping");
-                return;
+        if ("AGE".equals(retentionType.get())) {
+            final int retentionDays = withJdbiHandle(
+                    handle -> handle
+                            .attach(ConfigPropertyDao.class)
+                            .getValue(MAINTENANCE_PROJECTS_RETENTION_DAYS, Integer.class));
+            final Instant retentionCutOff = Instant.now().minus(Duration.ofDays(retentionDays));
+            final int deleted = runBatched(BATCH_SIZE, handle -> {
+                final List<ProjectDao.DeletedProject> deletedProjects = handle
+                        .attach(ProjectDao.class)
+                        .deleteInactiveProjectsForRetentionDuration(retentionCutOff, BATCH_SIZE);
+                logDeletedProjects(deletedProjects);
+                return deletedProjects.size();
+            });
+
+            return "deleted %d inactive projects by age".formatted(deleted);
+        }
+
+        final int versionCountThreshold = withJdbiHandle(
+                handle -> handle
+                        .attach(ConfigPropertyDao.class)
+                        .getValue(MAINTENANCE_PROJECTS_RETENTION_VERSIONS, Integer.class));
+
+        final int[] deletedVersions = new int[1];
+
+        runBatched(BATCH_SIZE, handle -> {
+            final var projectDao = handle.attach(ProjectDao.class);
+            final List<String> projectBatch = projectDao.getDistinctProjects(versionCountThreshold, BATCH_SIZE);
+
+            for (final String projectName : projectBatch) {
+                final List<ProjectDao.DeletedProject> deleted =
+                        projectDao.retainLastXInactiveProjects(projectName, versionCountThreshold);
+                deletedVersions[0] += deleted.size();
+                logDeletedProjects(deleted);
             }
 
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.info("Completed in %s: %s".formatted(taskDuration, statistics));
-        } catch (Throwable e) {
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.error("Failed to complete after %s".formatted(taskDuration), e);
-        }
+            return projectBatch.size();
+        });
+
+        return "deleted %d excess project versions".formatted(deletedVersions[0]);
     }
 
-    private record Statistics(int deletedInactiveProjects) {
+    private static void logDeletedProjects(List<ProjectDao.DeletedProject> deletedProjects) {
+        deletedProjects.forEach(deletedProject -> LOGGER.info(
+                "Inactive project deleted: [name:{}, version:{}, inactive since:{}, uuid:{}]",
+                deletedProject.name(),
+                deletedProject.version(),
+                deletedProject.inactiveSince(),
+                deletedProject.uuid()));
     }
 
-    private Statistics informLocked() {
-        assertLocked();
-        AtomicInteger numDeletedTotal = new AtomicInteger(0);
-
-        final var retentionType = withJdbiHandle(handle ->
-                handle.attach(ConfigPropertyDao.class).getOptionalValue(MAINTENANCE_PROJECTS_RETENTION_TYPE, String.class));
-
-        if (!retentionType.isEmpty() && !retentionType.get().isEmpty()) {
-            int batchSize = 100;
-            if (retentionType.get().equals("AGE")) {
-
-                final int retentionDays = withJdbiHandle(handle ->
-                        handle.attach(ConfigPropertyDao.class).getValue(MAINTENANCE_PROJECTS_RETENTION_DAYS, Integer.class));
-                final Duration retentionDuration = Duration.ofDays(retentionDays);
-                Instant retentionCutOff = Instant.now().minus(retentionDuration);
-                Integer numDeletedLastBatch = null;
-                while (numDeletedLastBatch == null || numDeletedLastBatch > 0) {
-                    final var deletedProjectsBatch = withJdbiHandle(
-                            batchHandle -> {
-                                final var projectDao = batchHandle.attach(ProjectDao.class);
-                                return projectDao.deleteInactiveProjectsForRetentionDuration(retentionCutOff, batchSize);
-                            });
-                    numDeletedLastBatch = deletedProjectsBatch.size();
-                    numDeletedTotal.addAndGet(numDeletedLastBatch);
-                    deletedProjectsBatch.forEach(deletedProject ->
-                            LOGGER.info("Inactive project deleted: [name:%s, version:%s, inactive since:%s, uuid:%s]".formatted(deletedProject.name(), deletedProject.version(), deletedProject.inactiveSince(), deletedProject.uuid())));
-                }
-            } else {
-                final int versionCountThreshold = withJdbiHandle(handle ->
-                        handle.attach(ConfigPropertyDao.class).getValue(MAINTENANCE_PROJECTS_RETENTION_VERSIONS, Integer.class));
-                Integer projectLastBatch = null;
-                while (projectLastBatch == null || projectLastBatch > 0) {
-                    projectLastBatch = inJdbiTransaction(
-                            batchHandle -> {
-                                final var projectDao = batchHandle.attach(ProjectDao.class);
-                                List<String> projectBatch = projectDao.getDistinctProjects(versionCountThreshold, batchSize);
-                                for (var projectName : projectBatch) {
-                                    final var deletedProjects = projectDao.retainLastXInactiveProjects(projectName, versionCountThreshold);
-                                    numDeletedTotal.addAndGet(deletedProjects.size());
-                                    deletedProjects.forEach(deletedProject ->
-                                            LOGGER.info("Inactive project deleted: [name:%s, version:%s, inactive since:%s, uuid:%s]".formatted(deletedProject.name(), deletedProject.version(), deletedProject.inactiveSince(), deletedProject.uuid())));
-                                }
-                                return projectBatch.size();
-                            });
-                }
-            }
-        } else {
-            LOGGER.info("Not deleting inactive projects because it is disabled");
-        }
-        return new Statistics(numDeletedTotal.get());
-    }
 }

--- a/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/TagMaintenanceTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/TagMaintenanceTask.java
@@ -18,74 +18,43 @@
  */
 package org.dependencytrack.tasks.maintenance;
 
-import alpine.event.framework.Event;
-import alpine.event.framework.Subscriber;
 import org.dependencytrack.event.maintenance.TagMaintenanceEvent;
 import org.dependencytrack.persistence.jdbi.ConfigPropertyDao;
 import org.dependencytrack.persistence.jdbi.TagDao;
-import org.jdbi.v3.core.Handle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-
-import static net.javacrumbs.shedlock.core.LockAssert.assertLocked;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_TAGS_DELETE_UNUSED;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
-import static org.dependencytrack.util.LockProvider.executeWithLock;
-import static org.dependencytrack.util.TaskUtil.getLockConfigForTask;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 /**
  * @since 5.0.0
  */
-public class TagMaintenanceTask implements Subscriber {
+public final class TagMaintenanceTask extends AbstractBatchingMaintenanceTask<TagMaintenanceEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TagMaintenanceTask.class);
+    private static final long ADVISORY_LOCK_ID = 5827314498267091435L;
+    private static final int BATCH_SIZE = 1000;
+    private static final int MAX_ITERATIONS = 1000;
+
+    public TagMaintenanceTask() {
+        super(
+                TagMaintenanceEvent.class,
+                "tag maintenance",
+                ADVISORY_LOCK_ID,
+                MAX_ITERATIONS);
+    }
 
     @Override
-    public void inform(final Event event) {
-        if (!(event instanceof TagMaintenanceEvent)) {
-            return;
+    String doRun() {
+        final boolean deleteUnusedEnabled = withJdbiHandle(handle -> handle
+                .attach(ConfigPropertyDao.class)
+                .getValue(MAINTENANCE_TAGS_DELETE_UNUSED, Boolean.class));
+        if (!deleteUnusedEnabled) {
+            return "unused tag deletion is disabled";
         }
 
-        final long startTimeNs = System.nanoTime();
-        try (final Handle jdbiHandle = openJdbiHandle()) {
-            LOGGER.info("Starting tag maintenance");
-            final Statistics statistics = executeWithLock(
-                    getLockConfigForTask(TagMaintenanceTask.class),
-                    () -> informLocked(jdbiHandle));
-            if (statistics == null) {
-                LOGGER.info("Task is locked by another instance; Skipping");
-                return;
-            }
-
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.info("Completed in %s: %s".formatted(taskDuration, statistics));
-        } catch (Throwable e) {
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.error("Failed to complete after %s".formatted(taskDuration), e);
-        }
-    }
-
-    private record Statistics(int deletedUnused) {
-    }
-
-    private Statistics informLocked(final Handle jdbiHandle) {
-        assertLocked();
-
-        final var configPropertyDao = jdbiHandle.attach(ConfigPropertyDao.class);
-        final var tagDao = jdbiHandle.attach(TagDao.class);
-
-        int numDeleted = 0;
-        if (configPropertyDao.getValue(MAINTENANCE_TAGS_DELETE_UNUSED, Boolean.class)) {
-            numDeleted = tagDao.deleteUnused();
-        } else {
-            LOGGER.info("Not deleting unused tags because %s:%s is disabled".formatted(
-                    MAINTENANCE_TAGS_DELETE_UNUSED.getGroupName(),
-                    MAINTENANCE_TAGS_DELETE_UNUSED.getPropertyName()));
-        }
-
-        return new Statistics(numDeleted);
+        final int deleted = runBatched(
+                BATCH_SIZE,
+                handle -> handle.attach(TagDao.class).deleteUnused(BATCH_SIZE));
+        return "deleted %d unused tags".formatted(deleted);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/VulnerabilityDatabaseMaintenanceTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/maintenance/VulnerabilityDatabaseMaintenanceTask.java
@@ -18,63 +18,34 @@
  */
 package org.dependencytrack.tasks.maintenance;
 
-import alpine.event.framework.Event;
-import alpine.event.framework.Subscriber;
 import org.dependencytrack.event.maintenance.VulnerabilityDatabaseMaintenanceEvent;
 import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
-import org.jdbi.v3.core.Handle;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.time.Duration;
-
-import static net.javacrumbs.shedlock.core.LockAssert.assertLocked;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.openJdbiHandle;
-import static org.dependencytrack.util.LockProvider.executeWithLock;
-import static org.dependencytrack.util.TaskUtil.getLockConfigForTask;
 
 /**
  * @since 5.0.0
  */
-public class VulnerabilityDatabaseMaintenanceTask implements Subscriber {
+public final class VulnerabilityDatabaseMaintenanceTask extends AbstractBatchingMaintenanceTask<VulnerabilityDatabaseMaintenanceEvent> {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(VulnerabilityDatabaseMaintenanceTask.class);
+    private static final long ADVISORY_LOCK_ID = 8243712092045174911L;
+    private static final int BATCH_SIZE = 1000;
+    private static final int MAX_ITERATIONS = 1000;
+
+    public VulnerabilityDatabaseMaintenanceTask() {
+        super(
+                VulnerabilityDatabaseMaintenanceEvent.class,
+                "vulnerability database maintenance",
+                ADVISORY_LOCK_ID,
+                MAX_ITERATIONS);
+    }
 
     @Override
-    public void inform(final Event event) {
-        if (!(event instanceof VulnerabilityDatabaseMaintenanceEvent)) {
-            return;
-        }
-
-        final long startTimeNs = System.nanoTime();
-        try (final Handle jdbiHandle = openJdbiHandle()) {
-            LOGGER.info("Starting vulnerability database maintenance");
-            final Statistics statistics = executeWithLock(
-                    getLockConfigForTask(VulnerabilityDatabaseMaintenanceTask.class),
-                    () -> informLocked(jdbiHandle));
-            if (statistics == null) {
-                LOGGER.info("Task is locked by another instance; Skipping");
-                return;
-            }
-
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.info("Completed in %s: %s".formatted(taskDuration, statistics));
-        } catch (Throwable e) {
-            final var taskDuration = Duration.ofNanos(System.nanoTime() - startTimeNs);
-            LOGGER.error("Failed to complete after %s".formatted(taskDuration), e);
-        }
-    }
-
-    private record Statistics(int deletedVulnerableSoftwareOrphans) {
-    }
-
-    private Statistics informLocked(final Handle jdbiHandle) {
-        assertLocked();
-
-        final var dao = jdbiHandle.attach(VulnerabilityDao.class);
-        final int numDeletedVs = dao.deleteOrphanVulnerableSoftware();
-
-        return new Statistics(numDeletedVs);
+    String doRun() {
+        final int deleted = runBatched(
+                BATCH_SIZE,
+                handle -> handle
+                        .attach(VulnerabilityDao.class)
+                        .deleteOrphanVulnerableSoftware(BATCH_SIZE));
+        return "deleted %d orphan VulnerableSoftware rows".formatted(deleted);
     }
 
 }

--- a/apiserver/src/main/resources/application.properties
+++ b/apiserver/src/main/resources/application.properties
@@ -754,24 +754,6 @@ dt.notification.outbox-relay.large-notification-threshold-bytes=65536
 # @type:     boolean
 dt.task-scheduler.enabled=true
 
-# Maximum duration in ISO 8601 format for which the vulnerability metrics update task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover the task's execution duration.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.vulnerability.metrics.update.lock.max.duration=PT15M
-
-# Minimum duration in ISO 8601 format for which the vulnerability metrics update task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover eventual clock skew across API server instances.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.vulnerability.metrics.update.lock.min.duration=PT90S
-
 # Maximum duration in ISO 8601 format for which the internal component identification task will hold a lock.
 # <br/><br/>
 # The duration should be long enough to cover the task's execution duration.
@@ -1112,24 +1094,6 @@ dt.dev.services.port.frontend=8081
 # @required
 dt.task.package.metadata.maintenance.cron=0 */12 * * *
 
-# Maximum duration in ISO 8601 format for which the package metadata maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover the task's execution duration.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.package.metadata.maintenance.lock.max.duration=PT15M
-
-# Minimum duration in ISO 8601 format for which the package metadata maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover eventual clock skew across API server instances.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.package.metadata.maintenance.lock.min.duration=PT1M
-
 # Cron expression of the package metadata resolution task.
 # <br/><br/>
 # Note that package metadata resolution is also triggered by other
@@ -1182,24 +1146,6 @@ dt.task.metrics.maintenance.lock.min.duration=PT1M
 # @required
 dt.task.tag.maintenance.cron=0 */12 * * *
 
-# Maximum duration in ISO 8601 format for which the tag maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover the task's execution duration.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.tag.maintenance.lock.max.duration=PT15M
-
-# Minimum duration in ISO 8601 format for which the tag maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover eventual clock skew across API server instances.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.tag.maintenance.lock.min.duration=PT1M
-
 # Cron expression of the vulnerability database maintenance task.
 # <br/><br/>
 # The task deletes orphaned records from the `VULNERABLESOFTWARE` table.
@@ -1208,24 +1154,6 @@ dt.task.tag.maintenance.lock.min.duration=PT1M
 # @type:     cron
 # @required
 dt.task.vulnerability.database.maintenance.cron=0 0 * * *
-
-# Maximum duration in ISO 8601 format for which the vulnerability database maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover the task's execution duration.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.vulnerability.database.maintenance.lock.max.duration=PT15M
-
-# Minimum duration in ISO 8601 format for which the vulnerability database maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover eventual clock skew across API server instances.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.vulnerability.database.maintenance.lock.min.duration=PT1M
 
 # Cron expression of the workflow maintenance task.
 # <br/><br/>
@@ -1268,24 +1196,6 @@ dt.task.workflow.maintenance.lock.min.duration=PT1M
 # @type:     cron
 # @required
 dt.task.project.maintenance.cron=0 */4 * * *
-
-# Maximum duration in ISO 8601 format for which the project maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover the task's execution duration.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.project.maintenance.lock.max.duration=PT15M
-
-# Minimum duration in ISO 8601 format for which the project maintenance task will hold a lock.
-# <br/><br/>
-# The duration should be long enough to cover eventual clock skew across API server instances.
-#
-# @category: Task Scheduling
-# @type:     duration
-# @required
-dt.task.project.maintenance.lock.min.duration=PT1M
 
 # Defines the file storage provider to use.
 #

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/PackageMetadataMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/PackageMetadataMaintenanceTaskTest.java
@@ -38,10 +38,10 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
-public class PackageMetadataMaintenanceTaskTest extends PersistenceCapableTest {
+class PackageMetadataMaintenanceTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void test() throws Exception {
+    void test() throws Exception {
         final var project = new Project();
         project.setName("acme-app");
         qm.persist(project);

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/ProjectMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/ProjectMaintenanceTaskTest.java
@@ -37,10 +37,10 @@ import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_PROJ
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_PROJECTS_RETENTION_VERSIONS;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
-public class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
+class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void testWithRetentionTypeAge() {
+    void testWithRetentionTypeAge() {
         qm.createConfigProperty(
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getGroupName(),
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getPropertyName(),
@@ -77,7 +77,7 @@ public class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithRetentionTypeVersionsForSameProject() {
+    void testWithRetentionTypeVersionsForSameProject() {
         qm.createConfigProperty(
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getGroupName(),
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getPropertyName(),
@@ -134,7 +134,7 @@ public class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithRetentionTypeVersionsForDifferentProjects() {
+    void testWithRetentionTypeVersionsForDifferentProjects() {
         qm.createConfigProperty(
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getGroupName(),
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getPropertyName(),
@@ -200,7 +200,7 @@ public class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithProjectRetentionDisabled() {
+    void testWithProjectRetentionDisabled() {
         qm.createConfigProperty(
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getGroupName(),
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getPropertyName(),
@@ -222,7 +222,7 @@ public class ProjectMaintenanceTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithProjectRetentionDisabledWithEmptyValue() {
+    void testWithProjectRetentionDisabledWithEmptyValue() {
         qm.createConfigProperty(
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getGroupName(),
                 MAINTENANCE_PROJECTS_RETENTION_TYPE.getPropertyName(),

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/TagMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/TagMaintenanceTaskTest.java
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.dependencytrack.model.ConfigPropertyConstants.MAINTENANCE_TAGS_DELETE_UNUSED;
 
-public class TagMaintenanceTaskTest extends PersistenceCapableTest {
+class TagMaintenanceTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void test() {
+    void test() {
         qm.createConfigProperty(
                 MAINTENANCE_TAGS_DELETE_UNUSED.getGroupName(),
                 MAINTENANCE_TAGS_DELETE_UNUSED.getPropertyName(),
@@ -73,7 +73,7 @@ public class TagMaintenanceTaskTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testWithDeleteUnusedDisabled() {
+    void testWithDeleteUnusedDisabled() {
         qm.createConfigProperty(
                 MAINTENANCE_TAGS_DELETE_UNUSED.getGroupName(),
                 MAINTENANCE_TAGS_DELETE_UNUSED.getPropertyName(),

--- a/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/VulnerabilityDatabaseMaintenanceTaskTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/tasks/maintenance/VulnerabilityDatabaseMaintenanceTaskTest.java
@@ -30,10 +30,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
-public class VulnerabilityDatabaseMaintenanceTaskTest extends PersistenceCapableTest {
+class VulnerabilityDatabaseMaintenanceTaskTest extends PersistenceCapableTest {
 
     @Test
-    public void test() {
+    void test() {
         final var vuln = new Vulnerability();
         vuln.setVulnId("CVE-123");
         vuln.setSource(Vulnerability.Source.NVD);


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Refactors maintenance tasks to handle large datasets better.

* Ensures all delete operations are bounded to prevent massive deletes from causing I/O spikes or long-running transactions.
* Caps max iterations at 1k to additionally limit the impact when there's lots of data to delete.
* Replaces shedlock-based locks with transaction-level advisory locks where possible. Less config surface.

Also extracts advisory lock acquisition logic into a central utility class.

Note that shedlock can't be ripped out entirely because we can't / don't want to use session-level advisory locks, since those are incompatible with central connection poolers.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
