### PR TITLE
Add endpoints to trigger and observe vuln datasource mirroring

### DIFF
--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -183,6 +183,8 @@ tags:
   description: Endpoints related to secrets
 - name: Task Queues
   description: Endpoints related to task queue management
+- name: Vuln Data Sources
+  description: Endpoints related to vulnerability data sources
 - name: Vuln Policies
   description: Endpoints related to vulnerability policies
 - name: Workflows
@@ -219,6 +221,10 @@ paths:
     $ref: "./resources/vuln-policies/vuln-policy-bundle.yaml"
   /vuln-policy-bundles/{uuid}/sync:
     $ref: "./resources/vuln-policies/vuln-policy-bundle-sync.yaml"
+  /vuln-data-sources/{name}/mirror-runs:
+    $ref: "./resources/vuln-data-sources/vuln-data-source-mirror-runs.yaml"
+  /vuln-data-sources/{name}/mirror-runs/latest:
+    $ref: "./resources/vuln-data-sources/vuln-data-source-mirror-run-latest.yaml"
   /internal/task-queues/{type}:
     $ref: "./resources/internal/task-queues/task-queues.yaml"
   /internal/task-queues/{type}/{name}:

--- a/api/src/main/openapi/resources/vuln-data-sources/schemas/vuln-data-source-mirror-status.yaml
+++ b/api/src/main/openapi/resources/vuln-data-sources/schemas/vuln-data-source-mirror-status.yaml
@@ -1,0 +1,35 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+type: object
+properties:
+  status:
+    type: string
+    description: Status of the mirror run.
+    enum:
+    - PENDING
+    - RUNNING
+    - COMPLETED
+    - FAILED
+  started_at:
+    $ref: "../../../shared/schemas/timestamp.yaml"
+  completed_at:
+    $ref: "../../../shared/schemas/timestamp.yaml"
+  failure_reason:
+    type: string
+    description: Reason for why the mirror run failed.
+required:
+- status

--- a/api/src/main/openapi/resources/vuln-data-sources/vuln-data-source-mirror-run-latest.yaml
+++ b/api/src/main/openapi/resources/vuln-data-sources/vuln-data-source-mirror-run-latest.yaml
@@ -1,0 +1,52 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: getLatestVulnDataSourceMirrorRun
+  summary: Get the latest vulnerability data source mirror run
+  description: |-
+    Returns the status of the most recent mirror run for a given
+    vulnerability data source.
+
+    Returns 404 if no mirror run is available
+    (e.g. none has been triggered yet, or the most recent run
+    is no longer retained), or if the data source is unknown.
+
+    Requires permission `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_READ`.
+  tags:
+    - Vuln Data Sources
+  parameters:
+    - name: name
+      in: path
+      description: Name of the vulnerability data source (e.g. `nvd`, `osv`, `github`).
+      required: true
+      schema:
+        type: string
+  responses:
+    "200":
+      description: Mirror run status
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/vuln-data-source-mirror-status.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/vuln-data-sources/vuln-data-source-mirror-runs.yaml
+++ b/api/src/main/openapi/resources/vuln-data-sources/vuln-data-source-mirror-runs.yaml
@@ -1,0 +1,61 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+post:
+  operationId: triggerVulnDataSourceMirrorRun
+  summary: Trigger a vulnerability data source mirror run
+  description: |-
+    Triggers a mirror run for the given vulnerability data source.
+
+    Requires permission `SYSTEM_CONFIGURATION` or `SYSTEM_CONFIGURATION_UPDATE`.
+  tags:
+    - Vuln Data Sources
+  parameters:
+    - name: name
+      in: path
+      description: Name of the vulnerability data source (e.g. `nvd`, `osv`, `github`).
+      required: true
+      schema:
+        type: string
+  responses:
+    "202":
+      description: Mirror run triggered
+      headers:
+        Location:
+          description: URL of the latest mirror run resource.
+          schema:
+            type: string
+            format: uri
+    "400":
+      description: Mirror run cannot be started
+      content:
+        application/problem+json:
+          schema:
+            $ref: "../../shared/schemas/problem-details.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    "409":
+      description: A mirror run is already in progress
+      content:
+        application/problem+json:
+          schema:
+            $ref: "../../shared/schemas/problem-details.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/shared/schemas/problem-details.yaml
+++ b/api/src/main/openapi/shared/schemas/problem-details.yaml
@@ -21,7 +21,7 @@ externalDocs:
 properties:
   type:
     type: string
-    format: uri
+    format: uri-reference
     default: about:blank
     description: A URI reference that identifies the problem type
   status:
@@ -41,7 +41,7 @@ properties:
     maxLength: 1024
   instance:
     type: string
-    format: uri
+    format: uri-reference
     description: Reference URI that identifies the specific occurrence of the problem
 required:
 - title

--- a/api/src/main/spectral/functions/is-problem-json-schema.js
+++ b/api/src/main/spectral/functions/is-problem-json-schema.js
@@ -25,7 +25,7 @@ type: object
 properties:
   type:
     type: string
-    format: uri
+    format: uri-reference
   title:
     type: string
   status:
@@ -42,8 +42,8 @@ const assertProblemSchema = (schema) => {
         throw "Problem json must have type 'object'";
     }
     const type = (schema.properties || {}).type || {};
-    if (type.type !== 'string' || type.format !== 'uri') {
-        throw "Problem json must have property 'type' with type 'string' and format 'uri'";
+    if (type.type !== 'string' || type.format !== 'uri-reference') {
+        throw "Problem json must have property 'type' with type 'string' and format 'uri-reference'";
     }
     const title = (schema.properties || {}).title || {};
     if (title.type !== 'string') {

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ResourceConfig.java
@@ -34,6 +34,7 @@ import org.dependencytrack.filters.DeprecationResponseFilter;
 import org.dependencytrack.filters.JerseyMetricsApplicationEventListener;
 import org.dependencytrack.plugin.PluginManagerBinder;
 import org.dependencytrack.secret.SecretManagerBinder;
+import org.dependencytrack.vulndatasource.VulnDataSourceMirrorServiceBinder;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
@@ -79,6 +80,7 @@ public final class ResourceConfig extends org.glassfish.jersey.server.ResourceCo
         register(FileStorageBinder.class);
         register(PluginManagerBinder.class);
         register(SecretManagerBinder.class);
+        register(VulnDataSourceMirrorServiceBinder.class);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnDataSourcesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnDataSourcesResource.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import alpine.server.auth.PermissionRequired;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+import org.dependencytrack.api.v2.VulnDataSourcesApi;
+import org.dependencytrack.api.v2.model.VulnDataSourceMirrorStatus;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.resources.AbstractApiResource;
+import org.dependencytrack.resources.v2.exception.ProblemDetailsException;
+import org.dependencytrack.resources.v2.exception.ProblemType;
+import org.dependencytrack.vulndatasource.VulnDataSourceMirrorService;
+import org.dependencytrack.vulndatasource.VulnDataSourceMirrorService.MirrorStatus;
+import org.dependencytrack.vulndatasource.VulnDataSourceMirrorService.TriggerResult;
+import org.owasp.security.logging.SecurityMarkers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @since 5.0.0
+ */
+@Provider
+public final class VulnDataSourcesResource extends AbstractApiResource implements VulnDataSourcesApi {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(VulnDataSourcesResource.class);
+
+    private final VulnDataSourceMirrorService mirrorService;
+
+    @Inject
+    VulnDataSourcesResource(VulnDataSourceMirrorService mirrorService) {
+        this.mirrorService = mirrorService;
+    }
+
+    @Override
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_READ
+    })
+    public Response getLatestVulnDataSourceMirrorRun(String name) {
+        final MirrorStatus status = mirrorService.getLatestStatus(name);
+        if (status == null) {
+            throw new NotFoundException();
+        }
+
+        return Response
+                .ok(VulnDataSourceMirrorStatus.builder()
+                        .status(convert(status.status()))
+                        .startedAt(status.startedAt() != null
+                                ? status.startedAt().toEpochMilli()
+                                : null)
+                        .completedAt(status.completedAt() != null
+                                ? status.completedAt().toEpochMilli()
+                                : null)
+                        .failureReason(status.failureReason())
+                        .build())
+                .build();
+    }
+
+    @Override
+    @PermissionRequired({
+            Permissions.Constants.SYSTEM_CONFIGURATION,
+            Permissions.Constants.SYSTEM_CONFIGURATION_UPDATE
+    })
+    public Response triggerVulnDataSourceMirrorRun(String name) {
+        final TriggerResult result = mirrorService.trigger(name, getPrincipal().getName());
+
+        return switch (result) {
+            case TriggerResult.Triggered ignored -> {
+                LOGGER.info(
+                        SecurityMarkers.SECURITY_AUDIT,
+                        "Triggered vulnerability data source mirror for {}",
+                        name);
+                yield Response
+                        .accepted()
+                        .header("Location", getUriInfo()
+                                .getBaseUriBuilder()
+                                .path("/vuln-data-sources/{name}/mirror-runs/latest")
+                                .resolveTemplate("name", name)
+                                .build())
+                        .build();
+            }
+            case TriggerResult.AlreadyRunning ignored -> throw ProblemDetailsException.of(
+                    ProblemType.VULN_DATA_SOURCE_MIRROR_ALREADY_RUNNING,
+                    "A mirror run for this data source is already in progress");
+            case TriggerResult.NotEnabled ignored -> throw ProblemDetailsException.of(
+                    ProblemType.VULN_DATA_SOURCE_NOT_ENABLED,
+                    "The vulnerability data source is not enabled");
+            case TriggerResult.NotFound ignored -> throw new NotFoundException();
+        };
+    }
+
+    private static VulnDataSourceMirrorStatus.StatusEnum convert(MirrorStatus.Status status) {
+        return switch (status) {
+            case PENDING -> VulnDataSourceMirrorStatus.StatusEnum.PENDING;
+            case RUNNING -> VulnDataSourceMirrorStatus.StatusEnum.RUNNING;
+            case COMPLETED -> VulnDataSourceMirrorStatus.StatusEnum.COMPLETED;
+            case FAILED -> VulnDataSourceMirrorStatus.StatusEnum.FAILED;
+        };
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnPoliciesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnPoliciesResource.java
@@ -35,7 +35,6 @@ import org.dependencytrack.api.v2.model.ListVulnPoliciesResponse;
 import org.dependencytrack.api.v2.model.ListVulnPoliciesResponseItem;
 import org.dependencytrack.api.v2.model.ListVulnPolicyBundlesResponse;
 import org.dependencytrack.api.v2.model.ListVulnPolicyBundlesResponseItem;
-import org.dependencytrack.api.v2.model.ProblemDetails;
 import org.dependencytrack.api.v2.model.TotalCount;
 import org.dependencytrack.api.v2.model.TotalCountType;
 import org.dependencytrack.api.v2.model.UpdateVulnPolicyRequest;
@@ -71,6 +70,7 @@ import org.dependencytrack.policy.vulnerability.VulnerabilityPolicyRating;
 import org.dependencytrack.proto.internal.workflow.v1.SyncVulnPolicyBundleArg;
 import org.dependencytrack.resources.AbstractApiResource;
 import org.dependencytrack.resources.v2.exception.ProblemDetailsException;
+import org.dependencytrack.resources.v2.exception.ProblemType;
 import org.owasp.security.logging.SecurityMarkers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -386,12 +386,9 @@ public final class VulnPoliciesResource extends AbstractApiResource implements V
                                         .setBundleUuid(uuid.toString())
                                         .build()));
         if (runId == null) {
-            throw new ProblemDetailsException(
-                    ProblemDetails.builder()
-                            .status(Response.Status.CONFLICT.getStatusCode())
-                            .title("Conflict")
-                            .detail("Bundle synchronization is already in progress")
-                            .build());
+            throw ProblemDetailsException.of(
+                    ProblemType.VULN_POLICY_BUNDLE_SYNC_ALREADY_RUNNING,
+                    "Bundle synchronization is already in progress");
         }
 
         LOGGER.info(SecurityMarkers.SECURITY_AUDIT, "Triggered vulnerability policy bundle sync");

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemDetailsException.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemDetailsException.java
@@ -33,6 +33,16 @@ public final class ProblemDetailsException extends RuntimeException {
         this.problemDetails = requireNonNull(problemDetails, "Problem details must not be null");
     }
 
+    public static ProblemDetailsException of(ProblemType type, String detail) {
+        return new ProblemDetailsException(
+                ProblemDetails.builder()
+                        .type(type.type())
+                        .status(type.status())
+                        .title(type.title())
+                        .detail(detail)
+                        .build());
+    }
+
     public ProblemDetails getProblemDetails() {
         return problemDetails;
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemType.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/exception/ProblemType.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2.exception;
+
+import jakarta.ws.rs.core.Response;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @since 5.0.0
+ */
+@NullMarked
+public enum ProblemType {
+
+    VULN_DATA_SOURCE_MIRROR_ALREADY_RUNNING("vuln-data-source-mirror-already-running", 409),
+    VULN_DATA_SOURCE_NOT_ENABLED("vuln-data-source-not-enabled", 400),
+    VULN_POLICY_BUNDLE_SYNC_ALREADY_RUNNING("vuln-policy-bundle-sync-already-running", 409);
+
+    private static final String PATH_PREFIX = "/problems/";
+
+    private final String type;
+    private final int status;
+    private final String title;
+
+    ProblemType(String slug, int status, @Nullable String title) {
+        this.type = PATH_PREFIX + slug;
+        this.status = status;
+        if (title != null) {
+            this.title = title;
+        } else {
+            final Response.Status responseStatus = Response.Status.fromStatusCode(status);
+            if (responseStatus == null) {
+                throw new IllegalArgumentException("No title specified for status code " + status);
+            }
+            this.title = responseStatus.getReasonPhrase();
+        }
+    }
+
+    ProblemType(String slug, int status) {
+        this(slug, status, null);
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public int status() {
+        return status;
+    }
+
+    public String title() {
+        return title;
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/tasks/TaskSchedulerInitializer.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/TaskSchedulerInitializer.java
@@ -47,10 +47,8 @@ import org.dependencytrack.persistence.QueryManager;
 import org.dependencytrack.persistence.jdbi.ScheduledNotificationDao;
 import org.dependencytrack.persistence.jdbi.VulnerabilityPolicyDao;
 import org.dependencytrack.pkgmetadata.ResolvePackageMetadataWorkflow;
-import org.dependencytrack.plugin.runtime.NoSuchExtensionException;
 import org.dependencytrack.plugin.runtime.PluginManager;
 import org.dependencytrack.policy.vulnerability.SyncVulnPolicyBundleWorkflow;
-import org.dependencytrack.proto.internal.workflow.v1.MirrorVulnDataSourceArg;
 import org.dependencytrack.proto.internal.workflow.v1.ProcessScheduledNotificationsWorkflowArg;
 import org.dependencytrack.proto.internal.workflow.v1.SyncVulnPolicyBundleArg;
 import org.dependencytrack.tasks.maintenance.MetricsMaintenanceTask;
@@ -58,9 +56,7 @@ import org.dependencytrack.tasks.maintenance.PackageMetadataMaintenanceTask;
 import org.dependencytrack.tasks.maintenance.ProjectMaintenanceTask;
 import org.dependencytrack.tasks.maintenance.TagMaintenanceTask;
 import org.dependencytrack.tasks.maintenance.VulnerabilityDatabaseMaintenanceTask;
-import org.dependencytrack.vulndatasource.MirrorVulnDataSourceWorkflow;
-import org.dependencytrack.vulndatasource.api.VulnDataSource;
-import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
+import org.dependencytrack.vulndatasource.VulnDataSourceMirrorService;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.slf4j.Logger;
@@ -112,6 +108,8 @@ public final class TaskSchedulerInitializer implements ServletContextListener {
         final var pluginManager = (PluginManager) event.getServletContext().getAttribute(PluginManager.class.getName());
         requireNonNull(pluginManager, "pluginManager has not been initialized");
 
+        final var vulnDataSourceMirrorService = new VulnDataSourceMirrorService(pluginManager, dexEngine);
+
         scheduler
                 .schedule(
                         "Package Metadata Maintenance",
@@ -145,7 +143,7 @@ public final class TaskSchedulerInitializer implements ServletContextListener {
                 .schedule(
                         "GitHub Advisories Mirror",
                         getCronScheduleFromConfig(config, "dt.task.git.hub.advisory.mirror.cron"),
-                        () -> maybeCreateVulnDataSourceMirrorWorkflowRun(pluginManager, dexEngine, "github", "GITHUB"),
+                        () -> vulnDataSourceMirrorService.trigger("github", null),
                         /* triggerOnFirstRun */ true)
                 .schedule(
                         "Internal Component Identification",
@@ -173,12 +171,12 @@ public final class TaskSchedulerInitializer implements ServletContextListener {
                 .schedule(
                         "NVD Mirror",
                         getCronScheduleFromConfig(config, "dt.task.nist.mirror.cron"),
-                        () -> maybeCreateVulnDataSourceMirrorWorkflowRun(pluginManager, dexEngine, "nvd", "NVD"),
+                        () -> vulnDataSourceMirrorService.trigger("nvd", null),
                         /* triggerOnFirstRun */ true)
                 .schedule(
                         "OSV Mirror",
                         getCronScheduleFromConfig(config, "dt.task.osv.mirror.cron"),
-                        () -> maybeCreateVulnDataSourceMirrorWorkflowRun(pluginManager, dexEngine, "osv", "OSV"),
+                        () -> vulnDataSourceMirrorService.trigger("osv", null),
                         /* triggerOnFirstRun */ true)
                 .schedule(
                         "Package Metadata Resolution",
@@ -265,31 +263,6 @@ public final class TaskSchedulerInitializer implements ServletContextListener {
     public void contextDestroyed(ServletContextEvent sce) {
         LOGGER.info("Stopping task scheduler");
         scheduler.close();
-    }
-
-    private static void maybeCreateVulnDataSourceMirrorWorkflowRun(
-            PluginManager pluginManager,
-            DexEngine dexEngine,
-            String dataSourceName,
-            String sourceName) {
-        final VulnDataSourceFactory factory;
-        try {
-            factory = pluginManager.getFactory(VulnDataSource.class, dataSourceName);
-        } catch (NoSuchExtensionException e) {
-            return;
-        }
-
-        if (!factory.isDataSourceEnabled()) {
-            return;
-        }
-
-        dexEngine.createRun(
-                new CreateWorkflowRunRequest<>(MirrorVulnDataSourceWorkflow.class)
-                        .withWorkflowInstanceId("mirror-vuln-data-source:" + dataSourceName)
-                        .withArgument(MirrorVulnDataSourceArg.newBuilder()
-                                .setDataSourceName(dataSourceName)
-                                .setSourceName(sourceName)
-                                .build()));
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/VulnDataSourceMirrorService.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/VulnDataSourceMirrorService.java
@@ -1,0 +1,187 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource;
+
+import org.dependencytrack.common.pagination.Page;
+import org.dependencytrack.common.pagination.SortDirection;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.dex.engine.api.WorkflowRun;
+import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
+import org.dependencytrack.plugin.runtime.NoSuchExtensionException;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.proto.internal.workflow.v1.MirrorVulnDataSourceArg;
+import org.dependencytrack.vulndatasource.api.VulnDataSource;
+import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
+import org.jspecify.annotations.Nullable;
+
+import java.time.Instant;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+import static org.dependencytrack.dex.DexWorkflowLabels.WF_LABEL_TRIGGERED_BY;
+
+/**
+ * @since 5.0.0
+ */
+public final class VulnDataSourceMirrorService {
+
+    private static final String WORKFLOW_INSTANCE_ID_PREFIX = "mirror-vuln-data-source:";
+
+    private final PluginManager pluginManager;
+    private final DexEngine dexEngine;
+
+    public VulnDataSourceMirrorService(PluginManager pluginManager, DexEngine dexEngine) {
+        this.pluginManager = requireNonNull(pluginManager, "pluginManager must not be null");
+        this.dexEngine = requireNonNull(dexEngine, "dexEngine must not be null");
+    }
+
+    public sealed interface TriggerResult {
+
+        record Triggered(UUID runId) implements TriggerResult {
+        }
+
+        record AlreadyRunning() implements TriggerResult {
+        }
+
+        record NotEnabled() implements TriggerResult {
+        }
+
+        record NotFound() implements TriggerResult {
+        }
+
+    }
+
+    public TriggerResult trigger(String dataSourceName, @Nullable String triggeredBy) {
+        final VulnDataSourceFactory factory;
+        try {
+            factory = pluginManager.getFactory(VulnDataSource.class, dataSourceName);
+        } catch (NoSuchExtensionException e) {
+            return new TriggerResult.NotFound();
+        }
+
+        if (!factory.isDataSourceEnabled()) {
+            return new TriggerResult.NotEnabled();
+        }
+
+        CreateWorkflowRunRequest<MirrorVulnDataSourceArg> request =
+                new CreateWorkflowRunRequest<>(MirrorVulnDataSourceWorkflow.class)
+                        .withWorkflowInstanceId(workflowInstanceId(dataSourceName))
+                        .withArgument(MirrorVulnDataSourceArg.newBuilder()
+                                .setDataSourceName(dataSourceName)
+                                .setSourceName(dataSourceName.toUpperCase(Locale.ROOT))
+                                .build());
+        if (triggeredBy != null) {
+            request = request.withLabels(Map.of(WF_LABEL_TRIGGERED_BY, triggeredBy));
+        }
+
+        final UUID runId = dexEngine.createRun(request);
+        if (runId == null) {
+            return new TriggerResult.AlreadyRunning();
+        }
+
+        return new TriggerResult.Triggered(runId);
+    }
+
+    public record MirrorStatus(
+            Status status,
+            @Nullable Instant startedAt,
+            @Nullable Instant completedAt,
+            @Nullable String failureReason) {
+
+        public enum Status {
+
+            PENDING,
+            RUNNING,
+            COMPLETED,
+            FAILED;
+
+            private static Status of(WorkflowRunStatus runStatus) {
+                return switch (runStatus) {
+                    case CREATED, SUSPENDED -> MirrorStatus.Status.PENDING;
+                    case RUNNING -> MirrorStatus.Status.RUNNING;
+                    case COMPLETED -> MirrorStatus.Status.COMPLETED;
+                    case CANCELLED, FAILED -> MirrorStatus.Status.FAILED;
+                };
+            }
+
+        }
+
+    }
+
+    public @Nullable MirrorStatus getLatestStatus(String dataSourceName) {
+        try {
+            pluginManager.getFactory(VulnDataSource.class, dataSourceName);
+        } catch (NoSuchExtensionException e) {
+            return null;
+        }
+
+        final Page<WorkflowRunMetadata> runsPage = dexEngine.listRuns(
+                new ListWorkflowRunsRequest()
+                        .withWorkflowInstanceId(workflowInstanceId(dataSourceName))
+                        .withSortBy(ListWorkflowRunsRequest.SortBy.CREATED_AT)
+                        .withSortDirection(SortDirection.DESC)
+                        .withLimit(1));
+        if (runsPage.items().isEmpty()) {
+            return null;
+        }
+
+        final WorkflowRunMetadata runMetadata = runsPage.items().getFirst();
+        final String failureReason = switch (runMetadata.status()) {
+            case FAILED -> extractFailureReason(runMetadata.id());
+            case CANCELLED -> "Cancelled";
+            default -> null;
+        };
+
+        return new MirrorStatus(
+                MirrorStatus.Status.of(runMetadata.status()),
+                runMetadata.startedAt(),
+                runMetadata.completedAt(),
+                failureReason);
+    }
+
+    private @Nullable String extractFailureReason(UUID runId) {
+        final WorkflowRun run = dexEngine.getRunById(runId);
+        if (run == null || run.failure() == null) {
+            return null;
+        }
+
+        return switch (run.failure().getFailureDetailsCase()) {
+            case ACTIVITY_FAILURE_DETAILS,
+                 CHILD_WORKFLOW_FAILURE_DETAILS -> {
+                if (!run.failure().hasCause()) {
+                    yield "Unknown failure";
+                }
+                
+                final String causeMessage = run.failure().getCause().getMessage();
+                yield causeMessage.isEmpty() ? "Unknown failure" : causeMessage;
+            }
+            default -> run.failure().getMessage();
+        };
+    }
+
+    private static String workflowInstanceId(String dataSourceName) {
+        return WORKFLOW_INSTANCE_ID_PREFIX + dataSourceName;
+    }
+
+}

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/VulnDataSourceMirrorServiceBinder.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/VulnDataSourceMirrorServiceBinder.java
@@ -1,0 +1,67 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+import jakarta.servlet.ServletContext;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.glassfish.hk2.api.Factory;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * @since 5.0.0
+ */
+public final class VulnDataSourceMirrorServiceBinder extends AbstractBinder {
+
+    @Override
+    protected void configure() {
+        bindFactory(VulnDataSourceMirrorServiceFactory.class)
+                .to(VulnDataSourceMirrorService.class)
+                .in(Singleton.class);
+    }
+
+    private static final class VulnDataSourceMirrorServiceFactory implements Factory<VulnDataSourceMirrorService> {
+
+        private final ServletContext servletContext;
+
+        @Inject
+        private VulnDataSourceMirrorServiceFactory(ServletContext servletContext) {
+            this.servletContext = servletContext;
+        }
+
+        @Override
+        public VulnDataSourceMirrorService provide() {
+            final var pluginManager = (PluginManager) servletContext.getAttribute(PluginManager.class.getName());
+            final var dexEngine = (DexEngine) servletContext.getAttribute(DexEngine.class.getName());
+            return new VulnDataSourceMirrorService(
+                    requireNonNull(pluginManager, "pluginManager is not initialized"),
+                    requireNonNull(dexEngine, "dexEngine is not initialized"));
+        }
+
+        @Override
+        public void dispose(VulnDataSourceMirrorService instance) {
+        }
+
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnDataSourcesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnDataSourcesResourceTest.java
@@ -1,0 +1,419 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.resources.v2;
+
+import io.smallrye.config.SmallRyeConfigBuilder;
+import jakarta.ws.rs.core.Response;
+import org.dependencytrack.JerseyTestExtension;
+import org.dependencytrack.ResourceTest;
+import org.dependencytrack.auth.Permissions;
+import org.dependencytrack.cache.api.NoopCacheManager;
+import org.dependencytrack.common.pagination.Page;
+import org.dependencytrack.dex.engine.api.DexEngine;
+import org.dependencytrack.dex.engine.api.WorkflowRun;
+import org.dependencytrack.dex.engine.api.WorkflowRunMetadata;
+import org.dependencytrack.dex.engine.api.WorkflowRunStatus;
+import org.dependencytrack.dex.engine.api.request.CreateWorkflowRunRequest;
+import org.dependencytrack.dex.engine.api.request.ListWorkflowRunsRequest;
+import org.dependencytrack.dex.proto.failure.v1.ActivityFailureDetails;
+import org.dependencytrack.dex.proto.failure.v1.Failure;
+import org.dependencytrack.persistence.jdbi.JdbiFactory;
+import org.dependencytrack.plugin.api.ServiceRegistry;
+import org.dependencytrack.plugin.runtime.PluginManager;
+import org.dependencytrack.secret.TestSecretManager;
+import org.dependencytrack.secret.management.SecretManager;
+import org.dependencytrack.vulndatasource.VulnDataSourceMirrorService;
+import org.dependencytrack.vulndatasource.api.VulnDataSource;
+import org.dependencytrack.vulndatasource.api.VulnDataSourceFactory;
+import org.glassfish.jersey.inject.hk2.AbstractBinder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.ArgumentMatchers;
+
+import java.net.http.HttpClient;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+class VulnDataSourcesResourceTest extends ResourceTest {
+
+    private static final DexEngine DEX_ENGINE_MOCK = mock(DexEngine.class);
+    private static SecretManager secretManager;
+    private static PluginManager pluginManager;
+    private static VulnDataSourceMirrorService mirrorService;
+
+    @RegisterExtension
+    static JerseyTestExtension jersey = new JerseyTestExtension(
+            new ResourceConfig()
+                    .register(new AbstractBinder() {
+                        @Override
+                        protected void configure() {
+                            bindFactory(() -> mirrorService).to(VulnDataSourceMirrorService.class);
+                        }
+                    }));
+
+    @BeforeAll
+    static void beforeAll() {
+        secretManager = new TestSecretManager();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        reset(DEX_ENGINE_MOCK);
+        pluginManager = new PluginManager(
+                new SmallRyeConfigBuilder().build(),
+                new NoopCacheManager(),
+                secretManager::getSecretValue,
+                JdbiFactory.createJdbi(),
+                HttpClient.newHttpClient(),
+                List.of(VulnDataSource.class));
+        mirrorService = new VulnDataSourceMirrorService(pluginManager, DEX_ENGINE_MOCK);
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (pluginManager != null) {
+            pluginManager.close();
+        }
+    }
+
+    @Test
+    void shouldTriggerMirror() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        when(DEX_ENGINE_MOCK.createRun(ArgumentMatchers.<CreateWorkflowRunRequest<?>>any()))
+                .thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(202);
+        assertThat(response.getHeaderString("Location")).endsWith("/vuln-data-sources/osv/mirror-runs/latest");
+        assertThat(getPlainTextBody(response)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnConflictWhenMirrorAlreadyInProgress() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        when(DEX_ENGINE_MOCK.createRun(ArgumentMatchers.<CreateWorkflowRunRequest<?>>any()))
+                .thenReturn(null);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(409);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "/problems/vuln-data-source-mirror-already-running",
+                  "status": 409,
+                  "title": "Conflict",
+                  "detail": "A mirror run for this data source is already in progress"
+                }
+                """);
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDataSourceNotEnabled() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", false));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "/problems/vuln-data-source-not-enabled",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "detail": "The vulnerability data source is not enabled"
+                }
+                """);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenTriggeringUnknownDataSource() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_UPDATE);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/does-not-exist/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturnForbiddenWhenTriggeringWithoutPermission() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .post(null);
+
+        assertThat(response.getStatus()).isEqualTo(403);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenNoRunExists() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(), null, null));
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenGettingStatusOfUnknownDataSource() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/does-not-exist/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void shouldReturnRunningStatus() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var runId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+        final var startedAt = Instant.parse("2026-04-15T10:00:00Z");
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(new WorkflowRunMetadata(
+                        runId, "MirrorVulnDataSourceWorkflow", 1,
+                        "mirror-vuln-data-source:osv",
+                        "default", WorkflowRunStatus.RUNNING, null, 0, null, null,
+                        startedAt, startedAt, startedAt, null)), null, null));
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": "RUNNING",
+                  "started_at": %d
+                }
+                """.formatted(startedAt.toEpochMilli()));
+    }
+
+    @Test
+    void shouldReturnStatusWithFailureReasonWhenRunFailed() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var runId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+        final var startedAt = Instant.parse("2026-04-15T10:00:00Z");
+        final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
+
+        final var runMetadata = new WorkflowRunMetadata(
+                runId, "MirrorVulnDataSourceWorkflow", 1,
+                "mirror-vuln-data-source:osv",
+                "default", WorkflowRunStatus.FAILED, null, 0, null, null,
+                startedAt, completedAt, startedAt, completedAt);
+
+        final var failure = Failure.newBuilder()
+                .setMessage("activity failed")
+                .setActivityFailureDetails(ActivityFailureDetails.newBuilder()
+                        .setActivityName("MirrorVulnDataSourceActivity")
+                        .build())
+                .setCause(Failure.newBuilder()
+                        .setMessage("connection refused")
+                        .build())
+                .build();
+
+        final var run = new WorkflowRun(
+                runId, "MirrorVulnDataSourceWorkflow", 1,
+                "mirror-vuln-data-source:osv",
+                WorkflowRunStatus.FAILED, null, 0, null, null,
+                startedAt, completedAt, startedAt, completedAt,
+                null, null, failure, List.of());
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(runMetadata), null, null));
+        when(DEX_ENGINE_MOCK.getRunById(runId)).thenReturn(run);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": "FAILED",
+                  "started_at": %d,
+                  "completed_at": %d,
+                  "failure_reason": "connection refused"
+                }
+                """.formatted(startedAt.toEpochMilli(), completedAt.toEpochMilli()));
+    }
+
+    @Test
+    void shouldReturnGenericFailureReasonWhenCauseAbsent() {
+        loadFactory(new DummyVulnDataSourceFactory("osv", true));
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final var runId = UUID.fromString("00000000-0000-0000-0000-000000000004");
+        final var startedAt = Instant.parse("2026-04-15T10:00:00Z");
+        final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
+
+        final var runMetadata = new WorkflowRunMetadata(
+                runId, "MirrorVulnDataSourceWorkflow", 1,
+                "mirror-vuln-data-source:osv",
+                "default", WorkflowRunStatus.FAILED, null, 0, null, null,
+                startedAt, completedAt, startedAt, completedAt);
+
+        final var failure = Failure.newBuilder()
+                .setMessage("activity failed")
+                .setActivityFailureDetails(ActivityFailureDetails.newBuilder()
+                        .setActivityName("MirrorVulnDataSourceActivity")
+                        .build())
+                .build();
+
+        final var run = new WorkflowRun(
+                runId, "MirrorVulnDataSourceWorkflow", 1,
+                "mirror-vuln-data-source:osv",
+                WorkflowRunStatus.FAILED, null, 0, null, null,
+                startedAt, completedAt, startedAt, completedAt,
+                null, null, failure, List.of());
+
+        when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
+                .thenReturn(new Page<>(List.of(runMetadata), null, null));
+        when(DEX_ENGINE_MOCK.getRunById(runId)).thenReturn(run);
+
+        final Response response = jersey
+                .target("/vuln-data-sources/osv/mirror-runs/latest")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                {
+                  "status": "FAILED",
+                  "started_at": %d,
+                  "completed_at": %d,
+                  "failure_reason": "Unknown failure"
+                }
+                """.formatted(startedAt.toEpochMilli(), completedAt.toEpochMilli()));
+    }
+
+    private static void loadFactory(final VulnDataSourceFactory factory) {
+        pluginManager.loadPlugins(List.of(() -> List.of(factory)));
+    }
+
+    private static final class DummyVulnDataSource implements VulnDataSource {
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public org.cyclonedx.proto.v1_7.Bom next() {
+            throw new java.util.NoSuchElementException();
+        }
+    }
+
+    private static final class DummyVulnDataSourceFactory implements VulnDataSourceFactory {
+
+        private final String name;
+        private final boolean enabled;
+
+        DummyVulnDataSourceFactory(final String name, final boolean enabled) {
+            this.name = name;
+            this.enabled = enabled;
+        }
+
+        @Override
+        public String extensionName() {
+            return name;
+        }
+
+        @Override
+        public Class<? extends VulnDataSource> extensionClass() {
+            return DummyVulnDataSource.class;
+        }
+
+        @Override
+        public int priority() {
+            return PRIORITY_HIGHEST;
+        }
+
+        @Override
+        public void init(final ServiceRegistry serviceRegistry) {
+        }
+
+        @Override
+        public boolean isDataSourceEnabled() {
+            return enabled;
+        }
+
+        @Override
+        public VulnDataSource create() {
+            throw new UnsupportedOperationException();
+        }
+
+    }
+
+}


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds endpoints to trigger and observe vuln datasource mirroring.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/hyades-frontend/pull/527

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
