### PR TITLE
Improve logging during vuln datasource mirroring

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/common/MdcKeys.java
+++ b/apiserver/src/main/java/org/dependencytrack/common/MdcKeys.java
@@ -45,6 +45,7 @@ public final class MdcKeys {
     public static final String MDC_PROJECT_VERSION = "projectVersion";
     public static final String MDC_VEX_UPLOAD_TOKEN = "vexUploadToken";
     public static final String MDC_VULN_ANALYZER_NAME = "vulnAnalyzerName";
+    public static final String MDC_VULN_DATA_SOURCE_NAME = "vulnDataSourceName";
     public static final String MDC_VULN_ID = "vulnId";
     public static final String MDC_VULN_POLICY_NAME = "vulnPolicyName";
     public static final String MDC_VULN_SOURCE = "vulnSource";

--- a/apiserver/src/main/java/org/dependencytrack/tasks/EpssMirrorTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/EpssMirrorTask.java
@@ -40,6 +40,7 @@ import java.net.http.HttpResponse;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
@@ -54,7 +55,8 @@ import static org.dependencytrack.util.TaskUtil.getLockConfigForTask;
 public class EpssMirrorTask implements Subscriber {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EpssMirrorTask.class);
-    private static final int BATCH_SIZE = 100;
+    private static final int BATCH_SIZE = 1000;
+    private static final Duration HEARTBEAT_LOG_INTERVAL = Duration.ofSeconds(30);
 
     private final HttpClient httpClient;
 
@@ -79,14 +81,24 @@ public class EpssMirrorTask implements Subscriber {
     private void informLocked() throws IOException {
         final Config config = loadConfig();
         if (!config.isEnabled()) {
+            LOGGER.info("EPSS data source is disabled; Skipping mirror");
             return;
         }
 
-        LOGGER.info("Downloading feed file from {}", config.feedsBaseUrl());
-        final Path feedFilePath = downloadFeedFile(config.feedsBaseUrl());
+        LOGGER.info("Starting EPSS mirror");
+        final long startTimeNs = System.nanoTime();
 
-        LOGGER.info("Processing feed file {}", feedFilePath);
-        processFeedFile(feedFilePath);
+        LOGGER.info("Downloading EPSS feed from {}", config.feedsBaseUrl());
+        final Path feedFilePath = downloadFeedFile(config.feedsBaseUrl());
+        LOGGER.debug("Download destination: {}", feedFilePath);
+
+        LOGGER.info("Processing EPSS feed");
+        final int recordsModified = processFeedFile(feedFilePath);
+
+        LOGGER.info(
+                "Completed EPSS mirror; modified {} record(s) in {}",
+                recordsModified,
+                Duration.ofNanos(System.nanoTime() - startTimeNs));
     }
 
     private Path downloadFeedFile(final String baseUrl) throws IOException {
@@ -110,7 +122,11 @@ public class EpssMirrorTask implements Subscriber {
         return tempFile;
     }
 
-    private void processFeedFile(final Path feedFilePath) throws IOException {
+    private int processFeedFile(final Path feedFilePath) throws IOException {
+        int recordsRead = 0;
+        int recordsModified = 0;
+        long lastHeartbeatNs = System.nanoTime();
+
         try (final var fileInputStream = Files.newInputStream(feedFilePath, StandardOpenOption.DELETE_ON_CLOSE);
              final var bufferedInputStream = new BufferedInputStream(fileInputStream);
              final var gzipInputStream = new GZIPInputStream(bufferedInputStream);
@@ -135,24 +151,32 @@ public class EpssMirrorTask implements Subscriber {
                 recordBatch.add(record);
 
                 if (recordBatch.size() == BATCH_SIZE) {
-                    processBatch(recordBatch);
+                    recordsModified += processBatch(recordBatch);
+                    recordsRead += recordBatch.size();
                     recordBatch.clear();
+                    if (System.nanoTime() - lastHeartbeatNs >= HEARTBEAT_LOG_INTERVAL.toNanos()) {
+                        LOGGER.info(
+                                "Read {} records so far ({} modified)",
+                                recordsRead, recordsModified);
+                        lastHeartbeatNs = System.nanoTime();
+                    }
                 }
             }
 
             if (!recordBatch.isEmpty()) {
-                processBatch(recordBatch);
+                recordsModified += processBatch(recordBatch);
                 recordBatch.clear();
             }
         }
+
+        return recordsModified;
     }
 
-    private void processBatch(final List<Epss> records) {
+    private int processBatch(final List<Epss> records) {
         LOGGER.debug("Processing batch of {} records", records.size());
 
-        final int recordsModified = inJdbiTransaction(
+        return inJdbiTransaction(
                 handle -> handle.attach(EpssDao.class).createOrUpdateAll(records));
-        LOGGER.debug("Created or updated {} records", recordsModified);
     }
 
     private static Epss parseEpssRecord(final String csvLine) {

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jdo.Query;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -53,6 +54,7 @@ import java.util.Set;
 
 import static org.datanucleus.PropertyNames.PROPERTY_MANAGE_RELATIONSHIPS;
 import static org.datanucleus.PropertyNames.PROPERTY_PERSISTENCE_BY_REACHABILITY_AT_COMMIT;
+import static org.dependencytrack.common.MdcKeys.MDC_VULN_DATA_SOURCE_NAME;
 import static org.dependencytrack.common.MdcKeys.MDC_VULN_ID;
 import static org.dependencytrack.common.MdcKeys.MDC_VULN_SOURCE;
 import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransaction;
@@ -64,6 +66,7 @@ import static org.dependencytrack.persistence.jdbi.JdbiFactory.useJdbiTransactio
 public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDataSourceArg, Void> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MirrorVulnDataSourceActivity.class);
+    private static final Duration HEARTBEAT_LOG_INTERVAL = Duration.ofSeconds(30);
 
     private final PluginManager pluginManager;
 
@@ -102,34 +105,55 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
         final var updatePolicy = new VulnerabilityUpdatePolicy(pluginManager);
 
-        try (final VulnDataSource dataSource = dataSourceFactory.create()) {
-            final var bovBatch = new ArrayList<Bom>(25);
-            while (dataSource.hasNext()) {
-                if (Thread.interrupted()) {
-                    throw new InterruptedException("Interrupted before all BOVs could be consumed");
-                }
-                ctx.maybeHeartbeat();
+        try (var ignoredMdc = new MdcScope(Map.of(MDC_VULN_DATA_SOURCE_NAME, arg.getDataSourceName()))) {
+            LOGGER.info("Starting mirror");
+            final long startTimeNs = System.nanoTime();
+            long lastHeartbeatNs = startTimeNs;
+            int vulnsProcessed = 0;
+            int vulnsSkipped = 0;
 
-                final Bom bov = dataSource.next();
-                if (!bov.getVulnerabilities(0).hasRejected()) {
-                    bovBatch.add(bov);
-                    if (bovBatch.size() == 25) {
-                        processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
-                        bovBatch.clear();
+            try (final VulnDataSource dataSource = dataSourceFactory.create()) {
+                final var bovBatch = new ArrayList<Bom>(25);
+                while (dataSource.hasNext()) {
+                    if (Thread.interrupted()) {
+                        throw new InterruptedException("Interrupted before all vulnerabilities could be consumed");
                     }
-                } else {
-                    LOGGER.warn(
-                            "Skipping vulnerability {} rejected at {}",
-                            bov.getVulnerabilities(0).getId(),
-                            Timestamps.toString(bov.getVulnerabilities(0).getRejected()));
+                    ctx.maybeHeartbeat();
+
+                    final Bom bov = dataSource.next();
+                    if (!bov.getVulnerabilities(0).hasRejected()) {
+                        bovBatch.add(bov);
+                        if (bovBatch.size() == 25) {
+                            processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
+                            vulnsProcessed += bovBatch.size();
+                            bovBatch.clear();
+                            if (System.nanoTime() - lastHeartbeatNs >= HEARTBEAT_LOG_INTERVAL.toNanos()) {
+                                LOGGER.info("Processed {} vulnerabilities so far", vulnsProcessed);
+                                lastHeartbeatNs = System.nanoTime();
+                            }
+                        }
+                    } else {
+                        vulnsSkipped++;
+                        LOGGER.warn(
+                                "Skipping vulnerability {} rejected at {}",
+                                bov.getVulnerabilities(0).getId(),
+                                Timestamps.toString(bov.getVulnerabilities(0).getRejected()));
+                    }
+                }
+
+                if (!bovBatch.isEmpty()) {
+                    ctx.maybeHeartbeat();
+                    processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
+                    vulnsProcessed += bovBatch.size();
+                    bovBatch.clear();
                 }
             }
 
-            if (!bovBatch.isEmpty()) {
-                ctx.maybeHeartbeat();
-                processBatch(dataSource, bovBatch, source, arg.getDataSourceName(), updatePolicy);
-                bovBatch.clear();
-            }
+            LOGGER.info(
+                    "Completed mirror; processed {} vulnerabilities ({} skipped) in {}",
+                    vulnsProcessed,
+                    vulnsSkipped,
+                    Duration.ofNanos(System.nanoTime() - startTimeNs));
         }
 
         return null;
@@ -141,7 +165,7 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             Vulnerability.Source source,
             String dataSourceName,
             VulnerabilityUpdatePolicy updatePolicy) {
-        LOGGER.debug("Processing batch of {} BOVs", bovs.size());
+        LOGGER.debug("Processing batch of {} vulnerabilities", bovs.size());
 
         final var vulns = new ArrayList<Vulnerability>(bovs.size());
         final var vsListByVulnId = new HashMap<String, List<VulnerableSoftware>>(bovs.size());
@@ -149,12 +173,12 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
         for (final Bom bov : bovs) {
             if (bov.getVulnerabilitiesCount() == 0) {
-                LOGGER.warn("BOV contains no vulnerabilities; Skipping");
+                LOGGER.warn("Encountered record with no vulnerabilities; Skipping");
                 continue;
             }
 
             if (bov.getVulnerabilitiesCount() > 1) {
-                LOGGER.warn("BOV contains more than one vulnerability; Skipping");
+                LOGGER.warn("Encountered record with more than one vulnerability; Skipping");
                 continue;
             }
 

--- a/vuln-data-source/github/src/main/java/org/dependencytrack/vulndatasource/github/GitHubVulnDataSource.java
+++ b/vuln-data-source/github/src/main/java/org/dependencytrack/vulndatasource/github/GitHubVulnDataSource.java
@@ -47,6 +47,9 @@ final class GitHubVulnDataSource implements VulnDataSource {
     private final boolean isAliasSyncEnabled;
     private final Queue<SecurityAdvisory> advisoryQueue;
     private boolean hasNextCalled = false;
+    private boolean startLogged = false;
+    private int pagesFetched = 0;
+    private int advisoriesFetched = 0;
 
     GitHubVulnDataSource(
             final WatermarkManager watermarkManager,
@@ -69,12 +72,20 @@ final class GitHubVulnDataSource implements VulnDataSource {
         if (!advisoryQueue.isEmpty()) {
             return true;
         }
+        if (!startLogged) {
+            LOGGER.info(
+                    "Downloading and processing GitHub advisories updated since {} (interleaved by page)",
+                    watermarkManager.getWatermark());
+            startLogged = true;
+        }
         if (!client.hasNext()) {
             return false;
         }
 
         final Collection<SecurityAdvisory> advisories = client.next();
-        LOGGER.debug("Fetched {} advisories", advisories.size());
+        pagesFetched++;
+        advisoriesFetched += advisories.size();
+        LOGGER.debug("Fetched page {} ({} advisories)", pagesFetched, advisories.size());
 
         advisoryQueue.addAll(advisories);
         return !advisoryQueue.isEmpty();
@@ -119,6 +130,8 @@ final class GitHubVulnDataSource implements VulnDataSource {
     @Override
     public void close() {
         watermarkManager.maybeCommit(/* ignoreMinCommitInterval */ true);
+
+        LOGGER.info("Fetched {} advisories across {} page(s)", advisoriesFetched, pagesFetched);
 
         try {
             client.close();

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSource.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSource.java
@@ -63,6 +63,8 @@ final class NvdVulnDataSource implements VulnDataSource {
     private NvdDataFeed currentFeed;
     private @Nullable String currentFeedSha256;
     private int currentFeedIndex = 0;
+    private int currentFeedCvesProcessed = 0;
+    private int currentFeedCvesSkipped = 0;
     private InputStream currentFileInputStream;
     private JsonParser currentJsonParser;
     private boolean hasNextCalled = false;
@@ -98,6 +100,7 @@ final class NvdVulnDataSource implements VulnDataSource {
             }
 
             recordCurrentFeedDigest();
+            logCurrentFeedSummary();
             closeCurrentFeed();
             currentFeedIndex++;
         }
@@ -111,6 +114,7 @@ final class NvdVulnDataSource implements VulnDataSource {
                     return true;
                 }
                 recordCurrentFeedDigest();
+                logCurrentFeedSummary();
                 closeCurrentFeed();
             }
             currentFeedIndex++;
@@ -173,7 +177,8 @@ final class NvdVulnDataSource implements VulnDataSource {
         }
 
         currentFeed = feeds.get(currentFeedIndex);
-        LOGGER.info("Opening {}", currentFeed);
+        currentFeedCvesProcessed = 0;
+        currentFeedCvesSkipped = 0;
 
         final NvdDataFeedMetadata feedMetadata = retrieveFeedMetadata(currentFeed);
 
@@ -214,6 +219,7 @@ final class NvdVulnDataSource implements VulnDataSource {
 
                 if ("vulnerabilities".equals(fieldName)) {
                     if (currentToken == JsonToken.START_ARRAY) {
+                        LOGGER.info("Processing feed {}", currentFeed);
                         return true;
                     } else {
                         currentJsonParser.skipChildren();
@@ -250,6 +256,7 @@ final class NvdVulnDataSource implements VulnDataSource {
 
                 if (watermark != null && !watermark.isBefore(cveLastModified)) {
                     LOGGER.debug("Skipping CVE {}: Below watermark", defCveItem.getCve().getId());
+                    currentFeedCvesSkipped++;
                     defCveItem = null;
                 }
             } catch (IOException e) {
@@ -257,7 +264,18 @@ final class NvdVulnDataSource implements VulnDataSource {
             }
         }
 
+        currentFeedCvesProcessed++;
         return ModelConverter.convert(defCveItem);
+    }
+
+    private void logCurrentFeedSummary() {
+        if (currentFeed == null) {
+            return;
+        }
+
+        LOGGER.info(
+                "Finished {}: processed {} CVE(s), skipped {} below watermark",
+                currentFeed, currentFeedCvesProcessed, currentFeedCvesSkipped);
     }
 
     private void recordCurrentFeedDigest() {
@@ -330,7 +348,8 @@ final class NvdVulnDataSource implements VulnDataSource {
             throw new IllegalStateException("Failed to create temp file", e);
         }
 
-        LOGGER.info("Downloading {} to {}", feedFileUri, tempFile);
+        LOGGER.info("Downloading feed {} from {}", feed, feedFileUri);
+        LOGGER.debug("Download destination: {}", tempFile);
         final HttpResponse<Path> response;
         try {
             response = httpClient.send(

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
@@ -73,6 +73,7 @@ final class OsvVulnDataSource implements VulnDataSource {
     private final ModelConverter modelConverter;
     private String currentEcosystem;
     private int currentEcosystemIndex;
+    private int currentEcosystemAdvisoriesProcessed;
     private Path currentEcosystemDirPath;
     private Stream<Path> currentEcosystemFileStream;
     private Iterator<Path> currentEcosystemFileIterator;
@@ -116,6 +117,7 @@ final class OsvVulnDataSource implements VulnDataSource {
             if (watermarkManager != null) {
                 watermarkManager.maybeCommit(List.of(currentEcosystem));
             }
+            logCurrentEcosystemSummary();
             closeCurrentEcosystem();
             currentEcosystemIndex++;
         }
@@ -132,6 +134,7 @@ final class OsvVulnDataSource implements VulnDataSource {
                 if (watermarkManager != null) {
                     watermarkManager.maybeCommit(List.of(currentEcosystem));
                 }
+                logCurrentEcosystemSummary();
                 closeCurrentEcosystem();
             }
             currentEcosystemIndex++;
@@ -197,16 +200,27 @@ final class OsvVulnDataSource implements VulnDataSource {
         }
 
         final Path filePath = currentEcosystemFileIterator.next();
-        LOGGER.debug("Reading advisory {}", filePath);
 
         final Osv osv;
         try {
             osv = objectMapper.readValue(filePath.toFile(), Osv.class);
         } catch (IOException e) {
-            throw new UncheckedIOException("Failed to read OSV advisory", e);
+            throw new UncheckedIOException("Failed to read OSV advisory " + filePath.getFileName(), e);
         }
 
+        currentEcosystemAdvisoriesProcessed++;
         return modelConverter.convert(osv, isAliasSyncEnabled, currentEcosystem);
+    }
+
+    private void logCurrentEcosystemSummary() {
+        if (currentEcosystem == null) {
+            return;
+        }
+
+        LOGGER.info(
+                "Finished ecosystem {}: processed {} advisories",
+                currentEcosystem,
+                currentEcosystemAdvisoriesProcessed);
     }
 
     private boolean openNextEcosystem() {
@@ -215,7 +229,7 @@ final class OsvVulnDataSource implements VulnDataSource {
         }
 
         currentEcosystem = ecosystems.get(currentEcosystemIndex);
-        LOGGER.info("Opening ecosystem {}", currentEcosystem);
+        currentEcosystemAdvisoriesProcessed = 0;
 
         currentEcosystemDirPath = downloadEcosystemFiles(currentEcosystem);
         try {
@@ -228,6 +242,7 @@ final class OsvVulnDataSource implements VulnDataSource {
             throw new UncheckedIOException("Failed to walk " + currentEcosystemDirPath, e);
         }
 
+        LOGGER.info("Processing ecosystem {}", currentEcosystem);
         return true;
     }
 
@@ -257,7 +272,7 @@ final class OsvVulnDataSource implements VulnDataSource {
     }
 
     private void downloadEcosystemFilesAll(final String ecosystem, final Path destDirPath) {
-        LOGGER.info("Downloading all advisories for ecosystem {}", ecosystem);
+        LOGGER.info("Downloading all advisories for ecosystem {} from upstream", ecosystem);
         final var request = HttpRequest.newBuilder()
                 .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, ecosystem)))
                 .build();
@@ -272,7 +287,8 @@ final class OsvVulnDataSource implements VulnDataSource {
             throw new IllegalStateException("Interrupted while downloading advisory archive", e);
         }
 
-        LOGGER.info("Extracting advisories for ecosystem {} to {}", ecosystem, destDirPath);
+        LOGGER.info("Extracting advisories for ecosystem {}", ecosystem);
+        LOGGER.debug("Extraction destination: {}", destDirPath);
         try (final InputStream responseBodyInputStream = response.body();
              final var zipInputStream = new ZipInputStream(responseBodyInputStream)) {
             ZipEntry zipEntry;
@@ -307,7 +323,7 @@ final class OsvVulnDataSource implements VulnDataSource {
         }
 
         // TODO: Use structured concurrency after Java 25 upgrade (https://openjdk.org/jeps/505).
-        LOGGER.info("Downloading {} new or updated advisories", modifiedIds.size());
+        LOGGER.info("Downloading {} new or updated advisories for ecosystem {}", modifiedIds.size(), ecosystem);
         for (final String modifiedId : modifiedIds) {
             LOGGER.debug("Downloading advisory {}", modifiedId);
             downloadAdvisoryFile(ecosystem, modifiedId, destDirPath);
@@ -335,8 +351,6 @@ final class OsvVulnDataSource implements VulnDataSource {
     }
 
     private void closeCurrentEcosystem() {
-        LOGGER.info("Closing ecosystem {}", currentEcosystem);
-
         if (currentEcosystemFileStream != null) {
             currentEcosystemFileStream.close();
             currentEcosystemFileIterator = null;


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves logging during vuln datasource mirroring.

Makes logs more useful and emits status updates in regular intervals of ~30s to allow users to monitor progress better.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
