### PR TITLE
Fix inconsistent handling of inactive findings for project cloning and VDR exports

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -34,6 +34,7 @@ import org.dependencytrack.persistence.jdbi.FindingDao;
 import javax.jdo.FetchGroup;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -85,8 +86,11 @@ public class CycloneDXExporter {
 
     private Bom create(List<Component>components, final List<ServiceComponent> services, final List<Finding> findings, final Project project) {
         if (Variant.VDR == variant) {
+            final Set<UUID> vulnerableComponentUuids = findings.stream()
+                    .map(finding -> (UUID) finding.getComponent().get("uuid"))
+                    .collect(Collectors.toSet());
             components = components.stream()
-                    .filter(component -> !component.getVulnerabilities().isEmpty())
+                    .filter(component -> vulnerableComponentUuids.contains(component.getUuid()))
                     .toList();
         }
         final List<org.cyclonedx.model.Component> cycloneComponents = (Variant.VEX != variant && components != null) ? components.stream().map(component -> ModelConverter.convert(component)).collect(Collectors.toList()) : null;

--- a/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/persistence/jdbi/ProjectDaoTest.java
@@ -42,6 +42,7 @@ import org.dependencytrack.notification.NotificationLevel;
 import org.dependencytrack.notification.NotificationScope;
 import org.dependencytrack.persistence.command.MakeAnalysisCommand;
 import org.dependencytrack.persistence.command.MakeViolationAnalysisCommand;
+import org.dependencytrack.persistence.jdbi.command.CloneProjectCommand;
 import org.dependencytrack.util.DateUtil;
 import org.jdbi.v3.core.Handle;
 import org.junit.jupiter.api.AfterEach;
@@ -149,7 +150,7 @@ public class ProjectDaoTest extends PersistenceCapableTest {
                         .withComment("someComment"));
 
         // Create metrics for project and component.
-        useJdbiHandle(handle ->  {
+        useJdbiHandle(handle -> {
             var dao = handle.attach(MetricsTestDao.class);
             dao.createMetricsPartitionsForDate("PROJECTMETRICS", LocalDate.of(2025, 1, 1));
             dao.createMetricsPartitionsForDate("DEPENDENCYMETRICS", LocalDate.of(2025, 1, 1));
@@ -234,6 +235,162 @@ public class ProjectDaoTest extends PersistenceCapableTest {
         MetricsDao dao = jdbiHandle.attach(MetricsDao.class);
         assertThat(dao.getProjectMetricsSince(project.getId(), DateUtil.parseShortDate("20250101").toInstant())).isEmpty();
         assertThat(dao.getDependencyMetricsSince(component.getId(), DateUtil.parseShortDate("20250101").toInstant())).isEmpty();
+    }
+
+    @Test
+    public void shouldExcludeInactiveFindingsWhenCloningProject() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("2.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "internal");
+
+        qm.makeAnalysis(
+                new MakeAnalysisCommand(component, vuln)
+                        .withState(AnalysisState.NOT_AFFECTED)
+                        .withJustification(AnalysisJustification.CODE_NOT_REACHABLE)
+                        .withResponse(AnalysisResponse.WORKAROUND_AVAILABLE)
+                        .withDetails("analysisDetails")
+                        .withCommenter("someCommenter")
+                        .withComment("someComment"));
+
+        jdbiHandle.createUpdate(/* language=SQL */ """
+                        UPDATE "FINDINGATTRIBUTION"
+                           SET "DELETED_AT" = NOW()
+                         WHERE "COMPONENT_ID" = :componentId
+                           AND "VULNERABILITY_ID" = :vulnerabilityId
+                        """)
+                .bind("componentId", component.getId())
+                .bind("vulnerabilityId", vuln.getId())
+                .execute();
+
+        final UUID clonedUuid = projectDao.cloneProject(new CloneProjectCommand(
+                project.getUuid(),
+                "1.1.0",
+                /* targetProjectVersionIsLatest */ false,
+                /* includeAcl */ false,
+                /* includeComponents */ true,
+                /* includeFindings */ true,
+                /* includeFindingsAuditHistory */ true,
+                /* includePolicyViolations */ false,
+                /* includePolicyViolationsAuditHistory */ false,
+                /* includeProperties */ false,
+                /* includeServices */ false,
+                /* includeTags */ false));
+
+        final Long clonedComponentId = jdbiHandle.createQuery(/* language=SQL */ """
+                        SELECT c."ID"
+                          FROM "COMPONENT" AS c
+                         INNER JOIN "PROJECT" AS p
+                            ON p."ID" = c."PROJECT_ID"
+                         WHERE p."UUID" = :projectUuid
+                        """)
+                .bind("projectUuid", clonedUuid)
+                .mapTo(Long.class)
+                .one();
+
+        final long clonedCvCount = jdbiHandle.createQuery(/* language=SQL */ """
+                        SELECT COUNT(*)
+                          FROM "COMPONENTS_VULNERABILITIES"
+                         WHERE "COMPONENT_ID" = :componentId
+                        """)
+                .bind("componentId", clonedComponentId)
+                .mapTo(Long.class)
+                .one();
+        assertThat(clonedCvCount).isZero();
+
+        final long clonedAttributionCount = jdbiHandle.createQuery(/* language=SQL */ """
+                        SELECT COUNT(*)
+                          FROM "FINDINGATTRIBUTION"
+                         WHERE "COMPONENT_ID" = :componentId
+                        """)
+                .bind("componentId", clonedComponentId)
+                .mapTo(Long.class)
+                .one();
+        assertThat(clonedAttributionCount).isZero();
+
+        final long clonedAnalysisCount = jdbiHandle.createQuery(/* language=SQL */ """
+                        SELECT COUNT(*)
+                          FROM "ANALYSIS"
+                         WHERE "COMPONENT_ID" = :componentId
+                        """)
+                .bind("componentId", clonedComponentId)
+                .mapTo(Long.class)
+                .one();
+        assertThat(clonedAnalysisCount).isZero();
+
+        final long clonedCommentCount = jdbiHandle.createQuery(/* language=SQL */ """
+                        SELECT COUNT(*)
+                          FROM "ANALYSISCOMMENT" AS ac
+                         INNER JOIN "ANALYSIS" AS a
+                            ON a."ID" = ac."ANALYSIS_ID"
+                         WHERE a."COMPONENT_ID" = :componentId
+                        """)
+                .bind("componentId", clonedComponentId)
+                .mapTo(Long.class)
+                .one();
+        assertThat(clonedCommentCount).isZero();
+    }
+
+    @Test
+    public void shouldCloneActiveFindingsWhenCloningProject() {
+        final var project = new Project();
+        project.setName("acme-app");
+        project.setVersion("1.0.0");
+        qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setName("acme-lib");
+        component.setVersion("2.0.0");
+        qm.persist(component);
+
+        final var vuln = new Vulnerability();
+        vuln.setVulnId("INT-123");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        qm.persist(vuln);
+
+        qm.addVulnerability(vuln, component, "internal");
+
+        final UUID clonedUuid = projectDao.cloneProject(new CloneProjectCommand(
+                project.getUuid(),
+                "1.1.0",
+                /* targetProjectVersionIsLatest */ false,
+                /* includeAcl */ false,
+                /* includeComponents */ true,
+                /* includeFindings */ true,
+                /* includeFindingsAuditHistory */ true,
+                /* includePolicyViolations */ false,
+                /* includePolicyViolationsAuditHistory */ false,
+                /* includeProperties */ false,
+                /* includeServices */ false,
+                /* includeTags */ false));
+
+        final long clonedCvCount = jdbiHandle.createQuery(/* language=SQL */ """
+                        SELECT COUNT(*)
+                          FROM "COMPONENTS_VULNERABILITIES" cv
+                         INNER JOIN "COMPONENT" c
+                            ON c."ID" = cv."COMPONENT_ID"
+                         INNER JOIN "PROJECT" p
+                            ON p."ID" = c."PROJECT_ID"
+                         WHERE p."UUID" = :projectUuid
+                        """)
+                .bind("projectUuid", clonedUuid)
+                .mapTo(Long.class)
+                .one();
+        assertThat(clonedCvCount).isOne();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -113,6 +113,7 @@ import static org.dependencytrack.notification.NotificationTestUtil.createCatchA
 import static org.dependencytrack.notification.proto.v1.Group.GROUP_BOM_VALIDATION_FAILED;
 import static org.dependencytrack.notification.proto.v1.Level.LEVEL_ERROR;
 import static org.dependencytrack.notification.proto.v1.Scope.SCOPE_PORTFOLIO;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiHandle;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -1003,6 +1004,62 @@ class BomResourceTest extends ResourceTest {
         assertThat(componentWithoutVuln.getDirectDependencies()).isNotNull();
         assertThat(componentWithVuln.getDirectDependencies()).isNotNull();
         assertThat(componentWithVulnAndAnalysis.getDirectDependencies()).isNotNull();
+    }
+
+    @Test
+    void shouldExcludeComponentsWithOnlyInactiveFindingsFromVdr() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO, Permissions.VIEW_VULNERABILITY);
+
+        var vulnerability = new Vulnerability();
+        vulnerability.setVulnId("INT-001");
+        vulnerability.setSource(Vulnerability.Source.INTERNAL);
+        vulnerability.setSeverity(Severity.HIGH);
+        vulnerability = qm.createVulnerability(vulnerability);
+
+        var project = new Project();
+        project.setName("acme-app");
+        project.setClassifier(Classifier.APPLICATION);
+        qm.createProject(project, null, false);
+
+        var componentWithActiveFinding = new Component();
+        componentWithActiveFinding.setProject(project);
+        componentWithActiveFinding.setName("acme-lib-active");
+        componentWithActiveFinding.setVersion("1.0.0");
+        componentWithActiveFinding.setDirectDependencies("[]");
+        qm.createComponent(componentWithActiveFinding, false);
+        qm.addVulnerability(vulnerability, componentWithActiveFinding, "internal");
+
+        var componentWithInactiveFinding = new Component();
+        componentWithInactiveFinding.setProject(project);
+        componentWithInactiveFinding.setName("acme-lib-inactive");
+        componentWithInactiveFinding.setVersion("1.0.0");
+        componentWithInactiveFinding.setDirectDependencies("[]");
+        qm.createComponent(componentWithInactiveFinding, false);
+        qm.addVulnerability(vulnerability, componentWithInactiveFinding, "internal");
+
+        final long inactiveComponentId = componentWithInactiveFinding.getId();
+        final long inactiveVulnerabilityId = vulnerability.getId();
+        useJdbiHandle(handle -> handle.createUpdate(/* language=SQL */ """
+                        UPDATE "FINDINGATTRIBUTION"
+                           SET "DELETED_AT" = NOW()
+                         WHERE "COMPONENT_ID" = :componentId
+                           AND "VULNERABILITY_ID" = :vulnerabilityId
+                        """)
+                .bind("componentId", inactiveComponentId)
+                .bind("vulnerabilityId", inactiveVulnerabilityId)
+                .execute());
+
+        final Response response = jersey.target(V1_BOM + "/cyclonedx/project/" + project.getUuid())
+                .queryParam("variant", "vdr")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.SC_OK);
+
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.components[*].name")
+                .isArray()
+                .containsExactly("acme-lib-active");
     }
 
     @Test

--- a/migration/src/main/resources/org/dependencytrack/migration/R__clone_project.sql
+++ b/migration/src/main/resources/org/dependencytrack/migration/R__clone_project.sql
@@ -318,11 +318,19 @@ BEGIN
     IF include_findings THEN
       INSERT INTO "COMPONENTS_VULNERABILITIES" ("COMPONENT_ID", "VULNERABILITY_ID")
       SELECT tmp_component_mapping.target_id
-           , "VULNERABILITY_ID"
-        FROM "COMPONENTS_VULNERABILITIES"
+           , cv."VULNERABILITY_ID"
+        FROM "COMPONENTS_VULNERABILITIES" AS cv
        INNER JOIN tmp_component_mapping
-          ON tmp_component_mapping.source_id = "COMPONENT_ID"
-       ORDER BY "VULNERABILITY_ID"
+          ON tmp_component_mapping.source_id = cv."COMPONENT_ID"
+       WHERE EXISTS (
+         SELECT 1
+           FROM "FINDINGATTRIBUTION" AS fa
+          WHERE fa."COMPONENT_ID" = cv."COMPONENT_ID"
+            AND fa."VULNERABILITY_ID" = cv."VULNERABILITY_ID"
+            AND fa."PROJECT_ID" = source_project.id
+            AND fa."DELETED_AT" IS NULL
+       )
+       ORDER BY cv."VULNERABILITY_ID"
               , tmp_component_mapping.target_id;
 
       INSERT INTO "FINDINGATTRIBUTION" (
@@ -354,8 +362,16 @@ BEGIN
         source_analysis AS (
           SELECT *
                , ROW_NUMBER() OVER(ORDER BY "ID") AS rn
-            FROM "ANALYSIS"
-           WHERE "PROJECT_ID" = source_project.id
+            FROM "ANALYSIS" AS a
+           WHERE a."PROJECT_ID" = source_project.id
+             AND EXISTS (
+               SELECT 1
+                 FROM "FINDINGATTRIBUTION" AS fa
+                WHERE fa."COMPONENT_ID" = a."COMPONENT_ID"
+                  AND fa."VULNERABILITY_ID" = a."VULNERABILITY_ID"
+                  AND fa."PROJECT_ID" = source_project.id
+                  AND fa."DELETED_AT" IS NULL
+             )
         ),
         target_analysis AS (
           INSERT INTO "ANALYSIS" (


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes inconsistent handling of inactive findings for project cloning and VDR exports.

Project cloning previously cloned all findings regardless of their status, causing potentially many records along that are no longer of relevance. With this change, only active findings are cloned.

VDR exports previously included components even when all their findings were inactive. While not necessarily wrong, it's inconsistent. So now we only include components with active findings.

Both of the above were oversights when implementing ADR 013.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Identified while working on #2162 

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
