### PR TITLE
Improve VEX import performance

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
@@ -21,7 +21,6 @@ package org.dependencytrack.parser.cyclonedx;
 import org.apache.commons.collections4.CollectionUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.util.BomLink;
-import org.cyclonedx.util.ObjectLocator;
 import org.dependencytrack.model.AnalysisJustification;
 import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
@@ -32,18 +31,17 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.parser.cyclonedx.util.ModelConverter;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
-import org.dependencytrack.persistence.jdbi.VulnerabilityDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.dependencytrack.parser.cyclonedx.util.ModelConverter.convertCdxVulnAnalysisJustificationToDtAnalysisJustification;
 import static org.dependencytrack.parser.cyclonedx.util.ModelConverter.convertCdxVulnAnalysisStateToDtAnalysisState;
-import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
-import static org.dependencytrack.util.PersistenceUtil.isPersistent;
 
 public class CycloneDXVexImporter {
 
@@ -56,9 +54,8 @@ public class CycloneDXVexImporter {
             LOGGER.info("The uploaded VEX does not contain any vulnerabilities; Skipping VEX import");
             return;
         }
-        if (!withJdbiHandle(handle ->
-                handle.attach(VulnerabilityDao.class).hasVulnerabilities(project.getId()))) {
-            LOGGER.info("The project %s does not have any vulnerabilities; Skipping VEX import".formatted(project));
+        if (!qm.hasVulnerabilities(project)) {
+            LOGGER.info("The project {} does not have any vulnerabilities; Skipping VEX import", project);
             return;
         }
 
@@ -68,41 +65,52 @@ public class CycloneDXVexImporter {
             return;
         }
 
+        final Map<String, BomRefTarget> targetByBomRef = indexComponents(bom);
+        final Map<String, List<Component>> componentsByBomRef = new HashMap<>();
+
         for (final org.cyclonedx.model.vulnerability.Vulnerability vexVuln : vexVulns) {
             final Vulnerability dtVuln = qm.getVulnerabilityByVulnId(vexVuln.getSource().getName(), vexVuln.getId());
             if (dtVuln == null) {
                 LOGGER.warn("""
-                        VEX contains analysis for vulnerability %s/%s, but the project is not affected by it. \
+                        VEX contains analysis for vulnerability {}/{}, but the project is not affected by it. \
                         Analyses can currently only be applied to existing findings.\
-                        """.formatted(vexVuln.getSource().getName(), vexVuln.getId()));
+                        """, vexVuln.getSource().getName(), vexVuln.getId());
                 continue;
             }
 
-            for (org.cyclonedx.model.vulnerability.Vulnerability.Affect affect : vexVuln.getAffects()) {
-                final ObjectLocator ol = new ObjectLocator(bom, affect.getRef()).locate();
-                if ((ol.found() && ol.isMetadataComponent()) || (!ol.found() && BomLink.isBomLink(affect.getRef()))) {
-                    // Affects the project itself
-                    List<Component> components = qm.getAllVulnerableComponents(project, dtVuln, true);
+            List<Component> vulnerableComponents = null;
+
+            for (final org.cyclonedx.model.vulnerability.Vulnerability.Affect affect : vexVuln.getAffects()) {
+                final String affectedBomRef = affect.getRef();
+                final BomRefTarget target = affectedBomRef != null
+                        ? targetByBomRef.get(affectedBomRef)
+                        : null;
+
+                final boolean isProjectScoped =
+                        (target != null && target.isMetadataComponent())
+                                || (target == null && affectedBomRef != null && BomLink.isBomLink(affectedBomRef));
+
+                if (isProjectScoped) {
+                    if (vulnerableComponents == null) {
+                        vulnerableComponents = qm.getAllVulnerableComponents(project, dtVuln);
+                    }
+                    for (final Component component : vulnerableComponents) {
+                        updateAnalysis(qm, component, dtVuln, vexVuln);
+                    }
+                } else if (target != null) {
+                    final List<Component> components = componentsByBomRef.computeIfAbsent(affectedBomRef, ignored -> {
+                        final var cid = new ComponentIdentity(target.component());
+                        return qm.matchIdentity(project, cid);
+                    });
                     for (final Component component : components) {
                         updateAnalysis(qm, component, dtVuln, vexVuln);
                     }
-                } else if (ol.found() && ol.isComponent()) {
-                    // Affects an individual component
-                    final org.cyclonedx.model.Component cdxComponent = (org.cyclonedx.model.Component) ol.getObject();
-                    final ComponentIdentity cid = new ComponentIdentity(cdxComponent);
-                    List<Component> components = qm.matchIdentity(project, cid);
-                    for (final Component component : components) {
-                        updateAnalysis(qm, component, dtVuln, vexVuln);
-                    }
-                } else if (ol.found() && ol.isService()) {
-                    // Affects an individual service
-                    // TODO add VEX support for services
                 } else {
                     LOGGER.warn("""
-                            Unable to locate affected element (metadata.component, components[].component, \
-                            or services[].service) based on the BOM reference %s. The vulnerability.affects[].ref \
-                            node of %s/%s is not resolvable; Skipping it\
-                            """.formatted(affect.getRef(), vexVuln.getSource().getName(), vexVuln.getId()));
+                            Unable to locate affected element (metadata.component or components[].component) \
+                            based on the BOM reference {}. The vulnerability.affects[].ref \
+                            node of {}/{} is not resolvable; Skipping it\
+                            """, affectedBomRef, vexVuln.getSource().getName(), vexVuln.getId());
                 }
             }
         }
@@ -111,28 +119,33 @@ public class CycloneDXVexImporter {
     private static List<org.cyclonedx.model.vulnerability.Vulnerability> getApplicableVexVulnerabilities(
             final List<org.cyclonedx.model.vulnerability.Vulnerability> vexVulns) {
         final var applicableVulns = new ArrayList<org.cyclonedx.model.vulnerability.Vulnerability>();
-        for (final var vexVuln : vexVulns) {
-            final int vexVulnPos = vexVulns.indexOf(vexVuln);
+        for (int vexVulnPos = 0; vexVulnPos < vexVulns.size(); vexVulnPos++) {
+            final var vexVuln = vexVulns.get(vexVulnPos);
             if (isBlank(vexVuln.getId()) || vexVuln.getSource() == null || isBlank(vexVuln.getSource().getName())) {
-                LOGGER.warn("VEX vulnerability at position #%d does not have an ID and / or source; Skipping it".formatted(vexVulnPos));
+                LOGGER.warn(
+                        "VEX vulnerability at position #{} does not have an ID and / or source; Skipping it",
+                        vexVulnPos);
                 continue;
             }
 
             final String vexVulnId = vexVuln.getId();
             final String vexVulnSource = vexVuln.getSource().getName();
-            if (!Vulnerability.Source.isKnownSource(vexVuln.getSource().getName())) {
-                LOGGER.warn("VEX vulnerability %s/%s at position #%d is from an unsupported source; Skipping it"
-                        .formatted(vexVulnSource, vexVulnId, vexVulnPos));
+            if (!Vulnerability.Source.isKnownSource(vexVulnSource)) {
+                LOGGER.warn(
+                        "VEX vulnerability {}/{} at position #{} is from an unsupported source; Skipping it",
+                        vexVulnSource, vexVulnId, vexVulnPos);
                 continue;
             }
             if (CollectionUtils.isEmpty(vexVuln.getAffects())) {
-                LOGGER.debug("VEX vulnerability %s/%s at position #%d does not have an affects node; Skipping it"
-                        .formatted(vexVulnSource, vexVulnId, vexVulnPos));
+                LOGGER.debug(
+                        "VEX vulnerability {}/{} at position #{} does not have an affects node; Skipping it",
+                        vexVulnSource, vexVulnId, vexVulnPos);
                 continue;
             }
             if (vexVuln.getAnalysis() == null) {
-                LOGGER.debug("VEX vulnerability %s/%s at position #%d does not have an analysis; Skipping it"
-                        .formatted(vexVulnSource, vexVulnId, vexVulnPos));
+                LOGGER.debug(
+                        "VEX vulnerability {}/{} at position #{} does not have an analysis; Skipping it",
+                        vexVulnSource, vexVulnId, vexVulnPos);
                 continue;
             }
 
@@ -142,48 +155,78 @@ public class CycloneDXVexImporter {
         return applicableVulns;
     }
 
-    private static void updateAnalysis(final QueryManager qm, final Component component, final Vulnerability vuln,
-                                       final org.cyclonedx.model.vulnerability.Vulnerability cdxVuln) {
-        qm.runInTransaction(() -> {
-            final AnalysisState state =
-                    convertCdxVulnAnalysisStateToDtAnalysisState(cdxVuln.getAnalysis().getState());
-            final AnalysisJustification justification =
-                    convertCdxVulnAnalysisJustificationToDtAnalysisJustification(cdxVuln.getAnalysis().getJustification());
+    private record BomRefTarget(org.cyclonedx.model.Component component, boolean isMetadataComponent) {
+    }
 
-            // CycloneDX supports multiple responses, DT only one.
-            // The decision to effectively pick the last one is legacy behavior,
-            // there's no other particular reason for doing it.
-            final AnalysisResponse response;
-            if (cdxVuln.getAnalysis().getResponses() != null
-                    && !cdxVuln.getAnalysis().getResponses().isEmpty()) {
-                response = cdxVuln.getAnalysis().getResponses().stream()
-                        .map(ModelConverter::convertCdxVulnAnalysisResponseToDtAnalysisResponse)
-                        .toList()
-                        .getLast();
-            } else {
-                response = null;
+    private static Map<String, BomRefTarget> indexComponents(final Bom bom) {
+        final Map<String, BomRefTarget> targetByBomRef = new HashMap<>();
+        if (bom == null) {
+            return targetByBomRef;
+        }
+
+        if (bom.getMetadata() != null && bom.getMetadata().getComponent() != null) {
+            indexComponents(List.of(bom.getMetadata().getComponent()), targetByBomRef, true);
+        }
+
+        indexComponents(bom.getComponents(), targetByBomRef, false);
+        return targetByBomRef;
+    }
+
+    private static void indexComponents(
+            final List<org.cyclonedx.model.Component> components,
+            final Map<String, BomRefTarget> targetByBomRef,
+            final boolean metadataComponent) {
+        if (components == null) {
+            return;
+        }
+
+        for (final var component : components) {
+            if (component.getBomRef() != null) {
+                targetByBomRef.putIfAbsent(
+                        component.getBomRef(),
+                        new BomRefTarget(component, metadataComponent));
             }
 
-            final boolean isSuppressed =
-                    state == AnalysisState.FALSE_POSITIVE
-                            || state == AnalysisState.NOT_AFFECTED
-                            || state == AnalysisState.RESOLVED;
-
-            final Component persistentComponent = !isPersistent(component)
-                    ? qm.getObjectById(Component.class, component.getId())
-                    : component;
-            final Vulnerability persistentVuln = !isPersistent(vuln)
-                    ? qm.getObjectById(Vulnerability.class, vuln.getId())
-                    : vuln;
-
-            qm.makeAnalysis(
-                    new MakeAnalysisCommand(persistentComponent, persistentVuln)
-                            .withState(state)
-                            .withJustification(justification)
-                            .withResponse(response)
-                            .withDetails(cdxVuln.getAnalysis().getDetail())
-                            .withCommenter(COMMENTER)
-                            .withSuppress(isSuppressed));
-        });
+            if (component.getComponents() != null && !component.getComponents().isEmpty()) {
+                indexComponents(component.getComponents(), targetByBomRef, false);
+            }
+        }
     }
+
+    private static void updateAnalysis(final QueryManager qm, final Component component, final Vulnerability vuln,
+                                       final org.cyclonedx.model.vulnerability.Vulnerability cdxVuln) {
+        final AnalysisState state =
+                convertCdxVulnAnalysisStateToDtAnalysisState(cdxVuln.getAnalysis().getState());
+        final AnalysisJustification justification =
+                convertCdxVulnAnalysisJustificationToDtAnalysisJustification(cdxVuln.getAnalysis().getJustification());
+
+        // CycloneDX supports multiple responses, DT only one.
+        // The decision to effectively pick the last one is legacy behavior,
+        // there's no other particular reason for doing it.
+        final AnalysisResponse response;
+        if (cdxVuln.getAnalysis().getResponses() != null
+                && !cdxVuln.getAnalysis().getResponses().isEmpty()) {
+            response = cdxVuln.getAnalysis().getResponses().stream()
+                    .map(ModelConverter::convertCdxVulnAnalysisResponseToDtAnalysisResponse)
+                    .toList()
+                    .getLast();
+        } else {
+            response = null;
+        }
+
+        final boolean isSuppressed =
+                state == AnalysisState.FALSE_POSITIVE
+                        || state == AnalysisState.NOT_AFFECTED
+                        || state == AnalysisState.RESOLVED;
+
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(component, vuln)
+                        .withState(state)
+                        .withJustification(justification)
+                        .withResponse(response)
+                        .withDetails(cdxVuln.getAnalysis().getDetail())
+                        .withCommenter(COMMENTER)
+                        .withSuppress(isSuppressed));
+    }
+
 }

--- a/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/QueryManager.java
@@ -730,6 +730,10 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().hasAffectedVersionAttribution(vulnerability, vulnerableSoftware, source);
     }
 
+    public boolean hasVulnerabilities(final Project project) {
+        return getVulnerabilityQueryManager().hasVulnerabilities(project);
+    }
+
     public boolean contains(Vulnerability vulnerability, Component component) {
         return getVulnerabilityQueryManager().contains(vulnerability, component);
     }
@@ -832,8 +836,8 @@ public class QueryManager extends AlpineQueryManager {
         return getVulnerabilityQueryManager().getVulnerabilities(component, includeSuppressed);
     }
 
-    public List<Component> getAllVulnerableComponents(Project project, Vulnerability vulnerability, boolean includeSuppressed) {
-        return getVulnerabilityQueryManager().getAllVulnerableComponents(project, vulnerability, includeSuppressed);
+    public List<Component> getAllVulnerableComponents(Project project, Vulnerability vulnerability) {
+        return getVulnerabilityQueryManager().getAllVulnerableComponents(project, vulnerability);
     }
 
     public List<Vulnerability> getAllVulnerabilities(Component component, boolean includeSuppressed) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/VulnerabilityQueryManager.java
@@ -38,7 +38,6 @@ import org.jdbi.v3.core.Handle;
 
 import javax.jdo.PersistenceManager;
 import javax.jdo.Query;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -172,6 +171,16 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      */
     public Vulnerability getVulnerabilityByVulnId(Vulnerability.Source source, String vulnId, boolean includeVulnerableSoftware) {
         return getVulnerabilityByVulnId(source.name(), vulnId, includeVulnerableSoftware);
+    }
+
+    public boolean hasVulnerabilities(final Project project) {
+        final Query<FindingAttribution> query = pm.newQuery(
+                FindingAttribution.class,
+                "project == :project && deletedAt == null");
+        query.setParameters(project);
+        query.setRange(0, 1);
+        query.setResult("id");
+        return !executeAndCloseResultList(query, Long.class).isEmpty();
     }
 
     /**
@@ -379,19 +388,14 @@ final class VulnerabilityQueryManager extends QueryManager implements IQueryMana
      * @param vulnerability the vulnerability to query on
      * @return a List of Component objects
      */
-    public List<Component> getAllVulnerableComponents(Project project, Vulnerability vulnerability, boolean includeSuppressed) {
-        final List<Component> components = new ArrayList<>();
-        for (final Component component: getAllComponents(project)) {
-            final Collection<Vulnerability> componentVulns = pm.detachCopyAll(
-                    getAllVulnerabilities(component, includeSuppressed)
-            );
-            for (final Vulnerability componentVuln: componentVulns) {
-                if (componentVuln.getUuid() == vulnerability.getUuid()) {
-                    components.add(component);
-                }
-            }
-        }
-        return components;
+    public List<Component> getAllVulnerableComponents(Project project, Vulnerability vulnerability) {
+        final Query<FindingAttribution> query = pm.newQuery(FindingAttribution.class,
+                "project == :project && vulnerability == :vulnerability && deletedAt == null");
+        query.setParameters(project, vulnerability);
+        return executeAndCloseList(query).stream()
+                .map(FindingAttribution::getComponent)
+                .distinct()
+                .toList();
     }
 
     /**

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/VulnerabilityDao.java
@@ -593,24 +593,6 @@ public interface VulnerabilityDao {
     int deleteVulnerability(@Bind final UUID vulnUuid);
 
     @SqlQuery("""
-            SELECT EXISTS(
-                SELECT 1
-                  FROM "COMPONENT" AS c
-                 INNER JOIN "COMPONENTS_VULNERABILITIES" AS cv
-                    ON cv."COMPONENT_ID" = c."ID"
-                 WHERE c."PROJECT_ID" = :projectId
-                   AND EXISTS (
-                     SELECT 1
-                       FROM "FINDINGATTRIBUTION" AS fa
-                      WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
-                        AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
-                        AND fa."DELETED_AT" IS NULL
-                   )
-            )
-            """)
-    boolean hasVulnerabilities(@Bind final long projectId);
-
-    @SqlQuery("""
             SELECT "ID" FROM "VULNERABILITY" WHERE "UUID" = :vulnUuid
             """)
     Long getVulnerabilityId(@Bind UUID vulnUuid);

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportVexActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportVexActivity.java
@@ -116,7 +116,7 @@ public final class ImportVexActivity implements Activity<ImportVexArg, Void> {
             vex.setSerialNumber(bom.getSerialNumber());
 
             final CycloneDXVexImporter vexImporter = new CycloneDXVexImporter();
-            vexImporter.applyVex(qm, bom, project);
+            qm.runInTransaction(() -> vexImporter.applyVex(qm, bom, project));
             LOGGER.info("Completed processing of CycloneDX VEX");
 
             final var notificationEmitter = new JdoNotificationEmitter(qm);

--- a/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporterTest.java
@@ -20,17 +20,22 @@ package org.dependencytrack.parser.cyclonedx;
 
 import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
+import org.cyclonedx.exception.ParseException;
 import org.cyclonedx.parsers.BomParserFactory;
 import org.dependencytrack.PersistenceCapableTest;
 import org.dependencytrack.model.Analysis;
+import org.dependencytrack.model.AnalysisComment;
 import org.dependencytrack.model.AnalysisJustification;
+import org.dependencytrack.model.AnalysisResponse;
 import org.dependencytrack.model.AnalysisState;
 import org.dependencytrack.model.Component;
+import org.dependencytrack.model.Project;
 import org.dependencytrack.model.Severity;
 import org.dependencytrack.model.Vulnerability;
 import org.junit.jupiter.api.Test;
 
 import javax.jdo.Query;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -139,6 +144,63 @@ public class CycloneDXVexImporterTest extends PersistenceCapableTest {
             });
             Assertions.assertThat(analysis.getAnalysisDetails()).isEqualTo("Unit test");
         });
+    }
+
+    @Test
+    public void shouldPersistLastResponseAndCommentEach() throws ParseException {
+        final var project = new Project();
+        project.setName("acme-app");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("Acme Component");
+        component.setVersion("1.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("CVE-2099-0001");
+        vuln.setSource(Vulnerability.Source.NVD);
+        vuln.setSeverity(Severity.HIGH);
+        vuln.setComponents(List.of(component));
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "none");
+
+        final byte[] vexBytes = /* language=JSON */ """
+                {
+                  "bomFormat": "CycloneDX",
+                  "specVersion": "1.4",
+                  "version": 1,
+                  "metadata": {
+                    "component": {
+                      "type": "application",
+                      "bom-ref": "project",
+                      "name": "Acme Example",
+                      "version": "1.0"
+                    }
+                  },
+                  "vulnerabilities": [
+                    {
+                      "id": "CVE-2099-0001",
+                      "source": { "name": "NVD" },
+                      "analysis": {
+                        "response": ["will_not_fix", "update"]
+                      },
+                      "affects": [{ "ref": "project" }]
+                    }
+                  ]
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+        final var vex = BomParserFactory.createParser(vexBytes).parse(vexBytes);
+
+        vexImporter.applyVex(qm, vex, project);
+
+        final Analysis analysis = qm.getAnalysis(component, vuln);
+        Assertions.assertThat(analysis.getAnalysisResponse()).isEqualTo(AnalysisResponse.UPDATE);
+        Assertions.assertThat(analysis.getAnalysisComments())
+                .extracting(AnalysisComment::getComment)
+                .containsExactly("Vendor Response: NOT_SET → UPDATE");
     }
 
 }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/VulnerabilityQueryManagerTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -296,6 +297,58 @@ public class VulnerabilityQueryManagerTest extends PersistenceCapableTest {
 
             assertThat(catchThrowable(() -> qm.updateVulnerability(target, transientVuln)))
                     .isInstanceOf(IllegalStateException.class);
+        }
+
+    }
+
+    @Nested
+    public class HasVulnerabilitiesTest {
+
+        @Test
+        public void shouldReturnFalseWhenProjectHasNoFindings() {
+            final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+            assertThat(qm.hasVulnerabilities(project)).isFalse();
+        }
+
+        @Test
+        public void shouldReturnTrueWhenProjectHasUndeletedFinding() {
+            final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+
+            final var component = new Component();
+            component.setProject(project);
+            component.setName("acme-lib");
+            component.setVersion("2.0.0");
+            qm.persist(component);
+
+            final var vuln = new Vulnerability();
+            vuln.setVulnId("INT-123");
+            vuln.setSource(Vulnerability.Source.NVD);
+            qm.persist(vuln);
+
+            qm.addVulnerability(vuln, component, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
+
+            assertThat(qm.hasVulnerabilities(project)).isTrue();
+        }
+
+        @Test
+        public void shouldReturnFalseWhenAllFindingsAreSoftDeleted() {
+            final var project = qm.createProject("acme-app", null, "1.0.0", null, null, null, null, false);
+
+            final var component = new Component();
+            component.setProject(project);
+            component.setName("acme-lib");
+            component.setVersion("2.0.0");
+            qm.persist(component);
+
+            final var vuln = new Vulnerability();
+            vuln.setVulnId("INT-123");
+            vuln.setSource(Vulnerability.Source.NVD);
+            qm.persist(vuln);
+
+            qm.addVulnerability(vuln, component, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
+            qm.getFindingAttributions(vuln, component).forEach(fa -> fa.setDeletedAt(new Date()));
+
+            assertThat(qm.hasVulnerabilities(project)).isFalse();
         }
 
     }

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/VulnerabilityDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/VulnerabilityDaoTest.java
@@ -53,50 +53,6 @@ public class VulnerabilityDaoTest extends PersistenceCapableTest {
     }
 
     @Test
-    public void testProjectHasVulnerabilities() {
-        final var project = qm.createProject("acme-app", "Description 1", "1.0.0", null, null, null, null, false);
-
-        final var component = new Component();
-        component.setProject(project);
-        component.setName("acme-lib");
-        component.setVersion("2.0.0");
-        qm.persist(component);
-
-        final var vuln = new Vulnerability();
-        vuln.setVulnId("INT-123");
-        vuln.setSource(NVD);
-        qm.persist(vuln);
-
-        assertThat(vulnerabilityDao.hasVulnerabilities(project.getId())).isFalse();
-        qm.addVulnerability(vuln, component, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
-        assertThat(vulnerabilityDao.hasVulnerabilities(project.getId())).isTrue();
-    }
-
-    @Test
-    public void testProjectHasVulnerabilitiesWithDeletedFinding() {
-        final var project = qm.createProject("acme-app", "Description 1", "1.0.0", null, null, null, null, false);
-
-        final var component = new Component();
-        component.setProject(project);
-        component.setName("acme-lib");
-        component.setVersion("2.0.0");
-        qm.persist(component);
-
-        final var vuln = new Vulnerability();
-        vuln.setVulnId("INT-123");
-        vuln.setSource(NVD);
-        qm.persist(vuln);
-
-        qm.addVulnerability(vuln, component, "internal", "Vuln1", "http://vuln.com/vuln1", new Date());
-        assertThat(vulnerabilityDao.hasVulnerabilities(project.getId())).isTrue();
-
-        final var attributions = qm.getFindingAttributions(vuln, component);
-        attributions.forEach(fa -> fa.setDeletedAt(new Date()));
-
-        assertThat(vulnerabilityDao.hasVulnerabilities(project.getId())).isFalse();
-    }
-
-    @Test
     public void testGetVulnerableComponentsWithDeletedFinding() {
         final var project = qm.createProject("acme-app", "Description 1", "1.0.0", null, null, null, null, false);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Ports https://github.com/DependencyTrack/dependency-track/pull/6141

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Note that VulnerabilityDao#hasVulnerabilities was replaced with an equivalent QueryManager method because we'd otherwise be calling JDBI from within a JDO transaction, which would lead to two DB connections being blocked by a VEX import.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
