### PR TITLE
Close remaining ACL gaps

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/ProjectQueryManager.java
@@ -45,6 +45,7 @@ import javax.jdo.metadata.TypeMetadata;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -829,11 +830,13 @@ final class ProjectQueryManager extends QueryManager implements IQueryManager {
 
     private List<ProjectVersion> getProjectVersions(Project project) {
         final Query<Project> query = pm.newQuery(Project.class);
-        query.setFilter("name == :name");
-        query.setParameters(project.getName());
         query.setResult("uuid, version, inactiveSince");
         query.setOrdering("id asc"); // Ensure consistent ordering
-        return query.executeResultList(ProjectVersion.class);
+        final var params = new HashMap<String, Object>();
+        params.put("name", project.getName());
+        preprocessACLs(query, "name == :name", params);
+        query.setNamedParameters(params);
+        return executeAndCloseResultList(query, ProjectVersion.class);
     }
 
     private void populateMetrics(final Collection<Project> projects) {

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -629,6 +629,15 @@ public interface ProjectDao extends SqlObject {
             """)
     Boolean isAccessible(@Bind UUID projectUuid);
 
+    @SqlQuery(/* language=InjectedFreeMarker */ """
+            <#-- @ftlvariable name="apiProjectAclCondition" type="String" -->
+            SELECT "UUID"
+              FROM "PROJECT"
+             WHERE "UUID" = ANY(:projectUuids)
+               AND ${apiProjectAclCondition}
+            """)
+    Set<UUID> getAccessibleProjectUuids(@Bind Collection<UUID> projectUuids);
+
     /**
      * @param command The clone command.
      * @return The {@link UUID} of the cloned project.

--- a/apiserver/src/main/java/org/dependencytrack/resources/AbstractApiResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/AbstractApiResource.java
@@ -24,6 +24,7 @@ import org.dependencytrack.api.v2.model.TotalCountType;
 import org.dependencytrack.common.MdcScope;
 import org.dependencytrack.common.pagination.Page;
 import org.dependencytrack.exception.ProjectAccessDeniedException;
+import org.dependencytrack.model.Policy;
 import org.dependencytrack.model.Project;
 import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.ComponentDao;
@@ -34,15 +35,21 @@ import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.security.Principal;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNullElse;
 import static org.dependencytrack.common.MdcKeys.MDC_COMPONENT_UUID;
 import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_NAME;
 import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
 import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_VERSION;
+import static org.dependencytrack.persistence.jdbi.JdbiFactory.withJdbiHandle;
 
 /**
  * @since 5.0.0
@@ -59,12 +66,12 @@ public abstract class AbstractApiResource extends AlpineResource {
     }
 
     /**
-     * Asserts that the authenticated {@link java.security.Principal} has access to a given {@link Project}.
+     * Asserts that the authenticated {@link Principal} has access to a given {@link Project}.
      *
      * @param qm      The {@link QueryManager} to use.
      * @param project The {@link Project} to verify access permission for.
      * @param message The message to use if a {@link ProjectAccessDeniedException} is thrown.
-     * @throws ProjectAccessDeniedException When the authenticated {@link java.security.Principal}
+     * @throws ProjectAccessDeniedException When the authenticated {@link Principal}
      *                                      does not have access to the given {@link Project}.
      */
     protected void requireAccess(final QueryManager qm, final Project project, final String message) {
@@ -87,12 +94,12 @@ public abstract class AbstractApiResource extends AlpineResource {
     }
 
     /**
-     * Asserts that the authenticated {@link java.security.Principal} has access to the component with a given {@link UUID}.
+     * Asserts that the authenticated {@link Principal} has access to the component with a given {@link UUID}.
      *
      * @param jdbiHandle    The {@link Handle} to use.
      * @param componentUuid {@link UUID} of the component to verify access permission for.
      * @throws NoSuchElementException       When no component with the given {@link UUID} exists.
-     * @throws ProjectAccessDeniedException When the authenticated {@link java.security.Principal}
+     * @throws ProjectAccessDeniedException When the authenticated {@link Principal}
      *                                      does not have access to the given {@link Project}.
      */
     protected void requireComponentAccess(final Handle jdbiHandle, final UUID componentUuid) {
@@ -111,12 +118,12 @@ public abstract class AbstractApiResource extends AlpineResource {
     }
 
     /**
-     * Asserts that the authenticated {@link java.security.Principal} has access to the project with a given {@link UUID}.
+     * Asserts that the authenticated {@link Principal} has access to the project with a given {@link UUID}.
      *
      * @param jdbiHandle  The {@link Handle} to use.
      * @param projectUuid {@link UUID} of the project to verify access permission for.
      * @throws NoSuchElementException       When no project with the given {@link UUID} exists.
-     * @throws ProjectAccessDeniedException When the authenticated {@link java.security.Principal}
+     * @throws ProjectAccessDeniedException When the authenticated {@link Principal}
      *                                      does not have access to the given {@link Project}.
      */
     protected void requireProjectAccess(final Handle jdbiHandle, final UUID projectUuid) {
@@ -130,6 +137,39 @@ public abstract class AbstractApiResource extends AlpineResource {
             }
             throw new ProjectAccessDeniedException("Access to the requested project is forbidden");
         }
+    }
+
+    /**
+     * Returns the subset of {@code projects} that the authenticated {@link Principal}
+     * has access to. The order of the input is preserved.
+     * <p>
+     * The intended use is to filter {@link Project} collections embedded in a response payload
+     * (e.g. {@link Policy#projects}) prior to serialization, where the persistence layer does
+     * not natively apply ACL to the loaded child collection.
+     * <p>
+     * <strong>This is a stopgap</strong>! The proper remediation is paginated sub-resources,
+     * where the listing itself enforces ACL. <strong>Only use this method for legacy endpoints</strong>,
+     * do not design new endpoints around this logic!
+     *
+     * @return Subset of {@code projects} that the authenticated {@link Principal} has access to.
+     */
+    protected List<Project> filterAccessibleProjects(@Nullable Collection<Project> projects) {
+        if (projects == null || projects.isEmpty()) {
+            return List.of();
+        }
+
+        final Set<UUID> accessibleUuids = withJdbiHandle(
+                super.getAlpineRequest(),
+                handle -> handle
+                        .attach(ProjectDao.class)
+                        .getAccessibleProjectUuids(
+                                projects.stream()
+                                        .map(Project::getUuid)
+                                        .collect(Collectors.toSet())));
+
+        return projects.stream()
+                .filter(project -> accessibleUuids.contains(project.getUuid()))
+                .toList();
     }
 
     protected @Nullable TotalCount convertTotalCount(Page.@Nullable TotalCount totalCount) {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/NotificationRuleResource.java
@@ -74,7 +74,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * JAX-RS resources for processing notification rules.
@@ -125,7 +128,33 @@ public class NotificationRuleResource extends AbstractApiResource {
             @QueryParam("triggerType") final NotificationTriggerType triggerTypeFilter) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getNotificationRules(triggerTypeFilter);
-            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+            final List<NotificationRule> rules = result.getList(NotificationRule.class);
+
+            qm.makeTransientAll(rules);
+
+            final Set<UUID> accessibleProjectUuids =
+                    filterAccessibleProjects(
+                            rules.stream()
+                                    .map(NotificationRule::getProjects)
+                                    .filter(Objects::nonNull)
+                                    .flatMap(List::stream)
+                                    .toList())
+                            .stream()
+                            .map(Project::getUuid)
+                            .collect(Collectors.toSet());
+            for (final NotificationRule rule : rules) {
+                final List<Project> projects = rule.getProjects();
+                if (projects == null) {
+                    rule.setProjects(List.of());
+                    continue;
+                }
+
+                rule.setProjects(projects.stream()
+                        .filter(project -> accessibleProjectUuids.contains(project.getUuid()))
+                        .toList());
+            }
+
+            return Response.ok(rules).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }
 
@@ -290,7 +319,7 @@ public class NotificationRuleResource extends AbstractApiResource {
 
         final NotificationRule updatedRule;
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            updatedRule = qm.callInTransaction(() -> {
+            final NotificationRule persisted = qm.callInTransaction(() -> {
                 var rule = qm.getObjectByUuid(NotificationRule.class, request.uuid());
                 if (rule == null) {
                     throw new ClientErrorException(Response
@@ -360,6 +389,10 @@ public class NotificationRuleResource extends AbstractApiResource {
                             .build());
                 }
             });
+
+            qm.makeTransient(persisted);
+            persisted.setProjects(filterAccessibleProjects(persisted.getProjects()));
+            updatedRule = persisted;
         }
 
         LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Updated notification rule '{}'", updatedRule.getName());
@@ -427,27 +460,42 @@ public class NotificationRuleResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the project to add to the rule", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("projectUuid") @ValidUuid String projectUuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            return qm.callInTransaction(() -> {
+            final NotificationRule updatedRule = qm.callInTransaction(() -> {
                 final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
                 if (rule == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The notification rule could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The notification rule could not be found.")
+                            .build());
                 }
                 if (rule.getScope() != NotificationScope.PORTFOLIO) {
-                    return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Project limitations are only possible on notification rules with PORTFOLIO scope.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_ACCEPTABLE)
+                            .entity("Project limitations are only possible on notification rules with PORTFOLIO scope.")
+                            .build());
                 }
                 final Project project = qm.getObjectByUuid(Project.class, projectUuid);
                 if (project == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build());
                 }
                 requireAccess(qm, project);
                 final List<Project> projects = rule.getProjects();
-                if (projects != null && !projects.contains(project)) {
-                    rule.getProjects().add(project);
-                    qm.persist(rule);
-                    return Response.ok(rule).build();
+                if (projects == null || projects.contains(project)) {
+                    return null;
                 }
-                return Response.status(Response.Status.NOT_MODIFIED).build();
+                rule.getProjects().add(project);
+                return rule;
             });
+            if (updatedRule == null) {
+                return Response.status(Response.Status.NOT_MODIFIED).build();
+            }
+
+            qm.makeTransient(updatedRule);
+            updatedRule.setProjects(filterAccessibleProjects(updatedRule.getProjects()));
+            return Response.ok(updatedRule).build();
         }
     }
 
@@ -479,27 +527,42 @@ public class NotificationRuleResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the project to remove from the rule", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("projectUuid") @ValidUuid String projectUuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            return qm.callInTransaction(() -> {
+            final NotificationRule updatedRule = qm.callInTransaction(() -> {
                 final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
                 if (rule == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The notification rule could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The notification rule could not be found.")
+                            .build());
                 }
                 if (rule.getScope() != NotificationScope.PORTFOLIO) {
-                    return Response.status(Response.Status.NOT_ACCEPTABLE).entity("Project limitations are only possible on notification rules with PORTFOLIO scope.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_ACCEPTABLE)
+                            .entity("Project limitations are only possible on notification rules with PORTFOLIO scope.")
+                            .build());
                 }
                 final Project project = qm.getObjectByUuid(Project.class, projectUuid);
                 if (project == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build());
                 }
                 requireAccess(qm, project);
                 final List<Project> projects = rule.getProjects();
-                if (projects != null && projects.contains(project)) {
-                    rule.getProjects().remove(project);
-                    qm.persist(rule);
-                    return Response.ok(rule).build();
+                if (projects == null || !projects.contains(project)) {
+                    return null;
                 }
-                return Response.status(Response.Status.NOT_MODIFIED).build();
+                rule.getProjects().remove(project);
+                return rule;
             });
+            if (updatedRule == null) {
+                return Response.status(Response.Status.NOT_MODIFIED).build();
+            }
+
+            qm.makeTransient(updatedRule);
+            updatedRule.setProjects(filterAccessibleProjects(updatedRule.getProjects()));
+            return Response.ok(updatedRule).build();
         }
     }
 
@@ -527,23 +590,35 @@ public class NotificationRuleResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the team to add to the rule", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("teamUuid") @ValidUuid String teamUuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            return qm.callInTransaction(() -> {
+            final NotificationRule updatedRule = qm.callInTransaction(() -> {
                 final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
                 if (rule == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The notification rule could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The notification rule could not be found.")
+                            .build());
                 }
                 final Team team = qm.getObjectByUuid(Team.class, teamUuid);
                 if (team == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The team could not be found.")
+                            .build());
                 }
                 final Set<Team> teams = rule.getTeams();
-                if (teams != null && !teams.contains(team)) {
-                    rule.getTeams().add(team);
-                    qm.persist(rule);
-                    return Response.ok(rule).build();
+                if (teams == null || teams.contains(team)) {
+                    return null;
                 }
-                return Response.status(Response.Status.NOT_MODIFIED).build();
+                rule.getTeams().add(team);
+                return rule;
             });
+            if (updatedRule == null) {
+                return Response.status(Response.Status.NOT_MODIFIED).build();
+            }
+
+            qm.makeTransient(updatedRule);
+            updatedRule.setProjects(filterAccessibleProjects(updatedRule.getProjects()));
+            return Response.ok(updatedRule).build();
         }
     }
 
@@ -571,23 +646,35 @@ public class NotificationRuleResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the project to remove from the rule", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("teamUuid") @ValidUuid String teamUuid) {
         try (final var qm = new QueryManager(getAlpineRequest())) {
-            return qm.callInTransaction(() -> {
+            final NotificationRule updatedRule = qm.callInTransaction(() -> {
                 final NotificationRule rule = qm.getObjectByUuid(NotificationRule.class, ruleUuid);
                 if (rule == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The notification rule could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The notification rule could not be found.")
+                            .build());
                 }
                 final Team team = qm.getObjectByUuid(Team.class, teamUuid);
                 if (team == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The team could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The team could not be found.")
+                            .build());
                 }
                 final Set<Team> teams = rule.getTeams();
-                if (teams != null && teams.contains(team)) {
-                    rule.getTeams().remove(team);
-                    qm.persist(rule);
-                    return Response.ok(rule).build();
+                if (teams == null || !teams.contains(team)) {
+                    return null;
                 }
-                return Response.status(Response.Status.NOT_MODIFIED).build();
+                rule.getTeams().remove(team);
+                return rule;
             });
+            if (updatedRule == null) {
+                return Response.status(Response.Status.NOT_MODIFIED).build();
+            }
+
+            qm.makeTransient(updatedRule);
+            updatedRule.setProjects(filterAccessibleProjects(updatedRule.getProjects()));
+            return Response.ok(updatedRule).build();
         }
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/PolicyResource.java
@@ -31,6 +31,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import jakarta.validation.Validator;
+import jakarta.ws.rs.ClientErrorException;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.GET;
@@ -52,6 +53,10 @@ import org.dependencytrack.resources.v1.openapi.PaginatedApi;
 import org.dependencytrack.resources.v1.problems.ProblemDetails;
 
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * JAX-RS resources for processing policies.
@@ -87,7 +92,33 @@ public class PolicyResource extends AbstractApiResource {
     public Response getPolicies() {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final PaginatedResult result = qm.getPolicies();
-            return Response.ok(result.getObjects()).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
+            final List<Policy> policies = result.getList(Policy.class);
+
+            qm.makeTransientAll(policies);
+
+            final Set<UUID> accessibleProjectUuids =
+                    filterAccessibleProjects(
+                            policies.stream()
+                                    .map(Policy::getProjects)
+                                    .filter(Objects::nonNull)
+                                    .flatMap(List::stream)
+                                    .toList())
+                            .stream()
+                            .map(Project::getUuid)
+                            .collect(Collectors.toSet());
+            for (final Policy policy : policies) {
+                final List<Project> projects = policy.getProjects();
+                if (projects == null) {
+                    policy.setProjects(List.of());
+                    continue;
+                }
+
+                policy.setProjects(projects.stream()
+                        .filter(project -> accessibleProjectUuids.contains(project.getUuid()))
+                        .toList());
+            }
+
+            return Response.ok(policies).header(TOTAL_COUNT_HEADER, result.getTotal()).build();
         }
     }
 
@@ -111,13 +142,15 @@ public class PolicyResource extends AbstractApiResource {
     public Response getPolicy(
             @Parameter(description = "The UUID of the policy to retrieve", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (QueryManager qm = new QueryManager()) {
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Policy policy = qm.getObjectByUuid(Policy.class, uuid);
-            if (policy != null) {
-                return Response.ok(policy).build();
-            } else {
+            if (policy == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The policy could not be found.").build();
             }
+
+            qm.makeTransient(policy);
+            policy.setProjects(filterAccessibleProjects(policy.getProjects()));
+            return Response.ok(policy).build();
         }
     }
 
@@ -189,21 +222,26 @@ public class PolicyResource extends AbstractApiResource {
         failOnValidationError(
                 validator.validateProperty(jsonPolicy, "name")
         );
-        try (QueryManager qm = new QueryManager()) {
-            return qm.callInTransaction(() -> {
-                Policy policy = qm.getObjectByUuid(Policy.class, jsonPolicy.getUuid());
-                if (policy != null) {
-                    policy.setName(StringUtils.trimToNull(jsonPolicy.getName()));
-                    policy.setOperator(jsonPolicy.getOperator());
-                    policy.setViolationState(jsonPolicy.getViolationState());
-                    policy.setIncludeChildren(jsonPolicy.isIncludeChildren());
-                    policy.setOnlyLatestProjectVersion(jsonPolicy.isOnlyLatestProjectVersion());
-                    policy = qm.persist(policy);
-                    return Response.ok(policy).build();
-                } else {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The policy could not be found.").build();
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
+            final Policy updatedPolicy = qm.callInTransaction(() -> {
+                final Policy policy = qm.getObjectByUuid(Policy.class, jsonPolicy.getUuid());
+                if (policy == null) {
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The policy could not be found.")
+                            .build());
                 }
+                policy.setName(StringUtils.trimToNull(jsonPolicy.getName()));
+                policy.setOperator(jsonPolicy.getOperator());
+                policy.setViolationState(jsonPolicy.getViolationState());
+                policy.setIncludeChildren(jsonPolicy.isIncludeChildren());
+                policy.setOnlyLatestProjectVersion(jsonPolicy.isOnlyLatestProjectVersion());
+                return qm.persist(policy);
             });
+
+            qm.makeTransient(updatedPolicy);
+            updatedPolicy.setProjects(filterAccessibleProjects(updatedPolicy.getProjects()));
+            return Response.ok(updatedPolicy).build();
         }
     }
 
@@ -266,24 +304,36 @@ public class PolicyResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the project to add to the rule", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("projectUuid") @ValidUuid String projectUuid) {
         try (QueryManager qm = new QueryManager()) {
-            return qm.callInTransaction(() -> {
+            final Policy updatedPolicy = qm.callInTransaction(() -> {
                 final Policy policy = qm.getObjectByUuid(Policy.class, policyUuid);
                 if (policy == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The policy could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The policy could not be found.")
+                            .build());
                 }
                 final Project project = qm.getObjectByUuid(Project.class, projectUuid);
                 if (project == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build());
                 }
                 requireAccess(qm, project);
                 final List<Project> projects = policy.getProjects();
-                if (projects != null && !projects.contains(project)) {
-                    policy.getProjects().add(project);
-                    qm.persist(policy);
-                    return Response.ok(policy).build();
+                if (projects == null || projects.contains(project)) {
+                    return null;
                 }
-                return Response.status(Response.Status.NOT_MODIFIED).build();
+                policy.getProjects().add(project);
+                return policy;
             });
+            if (updatedPolicy == null) {
+                return Response.status(Response.Status.NOT_MODIFIED).build();
+            }
+
+            qm.makeTransient(updatedPolicy);
+            updatedPolicy.setProjects(filterAccessibleProjects(updatedPolicy.getProjects()));
+            return Response.ok(updatedPolicy).build();
         }
     }
 
@@ -316,24 +366,36 @@ public class PolicyResource extends AbstractApiResource {
             @Parameter(description = "The UUID of the project to remove from the policy", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("projectUuid") @ValidUuid String projectUuid) {
         try (QueryManager qm = new QueryManager()) {
-            return qm.callInTransaction(() -> {
+            final Policy updatedPolicy = qm.callInTransaction(() -> {
                 final Policy policy = qm.getObjectByUuid(Policy.class, policyUuid);
                 if (policy == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The policy could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The policy could not be found.")
+                            .build());
                 }
                 final Project project = qm.getObjectByUuid(Project.class, projectUuid);
                 if (project == null) {
-                    return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
+                    throw new ClientErrorException(Response
+                            .status(Response.Status.NOT_FOUND)
+                            .entity("The project could not be found.")
+                            .build());
                 }
                 requireAccess(qm, project);
                 final List<Project> projects = policy.getProjects();
-                if (projects != null && projects.contains(project)) {
-                    policy.getProjects().remove(project);
-                    qm.persist(policy);
-                    return Response.ok(policy).build();
+                if (projects == null || !projects.contains(project)) {
+                    return null;
                 }
-                return Response.status(Response.Status.NOT_MODIFIED).build();
+                policy.getProjects().remove(project);
+                return policy;
             });
+            if (updatedPolicy == null) {
+                return Response.status(Response.Status.NOT_MODIFIED).build();
+            }
+
+            qm.makeTransient(updatedPolicy);
+            updatedPolicy.setProjects(filterAccessibleProjects(updatedPolicy.getProjects()));
+            return Response.ok(updatedPolicy).build();
         }
     }
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -291,14 +291,23 @@ public class ProjectResource extends AbstractApiResource {
     public Response getProject(
             @Parameter(description = "The UUID of the project to retrieve", schema = @Schema(type = "string", format = "uuid"), required = true)
             @PathParam("uuid") @ValidUuid String uuid) {
-        try (QueryManager qm = new QueryManager()) {
+        try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Project project = qm.getProject(uuid);
-            if (project != null) {
-                requireAccess(qm, project);
-                return Response.ok(project).build();
-            } else {
+            if (project == null) {
                 return Response.status(Response.Status.NOT_FOUND).entity("The project could not be found.").build();
             }
+            requireAccess(qm, project);
+
+            final boolean isParentAccessible =
+                    project.getParent() != null
+                            && qm.hasAccess(getPrincipal(), project.getParent());
+
+            qm.makeTransient(project);
+            if (!isParentAccessible) {
+                project.setParent(null);
+            }
+
+            return Response.ok(project).build();
         }
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/NotificationRuleResourceTest.java
@@ -65,7 +65,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 class NotificationRuleResourceTest extends ResourceTest {
@@ -492,6 +492,213 @@ class NotificationRuleResourceTest extends ResourceTest {
 
         response = responseSupplier.get();
         assertThat(response.getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleProjectsViaGetAllNotificationRulesWhenAclEnabled() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final NotificationRule rule = qm.createNotificationRule(
+                "Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setProjects(List.of(accessibleProject, inaccessibleProject));
+        qm.persist(rule);
+
+        final Response response = jersey.target(V1_NOTIFICATION_RULE).request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[0].projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleProjectsInAddProjectToRuleResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final NotificationRule rule = qm.createNotificationRule(
+                "Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setProjects(List.of(inaccessibleProject));
+        qm.persist(rule);
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_RULE + "/" + rule.getUuid() + "/project/" + accessibleProject.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleProjectsInUpdateNotificationRuleResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final NotificationRule rule = qm.createNotificationRule(
+                "Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setProjects(List.of(accessibleProject, inaccessibleProject));
+        rule.setPublisherConfig("{\"destinationUrl\":\"https://slack.example.com\"}");
+        qm.persist(rule);
+
+        final Response response = jersey.target(V1_NOTIFICATION_RULE).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "name": "renamed",
+                          "scope": "PORTFOLIO",
+                          "level": "INFORMATIONAL",
+                          "enabled": true,
+                          "notifyChildren": true,
+                          "logSuccessfulPublish": false,
+                          "notifyOn": [],
+                          "tags": [],
+                          "publisherConfig": "{\\"destinationUrl\\":\\"https://slack.example.com\\"}"
+                        }
+                        """.formatted(rule.getUuid())));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleProjectsInAddTeamToRuleResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final NotificationRule rule = qm.createNotificationRule(
+                "Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setProjects(List.of(accessibleProject, inaccessibleProject));
+        qm.persist(rule);
+
+        final Team newTeam = qm.createTeam("notify-team");
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_RULE + "/" + rule.getUuid() + "/team/" + newTeam.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(""));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleProjectsInRemoveTeamFromRuleResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final Team existingTeam = qm.createTeam("notify-team");
+
+        final NotificationRule rule = qm.createNotificationRule(
+                "Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setProjects(List.of(accessibleProject, inaccessibleProject));
+        rule.setTeams(Set.of(existingTeam));
+        qm.persist(rule);
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_RULE + "/" + rule.getUuid() + "/team/" + existingTeam.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleProjectsInRemoveProjectFromRuleResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_DELETE);
+        enablePortfolioAccessControl();
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final NotificationRule rule = qm.createNotificationRule(
+                "Rule", NotificationScope.PORTFOLIO, NotificationLevel.INFORMATIONAL, publisher);
+        rule.setProjects(List.of(inaccessibleProject, accessibleProject));
+        qm.persist(rule);
+
+        final Response response = jersey
+                .target(V1_NOTIFICATION_RULE + "/" + rule.getUuid() + "/project/" + accessibleProject.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects")
+                .isArray()
+                .isEmpty();
     }
 
     @Test

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/PolicyResourceTest.java
@@ -387,4 +387,246 @@ public class PolicyResourceTest extends ResourceTest {
         assertThat(response.getStatus()).isEqualTo(200);
     }
 
+    @Test
+    public void shouldNotLeakInaccessibleProjectsViaGetPolicyWhenAclEnabled() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT_READ);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(accessibleProject, inaccessibleProject));
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    public void shouldNotLeakInaccessibleProjectsViaGetPoliciesWhenAclEnabled() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT_READ);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(accessibleProject, inaccessibleProject));
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_POLICY)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[0].projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    public void shouldNotLeakInaccessibleProjectsInAddProjectToPolicyResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(inaccessibleProject));
+        qm.persist(policy);
+
+        final Response response = jersey
+                .target(V1_POLICY + "/" + policy.getUuid() + "/project/" + accessibleProject.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    public void shouldPreserveInaccessibleProjectsInDatabaseWhenScrubbingPolicyResponse() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT_READ);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(accessibleProject, inaccessibleProject));
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+
+        qm.getPersistenceManager().refresh(policy);
+        assertThat(policy.getProjects())
+                .extracting(Project::getUuid)
+                .containsExactlyInAnyOrder(accessibleProject.getUuid(), inaccessibleProject.getUuid());
+    }
+
+    @Test
+    public void shouldReturnAllProjectsViaGetPolicyWhenCallerBypassesAcl() {
+        initializeWithPermissions(
+                Permissions.POLICY_MANAGEMENT_READ,
+                Permissions.PORTFOLIO_ACCESS_CONTROL_BYPASS);
+        enablePortfolioAccessControl();
+
+        final var projectA = new Project();
+        projectA.setName("a");
+        qm.persist(projectA);
+
+        final var projectB = new Project();
+        projectB.setName("b");
+        qm.persist(projectB);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(projectA, projectB));
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_POLICY + "/" + policy.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactlyInAnyOrder(
+                        projectA.getUuid().toString(),
+                        projectB.getUuid().toString());
+    }
+
+    @Test
+    public void shouldNotLeakInaccessibleProjectsInUpdatePolicyResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(accessibleProject, inaccessibleProject));
+        qm.persist(policy);
+
+        final Response response = jersey.target(V1_POLICY).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "name": "renamed",
+                          "operator": "ANY",
+                          "violationState": "INFO"
+                        }
+                        """.formatted(policy.getUuid())));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects[*].uuid")
+                .isArray()
+                .containsExactly(accessibleProject.getUuid().toString());
+    }
+
+    @Test
+    public void shouldNotLeakInaccessibleProjectsInRemoveProjectFromPolicyResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.POLICY_MANAGEMENT_DELETE);
+        enablePortfolioAccessControl();
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var accessibleProject = new Project();
+        accessibleProject.setName("accessible");
+        qm.persist(accessibleProject);
+        accessibleProject.addAccessTeam(super.team);
+
+        final var policy = new Policy();
+        policy.setName("policy");
+        policy.setOperator(Policy.Operator.ANY);
+        policy.setViolationState(Policy.ViolationState.INFO);
+        policy.setProjects(List.of(inaccessibleProject, accessibleProject));
+        qm.persist(policy);
+
+        final Response response = jersey
+                .target(V1_POLICY + "/" + policy.getUuid() + "/project/" + accessibleProject.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .delete();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.projects")
+                .isArray()
+                .isEmpty();
+    }
+
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/ProjectResourceTest.java
@@ -4583,4 +4583,96 @@ class ProjectResourceTest extends ResourceTest {
         assertThat(clonedProject.getCollectionTag()).isNotNull();
         assertThat(clonedProject.getCollectionTag().getName()).isEqualTo("prod");
     }
+
+    @Test
+    void shouldNotLeakInaccessibleParentViaGetProjectByUuidWhenAclEnabled() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var parent = qm.createProject("secret-parent", null, "1.0", null, null, null, null, false);
+        final var child = qm.createProject("acme-child", null, "1.0", null, parent, null, null, false);
+        child.addAccessTeam(super.team);
+
+        final Response response = jersey.target(V1_PROJECT + "/" + child.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.parent")
+                .isAbsent();
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleParentViaProjectLookupWhenAclEnabled() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var parent = qm.createProject("secret-parent", null, "1.0", null, null, null, null, false);
+        final var child = qm.createProject("acme-child", null, "1.0", null, parent, null, null, false);
+        child.addAccessTeam(super.team);
+
+        final Response response = jersey.target(V1_PROJECT + "/lookup")
+                .queryParam("name", "acme-child")
+                .queryParam("version", "1.0")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.parent")
+                .isAbsent();
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleParentViaUpdateProjectWhenAclEnabled() {
+        initializeWithPermissions(Permissions.PORTFOLIO_MANAGEMENT_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var parent = qm.createProject("secret-parent", null, "1.0", null, null, null, null, false);
+        final var child = qm.createProject("acme-child", null, "1.0", null, parent, null, null, false);
+        child.addAccessTeam(super.team);
+
+        final Response response = jersey.target(V1_PROJECT)
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "name": "acme-child",
+                          "version": "1.0",
+                          "description": "renamed"
+                        }
+                        """.formatted(child.getUuid())));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.parent")
+                .isAbsent();
+    }
+
+    @Test
+    void shouldNotLeakInaccessibleVersionsViaGetProjectByUuidWhenAclEnabled() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var accessibleVersion = qm.createProject("shared-name", null, "1.0", null, null, null, null, false);
+        accessibleVersion.addAccessTeam(super.team);
+        qm.persist(accessibleVersion);
+        final var inaccessibleVersion = qm.createProject("shared-name", null, "2.0", null, null, null, null, false);
+
+        final Response response = jersey.target(V1_PROJECT + "/" + accessibleVersion.getUuid())
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.versions[*].uuid")
+                .isArray()
+                .containsExactly(accessibleVersion.getUuid().toString());
+    }
+
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/VulnerabilityResourceTest.java
@@ -1838,6 +1838,76 @@ public class VulnerabilityResourceTest extends ResourceTest {
     }
 
     @Test
+    public void shouldNotLeakInaccessibleComponentsInUpdateVulnerabilityResponseWhenAclEnabled() {
+        initializeWithPermissions(Permissions.VULNERABILITY_MANAGEMENT_UPDATE);
+        enablePortfolioAccessControl();
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var inaccessibleComponent = new Component();
+        inaccessibleComponent.setProject(inaccessibleProject);
+        inaccessibleComponent.setName("secret-component");
+        qm.createComponent(inaccessibleComponent, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("UPD-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln);
+        qm.addVulnerability(vuln, inaccessibleComponent, "none");
+
+        final Response response = jersey.target(V1_VULNERABILITY).request()
+                .header(X_API_KEY, apiKey)
+                .post(Entity.json(/* language=JSON */ """
+                        {
+                          "uuid": "%s",
+                          "vulnId": "UPD-1",
+                          "source": "INTERNAL",
+                          "severity": "CRITICAL"
+                        }
+                        """.formatted(vuln.getUuid())));
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$.components")
+                .isAbsent();
+    }
+
+    @Test
+    public void shouldNotLeakInaccessibleComponentsViaGetAllVulnerabilitiesWhenAclEnabled() {
+        initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
+        enablePortfolioAccessControl();
+
+        final var inaccessibleProject = new Project();
+        inaccessibleProject.setName("inaccessible");
+        qm.persist(inaccessibleProject);
+
+        final var inaccessibleComponent = new Component();
+        inaccessibleComponent.setProject(inaccessibleProject);
+        inaccessibleComponent.setName("secret-component");
+        qm.createComponent(inaccessibleComponent, false);
+
+        var vuln = new Vulnerability();
+        vuln.setVulnId("ACME-1");
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        vuln.setSeverity(Severity.HIGH);
+        vuln = qm.createVulnerability(vuln);
+        qm.addVulnerability(vuln, inaccessibleComponent, "none");
+
+        final Response response = jersey.target(V1_VULNERABILITY).request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[?(@.vulnId == 'ACME-1')].components")
+                .isArray()
+                .isEmpty();
+    }
+
+    @Test
     public void getVulnerabilitiesByTagTest() {
         initializeWithPermissions(Permissions.VIEW_PORTFOLIO);
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Closes remaining ACL gaps.

* Ensures that `/api/v1/notificationRule` and `/api/v1/policy` endpoints only return project sub-collections filtered based on which projects are accessible by the authenticated principal.
* Applies ACL filtering to `parent` project and `versions` in the response of `/api/v1/project/{uuid}`.
* Adds regression tests, including for other endpoints that were inspected but did not need implementation corrections.

Note most of these endpoints already require admin-like permissions, so this is more defense-in-depth than anything else.

The fact that some endpoints return sub-collections of unlimited depth is in itself a design flaw because it doesn't allow for pagination. Unfortunately, we cannot change that without breaking API changes, hence requiring additional filter steps. We'll do better in API v2 going forward.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Relates to https://github.com/DependencyTrack/hyades/issues/1645

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
