### PR TITLE
Improve efficiency of package metadata resolution

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/JdbiFactory.java
@@ -26,6 +26,7 @@ import io.micrometer.core.instrument.Metrics;
 import org.dependencytrack.common.datasource.DataSourceRegistry;
 import org.dependencytrack.common.pagination.SimplePageTokenEncoder;
 import org.dependencytrack.persistence.QueryManager;
+import org.dependencytrack.persistence.jdbi.mapping.PackageArtifactMetadataRowMapper;
 import org.dependencytrack.persistence.jdbi.mapping.PackageMetadataRowMapper;
 import org.dependencytrack.support.jdbi.exception.ExceptionTranslationPlugin;
 import org.dependencytrack.support.jdbi.mapping.PurlColumnMapper;
@@ -179,7 +180,8 @@ public class JdbiFactory {
                 .registerArrayType(Date.class, "TIMESTAMPTZ")
                 .registerArrayType(Timestamp.class, "TIMESTAMPTZ")
                 .registerColumnMapper(new PurlColumnMapper())
-                .registerRowMapper(new PackageMetadataRowMapper());
+                .registerRowMapper(new PackageMetadataRowMapper())
+                .registerRowMapper(new PackageArtifactMetadataRowMapper());
 
         preparedJdbi
                 .getConfig(PaginationConfig.class)

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/PackageArtifactMetadataDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/PackageArtifactMetadataDao.java
@@ -23,6 +23,7 @@ import org.jdbi.v3.core.Handle;
 
 import java.sql.Timestamp;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * @since 5.0.0
@@ -33,6 +34,31 @@ public final class PackageArtifactMetadataDao {
 
     public PackageArtifactMetadataDao(Handle jdbiHandle) {
         this.jdbiHandle = jdbiHandle;
+    }
+
+    public List<PackageArtifactMetadata> getAll(Collection<String> purls) {
+        if (purls == null || purls.isEmpty()) {
+            return List.of();
+        }
+
+        return jdbiHandle
+                .createQuery(/* language=SQL */ """
+                        SELECT "PURL"
+                             , "PACKAGE_PURL"
+                             , "HASH_MD5"
+                             , "HASH_SHA1"
+                             , "HASH_SHA256"
+                             , "HASH_SHA512"
+                             , "PUBLISHED_AT"
+                             , "RESOLVED_BY"
+                             , "RESOLVED_FROM"
+                             , "RESOLVED_AT"
+                          FROM "PACKAGE_ARTIFACT_METADATA"
+                         WHERE "PURL" = ANY(:purls)
+                        """)
+                .bindArray("purls", String.class, purls)
+                .mapTo(PackageArtifactMetadata.class)
+                .list();
     }
 
     public int upsertAll(Collection<PackageArtifactMetadata> metadata) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/PackageArtifactMetadataRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/PackageArtifactMetadataRowMapper.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.persistence.jdbi.mapping;
+
+import com.github.packageurl.PackageURL;
+import org.dependencytrack.model.PackageArtifactMetadata;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.mapper.ColumnMapper;
+import org.jdbi.v3.core.mapper.ColumnMappers;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 5.0.0
+ */
+@NullMarked
+public final class PackageArtifactMetadataRowMapper implements RowMapper<PackageArtifactMetadata> {
+
+    private @Nullable ColumnMapper<Instant> instantColumnMapper;
+    private @Nullable ColumnMapper<PackageURL> purlColumnMapper;
+
+    @Override
+    public void init(ConfigRegistry registry) {
+        final var columnMappers = registry.get(ColumnMappers.class);
+        instantColumnMapper = columnMappers.findFor(Instant.class).orElseThrow();
+        purlColumnMapper = columnMappers.findFor(PackageURL.class).orElseThrow();
+    }
+
+    @Override
+    public PackageArtifactMetadata map(ResultSet rs, StatementContext ctx) throws SQLException {
+        requireNonNull(instantColumnMapper);
+        requireNonNull(purlColumnMapper);
+
+        return new PackageArtifactMetadata(
+                purlColumnMapper.map(rs, "PURL", ctx),
+                purlColumnMapper.map(rs, "PACKAGE_PURL", ctx),
+                rs.getString("HASH_MD5"),
+                rs.getString("HASH_SHA1"),
+                rs.getString("HASH_SHA256"),
+                rs.getString("HASH_SHA512"),
+                instantColumnMapper.map(rs, "PUBLISHED_AT", ctx),
+                rs.getString("RESOLVED_BY"),
+                rs.getString("RESOLVED_FROM"),
+                instantColumnMapper.map(rs, "RESOLVED_AT", ctx));
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
@@ -50,14 +50,13 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import java.time.Instant;
-import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -111,10 +110,18 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
         try (var ignoredMdcResolver = MDC.putCloseable(MDC_PKG_METADATA_RESOLVER_NAME, resolverName)) {
             final PackageMetadataResolverFactory resolverFactory = getResolverFactory(resolverName);
 
-            // Determine which PURLs have already been resolved. In case the activity was
-            // restarted (i.e. retry or previously interrupted), it may already have made
-            // progress in this batch.
-            final Set<String> recentlyResolvedPurls = getRecentlyResolvedPurls(purlStrings);
+            // Surface previously-resolved artifact metadata as an opt-in hint to resolvers.
+            // Resolvers that can short-circuit on it (e.g. Maven for stable versions) will
+            // skip the corresponding HTTP fetches. The per-repository match is enforced
+            // before resolvers are called.
+            final Map<String, org.dependencytrack.model.PackageArtifactMetadata> priorArtifactMetadataByPurl =
+                    withJdbiHandle(handle -> new PackageArtifactMetadataDao(handle)
+                            .getAll(purlStrings)
+                            .stream()
+                            .collect(Collectors.toMap(
+                                    pam -> pam.purl().canonicalize(),
+                                    Function.identity(),
+                                    (a, b) -> a)));
 
             final var repoByPurlType = new HashMap<String, List<Repository>>();
             final var passwordByRepoTypeAndName = new HashMap<String, Optional<String>>();
@@ -134,11 +141,6 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
 
                     MDC.put(MDC_PURL, purlStr);
                     try {
-                        if (recentlyResolvedPurls.contains(purlStr)) {
-                            LOGGER.debug("PURL already resolved recently; Skipping");
-                            continue;
-                        }
-
                         processPurl(
                                 purlStr,
                                 resolverFactory,
@@ -146,6 +148,7 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
                                 repoByPurlType,
                                 passwordByRepoTypeAndName,
                                 isInternalFunc,
+                                priorArtifactMetadataByPurl,
                                 resultBuffer);
                     } catch (InterruptedException e) {
                         resultBuffer.flush();
@@ -177,6 +180,7 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
             Map<String, List<Repository>> repoByPurlType,
             Map<String, Optional<String>> passwordByRepoTypeAndName,
             Function<PackageURL, Boolean> isInternalFunc,
+            Map<String, org.dependencytrack.model.PackageArtifactMetadata> priorArtifactMetadataByPurl,
             ResultBuffer buffer) throws Exception {
         final PackageURL purl;
         try {
@@ -195,13 +199,21 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
             return;
         }
 
+        // NB: prior is stored under the original PURL, so look up by the original PURL
+        // and NOT the normalized one. Resolvers that inject qualifiers during normalization
+        // (e.g. Maven's type=jar) would otherwise miss prior rows persisted under the unqualified
+        // component PURL.
+        final org.dependencytrack.model.PackageArtifactMetadata priorArtifactMetadata =
+                priorArtifactMetadataByPurl.get(purl.canonicalize());
+
         final ResolutionResult result = resolve(
                 normalizedPurl,
                 resolverFactory,
                 resolver,
                 repoByPurlType,
                 passwordByRepoTypeAndName,
-                isInternalFunc);
+                isInternalFunc,
+                priorArtifactMetadata);
         if (result != null) {
             buffer.addResult(purl, result);
         } else {
@@ -221,7 +233,8 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
             PackageMetadataResolver resolver,
             Map<String, List<Repository>> repoByPurlType,
             Map<String, Optional<String>> passwordByRepoTypeAndName,
-            Function<PackageURL, Boolean> isInternalFunc) throws Exception {
+            Function<PackageURL, Boolean> isInternalFunc,
+            org.dependencytrack.model.@Nullable PackageArtifactMetadata priorArtifactMetadata) throws Exception {
         if (resolverFactory.requiresRepository()) {
             final List<Repository> repos = repoByPurlType.computeIfAbsent(
                     normalizedPurl.getType(),
@@ -271,8 +284,19 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
                             password);
 
 
+                    // Only surface priorArtifactMetadata to the resolver if it was originally resolved
+                    // from the repository currently being attempted. Cross-repo reuse is unsafe
+                    // (publishedAt timestamps can differ across mirrors / proxies).
+                    final PackageArtifactMetadata effectivePriorArtifactMetadata =
+                            (priorArtifactMetadata != null && Objects.equals(priorArtifactMetadata.resolvedFrom(), repo.getIdentifier()))
+                                    ? convert(priorArtifactMetadata)
+                                    : null;
+
                     LOGGER.debug("Resolving metadata from repository");
-                    final PackageMetadata result = resolver.resolve(normalizedPurl, packageRepository);
+                    final PackageMetadata result = resolver.resolve(
+                            normalizedPurl,
+                            packageRepository,
+                            effectivePriorArtifactMetadata);
                     if (result != null) {
                         return new ResolutionResult(result, repo.getIdentifier(), resolverFactory.extensionName());
                     }
@@ -280,13 +304,39 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
             }
         } else {
             LOGGER.debug("Resolving metadata");
-            final PackageMetadata result = resolver.resolve(normalizedPurl, null);
+            final PackageMetadata result = resolver.resolve(
+                    normalizedPurl,
+                    /* repository */ null,
+                    priorArtifactMetadata != null ? convert(priorArtifactMetadata) : null);
             if (result != null) {
                 return new ResolutionResult(result, null, resolverFactory.extensionName());
             }
         }
 
         return null;
+    }
+
+    private static PackageArtifactMetadata convert(org.dependencytrack.model.PackageArtifactMetadata internal) {
+        final var hashes = new EnumMap<HashAlgorithm, String>(HashAlgorithm.class);
+        if (internal.md5() != null) {
+            hashes.put(HashAlgorithm.MD5, internal.md5());
+        }
+        if (internal.sha1() != null) {
+            hashes.put(HashAlgorithm.SHA1, internal.sha1());
+        }
+        if (internal.sha256() != null) {
+            hashes.put(HashAlgorithm.SHA256, internal.sha256());
+        }
+        if (internal.sha512() != null) {
+            hashes.put(HashAlgorithm.SHA512, internal.sha512());
+        }
+
+        return new PackageArtifactMetadata(
+                internal.resolvedAt() != null
+                        ? internal.resolvedAt()
+                        : Instant.EPOCH,
+                internal.publishedAt(),
+                hashes);
     }
 
     private PackageMetadataResolverFactory getResolverFactory(String resolverName) {
@@ -315,19 +365,6 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
                 .bind("type", repoType.name())
                 .mapToBean(Repository.class)
                 .list());
-    }
-
-    private static Set<String> getRecentlyResolvedPurls(Collection<String> purls) {
-        return withJdbiHandle(handle -> handle
-                .createQuery(/* language=SQL */ """
-                        SELECT "PURL"
-                          FROM "PACKAGE_ARTIFACT_METADATA"
-                         WHERE "PURL" = ANY(:purls)
-                           AND "RESOLVED_AT" > NOW() - INTERVAL '5 minutes'
-                        """)
-                .bindArray("purls", String.class, purls)
-                .mapTo(String.class)
-                .collect(Collectors.toSet()));
     }
 
     private static boolean isInternal(

--- a/apiserver/src/test/java/org/dependencytrack/pkgmetadata/MockPackageMetadataResolverPlugin.java
+++ b/apiserver/src/test/java/org/dependencytrack/pkgmetadata/MockPackageMetadataResolverPlugin.java
@@ -18,7 +18,9 @@
  */
 package org.dependencytrack.pkgmetadata;
 
+import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolverFactory;
@@ -35,13 +37,16 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static com.github.packageurl.PackageURLBuilder.aPackageURL;
+
 final class MockPackageMetadataResolverPlugin implements Plugin {
 
     private final MockPackageMetadataResolverFactory factory;
 
     MockPackageMetadataResolverPlugin(
-            AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef) {
-        this.factory = new MockPackageMetadataResolverFactory(resolveFnRef);
+            AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef,
+            AtomicReference<PackageArtifactMetadata> lastSeenPriorRef) {
+        this.factory = new MockPackageMetadataResolverFactory(resolveFnRef, lastSeenPriorRef);
     }
 
     @Override
@@ -52,13 +57,21 @@ final class MockPackageMetadataResolverPlugin implements Plugin {
     private static final class MockPackageMetadataResolver implements PackageMetadataResolver {
 
         private final AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef;
+        private final AtomicReference<PackageArtifactMetadata> lastSeenPriorRef;
 
-        MockPackageMetadataResolver(AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef) {
+        MockPackageMetadataResolver(
+                AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef,
+                AtomicReference<PackageArtifactMetadata> lastSeenPriorRef) {
             this.resolveFnRef = resolveFnRef;
+            this.lastSeenPriorRef = lastSeenPriorRef;
         }
 
         @Override
-        public @Nullable PackageMetadata resolve(PackageURL purl, @Nullable PackageRepository repository) {
+        public @Nullable PackageMetadata resolve(
+                PackageURL purl,
+                @Nullable PackageRepository repository,
+                @Nullable PackageArtifactMetadata prior) {
+            lastSeenPriorRef.set(prior);
             return resolveFnRef.get().apply(purl);
         }
 
@@ -67,9 +80,13 @@ final class MockPackageMetadataResolverPlugin implements Plugin {
     private static final class MockPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
 
         private final AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef;
+        private final AtomicReference<PackageArtifactMetadata> lastSeenPriorRef;
 
-        MockPackageMetadataResolverFactory(AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef) {
+        MockPackageMetadataResolverFactory(
+                AtomicReference<Function<PackageURL, PackageMetadata>> resolveFnRef,
+                AtomicReference<PackageArtifactMetadata> lastSeenPriorRef) {
             this.resolveFnRef = resolveFnRef;
+            this.lastSeenPriorRef = lastSeenPriorRef;
         }
 
         @Override
@@ -88,15 +105,35 @@ final class MockPackageMetadataResolverPlugin implements Plugin {
 
         @Override
         public PackageMetadataResolver create() {
-            return new MockPackageMetadataResolver(resolveFnRef);
+            return new MockPackageMetadataResolver(resolveFnRef, lastSeenPriorRef);
         }
 
         @Override
         public @Nullable PackageURL normalize(PackageURL purl) {
-            if ("maven".equals(purl.getType())) {
+            if (!"maven".equals(purl.getType())) {
+                return null;
+            }
+            if (purl.getQualifiers() != null && purl.getQualifiers().containsKey("type")) {
                 return purl;
             }
-            return null;
+
+            try {
+                final var builder = aPackageURL()
+                        .withType(purl.getType())
+                        .withNamespace(purl.getNamespace())
+                        .withName(purl.getName())
+                        .withVersion(purl.getVersion())
+                        .withQualifier("type", "jar");
+                if (purl.getQualifiers() != null) {
+                    for (final var qualifier : purl.getQualifiers().entrySet()) {
+                        builder.withQualifier(qualifier.getKey(), qualifier.getValue());
+                    }
+                }
+
+                return builder.build();
+            } catch (MalformedPackageURLException e) {
+                return purl;
+            }
         }
 
         @Override

--- a/apiserver/src/test/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataWorkflowTest.java
@@ -34,6 +34,8 @@ import org.dependencytrack.dex.testing.WorkflowTestExtension;
 import org.dependencytrack.model.Component;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.persistence.jdbi.JdbiFactory;
+import org.dependencytrack.persistence.jdbi.PackageArtifactMetadataDao;
+import org.dependencytrack.persistence.jdbi.PackageMetadataDao;
 import org.dependencytrack.pkgmetadata.resolution.api.HashAlgorithm;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
@@ -59,6 +61,7 @@ import java.util.function.Function;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.dependencytrack.dex.api.payload.PayloadConverters.protoConverter;
 import static org.dependencytrack.dex.api.payload.PayloadConverters.voidConverter;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 class ResolvePackageMetadataWorkflowTest extends PersistenceCapableTest {
@@ -70,10 +73,12 @@ class ResolvePackageMetadataWorkflowTest extends PersistenceCapableTest {
     private PluginManager pluginManager;
     private final AtomicReference<Function<PackageURL, PackageMetadata>> mockResolveFnRef =
             new AtomicReference<>(purl -> null);
+    private final AtomicReference<PackageArtifactMetadata> mockLastSeenPriorRef =
+            new AtomicReference<>(null);
 
     @BeforeEach
     void beforeEach() {
-        final var mockPlugin = new MockPackageMetadataResolverPlugin(mockResolveFnRef);
+        final var mockPlugin = new MockPackageMetadataResolverPlugin(mockResolveFnRef, mockLastSeenPriorRef);
 
         pluginManager = new PluginManager(
                 new SmallRyeConfigBuilder().build(),
@@ -272,6 +277,56 @@ class ResolvePackageMetadataWorkflowTest extends PersistenceCapableTest {
     }
 
     @Test
+    void shouldPassPriorArtifactMetadataToResolverWhenAvailable() {
+        useJdbiTransaction(handle -> {
+            new PackageMetadataDao(handle).upsertAll(List.of(
+                    new org.dependencytrack.model.PackageMetadata(
+                            parsePurl("pkg:maven/org.acme/foo"),
+                            "1.0",
+                            Instant.parse("2024-06-15T12:00:00Z"),
+                            Instant.parse("2024-06-15T12:00:00Z"),
+                            null,
+                            "mock")));
+            new PackageArtifactMetadataDao(handle).upsertAll(List.of(
+                    new org.dependencytrack.model.PackageArtifactMetadata(
+                            parsePurl("pkg:maven/org.acme/foo@1.0"),
+                            parsePurl("pkg:maven/org.acme/foo"),
+                            null,
+                            "da39a3ee5e6b4b0d3255bfef95601890afd80709",
+                            null,
+                            null,
+                            Instant.parse("2024-06-15T12:00:00Z"),
+                            "mock",
+                            null,
+                            Instant.parse("2024-06-15T12:00:00Z"))));
+        });
+
+        final Instant resolvedAt = Instant.now();
+        mockResolveFnRef.set(purl -> new PackageMetadata("9.9.9", Instant.now(), resolvedAt, null));
+
+        var project = new Project();
+        project.setName("test-project");
+        project = qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setGroup("org.acme");
+        component.setName("foo");
+        component.setVersion("1.0");
+        component.setPurl("pkg:maven/org.acme/foo@1.0");
+        qm.persist(component);
+
+        final UUID runId = workflowTest.getEngine().createRun(
+                new CreateWorkflowRunRequest<>(ResolvePackageMetadataWorkflow.class));
+        workflowTest.awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+
+        final PackageArtifactMetadata seenPrior = mockLastSeenPriorRef.get();
+        assertThat(seenPrior).isNotNull();
+        assertThat(seenPrior.publishedAt()).isEqualTo(Instant.parse("2024-06-15T12:00:00Z"));
+        assertThat(seenPrior.hashes()).containsEntry(HashAlgorithm.SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    }
+
+    @Test
     void shouldHandleResolverFailureGracefully() {
         mockResolveFnRef.set(purl -> {
             throw new RuntimeException("Simulated resolver failure");
@@ -304,6 +359,14 @@ class ResolvePackageMetadataWorkflowTest extends PersistenceCapableTest {
             assertThat(row).containsEntry("purl", "pkg:maven/org.acme/foo");
             assertThat(row).containsEntry("latest_version", null);
         });
+    }
+
+    private static PackageURL parsePurl(String purl) {
+        try {
+            return new PackageURL(purl);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/docs/adr/021-package-metadata-conditional-revalidation.md
+++ b/docs/adr/021-package-metadata-conditional-revalidation.md
@@ -42,9 +42,9 @@ would survive to revalidate with. This is Renovate's [soft / hard TTL][renovate-
 
 ### Negative responses
 
-`404` and `410` are cached as bodyless entries under the same freshness rules. Resolution starts from a PURL asserted
-to exist upstream, so a not-found typically reflects a misconfigured or wrong registry, not a transient state worth
-revalidating per call.
+`404` and `410` are cached as bodyless entries under the resolver's freshness cap. Resolution starts from a PURL
+asserted to exist upstream, so a not-found typically reflects a misconfigured or wrong registry, not a transient
+state worth revalidating per call.
 
 ### Storage
 
@@ -52,6 +52,25 @@ The cache reuses the existing [`cache`](../../cache) module.
 Validators are deliberately not added to `PACKAGE_METADATA` or `PACKAGE_ARTIFACT_METADATA`
 (see [ADR-015](./015-package-metadata.md)) since those tables model domain data, not HTTP responses, and resolvers do not
 all map one row to one URL.
+
+### Resolver-side reuse of prior domain data
+
+Domain tables (see [ADR-015](./015-package-metadata.md)) already persist publish timestamps and hashes for previously resolved versions.
+For immutable artifacts those values cannot change, so refetching them per cycle is wasted work, even with conditional
+revalidation in place.
+
+The orchestration layer surfaces the prior artifact metadata to the resolver as an opt-in hint. Orchestration
+owns repository identity: it only forwards the hint when the prior was resolved from the repository currently
+being attempted, since publish timestamps can legitimately differ across mirrors. The resolver owns version
+stability: it decides whether the hint is safe to reuse for the requested version.
+
+This benefits ecosystems that split latest-version and per-version metadata into separate requests.
+Ecosystems that fetch a single document containing both must still fetch on every cycle and ignore the hint.
+
+The boundary with ADR-015 is preserved: domain tables carry no HTTP validators, and resolvers retain
+request-shape knowledge. The trade-off being that a resolver bug that produced wrong values won't self-heal
+on the next refresh, requiring a one-time re-resolution or row purge to recover. This risk is outweighed by
+the benefit of fewer requests to public infrastructure.
 
 ### Adoption
 
@@ -72,20 +91,35 @@ deadline is not refreshed on fallback, so the next call still attempts revalidat
 stale window. The [RFC 9111][rfc9111] `stale-if-error` directive is not parsed because major registries do not emit it
 and the eviction TTL is already authoritative.
 
+### Rate-limit backoff
+
+`429`, `503`, and `504` gate the host until `Retry-After` elapses (default 30s, capped at 5m). `Retry-After` accepts
+delay-seconds or an HTTP-date per [RFC 9110][rfc9110]. Calls during the window serve stale cached values when possible,
+and otherwise surface a retryable failure.
+
+The gate is in-memory. Singleton workflow execution (see [ADR-015]) makes cross-instance coordination unnecessary,
+although we may revisit this in the future.
+
+Failover loses gate state and can re-trigger one burst, which is acceptable for an anti-thrashing aid.
+Renovate ships the same pattern in [`lib/util/http/retry-after.ts`][renovate-retry-after].
+
 ## Consequences
 
 Refreshes that would have transferred a full metadata document now exchange a conditional request and a small `304`
-when nothing has changed. This reduces bandwidth, conserves rate-limited quotas at registries where `304` responses
-are exempt from throttling, and avoids re-parsing unchanged bodies.
+when nothing has changed. This reduces bandwidth and avoids re-parsing unchanged bodies. Whether `304` responses
+actually count against rate-limit quotas depends on each registry's implementation. The prior-resolution hint described
+above is what eliminates the per-cycle request entirely for stable artifacts, independent of registry policy.
 
 Each adopting resolver previously kept a short-lived cache of parsed metadata structures. That cache becomes
 redundant once the URL cache is in place, since both cover the same access pattern. Adopting resolvers drop the parsed
 cache and re-derive structures from the cached body on each call. This removes a class of drift bug between parsed and
 raw representations. The cost is microseconds of redundant parsing work per duplicated PURL within a batch.
 
+[ADR-015]: ./015-package-metadata.md
 [open-not-costless]: https://www.sonatype.com/blog/open-is-not-costless-reclaiming-sustainable-infrastructure
 [renovate-hard-ttl]: https://docs.renovatebot.com/self-hosted-configuration/#cachehardttlminutes
 [renovate-pkg-cache]: https://github.com/renovatebot/renovate/blob/main/lib/util/http/cache/package-http-cache-provider.ts
+[renovate-retry-after]: https://github.com/renovatebot/renovate/blob/main/lib/util/http/retry-after.ts
 [renovate-soft-hard-cache]: https://docs.mend.io/wsk/renovate-soft-and-hard-package-cache-behavior
 [rfc9110]: https://www.rfc-editor.org/rfc/rfc9110
 [rfc9111]: https://www.rfc-editor.org/rfc/rfc9111

--- a/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/PackageMetadataResolver.java
+++ b/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/PackageMetadataResolver.java
@@ -38,13 +38,21 @@ public interface PackageMetadataResolver extends ExtensionPoint {
      * and respect rate limits of upstream repositories. When a transient
      * failure is detected (rate limiting, server errors, connection failures),
      * a {@link RetryableResolutionException} should be thrown.
+     * <p>
+     * The caller is responsible for ensuring that {@code prior}, when non-null, was resolved
+     * against the same repository as the one currently being attempted. Resolvers decide
+     * whether the prior data is safe to reuse (e.g. only for stable versions). Resolvers
+     * that cannot benefit from the hint may ignore the parameter entirely.
      *
      * @param purl       The package URL to resolve metadata for.
      * @param repository The repository to resolve against, or {@code null} for standalone resolvers.
+     * @param prior      Previously resolved artifact-level metadata for the same PURL and repository,
+     *                   or {@code null} if no prior data is available.
      * @return The resolved metadata, or {@code null} if no metadata could be resolved.
      */
     @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException;
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException;
 
 }

--- a/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionException.java
+++ b/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionException.java
@@ -21,7 +21,12 @@ package org.dependencytrack.pkgmetadata.resolution.api;
 import org.jspecify.annotations.Nullable;
 
 import java.net.http.HttpResponse;
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 
 /**
  * Exception for resolution failures that may be retried.
@@ -59,32 +64,47 @@ public class RetryableResolutionException extends RuntimeException {
         return retryAfter;
     }
 
-    public static void throwIfRetryableError(HttpResponse<?> response) {
+    public static void throwIfRetryableError(HttpResponse<?> response, Clock clock) {
         final int statusCode = response.statusCode();
 
         if (statusCode == 429) {
-            final Duration retryAfter = response.headers()
-                    .firstValue("Retry-After")
-                    .map(RetryableResolutionException::parseRetryAfterHeader)
-                    .orElse(null);
-
             throw new RetryableResolutionException(
-                    "Rate limited by %s".formatted(response.request().uri()), null, retryAfter);
+                    "Rate limited by %s".formatted(response.request().uri()),
+                    null,
+                    extractRetryAfter(response, clock));
         }
 
         if (statusCode == 503 || statusCode == 504) {
             throw new RetryableResolutionException(
-                    "Server error %d from %s".formatted(statusCode, response.request().uri()));
+                    "Server error %d from %s".formatted(statusCode, response.request().uri()),
+                    null,
+                    extractRetryAfter(response, clock));
         }
     }
 
-    private static @Nullable Duration parseRetryAfterHeader(String value) {
+    private static @Nullable Duration extractRetryAfter(HttpResponse<?> response, Clock clock) {
+        return response.headers()
+                .firstValue("Retry-After")
+                .map(value -> tryParseRetryAfterHeader(value, clock))
+                .orElse(null);
+    }
+
+    static @Nullable Duration tryParseRetryAfterHeader(String value, Clock clock) {
+        final String trimmed = value.strip();
         try {
-            final long seconds = Long.parseLong(value.strip());
-            return seconds > 0
-                    ? Duration.ofSeconds(seconds)
-                    : null;
-        } catch (NumberFormatException e) {
+            final long seconds = Long.parseLong(trimmed);
+            return seconds > 0 ? Duration.ofSeconds(seconds) : null;
+        } catch (NumberFormatException ignored) {
+            // Fallthrough to date parsing.
+        }
+
+        try {
+            final Instant deadline = ZonedDateTime
+                    .parse(trimmed, DateTimeFormatter.RFC_1123_DATE_TIME)
+                    .toInstant();
+            final Duration delta = Duration.between(clock.instant(), deadline);
+            return (delta.isZero() || delta.isNegative()) ? null : delta;
+        } catch (DateTimeParseException ignored) {
             return null;
         }
     }

--- a/package-metadata/api/src/test/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionExceptionTest.java
+++ b/package-metadata/api/src/test/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionExceptionTest.java
@@ -19,24 +19,60 @@
 package org.dependencytrack.pkgmetadata.resolution.api;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class RetryableResolutionExceptionTest {
 
-    @Test
-    void shouldThrowWhenRetryAfterIsNegative() {
+    private static final Instant FIXED_NOW = Instant.parse("2024-01-01T00:00:00Z");
+    private static final Clock FIXED_CLOCK = Clock.fixed(FIXED_NOW, ZoneOffset.UTC);
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1, 0})
+    void shouldRejectNonPositiveRetryAfter(long seconds) {
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new RetryableResolutionException(null, null, Duration.of(-1, ChronoUnit.SECONDS)));
+                .isThrownBy(() -> new RetryableResolutionException(
+                        null, null, Duration.of(seconds, ChronoUnit.SECONDS)));
     }
 
     @Test
-    void shouldThrowWhenRetryAfterIsZero() {
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new RetryableResolutionException(null, null, Duration.of(0, ChronoUnit.SECONDS)));
+    void shouldParseRetryAfterAsDelaySeconds() {
+        assertThat(RetryableResolutionException.tryParseRetryAfterHeader("60", FIXED_CLOCK))
+                .isEqualTo(Duration.ofSeconds(60));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"0", "-5", "not-a-date"})
+    void shouldReturnNullForUnusableHeaderValue(String value) {
+        assertThat(RetryableResolutionException.tryParseRetryAfterHeader(value, FIXED_CLOCK)).isNull();
+    }
+
+    @Test
+    void shouldParseRetryAfterAsHttpDate() {
+        final Instant deadline = FIXED_NOW.plus(Duration.ofMinutes(10));
+        final String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(deadline.atZone(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS));
+
+        assertThat(RetryableResolutionException.tryParseRetryAfterHeader(httpDate, FIXED_CLOCK))
+                .isEqualTo(Duration.ofMinutes(10));
+    }
+
+    @Test
+    void shouldReturnNullWhenHttpDateIsInPast() {
+        final String httpDate = DateTimeFormatter.RFC_1123_DATE_TIME
+                .format(FIXED_NOW.minus(Duration.ofMinutes(5)).atZone(ZoneOffset.UTC));
+
+        assertThat(RetryableResolutionException.tryParseRetryAfterHeader(httpDate, FIXED_CLOCK)).isNull();
     }
 
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
@@ -67,6 +67,7 @@ public final class CachingHttpClient {
     private final Duration freshnessCap;
     private final long maxBytes;
     private final Clock clock;
+    private final RateLimitGate rateLimitGate;
 
     public CachingHttpClient(HttpClient httpClient, Cache cache, Duration freshnessCap, long maxBytes) {
         this(httpClient, cache, freshnessCap, maxBytes, Clock.systemUTC());
@@ -84,6 +85,7 @@ public final class CachingHttpClient {
         }
         this.maxBytes = maxBytes;
         this.clock = requireNonNull(clock, "clock must not be null");
+        this.rateLimitGate = new RateLimitGate(clock);
     }
 
     public byte @Nullable [] get(
@@ -99,6 +101,12 @@ public final class CachingHttpClient {
 
         if (entry != null && isFresh(entry)) {
             return decodedBodyOf(entry);
+        }
+
+        final byte[] staleResponseBody =
+                shortCircuitIfRateLimited(uri, entry, this::staleBody);
+        if (staleResponseBody != null) {
+            return staleResponseBody;
         }
 
         applyValidators(requestBuilderCopy, entry);
@@ -125,6 +133,12 @@ public final class CachingHttpClient {
 
         if (entry != null && isFresh(entry)) {
             return isPositiveHeadEntry(entry) ? rebuildHeaders(entry) : null;
+        }
+
+        final HttpHeaders staleResponseHeaders =
+                shortCircuitIfRateLimited(uri, entry, CachingHttpClient::staleHeaders);
+        if (staleResponseHeaders != null) {
+            return staleResponseHeaders;
         }
 
         applyValidators(requestBuilderCopy, entry);
@@ -167,12 +181,38 @@ public final class CachingHttpClient {
         if (entry != null) {
             final T stale = staleExtractor.apply(entry);
             if (stale != null) {
-                LOGGER.warn("Revalidation failed for {}; serving stale cached value", uri, cause);
+                LOGGER.debug("Revalidation failed for {}; serving stale cached value", uri, cause);
                 return stale;
             }
         }
 
         throw rethrow.get();
+    }
+
+    private <T> @Nullable T shortCircuitIfRateLimited(
+            URI uri,
+            @Nullable CacheEntry entry,
+            Function<CacheEntry, @Nullable T> staleExtractor) {
+        final Instant rateLimitedUntil = rateLimitGate.checkRateLimited(uri);
+        if (rateLimitedUntil == null) {
+            return null;
+        }
+
+        if (entry != null) {
+            final T stale = staleExtractor.apply(entry);
+            if (stale != null) {
+                LOGGER.debug(
+                        "Host {} is rate-limited until {}; serving stale cached value",
+                        uri.getAuthority(), rateLimitedUntil);
+                return stale;
+            }
+        }
+
+        final Duration remaining = Duration.between(clock.instant(), rateLimitedUntil);
+        throw new RetryableResolutionException(
+                "Host %s gated until %s".formatted(uri.getAuthority(), rateLimitedUntil),
+                null,
+                remaining.isPositive() ? remaining : null);
     }
 
     private static void applyValidators(HttpRequest.Builder requestBuilderCopy, @Nullable CacheEntry entry) {
@@ -312,7 +352,10 @@ public final class CachingHttpClient {
         return throwUnexpected(response);
     }
 
-    private void cacheNegative(@Nullable CacheEntry entry, String cacheKey, CacheControl cacheControl) {
+    private void cacheNegative(
+            @Nullable CacheEntry entry,
+            String cacheKey,
+            CacheControl cacheControl) {
         // Negative responses are cached so that repeated lookups for the same PURL
         // do not hammer the registry.
         if (cacheControl.noStore()) {
@@ -332,8 +375,17 @@ public final class CachingHttpClient {
         }
     }
 
-    private static <T> T throwUnexpected(HttpResponse<?> response) {
-        RetryableResolutionException.throwIfRetryableError(response);
+    private <T> T throwUnexpected(HttpResponse<?> response) {
+        try {
+            RetryableResolutionException.throwIfRetryableError(response, clock);
+        } catch (RetryableResolutionException e) {
+            final Duration effectiveBackoff =
+                    rateLimitGate.recordRateLimit(
+                            response.request().uri(), e.retryAfter());
+            throw new RetryableResolutionException(
+                    e.getMessage(), e.getCause(), effectiveBackoff);
+        }
+
         throw new UncheckedIOException(new IOException(
                 "Unexpected status code %d for %s".formatted(response.statusCode(), response.request().uri())));
     }
@@ -415,11 +467,15 @@ public final class CachingHttpClient {
         return isPositiveHeadEntry(entry) ? rebuildHeaders(entry) : null;
     }
 
-    private Timestamp freshUntilTs(CacheControl cacheControl, @Nullable CacheEntry previousEntry) {
+    private Timestamp freshUntilTs(
+            CacheControl cacheControl,
+            @Nullable CacheEntry previousEntry) {
         return fromInstant(computeFreshUntil(cacheControl, previousEntry));
     }
 
-    private Instant computeFreshUntil(CacheControl cacheControl, @Nullable CacheEntry previousEntry) {
+    private Instant computeFreshUntil(
+            CacheControl cacheControl,
+            @Nullable CacheEntry previousEntry) {
         if (cacheControl.noCache()) {
             // Cache the body so that validators are available, but force the next call to
             // revalidate. RFC 7234 requires servers to perform validation before

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/RateLimitGate.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/RateLimitGate.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.pkgmetadata.resolution.cache;
+
+import org.jspecify.annotations.Nullable;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @since 5.0.0
+ */
+final class RateLimitGate {
+
+    private static final Duration DEFAULT_BACKOFF = Duration.ofSeconds(30);
+    private static final Duration MAX_BACKOFF = Duration.ofMinutes(5);
+
+    private final Map<String, Instant> rateLimitedUntilByHost = new ConcurrentHashMap<>();
+    private final Clock clock;
+
+    RateLimitGate(Clock clock) {
+        this.clock = clock;
+    }
+
+    @Nullable Instant checkRateLimited(URI uri) {
+        final String key = uri.getAuthority();
+        if (key == null) {
+            return null;
+        }
+
+        return rateLimitedUntilByHost
+                .computeIfPresent(
+                        key,
+                        (k, until) -> clock.instant().isBefore(until) ? until : null);
+    }
+
+    Duration recordRateLimit(URI uri, @Nullable Duration retryAfter) {
+        Duration backoffDuration = retryAfter != null
+                ? retryAfter
+                : DEFAULT_BACKOFF;
+        backoffDuration = backoffDuration.compareTo(MAX_BACKOFF) > 0
+                ? MAX_BACKOFF
+                : backoffDuration;
+
+        final String hostKey = uri.getAuthority();
+        if (hostKey == null) {
+            return backoffDuration;
+        }
+
+        final Instant now = clock.instant();
+        final Instant proposedUntil = now.plus(backoffDuration);
+        final Instant effectiveUntil = rateLimitedUntilByHost.merge(
+                hostKey,
+                proposedUntil,
+                (existing, proposed) -> proposed.isAfter(existing) ? proposed : existing);
+        
+        final Duration effective = Duration.between(now, effectiveUntil);
+        return effective.isPositive() ? effective : backoffDuration;
+    }
+
+}

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
@@ -58,7 +58,8 @@ final class CargoPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String url = UrlUtils.join(repository.url(), "api", "v1", "crates", purl.getName());

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolver.java
@@ -70,7 +70,8 @@ final class ComposerPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String packageKey = purl.getNamespace() + "/" + purl.getName();

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolver.java
@@ -56,8 +56,10 @@ final class CpanPackageMetadataResolver implements PackageMetadataResolver {
     }
 
     @Override
-    public @Nullable PackageMetadata resolve(PackageURL purl, @Nullable PackageRepository repository)
-            throws InterruptedException {
+    public @Nullable PackageMetadata resolve(
+            PackageURL purl,
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String url = UrlUtils.join(repository.url(), "v1", "release", purl.getName());

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolver.java
@@ -58,8 +58,10 @@ final class GemPackageMetadataResolver implements PackageMetadataResolver {
     }
 
     @Override
-    public @Nullable PackageMetadata resolve(PackageURL purl, @Nullable PackageRepository repository)
-            throws InterruptedException {
+    public @Nullable PackageMetadata resolve(
+            PackageURL purl,
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String url = UrlUtils.join(repository.url(), "api", "v1", "versions", purl.getName() + ".json");

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolver.java
@@ -57,7 +57,8 @@ final class GithubPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final byte[] latestBody = fetchLatestRelease(purl.getNamespace(), purl.getName(), repository);

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolver.java
@@ -57,7 +57,8 @@ final class GoModulesPackageMetadataResolver implements PackageMetadataResolver 
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         String modulePath = purl.getName();
@@ -85,6 +86,10 @@ final class GoModulesPackageMetadataResolver implements PackageMetadataResolver 
         if (purl.getVersion().equals(latestVersion)) {
             artifactMetadata = latestVersionPublishedAt != null
                     ? new PackageArtifactMetadata(resolvedAt, latestVersionPublishedAt, Map.of()) : null;
+        } else if (prior != null && prior.publishedAt() != null) {
+            // Go module versions are immutable by proxy contract,
+            // so any prior publishedAt for this PURL is safe to reuse.
+            artifactMetadata = new PackageArtifactMetadata(resolvedAt, prior.publishedAt(), Map.of());
         } else {
             final byte[] versionBody = fetchVersionInfo(modulePath, purl.getVersion(), repository);
             if (versionBody != null) {

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolver.java
@@ -21,6 +21,7 @@ package org.dependencytrack.pkgmetadata.resolution.hackage;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.packageurl.PackageURL;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
@@ -52,7 +53,8 @@ final class HackagePackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String url = UrlUtils.join(repository.url(), "package", purl.getName(), "preferred");

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolver.java
@@ -55,7 +55,8 @@ final class HexPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String url = UrlUtils.join(repository.url(), "api", "packages", purl.getName());

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolver.java
@@ -65,7 +65,8 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String baseUrl = join(repository.url(),
@@ -84,8 +85,18 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
             throw new InterruptedException();
         }
 
-        String artifactUrl = join(baseUrl, latestVersion, formatArtifactFileName(purl, latestVersion));
-        final var latestVersionPublishedAt = resolvePublishedAt(artifactUrl, repository);
+        // Prior is only trustworthy for stable versions of the same PURL.
+        // Snapshot versions are mutable, so artifact metadata can change.
+        final boolean canUsePrior = prior != null
+                && purl.getVersion() != null
+                && !isSnapshotVersion(purl.getVersion());
+        final boolean priorMatchesLatest =
+                canUsePrior && purl.getVersion().equals(latestVersion);
+
+        final String latestArtifactUrl = join(baseUrl, latestVersion, formatArtifactFileName(purl, latestVersion));
+        final Instant latestVersionPublishedAt = (priorMatchesLatest && prior.publishedAt() != null)
+                ? prior.publishedAt()
+                : resolvePublishedAt(latestArtifactUrl, repository);
         if (Thread.interrupted()) {
             throw new InterruptedException();
         }
@@ -94,16 +105,26 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
             return new PackageMetadata(latestVersion, latestVersionPublishedAt, resolvedAt, null);
         }
 
-        artifactUrl = join(baseUrl, purl.getVersion(), formatArtifactFileName(purl, null));
+        final String artifactUrl = join(baseUrl, purl.getVersion(), formatArtifactFileName(purl, null));
 
-        final var publishedAt = purl.getVersion().equals(latestVersion)
-                ? latestVersionPublishedAt
-                : resolvePublishedAt(artifactUrl, repository);
+        final Instant publishedAt;
+        if (purl.getVersion().equals(latestVersion)) {
+            publishedAt = latestVersionPublishedAt;
+        } else if (canUsePrior && prior.publishedAt() != null) {
+            publishedAt = prior.publishedAt();
+        } else {
+            publishedAt = resolvePublishedAt(artifactUrl, repository);
+        }
         if (Thread.interrupted()) {
             throw new InterruptedException();
         }
 
-        final String sha1 = fetchSha1Hash(artifactUrl, repository);
+        final String priorSha1 = canUsePrior
+                ? prior.hashes().get(HashAlgorithm.SHA1)
+                : null;
+        final String sha1 = priorSha1 == null
+                ? fetchSha1Hash(artifactUrl, repository)
+                : priorSha1;
         var hashes = new EnumMap<HashAlgorithm, String>(HashAlgorithm.class);
         if (sha1 != null) {
             hashes.put(HashAlgorithm.SHA1, sha1);
@@ -173,15 +194,6 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
                 .orElse(null);
     }
 
-    private static @Nullable Instant parseHttpDate(String value) {
-        try {
-            return ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
-        } catch (DateTimeParseException e) {
-            LOGGER.debug("Failed to parse Last-Modified header: {}", value, e);
-            return null;
-        }
-    }
-
     private @Nullable String fetchSha1Hash(
             String artifactUrl,
             PackageRepository repository) throws InterruptedException {
@@ -234,7 +246,9 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
         builder.header("Authorization", authHeaderValue);
     }
 
-    private static String formatArtifactFileName(PackageURL purl, String versionOverride) {
+    private static String formatArtifactFileName(
+            PackageURL purl,
+            @Nullable String versionOverride) {
         final Map<String, String> qualifiers = purl.getQualifiers();
 
         final String extension = qualifiers != null
@@ -247,12 +261,25 @@ final class MavenPackageMetadataResolver implements PackageMetadataResolver {
         final var sb = new StringBuilder()
                 .append(purl.getName())
                 .append('-')
-                .append(versionOverride == null ? purl.getVersion() :  versionOverride);
+                .append(versionOverride == null ? purl.getVersion() : versionOverride);
         if (classifier != null) {
             sb.append('-').append(classifier);
         }
 
         return sb.append('.').append(extension).toString();
+    }
+
+    static boolean isSnapshotVersion(String version) {
+        return version.toLowerCase().endsWith("-snapshot");
+    }
+
+    private static @Nullable Instant parseHttpDate(String value) {
+        try {
+            return ZonedDateTime.parse(value, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant();
+        } catch (DateTimeParseException e) {
+            LOGGER.debug("Failed to parse Last-Modified header: {}", value, e);
+            return null;
+        }
     }
 
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageIndex.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageIndex.java
@@ -36,6 +36,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
@@ -131,7 +132,7 @@ final class NixpkgsPackageIndex {
         }
 
         try (final InputStream body = response.body()) {
-            RetryableResolutionException.throwIfRetryableError(response);
+            RetryableResolutionException.throwIfRetryableError(response, Clock.systemUTC());
             if (response.statusCode() != 200) {
                 throw new UncheckedIOException(new IOException(
                         "Unexpected status code %d for %s".formatted(response.statusCode(), url)));

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageMetadataResolver.java
@@ -20,6 +20,7 @@ package org.dependencytrack.pkgmetadata.resolution.nixpkgs;
 
 import com.github.packageurl.PackageURL;
 import org.dependencytrack.cache.api.Cache;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
@@ -44,7 +45,8 @@ final class NixpkgsPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String cacheKey = CacheKeys.build(repository, purl.getName());

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolver.java
@@ -62,7 +62,8 @@ final class NpmPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String packageName = formatPackageName(purl);

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolver.java
@@ -83,7 +83,8 @@ final class NugetPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String registrationsBaseUrl = discoverRegistrationsBaseUrl(repository);
@@ -119,7 +120,14 @@ final class NugetPackageMetadataResolver implements PackageMetadataResolver {
         final Instant resolvedAt = Instant.now();
         PackageArtifactMetadata artifactMetadata = null;
         if (purl.getVersion() != null) {
-            final Instant publishedAt = findPublishedAt(pages, repository, purl.getVersion());
+            final Instant publishedAt;
+            if (prior != null && prior.publishedAt() != null && isStableVersion(purl.getVersion())) {
+                // Stable NuGet versions are immutable. Reuse the prior publishedAt and skip
+                // the per-version lookup, is it would otherwise trigger leaf page fetches.
+                publishedAt = prior.publishedAt();
+            } else {
+                publishedAt = findPublishedAt(pages, repository, purl.getVersion());
+            }
             if (publishedAt != null) {
                 artifactMetadata = new PackageArtifactMetadata(resolvedAt, publishedAt, Map.of());
             }
@@ -429,6 +437,14 @@ final class NugetPackageMetadataResolver implements PackageMetadataResolver {
     }
 
     private record CatalogEntry(String version, @Nullable Instant publishedAt) {
+    }
+
+    private static boolean isStableVersion(String version) {
+        try {
+            return VersionFactory.forScheme(SCHEME_NUGET, version).isStable();
+        } catch (InvalidVersionException e) {
+            return false;
+        }
     }
 
 }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolver.java
@@ -57,7 +57,8 @@ final class PypiPackageMetadataResolver implements PackageMetadataResolver {
     @Override
     public @Nullable PackageMetadata resolve(
             PackageURL purl,
-            @Nullable PackageRepository repository) throws InterruptedException {
+            @Nullable PackageRepository repository,
+            @Nullable PackageArtifactMetadata prior) throws InterruptedException {
         requireNonNull(repository, "repository must not be null");
 
         final String fileName = purl.getQualifiers() != null

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/PackageMetadataResolverIT.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/PackageMetadataResolverIT.java
@@ -88,7 +88,7 @@ class PackageMetadataResolverIT {
             final PackageMetadataResolver resolver = factory.create();
             final var purl = new PackageURL(purlString);
             final var repo = new PackageRepository(factory.extensionName(), repoUrl, null, null);
-            final PackageMetadata result = resolver.resolve(purl, repo);
+            final PackageMetadata result = resolver.resolve(purl, repo, null);
 
             assertThat(result)
                     .as("%s: %s", factory.extensionName(), purl)

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClientTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClientTest.java
@@ -216,17 +216,6 @@ class CachingHttpClientTest {
     }
 
     @Test
-    void shouldThrowRetryableExceptionOn429WithRetryAfter(WireMockRuntimeInfo wmRuntimeInfo) {
-        stubFor(get(urlPathEqualTo(PATH))
-                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "30")));
-
-        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES);
-        assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null))
-                .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
-    }
-
-    @Test
     void shouldThrowRetryableExceptionOn503(WireMockRuntimeInfo wmRuntimeInfo) {
         stubFor(get(urlPathEqualTo(PATH))
                 .willReturn(aResponse().withStatus(503)));
@@ -684,6 +673,10 @@ class CachingHttpClientTest {
         // First stale call falls back to cached body. fresh_until must remain in the past.
         cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
 
+        // Advance past the rate-limit gate that the 503 just engaged (default 30s backoff),
+        // so the next call is not short-circuited.
+        clock.advance(Duration.ofSeconds(31));
+
         // Second call must still revalidate via If-None-Match, thus proving
         // the entry's freshness deadline was not refreshed by the prior stale fallback.
         final byte[] body = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
@@ -1009,6 +1002,110 @@ class CachingHttpClientTest {
 
         assertThat(body).isEqualTo("fresh".getBytes(StandardCharsets.UTF_8));
         verify(1, getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    void shouldGateHostAfter429AndServeStale(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff")
+                .whenScenarioStateIs("Started")
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("ETag", "\"v1\"")
+                        .withBody("hello"))
+                .willSetStateTo("limited"));
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff")
+                .whenScenarioStateIs("limited")
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "60")));
+
+        final var clock = new MutableClock();
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        clock.advance(Duration.ofMinutes(2));
+
+        final byte[] firstStale = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        assertThat(firstStale).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+        verify(2, getRequestedFor(urlPathEqualTo(PATH)));
+
+        final byte[] gatedStale = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        assertThat(gatedStale).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+        verify(2, getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    void shouldGateHostAfter429AndThrowWhenNoStale(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(urlPathEqualTo(PATH))
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "60")));
+
+        final var clock = new MutableClock();
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofHours(1), MAX_BYTES, clock);
+        assertThatExceptionOfType(RetryableResolutionException.class)
+                .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null));
+
+        assertThatExceptionOfType(RetryableResolutionException.class)
+                .isThrownBy(() -> cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null))
+                .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(60));
+        verify(1, getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    void shouldReleaseHostGateAfterBackoffWindow(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff-release")
+                .whenScenarioStateIs("Started")
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("ETag", "\"v1\"")
+                        .withBody("hello"))
+                .willSetStateTo("limited"));
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff-release")
+                .whenScenarioStateIs("limited")
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "30"))
+                .willSetStateTo("recovered"));
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff-release")
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse().withStatus(304)));
+
+        final var clock = new MutableClock();
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        clock.advance(Duration.ofMinutes(2));
+
+        cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        verify(2, getRequestedFor(urlPathEqualTo(PATH)));
+
+        clock.advance(Duration.ofSeconds(60));
+        cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        verify(3, getRequestedFor(urlPathEqualTo(PATH)));
+    }
+
+    @Test
+    void shouldGateHostAfter503AndServeStale(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff-5xx")
+                .whenScenarioStateIs("Started")
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("ETag", "\"v1\"")
+                        .withBody("hello"))
+                .willSetStateTo("overloaded"));
+        stubFor(get(urlPathEqualTo(PATH))
+                .inScenario("backoff-5xx")
+                .whenScenarioStateIs("overloaded")
+                .willReturn(aResponse().withStatus(503)));
+
+        final var clock = new MutableClock();
+        final var cachingHttpClient = new CachingHttpClient(httpClient, cache, Duration.ofMinutes(1), MAX_BYTES, clock);
+        cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        clock.advance(Duration.ofMinutes(2));
+
+        final byte[] firstStale = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        assertThat(firstStale).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+        verify(2, getRequestedFor(urlPathEqualTo(PATH)));
+
+        final byte[] gatedStale = cachingHttpClient.get(requestBuilderFor(wmRuntimeInfo), null);
+        assertThat(gatedStale).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+        verify(2, getRequestedFor(urlPathEqualTo(PATH)));
     }
 
     private static byte[] gzip(byte[] input) throws Exception {

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/RateLimitGateTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cache/RateLimitGateTest.java
@@ -1,0 +1,153 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.pkgmetadata.resolution.cache;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.net.URI;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RateLimitGateTest {
+
+    private static final URI URI_A = URI.create("https://repo.example.com/path");
+    private static final URI URI_B = URI.create("https://other.example.com/path");
+
+    @Test
+    void shouldReturnNullWhenHostWasNeverRecorded() {
+        final var gate = new RateLimitGate(new MutableClock());
+
+        assertThat(gate.checkRateLimited(URI_A)).isNull();
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldGateForBackoffDerivedFromRetryAfter(Duration retryAfter, Duration expectedBackoff) {
+        final var clock = new MutableClock();
+        final var gate = new RateLimitGate(clock);
+
+        gate.recordRateLimit(URI_A, retryAfter);
+        assertThat(gate.checkRateLimited(URI_A))
+                .isEqualTo(clock.instant().plus(expectedBackoff));
+    }
+
+    static Stream<Arguments> shouldGateForBackoffDerivedFromRetryAfter() {
+        return Stream.of(
+                Arguments.of(null, Duration.ofSeconds(30)),
+                Arguments.of(Duration.ofSeconds(45), Duration.ofSeconds(45)),
+                Arguments.of(Duration.ofHours(1), Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void shouldClearEntryAfterWindowElapses() {
+        final var clock = new MutableClock();
+        final var gate = new RateLimitGate(clock);
+
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(30));
+        clock.advance(Duration.ofSeconds(31));
+
+        assertThat(gate.checkRateLimited(URI_A)).isNull();
+
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(10));
+        assertThat(gate.checkRateLimited(URI_A))
+                .isEqualTo(clock.instant().plusSeconds(10));
+    }
+
+    @Test
+    void shouldKeepLaterExpiryWhenRecordedTwice() {
+        final var clock = new MutableClock();
+        final var gate = new RateLimitGate(clock);
+
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(120));
+        final Instant longerWindow = gate.checkRateLimited(URI_A);
+
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(10));
+        assertThat(gate.checkRateLimited(URI_A)).isEqualTo(longerWindow);
+    }
+
+    @Test
+    void shouldExtendWindowWhenSecondSignalIsLater() {
+        final var clock = new MutableClock();
+        final var gate = new RateLimitGate(clock);
+
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(30));
+        clock.advance(Duration.ofSeconds(10));
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(60));
+
+        assertThat(gate.checkRateLimited(URI_A))
+                .isEqualTo(clock.instant().plusSeconds(60));
+    }
+
+    @Test
+    void shouldGateHostsIndependently() {
+        final var clock = new MutableClock();
+        final var gate = new RateLimitGate(clock);
+
+        gate.recordRateLimit(URI_A, Duration.ofSeconds(60));
+
+        assertThat(gate.checkRateLimited(URI_A)).isNotNull();
+        assertThat(gate.checkRateLimited(URI_B)).isNull();
+    }
+
+    @Test
+    void shouldIgnoreRecordWhenAuthorityIsNull() {
+        final var gate = new RateLimitGate(new MutableClock());
+        final URI relative = URI.create("/path-only");
+        assertThat(relative.getAuthority()).isNull();
+
+        gate.recordRateLimit(relative, Duration.ofSeconds(60));
+        assertThat(gate.checkRateLimited(relative)).isNull();
+    }
+
+    private static final class MutableClock extends Clock {
+
+        private final AtomicReference<Instant> now = new AtomicReference<>(Instant.parse("2024-01-01T00:00:00Z"));
+
+        @Override
+        public Instant instant() {
+            return now.get();
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            throw new UnsupportedOperationException();
+        }
+
+        void advance(Duration delta) {
+            now.updateAndGet(current -> current.plus(delta));
+        }
+
+    }
+
+}

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolverTest.java
@@ -102,7 +102,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.200");
@@ -144,7 +144,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.200");
@@ -177,7 +177,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.200");
@@ -198,7 +198,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -212,7 +212,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -234,7 +234,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.artifactMetadata()).isNotNull();
@@ -262,7 +262,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.artifactMetadata()).isNotNull();
@@ -284,7 +284,7 @@ class CargoPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -301,7 +301,7 @@ class CargoPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -321,7 +321,7 @@ class CargoPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("crates-io", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -337,7 +337,7 @@ class CargoPackageMetadataResolverTest {
                 .withType("cargo").withName("serde").withVersion("1.0.0").build();
 
         final var repo = new PackageRepository("crates", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         final String expected = "Basic " + Base64.getEncoder().encodeToString(
                 "user:secret".getBytes(StandardCharsets.UTF_8));
@@ -356,7 +356,7 @@ class CargoPackageMetadataResolverTest {
                 .withType("cargo").withName("serde").withVersion("1.0.0").build();
 
         final var repo = new PackageRepository("crates", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         verify(getRequestedFor(urlPathEqualTo("/api/v1/crates/serde"))
                 .withHeader("Authorization", equalTo("Bearer token")));

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolverTest.java
@@ -99,7 +99,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.2.0");
@@ -132,7 +132,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("v1", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("3.8.1");
@@ -164,7 +164,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v2.0.0");
@@ -185,7 +185,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("dummy", wmRuntimeInfo.getHttpBaseUrl() + "/therepo", null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.18.0");
@@ -199,7 +199,7 @@ class ComposerPackageMetadataResolverTest {
                 .withName("something")
                 .withVersion("1.0.0")
                 .build();
-        assertThat(resolver.resolve(purl2, repo)).isNull();
+        assertThat(resolver.resolve(purl2, repo, null)).isNull();
 
         verify(1, getRequestedFor(urlPathEqualTo("/therepo/packages.json")));
     }
@@ -218,7 +218,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("includes-repo", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.3.8");
@@ -245,7 +245,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("metadata-repo", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("6.6.6");
@@ -270,10 +270,10 @@ class ComposerPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
 
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
 
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
         verify(1, getRequestedFor(urlPathEqualTo("/p2/typo3/class-alias-loader.json")));
     }
@@ -293,9 +293,9 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("empty", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
 
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
     }
 
@@ -322,7 +322,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("drupal", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNotNull()
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull()
                 .satisfies(r -> assertThat(r.latestVersion()).isEqualTo("2.2.1"));
 
         final var nonMatching = aPackageURL()
@@ -331,7 +331,7 @@ class ComposerPackageMetadataResolverTest {
                 .withName("phpunit")
                 .withVersion("1.0.0")
                 .build();
-        assertThat(resolver.resolve(nonMatching, repo)).isNull();
+        assertThat(resolver.resolve(nonMatching, repo, null)).isNull();
 
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
         verify(1, getRequestedFor(urlPathEqualTo("/files/packages/8/p2/drupal/mollie.json")));
@@ -361,7 +361,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("available", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNotNull()
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull()
                 .satisfies(r -> assertThat(r.latestVersion()).isEqualTo("v1.2.0"));
 
         final var nonListed = aPackageURL()
@@ -370,7 +370,7 @@ class ComposerPackageMetadataResolverTest {
                 .withName("phpunit")
                 .withVersion("1.0.0")
                 .build();
-        assertThat(resolver.resolve(nonListed, repo)).isNull();
+        assertThat(resolver.resolve(nonListed, repo, null)).isNull();
 
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
         verify(1, getRequestedFor(urlPathEqualTo("/repository/p2/io/captain-hook.json")));
@@ -400,7 +400,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("patterns", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNotNull()
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull()
                 .satisfies(r -> assertThat(r.latestVersion()).isEqualTo("v1.2.0"));
 
         final var nonMatching = aPackageURL()
@@ -409,7 +409,7 @@ class ComposerPackageMetadataResolverTest {
                 .withName("phpunit")
                 .withVersion("1.0.0")
                 .build();
-        assertThat(resolver.resolve(nonMatching, repo)).isNull();
+        assertThat(resolver.resolve(nonMatching, repo, null)).isNull();
     }
 
     @Test
@@ -428,7 +428,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
     }
 
     @Test
@@ -444,7 +444,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("metadata-repo", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("9.9.9");
@@ -476,7 +476,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v2.0.0-beta.2");
@@ -506,7 +506,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
     }
 
     @Test
@@ -523,7 +523,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
     }
 
     @Test
@@ -541,7 +541,7 @@ class ComposerPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -560,7 +560,7 @@ class ComposerPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -573,7 +573,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -592,7 +592,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v2.0.0");
@@ -625,7 +625,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.5.0");
@@ -648,7 +648,7 @@ class ComposerPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("broken", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(UncheckedIOException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
 
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
     }
@@ -675,7 +675,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -704,7 +704,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("v1", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
     }
 
     @Test
@@ -721,8 +721,8 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("repo", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
 
         verify(1, getRequestedFor(urlPathEqualTo("/p2/space/cowboy.json")));
         verify(1, getRequestedFor(urlPathEqualTo("/packages.json")));
@@ -742,7 +742,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("mixed", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.3.8");
@@ -774,7 +774,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("patterns", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -795,7 +795,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("evil", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
     }
 
     @Test
@@ -821,7 +821,7 @@ class ComposerPackageMetadataResolverTest {
 
         stubFor(get(urlPathEqualTo("/p/vendor/package.json"))
                 .willReturn(aResponse().withStatus(404)));
-        assertThat(resolver.resolve(purl, repo)).isNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNull();
 
         verify(0, getRequestedFor(urlPathEqualTo("/etc/passwd")));
         verify(0, getRequestedFor(urlPathEqualTo("../../etc/passwd")));
@@ -852,7 +852,7 @@ class ComposerPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(UncheckedIOException.class)
-                .isThrownBy(() -> smallResolver.resolve(purl, repo));
+                .isThrownBy(() -> smallResolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -868,7 +868,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         final String expected = "Basic " + Base64.getEncoder().encodeToString(
                 "user:secret".getBytes(StandardCharsets.UTF_8));
@@ -891,7 +891,7 @@ class ComposerPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("packagist", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         verify(getRequestedFor(urlPathEqualTo("/packages.json"))
                 .withHeader("Authorization", equalTo("Bearer token")));

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolverTest.java
@@ -87,7 +87,7 @@ class CpanPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("cpan", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.2206");
@@ -119,7 +119,7 @@ class CpanPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("cpan", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.2206");
@@ -140,7 +140,7 @@ class CpanPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("cpan", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -154,7 +154,7 @@ class CpanPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -170,7 +170,7 @@ class CpanPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("cpan", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -187,7 +187,7 @@ class CpanPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("cpan", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gem/GemPackageMetadataResolverTest.java
@@ -91,7 +91,7 @@ class GemPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("7.1.3");
@@ -114,7 +114,7 @@ class GemPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -128,7 +128,7 @@ class GemPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -149,7 +149,7 @@ class GemPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("7.1.3");
@@ -178,7 +178,7 @@ class GemPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("7.1.3");
@@ -200,7 +200,7 @@ class GemPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -217,7 +217,7 @@ class GemPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -234,7 +234,7 @@ class GemPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("rubygems", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         final String expected = "Basic " + Base64.getEncoder().encodeToString(
                 "user:secret".getBytes(StandardCharsets.UTF_8));

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/github/GithubPackageMetadataResolverTest.java
@@ -97,7 +97,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -126,7 +126,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -160,7 +160,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -186,7 +186,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -213,7 +213,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, "ghp_testtoken123");
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
 
         verify(getRequestedFor(urlPathEqualTo("/repos/acme/project/releases/latest"))
                 .withHeader("Authorization", equalTo("Bearer ghp_testtoken123")));
@@ -229,7 +229,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -245,7 +245,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -264,7 +264,7 @@ class GithubPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(60));
     }
 
@@ -297,7 +297,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -337,7 +337,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -371,7 +371,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.artifactMetadata()).isNotNull();
@@ -405,7 +405,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -432,7 +432,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -461,7 +461,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v2.0.0");
@@ -488,7 +488,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v1.5.0");
@@ -511,7 +511,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("abcdef1");
@@ -542,7 +542,7 @@ class GithubPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, "ghp_testtoken123");
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
 
         verify(getRequestedFor(urlPathEqualTo("/repos/acme/project/commits/4359dee1b7bd29ee25bc78e358a1254a0277ee96"))
                 .withHeader("Authorization", equalTo("Bearer ghp_testtoken123")));
@@ -562,7 +562,7 @@ class GithubPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("github", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/gomodules/GoModulesPackageMetadataResolverTest.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.dependencytrack.cache.api.CacheManager;
 import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
@@ -91,7 +92,7 @@ class GoModulesPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v0.21.0");
@@ -128,7 +129,7 @@ class GoModulesPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("v0.21.0");
@@ -152,7 +153,7 @@ class GoModulesPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -167,7 +168,7 @@ class GoModulesPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -184,7 +185,7 @@ class GoModulesPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -202,7 +203,59 @@ class GoModulesPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
+    }
+
+    @Test
+    void shouldUsePriorPublishedAtForOlderVersionWhenAvailable(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/golang.org/x/text/@latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"Version": "v0.21.0", "Time": "2024-10-01T12:00:00Z"}
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("golang")
+                .withNamespace("golang.org/x")
+                .withName("text")
+                .withVersion("v0.19.0")
+                .build();
+        final var prior = new PackageArtifactMetadata(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2024-06-15T08:00:00Z"),
+                Map.of());
+
+        final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, prior);
+
+        assertThat(result).isNotNull();
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-06-15T08:00:00Z"));
+        verify(0, getRequestedFor(urlPathEqualTo("/golang.org/x/text/@v/v0.19.0.info")));
+    }
+
+    @Test
+    void shouldFetchVersionInfoWhenPriorAbsent(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/golang.org/x/text/@latest"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"Version": "v0.21.0", "Time": "2024-10-01T12:00:00Z"}
+                        """)));
+        stubFor(get(urlPathEqualTo("/golang.org/x/text/@v/v0.19.0.info"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=JSON */ """
+                        {"Version": "v0.19.0", "Time": "2024-06-15T08:00:00Z"}
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("golang")
+                .withNamespace("golang.org/x")
+                .withName("text")
+                .withVersion("v0.19.0")
+                .build();
+
+        final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        resolver.resolve(purl, repo, null);
+
+        verify(1, getRequestedFor(urlPathEqualTo("/golang.org/x/text/@v/v0.19.0.info")));
     }
 
     @Test
@@ -220,7 +273,7 @@ class GoModulesPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         final String expected = "Basic " + Base64.getEncoder().encodeToString(
                 "user:secret".getBytes(StandardCharsets.UTF_8));
@@ -243,7 +296,7 @@ class GoModulesPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("go-proxy", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         verify(getRequestedFor(urlPathEqualTo("/golang.org/x/text/@latest"))
                 .withHeader("Authorization", equalTo("Bearer token")));

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/hackage/HackagePackageMetadataResolverTest.java
@@ -83,7 +83,7 @@ class HackagePackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("hackage", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.2.3.0");
@@ -102,7 +102,7 @@ class HackagePackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("hackage", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -123,7 +123,7 @@ class HackagePackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("hackage", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -137,7 +137,7 @@ class HackagePackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -153,7 +153,7 @@ class HackagePackageMetadataResolverTest {
 
         final var repo = new PackageRepository("hackage", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -170,7 +170,7 @@ class HackagePackageMetadataResolverTest {
 
         final var repo = new PackageRepository("hackage", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolverTest.java
@@ -88,7 +88,7 @@ class HexPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("hex", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.7.14");
@@ -117,7 +117,7 @@ class HexPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("hex", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.7.14");
@@ -138,7 +138,7 @@ class HexPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("hex", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -152,7 +152,7 @@ class HexPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -168,7 +168,7 @@ class HexPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("hex", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -185,7 +185,7 @@ class HexPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("hex", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/maven/MavenPackageMetadataResolverTest.java
@@ -25,6 +25,7 @@ import io.smallrye.config.SmallRyeConfigBuilder;
 import org.dependencytrack.cache.api.CacheManager;
 import org.dependencytrack.cache.memory.MemoryCacheProvider;
 import org.dependencytrack.pkgmetadata.resolution.api.HashAlgorithm;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadataResolver;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
@@ -37,6 +38,8 @@ import org.dependencytrack.plugin.testing.MockKeyValueStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
@@ -55,6 +58,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.dependencytrack.pkgmetadata.resolution.maven.MavenPackageMetadataResolver.isSnapshotVersion;
 
 @WireMockTest
 class MavenPackageMetadataResolverTest {
@@ -116,7 +120,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -156,7 +160,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersionPublishedAt()).isNull();
@@ -201,7 +205,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("3.0.0");
@@ -245,7 +249,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -266,7 +270,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -281,7 +285,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -311,7 +315,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.artifactMetadata()).isNotNull();
@@ -345,7 +349,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -381,7 +385,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -408,7 +412,7 @@ class MavenPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(20));
     }
 
@@ -426,7 +430,7 @@ class MavenPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -457,8 +461,8 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata firstResult = resolver.resolve(purl, repo);
-        final PackageMetadata secondResult = resolver.resolve(purl, repo);
+        final PackageMetadata firstResult = resolver.resolve(purl, repo, null);
+        final PackageMetadata secondResult = resolver.resolve(purl, repo, null);
 
         assertThat(firstResult).isNotNull();
         assertThat(firstResult.latestVersion()).isEqualTo("2.0.0");
@@ -494,7 +498,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -523,7 +527,7 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), "user", "secret");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         final String expected = "Basic " + Base64.getEncoder().encodeToString(
                 "user:secret".getBytes(StandardCharsets.UTF_8));
@@ -553,10 +557,136 @@ class MavenPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, "token");
-        assertThat(resolver.resolve(purl, repo)).isNotNull();
+        assertThat(resolver.resolve(purl, repo, null)).isNotNull();
 
         verify(getRequestedFor(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
                 .withHeader("Authorization", equalTo("Bearer token")));
+    }
+
+    @Test
+    void shouldUsePriorPublishedAtAndSha1WhenAvailable(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <versioning><latest>2.0.0</latest></versioning>
+                        </metadata>
+                        """)));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .withVersion("1.0.0")
+                .build();
+        final var prior = new PackageArtifactMetadata(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2023-06-15T12:00:00Z"),
+                Map.of(HashAlgorithm.SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709"));
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        final PackageMetadata result = resolver.resolve(purl, repo, prior);
+
+        assertThat(result).isNotNull();
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2023-06-15T12:00:00Z"));
+        assertThat(result.artifactMetadata().hashes())
+                .containsEntry(HashAlgorithm.SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+
+        verify(0, headRequestedFor(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar")));
+        verify(0, getRequestedFor(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1")));
+    }
+
+    @Test
+    void shouldRefetchSnapshotVersionsEvenWithPrior(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <versioning><latest>2.0.0</latest></versioning>
+                        </metadata>
+                        """)));
+        stubFor(head(urlPathEqualTo("/com/example/mylib/1.0-SNAPSHOT/mylib-1.0-SNAPSHOT.jar"))
+                .willReturn(aResponse().withStatus(200)
+                        .withHeader("Last-Modified", "Sat, 04 Nov 2023 12:00:00 GMT")));
+        stubFor(get(urlPathEqualTo("/com/example/mylib/1.0-SNAPSHOT/mylib-1.0-SNAPSHOT.jar.sha1"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .withVersion("1.0-SNAPSHOT")
+                .build();
+        final var prior = new PackageArtifactMetadata(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Map.of(HashAlgorithm.SHA1, "0000000000000000000000000000000000000000"));
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        resolver.resolve(purl, repo, prior);
+
+        verify(1, headRequestedFor(urlPathEqualTo("/com/example/mylib/1.0-SNAPSHOT/mylib-1.0-SNAPSHOT.jar")));
+        verify(1, getRequestedFor(urlPathEqualTo("/com/example/mylib/1.0-SNAPSHOT/mylib-1.0-SNAPSHOT.jar.sha1")));
+    }
+
+    @Test
+    void shouldRefetchSha1WhenPriorMissesIt(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubFor(get(urlPathEqualTo("/com/example/mylib/maven-metadata.xml"))
+                .willReturn(aResponse().withStatus(200).withBody(/* language=XML */ """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <metadata>
+                          <versioning><latest>2.0.0</latest></versioning>
+                        </metadata>
+                        """)));
+        stubFor(get(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1"))
+                .willReturn(aResponse().withStatus(200)
+                        .withBody("da39a3ee5e6b4b0d3255bfef95601890afd80709")));
+
+        final var purl = PackageURLBuilder.aPackageURL()
+                .withType("maven")
+                .withNamespace("com.example")
+                .withName("mylib")
+                .withVersion("1.0.0")
+                .build();
+        final var prior = new PackageArtifactMetadata(
+                Instant.parse("2023-01-01T00:00:00Z"),
+                Instant.parse("2023-06-15T12:00:00Z"),
+                Map.of() /* no SHA1 */);
+
+        final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
+        resolver.resolve(purl, repo, prior);
+
+        verify(0, headRequestedFor(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar")));
+        verify(1, getRequestedFor(urlPathEqualTo("/com/example/mylib/1.0.0/mylib-1.0.0.jar.sha1")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "1.0-SNAPSHOT",
+            "1.2.3-SNAPSHOT",
+            "1.0-snapshot",
+            "1.0-Snapshot"
+    })
+    void shouldClassifySnapshotVersions(String version) {
+        assertThat(isSnapshotVersion(version)).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "1.0",
+            "1.2.3",
+            "5.7.0",
+            "1.0-1",
+            "1.0-alpha",
+            "2.0.0-rc1",
+            "1.0.0.Final",
+            "1.0-20231215.123456-1"
+    })
+    void shouldClassifyNonSnapshotVersions(String version) {
+        assertThat(isSnapshotVersion(version)).isFalse();
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/nixpkgs/NixpkgsPackageMetadataResolverTest.java
@@ -85,7 +85,7 @@ class NixpkgsPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("nixpkgs",
                 wmRuntimeInfo.getHttpBaseUrl() + "/packages.json.br", null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("8.7.1");
@@ -107,7 +107,7 @@ class NixpkgsPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("nixpkgs",
                 wmRuntimeInfo.getHttpBaseUrl() + "/packages.json.br", null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -128,7 +128,7 @@ class NixpkgsPackageMetadataResolverTest {
         final var repo = new PackageRepository("nixpkgs",
                 wmRuntimeInfo.getHttpBaseUrl() + "/packages.json.br", null, null);
 
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
 
         final var purl2 = PackageURLBuilder.aPackageURL()
                 .withType("nixpkgs")
@@ -136,7 +136,7 @@ class NixpkgsPackageMetadataResolverTest {
                 .withVersion("2.40.0")
                 .build();
 
-        final PackageMetadata result = resolver.resolve(purl2, repo);
+        final PackageMetadata result = resolver.resolve(purl2, repo, null);
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.44.0");
 
@@ -152,7 +152,7 @@ class NixpkgsPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -169,7 +169,7 @@ class NixpkgsPackageMetadataResolverTest {
         final var repo = new PackageRepository("nixpkgs",
                 wmRuntimeInfo.getHttpBaseUrl() + "/packages.json.br", null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(30));
     }
 
@@ -195,11 +195,11 @@ class NixpkgsPackageMetadataResolverTest {
         final var repoB = new PackageRepository("nixpkgs",
                 wmRuntimeInfo.getHttpBaseUrl() + "/channel-b/packages.json.br", null, null);
 
-        final PackageMetadata resultA = resolver.resolve(purl, repoA);
+        final PackageMetadata resultA = resolver.resolve(purl, repoA, null);
         assertThat(resultA).isNotNull();
         assertThat(resultA.latestVersion()).isEqualTo("8.7.1");
 
-        final PackageMetadata resultB = resolver.resolve(purl, repoB);
+        final PackageMetadata resultB = resolver.resolve(purl, repoB, null);
         assertThat(resultB).isNotNull();
         assertThat(resultB.latestVersion()).isEqualTo("8.7.1");
 
@@ -221,7 +221,7 @@ class NixpkgsPackageMetadataResolverTest {
         final var repo = new PackageRepository("nixpkgs",
                 wmRuntimeInfo.getHttpBaseUrl() + "/packages.json.br", null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
 }

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageMetadataResolverTest.java
@@ -109,7 +109,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -131,7 +131,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -145,7 +145,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -161,7 +161,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -180,7 +180,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -236,7 +236,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -261,7 +261,7 @@ class NpmPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(60));
     }
 
@@ -278,7 +278,7 @@ class NpmPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -293,7 +293,7 @@ class NpmPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, "my-token");
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
 
         verify(getRequestedFor(urlPathEqualTo("/mypackage"))
                 .withHeader("Authorization", equalTo("Bearer my-token")));

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolverTest.java
@@ -24,6 +24,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import org.dependencytrack.cache.api.CacheManager;
 import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.pkgmetadata.resolution.api.PackageArtifactMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageMetadata;
 import org.dependencytrack.pkgmetadata.resolution.api.PackageRepository;
 import org.dependencytrack.pkgmetadata.resolution.api.RetryableResolutionException;
@@ -40,6 +41,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Base64;
 import java.util.Map;
 
@@ -97,7 +99,7 @@ class NugetPackageMetadataResolverTest {
                         "nuget/https---nuget.org.registration-semver2.mds.index-inline-pages.json")));
 
         final PackageMetadata result = resolver.resolve(nugetPurl("Microsoft.Data.SqlClient", "5.0.1"),
-                new PackageRepository("test", wm.baseUrl(), null, null));
+                new PackageRepository("test", wm.baseUrl(), null, null), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("6.0.2");
@@ -110,7 +112,7 @@ class NugetPackageMetadataResolverTest {
         stubArtifactoryPage(ARTIFACTORY_PAGE2, "page2");
 
         final PackageMetadata result = resolver.resolve(
-                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo());
+                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo(), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("6.0.2");
@@ -123,7 +125,7 @@ class NugetPackageMetadataResolverTest {
         stubArtifactoryPage(ARTIFACTORY_PAGE2, "page2-check-pre-release");
 
         final PackageMetadata result = resolver.resolve(
-                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo());
+                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo(), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("5.1.2");
@@ -136,7 +138,7 @@ class NugetPackageMetadataResolverTest {
         stubArtifactoryPage(ARTIFACTORY_PAGE1, "page1");
 
         final PackageMetadata result = resolver.resolve(
-                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo());
+                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo(), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("5.1.0");
@@ -149,7 +151,7 @@ class NugetPackageMetadataResolverTest {
         stubArtifactoryPage(ARTIFACTORY_PAGE1, "page1");
 
         final PackageMetadata result = resolver.resolve(
-                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo());
+                nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo(), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("5.1.0");
@@ -165,7 +167,7 @@ class NugetPackageMetadataResolverTest {
 
         final PackageMetadata result = resolver.resolve(
                 nugetPurl("OpenTelemetry.Instrumentation.SqlClient", "1.12.0-beta.2"),
-                new PackageRepository("test", wm.baseUrl(), null, null));
+                new PackageRepository("test", wm.baseUrl(), null, null), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.12.0-beta.2");
@@ -179,7 +181,7 @@ class NugetPackageMetadataResolverTest {
         stubArtifactoryPage(ARTIFACTORY_PAGE1, "page1");
 
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
-                resolver.resolve(nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo()));
+                resolver.resolve(nugetPurl("Microsoft.Data.SqlClient", "5.1.0"), artifactoryRepo(), null));
     }
 
     @Test
@@ -209,7 +211,7 @@ class NugetPackageMetadataResolverTest {
                         """)));
 
         final PackageMetadata result = resolver.resolve(nugetPurl("MyPackage", "1.0.0"),
-                new PackageRepository("test", wm.baseUrl(), null, null));
+                new PackageRepository("test", wm.baseUrl(), null, null), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -233,7 +235,7 @@ class NugetPackageMetadataResolverTest {
                         """)));
 
         final PackageMetadata result = resolver.resolve(nugetPurl("MyPackage", "1.0.0"),
-                new PackageRepository("test", wm.baseUrl(), null, null));
+                new PackageRepository("test", wm.baseUrl(), null, null), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -252,7 +254,7 @@ class NugetPackageMetadataResolverTest {
                         """)));
 
         final PackageMetadata result = resolver.resolve(nugetPurl("MyPackage", "1.0.0"),
-                new PackageRepository("test", wm.baseUrl() + "/custom/v3/index.json", null, null));
+                new PackageRepository("test", wm.baseUrl() + "/custom/v3/index.json", null, null), null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -266,7 +268,7 @@ class NugetPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(404)));
 
         final PackageMetadata result = resolver.resolve(nugetPurl("nonexistent", "1.0.0"),
-                new PackageRepository("test", wm.baseUrl(), null, null));
+                new PackageRepository("test", wm.baseUrl(), null, null), null);
 
         assertThat(result).isNull();
     }
@@ -277,7 +279,7 @@ class NugetPackageMetadataResolverTest {
                 .willReturn(aResponse().withStatus(200).withBody("{\"resources\":[]}")));
 
         final PackageMetadata result = resolver.resolve(nugetPurl("MyPackage", "1.0.0"),
-                new PackageRepository("test", wm.baseUrl(), null, null));
+                new PackageRepository("test", wm.baseUrl(), null, null), null);
 
         assertThat(result).isNull();
     }
@@ -285,7 +287,7 @@ class NugetPackageMetadataResolverTest {
     @Test
     void shouldThrowWhenRepositoryIsNull() {
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(nugetPurl("MyPackage", "1.0.0"), null));
+                .isThrownBy(() -> resolver.resolve(nugetPurl("MyPackage", "1.0.0"), null, null));
     }
 
     @Test
@@ -295,7 +297,7 @@ class NugetPackageMetadataResolverTest {
 
         final PackageRepository repo = new PackageRepository("test", wm.baseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo))
+                .isThrownBy(() -> resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(10));
     }
 
@@ -306,7 +308,7 @@ class NugetPackageMetadataResolverTest {
 
         final PackageRepository repo = new PackageRepository("test", wm.baseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo));
+                .isThrownBy(() -> resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo, null));
     }
 
     @Test
@@ -319,7 +321,7 @@ class NugetPackageMetadataResolverTest {
                         """)));
 
         final PackageRepository repo = new PackageRepository("test", wm.baseUrl(), "user", "pass");
-        resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo);
+        resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo, null);
 
         final String expected = "Basic " + Base64.getEncoder()
                 .encodeToString("user:pass".getBytes(StandardCharsets.UTF_8));
@@ -339,7 +341,7 @@ class NugetPackageMetadataResolverTest {
                         """)));
 
         final PackageRepository repo = new PackageRepository("test", wm.baseUrl(), null, "tkn");
-        resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo);
+        resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo, null);
 
         verify(getRequestedFor(urlPathEqualTo("/v3/registration5-gz-semver2/mypackage/index.json"))
                 .withHeader("Authorization", equalTo("Bearer tkn")));
@@ -364,7 +366,7 @@ class NugetPackageMetadataResolverTest {
                             """)));
 
             final PackageRepository repo = new PackageRepository("test", wm.baseUrl(), null, "tkn");
-            final PackageMetadata result = resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo);
+            final PackageMetadata result = resolver.resolve(nugetPurl("MyPackage", "1.0.0"), repo, null);
 
             assertThat(result).isNotNull();
             assertThat(result.latestVersion()).isEqualTo("1.0.0");
@@ -400,6 +402,66 @@ class NugetPackageMetadataResolverTest {
     @ValueSource(strings = {"   ", "not-a-date", "2025-13-99"})
     void shouldReturnNullForBlankOrInvalidPublishedDate(String input) {
         assertThat(NugetPackageMetadataResolver.parsePublished(input)).isNull();
+    }
+
+    @Test
+    void shouldUsePriorPublishedAtForStableVersion() throws Exception {
+        stubFor(get(urlPathEqualTo("/v3/index.json"))
+                .willReturn(aResponse().withStatus(200).withBody("""
+                        {"resources":[{"@id":"{{request.baseUrl}}/reg/","@type":"RegistrationsBaseUrl/3.6.0"}]}
+                        """)));
+        stubFor(get(urlPathEqualTo("/reg/mypackage/index.json"))
+                .willReturn(aResponse().withStatus(200).withBody("""
+                        {"items":[{"upper":"1.0.0","items":[
+                          {"catalogEntry":{"version":"1.0.0","listed":true,"published":"2020-01-01T00:00:00Z"}}
+                        ]}]}
+                        """)));
+
+        // Prior carries a different publishedAt to prove the resolver uses it instead of
+        // re-reading the value from the registration response.
+        final var prior = new PackageArtifactMetadata(
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-06-15T12:00:00Z"),
+                Map.of());
+
+        final PackageMetadata result = resolver.resolve(
+                nugetPurl("MyPackage", "1.0.0"),
+                new PackageRepository("test", wm.baseUrl(), null, null),
+                prior);
+
+        assertThat(result).isNotNull();
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2024-06-15T12:00:00Z"));
+    }
+
+    @Test
+    void shouldRefetchForPreReleaseVersionEvenWithPrior() throws Exception {
+        stubFor(get(urlPathEqualTo("/v3/index.json"))
+                .willReturn(aResponse().withStatus(200).withBody("""
+                        {"resources":[{"@id":"{{request.baseUrl}}/reg/","@type":"RegistrationsBaseUrl/3.6.0"}]}
+                        """)));
+        stubFor(get(urlPathEqualTo("/reg/mypackage/index.json"))
+                .willReturn(aResponse().withStatus(200).withBody("""
+                        {"items":[{"upper":"1.0.0-alpha","items":[
+                          {"catalogEntry":{"version":"1.0.0-alpha","listed":true,"published":"2020-01-01T00:00:00Z"}}
+                        ]}]}
+                        """)));
+
+        final var prior = new PackageArtifactMetadata(
+                Instant.parse("2024-01-01T00:00:00Z"),
+                Instant.parse("2024-06-15T12:00:00Z"),
+                Map.of());
+
+        final PackageMetadata result = resolver.resolve(
+                nugetPurl("MyPackage", "1.0.0-alpha"),
+                new PackageRepository("test", wm.baseUrl(), null, null),
+                prior);
+
+        assertThat(result).isNotNull();
+        assertThat(result.artifactMetadata()).isNotNull();
+        assertThat(result.artifactMetadata().publishedAt())
+                .isEqualTo(Instant.parse("2020-01-01T00:00:00Z"));
     }
 
     private static PackageURL nugetPurl(String name, String version) throws Exception {

--- a/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverTest.java
+++ b/package-metadata/resolution/src/test/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverTest.java
@@ -129,7 +129,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -153,7 +153,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -176,7 +176,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -197,7 +197,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");
@@ -218,9 +218,9 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        resolver.resolve(purl, repo);
+        resolver.resolve(purl, repo, null);
 
-        final PackageMetadata secondResult = resolver.resolve(purl, repo);
+        final PackageMetadata secondResult = resolver.resolve(purl, repo, null);
         assertThat(secondResult).isNotNull();
         assertThat(secondResult.latestVersion()).isEqualTo("2.0.0");
         assertThat(secondResult.latestVersionPublishedAt()).isEqualTo(Instant.parse("2024-11-06T22:37:09.220617Z"));
@@ -241,7 +241,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNull();
     }
@@ -255,7 +255,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> resolver.resolve(purl, null));
+                .isThrownBy(() -> resolver.resolve(purl, null, null));
     }
 
     @Test
@@ -271,7 +271,7 @@ class PypiPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo))
+                .isThrownBy(() -> resolver.resolve(purl, repo, null))
                 .satisfies(e -> assertThat(e.retryAfter()).hasSeconds(15));
     }
 
@@ -288,7 +288,7 @@ class PypiPackageMetadataResolverTest {
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
         assertThatExceptionOfType(RetryableResolutionException.class)
-                .isThrownBy(() -> resolver.resolve(purl, repo));
+                .isThrownBy(() -> resolver.resolve(purl, repo, null));
     }
 
     @Test
@@ -304,7 +304,7 @@ class PypiPackageMetadataResolverTest {
                 .build();
 
         final var repo = new PackageRepository("test", wmRuntimeInfo.getHttpBaseUrl(), null, null);
-        final PackageMetadata result = resolver.resolve(purl, repo);
+        final PackageMetadata result = resolver.resolve(purl, repo, null);
 
         assertThat(result).isNotNull();
         assertThat(result.latestVersion()).isEqualTo("2.0.0");


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves efficiency of package metadata resolution.

* Surfaces previously-resolved artifact metadata to resolvers to enable short-circuiting when artifacts can be assumed to be immutable.
* Tracks rate limiting on a per-host basis to enable short-circuiting and serving stale cache entries directly if possible. Only in-memory for the moment, see update to ADR 021.
* Lowers log level for serving of stale cache entries from warn to debug to recude log noise.
* Supports date notation of Retry-After header to increase chances of adhering to upstream preferences for backoff.

These changes were primarily motivated by observing that we were issuing unnecessary revalidation requests to upstream repositories.

Our assumption of revalidation requests with 304 responses NOT counting towards rate limiting also turned out to be wrong for major registries.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
