### PR TITLE
Raise Java baseline to 25

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,7 +8,7 @@
 
 ## Prerequisites
 
-* JDK 21+ ([Temurin](https://adoptium.net/temurin/releases) distribution recommended)
+* JDK 25+ ([Temurin](https://adoptium.net/temurin/releases) distribution recommended)
 * Maven 3.9+
 * Docker or Podman (required for [tests](#testing) and [dev mode](#dev-mode))
 * A Java IDE (IntelliJ recommended)

--- a/alpine/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java
+++ b/alpine/alpine-infra/src/main/java/alpine/persistence/AbstractAlpineQueryManager.java
@@ -343,13 +343,13 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.3.0
      */
     public <T> T detach(Class<T> clazz, Object id) {
-        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+        try (var _ = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
             return pm.detachCopy(pm.getObjectById(clazz, id));
         }
     }
 
     public <T> T detach(final T object) {
-        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+        try (var _ = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
             return pm.detachCopy(object);
         }
     }
@@ -362,7 +362,7 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.3.0
      */
     public <T> List<T> detach(List<T> pcs) {
-        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+        try (var _ = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
             return new ArrayList<>(pm.detachCopyAll(pcs));
         }
     }
@@ -375,7 +375,7 @@ public abstract class AbstractAlpineQueryManager implements AutoCloseable {
      * @since 1.3.0
      */
     public <T> Set<T> detach(Set<T> pcs) {
-        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
+        try (var _ = new ScopedCustomization(pm).withDetachmentOptions(FetchPlan.DETACH_LOAD_FIELDS)) {
             return new LinkedHashSet<>(pm.detachCopyAll(pcs));
         }
     }

--- a/alpine/alpine-infra/src/test/java/alpine/persistence/ScopedCustomizationTest.java
+++ b/alpine/alpine-infra/src/test/java/alpine/persistence/ScopedCustomizationTest.java
@@ -58,7 +58,7 @@ public class ScopedCustomizationTest {
         pm.getFetchPlan().setDetachmentOptions(DETACH_LOAD_FIELDS);
         assertThat(pm.getFetchPlan().getDetachmentOptions()).isEqualTo(DETACH_LOAD_FIELDS);
 
-        try (var ignored = new ScopedCustomization(pm).withDetachmentOptions(DETACH_UNLOAD_FIELDS)) {
+        try (var _ = new ScopedCustomization(pm).withDetachmentOptions(DETACH_UNLOAD_FIELDS)) {
             assertThat(pm.getFetchPlan().getDetachmentOptions()).isEqualTo(DETACH_UNLOAD_FIELDS);
         }
 
@@ -71,7 +71,7 @@ public class ScopedCustomizationTest {
         pm.getFetchPlan().setGroups("foo");
         assertThat(pm.getFetchPlan().getGroups()).containsOnly("foo");
 
-        try (var ignored = new ScopedCustomization(pm).withFetchGroup("bar")) {
+        try (var _ = new ScopedCustomization(pm).withFetchGroup("bar")) {
             assertThat(pm.getFetchPlan().getGroups()).containsOnly("bar");
         }
 
@@ -83,7 +83,7 @@ public class ScopedCustomizationTest {
         pm.setProperty(PROPERTY_DETACH_ALL_ON_COMMIT, "true");
         assertThat(pm.getExecutionContext().getProperty(PROPERTY_DETACH_ALL_ON_COMMIT)).isEqualTo("true");
 
-        try (var ignored = new ScopedCustomization(pm).withProperty(PROPERTY_DETACH_ALL_ON_COMMIT, "false")) {
+        try (var _ = new ScopedCustomization(pm).withProperty(PROPERTY_DETACH_ALL_ON_COMMIT, "false")) {
             assertThat(pm.getExecutionContext().getProperty(PROPERTY_DETACH_ALL_ON_COMMIT)).isEqualTo("false");
         }
 

--- a/alpine/alpine-server/src/main/java/alpine/server/auth/DefaultOidcAuthenticationCustomizer.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/auth/DefaultOidcAuthenticationCustomizer.java
@@ -66,7 +66,7 @@ public class DefaultOidcAuthenticationCustomizer implements OidcAuthenticationCu
                     .map(String::trim)
                     .filter(not(String::isEmpty))
                     .toList();
-            case Collection<?> ignored -> claimsSet.getStringListClaim(teamsClaimName);
+            case Collection<?> _ -> claimsSet.getStringListClaim(teamsClaimName);
             case null, default -> Collections.emptyList();
         });
         profile.setEmail(claimsSet.getStringClaim(UserInfo.EMAIL_CLAIM_NAME));

--- a/alpine/alpine-server/src/main/java/alpine/server/auth/ManagedUserAuthenticationService.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/auth/ManagedUserAuthenticationService.java
@@ -85,7 +85,7 @@ public class ManagedUserAuthenticationService implements AuthenticationService {
             } else {
                 // Hash the provided password anyway to prevent different timings
                 // giving away the existence of a user.
-                char[] ignored = PasswordService.createHash(password.toCharArray());
+                char[] _ = PasswordService.createHash(password.toCharArray());
             }
         }
         throw new AlpineAuthenticationException(AlpineAuthenticationException.CauseType.INVALID_CREDENTIALS);

--- a/alpine/alpine-server/src/main/java/alpine/server/filters/ApiKeyUsageTracker.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/filters/ApiKeyUsageTracker.java
@@ -116,7 +116,7 @@ public class ApiKeyUsageTracker implements ApplicationEventListener {
             final var lastUsedByKeyId = new HashMap<Long, Long>();
             while (EVENT_QUEUE.peek() != null) {
                 final ApiKeyUsedEvent event = EVENT_QUEUE.poll();
-                lastUsedByKeyId.compute(event.keyId(), (ignored, prev) -> {
+                lastUsedByKeyId.compute(event.keyId(), (_, prev) -> {
                     if (prev == null) {
                         return event.timestamp();
                     }

--- a/alpine/alpine-server/src/main/java/alpine/server/filters/SessionUsageTracker.java
+++ b/alpine/alpine-server/src/main/java/alpine/server/filters/SessionUsageTracker.java
@@ -111,7 +111,7 @@ public class SessionUsageTracker implements ApplicationEventListener {
             final var lastUsedByHash = new HashMap<String, Long>();
             while (EVENT_QUEUE.peek() != null) {
                 final SessionUsedEvent event = EVENT_QUEUE.poll();
-                lastUsedByHash.compute(event.tokenHash(), (ignored, prev) -> {
+                lastUsedByHash.compute(event.tokenHash(), (_, prev) -> {
                     if (prev == null) {
                         return event.timestamp();
                     }

--- a/apiserver/src/main/java/org/dependencytrack/analysis/AnalyzeProjectWorkflow.java
+++ b/apiserver/src/main/java/org/dependencytrack/analysis/AnalyzeProjectWorkflow.java
@@ -49,7 +49,7 @@ public final class AnalyzeProjectWorkflow implements Workflow<AnalyzeProjectWork
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignored = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid())) {
             ctx.logger().info("Starting project analysis");
 
             final var vulnAnalysisArgBuilder = VulnAnalysisWorkflowArg.newBuilder()

--- a/apiserver/src/main/java/org/dependencytrack/integrations/kenna/KennaSecurityUploader.java
+++ b/apiserver/src/main/java/org/dependencytrack/integrations/kenna/KennaSecurityUploader.java
@@ -98,9 +98,9 @@ public class KennaSecurityUploader extends AbstractIntegrationPoint implements P
             }
 
             for (final Project project : projects) {
-                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
-                     var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
-                     var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
+                try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
+                     var _ = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
+                     var _ = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
                     if (Thread.currentThread().isInterrupted()) {
                         LOGGER.warn("Interrupted before project could be processed");
                         break;

--- a/apiserver/src/main/java/org/dependencytrack/notification/NotificationOutboxRelay.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/NotificationOutboxRelay.java
@@ -276,7 +276,7 @@ final class NotificationOutboxRelay implements Closeable {
         for (final var routerResult : routerResults) {
             final Notification notification = routerResult.notification();
 
-            try (var ignored = MDC.putCloseable(MDC_NOTIFICATION_ID, notification.getId())) {
+            try (var _ = MDC.putCloseable(MDC_NOTIFICATION_ID, notification.getId())) {
                 final var workflowArgBuilder =
                         PublishNotificationWorkflowArg.newBuilder()
                                 .setNotificationId(notification.getId())

--- a/apiserver/src/main/java/org/dependencytrack/notification/NotificationRouter.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/NotificationRouter.java
@@ -122,7 +122,7 @@ final class NotificationRouter {
             final Notification notification = entry.getKey();
             final List<RuleQueryResult> rules = entry.getValue();
 
-            try (var ignoredMdcScope = new MdcScope(Map.ofEntries(
+            try (var _ = new MdcScope(Map.ofEntries(
                     Map.entry(MDC_NOTIFICATION_ID, notification.getId()),
                     Map.entry(MDC_NOTIFICATION_SCOPE, convert(notification.getScope()).name()),
                     Map.entry(MDC_NOTIFICATION_GROUP, convert(notification.getGroup()).name()),
@@ -251,7 +251,7 @@ final class NotificationRouter {
 
         final var applicableRules = new ArrayList<RuleQueryResult>(ruleCandidates.size());
         for (final RuleQueryResult rule : ruleCandidates) {
-            try (var ignoredMdcRuleName = MDC.putCloseable("notificationRuleName", rule.name())) {
+            try (var _ = MDC.putCloseable("notificationRuleName", rule.name())) {
                 if (isApplicable(rule, notification, projectSubject, unpackedSubject)) {
                     LOGGER.debug("Rule is applicable");
                     applicableRules.add(rule);

--- a/apiserver/src/main/java/org/dependencytrack/notification/ProcessScheduledNotificationRuleActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/ProcessScheduledNotificationRuleActivity.java
@@ -113,7 +113,7 @@ public final class ProcessScheduledNotificationRuleActivity
                     "Rule with name %s not found".formatted(arg.getRuleName()));
         }
 
-        try (var ignored = MDC.putCloseable(MDC_NOTIFICATION_RULE_NAME, rule.getName())) {
+        try (var _ = MDC.putCloseable(MDC_NOTIFICATION_RULE_NAME, rule.getName())) {
             processRule(rule);
         }
 
@@ -530,7 +530,7 @@ public final class ProcessScheduledNotificationRuleActivity
                 .setNotificationId(notification.getId())
                 .addNotificationRuleNames(ruleName);
 
-        try (var ignored = MDC.putCloseable(MDC_NOTIFICATION_ID, notification.getId())) {
+        try (var _ = MDC.putCloseable(MDC_NOTIFICATION_ID, notification.getId())) {
             if (notification.getSerializedSize() > largeNotificationThresholdBytes) {
                 LOGGER.warn(
                         "Notification size {}b exceeds threshold of {}b; offloading to file storage",

--- a/apiserver/src/main/java/org/dependencytrack/notification/PublishNotificationActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/PublishNotificationActivity.java
@@ -92,7 +92,7 @@ public final class PublishNotificationActivity implements Activity<PublishNotifi
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignored = new MdcScope(Map.ofEntries(
+        try (var _ = new MdcScope(Map.ofEntries(
                 Map.entry(MDC_NOTIFICATION_ID, argument.getNotificationId()),
                 Map.entry(MDC_NOTIFICATION_RULE_NAME, argument.getNotificationRuleName())))) {
             final RuleMetadata ruleMetadata = getRuleMetadata(argument.getNotificationRuleName());

--- a/apiserver/src/main/java/org/dependencytrack/notification/PublishNotificationWorkflow.java
+++ b/apiserver/src/main/java/org/dependencytrack/notification/PublishNotificationWorkflow.java
@@ -56,7 +56,7 @@ public final class PublishNotificationWorkflow implements Workflow<PublishNotifi
                     "Neither notification nor notification file metadata provided");
         }
 
-        try (var ignoredMdcNotificationId = MDC.putCloseable(MDC_NOTIFICATION_ID, arg.getNotificationId())) {
+        try (var _ = MDC.putCloseable(MDC_NOTIFICATION_ID, arg.getNotificationId())) {
             final var awaitableByRuleName =
                     new LinkedHashMap<String, Awaitable<?>>(arg.getNotificationRuleNamesCount());
 

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXExporter.java
@@ -65,7 +65,7 @@ public class CycloneDXExporter {
     public Bom create(final Project project) {
         final List<Component> components;
         final List<ServiceComponent> services;
-        try (final var ignored = new ScopedCustomization(qm.getPersistenceManager())
+        try (var _ = new ScopedCustomization(qm.getPersistenceManager())
                 .withFetchGroup(FetchGroup.ALL)) {
             components = qm.getAllComponents(project);
             services = qm.getAllServiceComponents(project);

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/CycloneDXVexImporter.java
@@ -98,7 +98,7 @@ public class CycloneDXVexImporter {
                         updateAnalysis(qm, component, dtVuln, vexVuln);
                     }
                 } else if (target != null) {
-                    final List<Component> components = componentsByBomRef.computeIfAbsent(affectedBomRef, ignored -> {
+                    final List<Component> components = componentsByBomRef.computeIfAbsent(affectedBomRef, _ -> {
                         final var cid = new ComponentIdentity(target.component());
                         return qm.matchIdentity(project, cid);
                     });

--- a/apiserver/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/NotificationQueryManager.java
@@ -361,7 +361,7 @@ public class NotificationQueryManager extends QueryManager implements IQueryMana
      */
     @Override
     public void truncateNotificationOutbox() {
-        try (var ignored = new ScopedCustomization(pm).withProperty(PROPERTY_QUERY_SQL_ALLOWALL, "true")) {
+        try (var _ = new ScopedCustomization(pm).withProperty(PROPERTY_QUERY_SQL_ALLOWALL, "true")) {
             final Query<?> query = pm.newQuery(Query.SQL, /* language=SQL */ """
                 TRUNCATE TABLE "NOTIFICATION_OUTBOX"
                 """);

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/ProjectDao.java
@@ -706,9 +706,9 @@ public interface ProjectDao extends SqlObject {
         public ProjectListRow map(final ResultSet rs, final StatementContext ctx) throws SQLException {
             final Project project = projectMapper.map(rs, ctx);
             maybeSet(rs, "projectPurl", ResultSet::getString, project::setPurl);
-            maybeSet(rs, "teamsJson", (ignored, columnName) ->
+            maybeSet(rs, "teamsJson", (_, columnName) ->
                     deserializeJson(rs, columnName, TEAMS_TYPE_REF), project::setAccessTeams);
-            maybeSet(rs, "tagsJson", (ignored, columnName) ->
+            maybeSet(rs, "tagsJson", (_, columnName) ->
                     deserializeJson(rs, columnName, TAGS_TYPE_REF), project::setTags);
             final ProjectListRow projectListRow = new ProjectListRow(project, rs.getInt("totalCount"));
             return projectListRow;

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/VulnerabilityRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/VulnerabilityRowMapper.java
@@ -57,9 +57,9 @@ public class VulnerabilityRowMapper implements RowMapper<Vulnerability> {
         final Vulnerability vuln = vulnerabilityMapper.map(rs, ctx);
         final Epss epss = epssMapper.map(rs, ctx);
         vuln.setEpss(epss);
-        maybeSet(rs, "vulnAliasesJson", (ignored, columnName) ->
+        maybeSet(rs, "vulnAliasesJson", (_, columnName) ->
                 deserializeJson(rs, columnName, VULNERABILITY_ALIASES_TYPE_REF), vuln::setAliases);
-        maybeSet(rs, "vulnTagsJson", (ignored, columnName) ->
+        maybeSet(rs, "vulnTagsJson", (_, columnName) ->
                 deserializeJson(rs, columnName, VULNERABILITY_TAGS_TYPE_REF), vuln::setTags);
         if (hasColumn(rs, "componentIdsArray")) {
             var vulnerableComponentsIds = longArray(rs, "componentIdsArray");

--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/VulnerableSoftwareRowMapper.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/mapping/VulnerableSoftwareRowMapper.java
@@ -46,7 +46,7 @@ public class VulnerableSoftwareRowMapper implements RowMapper<VulnerableSoftware
     public VulnerableSoftware map(final ResultSet rs, final StatementContext ctx) throws SQLException {
         final VulnerableSoftware vs = vulnerableSoftwareMapper.map(rs, ctx);
         maybeSet(rs, "attributionsJson",
-                (ignored, columnName) -> deserializeJson(rs, columnName, ATTRIBUTIONS_TYPE_REF),
+                (_, columnName) -> deserializeJson(rs, columnName, ATTRIBUTIONS_TYPE_REF),
                 vs::setAffectedVersionAttributions);
         return vs;
     }

--- a/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/pkgmetadata/ResolvePackageMetadataActivity.java
@@ -107,7 +107,7 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
             return null;
         }
 
-        try (var ignoredMdcResolver = MDC.putCloseable(MDC_PKG_METADATA_RESOLVER_NAME, resolverName)) {
+        try (var _ = MDC.putCloseable(MDC_PKG_METADATA_RESOLVER_NAME, resolverName)) {
             final PackageMetadataResolverFactory resolverFactory = getResolverFactory(resolverName);
 
             // Surface previously-resolved artifact metadata as an opt-in hint to resolvers.
@@ -251,13 +251,13 @@ public final class ResolvePackageMetadataActivity implements Activity<ResolvePac
                     continue;
                 }
 
-                try (var ignoredMdcRepo = MDC.putCloseable(MDC_PKG_REPOSITORY_IDENTIFIER, repo.getIdentifier())) {
+                try (var _ = MDC.putCloseable(MDC_PKG_REPOSITORY_IDENTIFIER, repo.getIdentifier())) {
                     String password = null;
                     if (repo.isAuthenticationRequired() && repo.getPassword() != null) {
                         password = passwordByRepoTypeAndName
                                 .computeIfAbsent(
                                         "%s:%s".formatted(repo.getType(), repo.getIdentifier()),
-                                        ignored -> {
+                                        _ -> {
                                             final String secret = secretManager.getSecretValue(repo.getPassword());
                                             if (secret == null) {
                                                 LOGGER.warn("""

--- a/apiserver/src/main/java/org/dependencytrack/policy/EvalProjectPoliciesActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/EvalProjectPoliciesActivity.java
@@ -49,7 +49,7 @@ public final class EvalProjectPoliciesActivity implements Activity<EvalProjectPo
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignored = MDC.putCloseable(MDC_PROJECT_UUID, argument.getProjectUuid())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, argument.getProjectUuid())) {
             policyEngine.evaluateProject(UUID.fromString(argument.getProjectUuid()));
         }
 

--- a/apiserver/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
+++ b/apiserver/src/main/java/org/dependencytrack/policy/cel/CelVulnerabilityPolicyEvaluator.java
@@ -141,7 +141,7 @@ public final class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolic
             loadedComponentsById = vulnIdsByComponentId.keySet().stream()
                     .collect(Collectors.toMap(
                             Function.identity(),
-                            ignored -> Component.getDefaultInstance()));
+                            _ -> Component.getDefaultInstance()));
         }
 
         // Load required vulnerability data.
@@ -158,7 +158,7 @@ public final class CelVulnerabilityPolicyEvaluator implements VulnerabilityPolic
             loadedVulnsById = uniqueVulnIds.stream()
                     .collect(Collectors.toMap(
                             Function.identity(),
-                            ignored -> Vulnerability.getDefaultInstance()));
+                            _ -> Vulnerability.getDefaultInstance()));
         }
 
         final Map<String, VulnerabilityPolicy> policiesByName =

--- a/apiserver/src/main/java/org/dependencytrack/resources/AbstractApiResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/AbstractApiResource.java
@@ -81,7 +81,7 @@ public abstract class AbstractApiResource extends AlpineResource {
         //  requests, that would already help under high traffic conditions.
 
         if (!qm.hasAccess(super.getPrincipal(), project)) {
-            try (var ignored = new MdcScope(Map.ofEntries(
+            try (var _ = new MdcScope(Map.ofEntries(
                     Map.entry(MDC_PROJECT_UUID, project.getUuid().toString()),
                     Map.entry(MDC_PROJECT_NAME, project.getName()),
                     Map.entry(MDC_PROJECT_VERSION, String.valueOf(project.getVersion()))))) {
@@ -109,7 +109,7 @@ public abstract class AbstractApiResource extends AlpineResource {
         if (isAccessible == null) {
             throw new NoSuchElementException("Component could not be found");
         } else if (!isAccessible) {
-            try (var ignored = new MdcScope(Map.of(MDC_COMPONENT_UUID, componentUuid.toString()))) {
+            try (var _ = new MdcScope(Map.of(MDC_COMPONENT_UUID, componentUuid.toString()))) {
                 logSecurityEvent(logger, SecurityMarkers.SECURITY_FAILURE, "Unauthorized project access attempt");
             }
 
@@ -132,7 +132,7 @@ public abstract class AbstractApiResource extends AlpineResource {
         if (isAccessible == null) {
             throw new NoSuchElementException("Project could not be found");
         } else if (!isAccessible) {
-            try (var ignored = new MdcScope(Map.of(MDC_PROJECT_UUID, projectUuid.toString()))) {
+            try (var _ = new MdcScope(Map.of(MDC_PROJECT_UUID, projectUuid.toString()))) {
                 logSecurityEvent(logger, SecurityMarkers.SECURITY_FAILURE, "Unauthorized project access attempt");
             }
             throw new ProjectAccessDeniedException("Access to the requested project is forbidden");

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/ProjectResource.java
@@ -611,9 +611,9 @@ public class ProjectResource extends AbstractApiResource {
                 return project;
             });
 
-            try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, createdProject.getUuid().toString());
-                 var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, createdProject.getName());
-                 var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, createdProject.getVersion())) {
+            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, createdProject.getUuid().toString());
+                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, createdProject.getName());
+                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, createdProject.getVersion())) {
 
                 LOGGER.info("Project {} created by {}", createdProject, super.getPrincipal().getName());
             }
@@ -724,9 +724,9 @@ public class ProjectResource extends AbstractApiResource {
                 }
             });
 
-            try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, updatedProject.getUuid().toString());
-                 var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, updatedProject.getName());
-                 var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, updatedProject.getVersion())){
+            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, updatedProject.getUuid().toString());
+                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, updatedProject.getName());
+                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, updatedProject.getVersion())){
 
                 LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
             }
@@ -889,9 +889,9 @@ public class ProjectResource extends AbstractApiResource {
                 return Response.notModified().build();
             }
 
-            try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, updatedProject.getUuid().toString());
-                 var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, updatedProject.getName());
-                 var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, updatedProject.getVersion())){
+            try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, updatedProject.getUuid().toString());
+                 var _ = MDC.putCloseable(MDC_PROJECT_NAME, updatedProject.getName());
+                 var _ = MDC.putCloseable(MDC_PROJECT_VERSION, updatedProject.getVersion())){
 
                 LOGGER.info("Project {} updated by {}", updatedProject, super.getPrincipal().getName());
             }
@@ -964,9 +964,9 @@ public class ProjectResource extends AbstractApiResource {
                 }
                 requireAccess(qm, project);
 
-                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
-                     var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
-                     var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
+                try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
+                     var _ = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
+                     var _ = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
 
                     LOGGER.info("Project {} deletion request by {}", project, super.getPrincipal().getName());
                 }
@@ -1065,9 +1065,9 @@ public class ProjectResource extends AbstractApiResource {
                     }
                 }
 
-                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, sourceProject.getUuid().toString());
-                     var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, sourceProject.getName());
-                     var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, sourceProject.getVersion())){
+                try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, sourceProject.getUuid().toString());
+                     var _ = MDC.putCloseable(MDC_PROJECT_NAME, sourceProject.getName());
+                     var _ = MDC.putCloseable(MDC_PROJECT_VERSION, sourceProject.getVersion())){
 
                     LOGGER.info("Project {} is being cloned by {}", sourceProject, super.getPrincipal().getName());
                 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/ExtensionsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/ExtensionsResource.java
@@ -280,7 +280,7 @@ public class ExtensionsResource extends AbstractApiResource implements Extension
         final ExtensionFactory<?> extensionFactory =
                 getExtensionFactory(extensionPointClass, extensionName);
 
-        try (var ignoredMdcScope = new MdcScope(Map.ofEntries(
+        try (var _ = new MdcScope(Map.ofEntries(
                 Map.entry(MDC_EXTENSION_POINT_NAME, extensionPointName),
                 Map.entry(MDC_EXTENSION_NAME, extensionName)))) {
             LOGGER.info(

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnDataSourcesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnDataSourcesResource.java
@@ -85,7 +85,7 @@ public final class VulnDataSourcesResource extends AbstractApiResource implement
         final TriggerResult result = mirrorService.trigger(name, getPrincipal().getName());
 
         return switch (result) {
-            case TriggerResult.Triggered ignored -> {
+            case TriggerResult.Triggered _ -> {
                 LOGGER.info(
                         SecurityMarkers.SECURITY_AUDIT,
                         "Triggered vulnerability data source mirror for {}",
@@ -99,13 +99,13 @@ public final class VulnDataSourcesResource extends AbstractApiResource implement
                                 .build())
                         .build();
             }
-            case TriggerResult.AlreadyRunning ignored -> throw ProblemDetailsException.of(
+            case TriggerResult.AlreadyRunning _ -> throw ProblemDetailsException.of(
                     ProblemType.VULN_DATA_SOURCE_MIRROR_ALREADY_RUNNING,
                     "A mirror run for this data source is already in progress");
-            case TriggerResult.NotEnabled ignored -> throw ProblemDetailsException.of(
+            case TriggerResult.NotEnabled _ -> throw ProblemDetailsException.of(
                     ProblemType.VULN_DATA_SOURCE_NOT_ENABLED,
                     "The vulnerability data source is not enabled");
-            case TriggerResult.NotFound ignored -> throw new NotFoundException();
+            case TriggerResult.NotFound _ -> throw new NotFoundException();
         };
     }
 

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomActivity.java
@@ -161,10 +161,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
         project.setVersion(arg.getProjectVersion().isEmpty() ? null : arg.getProjectVersion());
 
         final var processCtx = new ProcessingContext(token, project);
-        try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
-             var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
-             var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
-             var ignoredMdcBomUploadToken = MDC.putCloseable(MDC_BOM_UPLOAD_TOKEN, arg.getBomUploadToken())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
+             var _ = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
+             var _ = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
+             var _ = MDC.putCloseable(MDC_BOM_UPLOAD_TOKEN, arg.getBomUploadToken())) {
             final byte[] cdxBomBytes;
             try (final InputStream cdxBomStream = fileStorage.get(arg.getBomFileMetadata())) {
                 cdxBomBytes = cdxBomStream.readAllBytes();
@@ -203,10 +203,10 @@ public final class ImportBomActivity implements Activity<ImportBomArg, Void> {
         dispatchBomConsumedNotification(ctx);
 
         final ProcessedBom processedBom;
-        try (var ignoredMdcBomFormat = MDC.putCloseable(MDC_BOM_FORMAT, ctx.bomFormat.getFormatShortName());
-             var ignoredMdcBomSpecVersion = MDC.putCloseable(MDC_BOM_SPEC_VERSION, ctx.bomSpecVersion);
-             var ignoredMdcBomSerialNumber = MDC.putCloseable(MDC_BOM_SERIAL_NUMBER, ctx.bomSerialNumber);
-             var ignoredMdcBomVersion = MDC.putCloseable(MDC_BOM_VERSION, String.valueOf(ctx.bomVersion))) {
+        try (var _ = MDC.putCloseable(MDC_BOM_FORMAT, ctx.bomFormat.getFormatShortName());
+             var _ = MDC.putCloseable(MDC_BOM_SPEC_VERSION, ctx.bomSpecVersion);
+             var _ = MDC.putCloseable(MDC_BOM_SERIAL_NUMBER, ctx.bomSerialNumber);
+             var _ = MDC.putCloseable(MDC_BOM_VERSION, String.valueOf(ctx.bomVersion))) {
             try {
                 processedBom = processBom(ctx, consumedBom);
             } catch (Throwable e) {

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomWorkflow.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportBomWorkflow.java
@@ -52,10 +52,10 @@ public final class ImportBomWorkflow implements Workflow<ImportBomArg, Void> {
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
-             var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
-             var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
-             var ignoredMdcBomUploadToken = MDC.putCloseable(MDC_BOM_UPLOAD_TOKEN, arg.getBomUploadToken())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
+             var _ = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
+             var _ = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
+             var _ = MDC.putCloseable(MDC_BOM_UPLOAD_TOKEN, arg.getBomUploadToken())) {
             ctx.logger().info("Starting BOM import");
 
             try {

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportVexActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportVexActivity.java
@@ -73,10 +73,10 @@ public final class ImportVexActivity implements Activity<ImportVexArg, Void> {
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
-             var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
-             var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
-             var ignoredMdcVexUploadToken = MDC.putCloseable(MDC_VEX_UPLOAD_TOKEN, arg.getVexUploadToken())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
+             var _ = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
+             var _ = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
+             var _ = MDC.putCloseable(MDC_VEX_UPLOAD_TOKEN, arg.getVexUploadToken())) {
             final byte[] vexBytes;
             try (final InputStream vexStream = fileStorage.get(arg.getVexFileMetadata())) {
                 vexBytes = vexStream.readAllBytes();

--- a/apiserver/src/main/java/org/dependencytrack/tasks/ImportVexWorkflow.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/ImportVexWorkflow.java
@@ -52,10 +52,10 @@ public final class ImportVexWorkflow implements Workflow<ImportVexArg, Void> {
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
-             var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
-             var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
-             var ignoredMdcVexUploadToken = MDC.putCloseable(MDC_VEX_UPLOAD_TOKEN, arg.getVexUploadToken())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid());
+             var _ = MDC.putCloseable(MDC_PROJECT_NAME, arg.getProjectName());
+             var _ = MDC.putCloseable(MDC_PROJECT_VERSION, arg.getProjectVersion());
+             var _ = MDC.putCloseable(MDC_VEX_UPLOAD_TOKEN, arg.getVexUploadToken())) {
             ctx.logger().info("Starting VEX import");
 
             try {

--- a/apiserver/src/main/java/org/dependencytrack/tasks/VulnerabilityManagementUploadTask.java
+++ b/apiserver/src/main/java/org/dependencytrack/tasks/VulnerabilityManagementUploadTask.java
@@ -75,9 +75,9 @@ public abstract class VulnerabilityManagementUploadTask implements Subscriber {
             }
 
             for (final Project project : projects) {
-                try (var ignoredMdcProjectUuid = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
-                     var ignoredMdcProjectName = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
-                     var ignoredMdcProjectVersion = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
+                try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, project.getUuid().toString());
+                     var _ = MDC.putCloseable(MDC_PROJECT_NAME, project.getName());
+                     var _ = MDC.putCloseable(MDC_PROJECT_VERSION, project.getVersion())) {
                     if (Thread.currentThread().isInterrupted()) {
                         LOGGER.warn("Interrupted before project could be processed");
                         break;

--- a/apiserver/src/main/java/org/dependencytrack/util/PurlUtil.java
+++ b/apiserver/src/main/java/org/dependencytrack/util/PurlUtil.java
@@ -108,7 +108,7 @@ public class PurlUtil {
 
         try {
             return new PackageURL(purl);
-        } catch (MalformedPackageURLException ignored) {
+        } catch (MalformedPackageURLException _) {
             return null;
         }
     }

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/AnalysisReconciler.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/AnalysisReconciler.java
@@ -99,7 +99,7 @@ final class AnalysisReconciler {
     @Nullable Result reconcile(VulnerabilityPolicy policy) {
         requireNonNull(policy, "policy must not be null");
 
-        try (var ignoredMdcPolicyName = MDC.putCloseable(MDC_VULN_POLICY_NAME, policy.getName())) {
+        try (var _ = MDC.putCloseable(MDC_VULN_POLICY_NAME, policy.getName())) {
             final VulnerabilityPolicyAnalysis policyAnalysis = policy.getAnalysis();
             if (policyAnalysis == null) {
                 LOGGER.warn("Vulnerability policy does not define an analysis");

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/InvokeVulnAnalyzerActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/InvokeVulnAnalyzerActivity.java
@@ -70,7 +70,7 @@ public final class InvokeVulnAnalyzerActivity implements Activity<InvokeVulnAnal
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignored = new MdcScope(Map.ofEntries(
+        try (var _ = new MdcScope(Map.ofEntries(
                 Map.entry(MDC_PROJECT_UUID, arg.getProjectUuid()),
                 Map.entry(MDC_VULN_ANALYZER_NAME, arg.getAnalyzerName())))) {
             LOGGER.debug("Retrieving BOM from {}", arg.getBomFileMetadata().getLocation());

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/PrepareVulnAnalysisActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/PrepareVulnAnalysisActivity.java
@@ -82,7 +82,7 @@ public final class PrepareVulnAnalysisActivity implements Activity<PrepareVulnAn
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignored = MDC.putCloseable(MDC_PROJECT_UUID, argument.getProjectUuid())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, argument.getProjectUuid())) {
             LOGGER.debug("Determining applicable analyzers");
             final Map<String, Set<VulnAnalyzerRequirement>> requirementsByAnalyzer = getApplicableAnalyzers();
             if (requirementsByAnalyzer.isEmpty()) {
@@ -119,7 +119,7 @@ public final class PrepareVulnAnalysisActivity implements Activity<PrepareVulnAn
             final var vulnAnalyzerFactory = (VulnAnalyzerFactory) factory;
             final var analyzerName = vulnAnalyzerFactory.extensionName();
 
-            try (var ignored = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
+            try (var _ = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
                 if (vulnAnalyzerFactory.isEnabled()) {
                     LOGGER.debug("Analyzer is enabled");
                     requirementsByAnalyzer

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
@@ -70,6 +70,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Gatherers;
 import java.util.stream.Stream;
 
 import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
@@ -93,6 +94,7 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
 
     private static final String INTERNAL_VULN_ID_PROPERTY = "dependencytrack:internal:vulnerability-id";
     private static final String REFERENCE_URL_PROPERTY = "dependency-track:vuln:reference-url";
+    private static final int SYNC_BATCH_SIZE = 100;
 
     private final FileStorage fileStorage;
     private final PluginManager pluginManager;
@@ -117,7 +119,7 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
 
         final var projectUuid = UUID.fromString(arg.getProjectUuid());
 
-        try (var ignored = MDC.putCloseable(MDC_PROJECT_UUID, projectUuid.toString())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, projectUuid.toString())) {
             LOGGER.debug(
                     "Reconciling results from {} vulnerability analyzers",
                     arg.getAnalyzerResultsCount());
@@ -139,7 +141,7 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
                 }
 
                 final String analyzerName = result.getAnalyzerName();
-                try (var ignoredMdcAnalyzerName = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
+                try (var _ = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
                     LOGGER.debug("Processing analyzer results");
 
                     if (!result.getSuccessful()) {
@@ -343,25 +345,15 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
     private Map<VulnerabilityKey, Long> syncVulns(
             List<Vulnerability> vulns,
             Predicate<String> canUpdatePredicate) throws InterruptedException {
-        if (vulns.size() <= 100) {
-            return syncVulnsBatch(vulns, canUpdatePredicate);
-        }
-
         final var syncedVulns = new HashMap<VulnerabilityKey, Long>(vulns.size());
 
-        final var batch = new ArrayList<Vulnerability>(100);
-        for (final Vulnerability vuln : vulns) {
+        for (final var batch : (Iterable<List<Vulnerability>>) () -> vulns.stream()
+                .gather(Gatherers.windowFixed(SYNC_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before synchronizing vulnerability batch");
             }
 
-            batch.add(vuln);
-            if (batch.size() >= 100) {
-                syncedVulns.putAll(syncVulnsBatch(batch, canUpdatePredicate));
-                batch.clear();
-            }
-        }
-        if (!batch.isEmpty()) {
             syncedVulns.putAll(syncVulnsBatch(batch, canUpdatePredicate));
         }
 

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflow.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflow.java
@@ -71,7 +71,7 @@ public final class VulnAnalysisWorkflow implements Workflow<VulnAnalysisWorkflow
             throw new TerminalApplicationFailureException("No argument provided");
         }
 
-        try (var ignored = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid())) {
+        try (var _ = MDC.putCloseable(MDC_PROJECT_UUID, arg.getProjectUuid())) {
             ctx.logger().info("Starting vulnerability analysis");
 
             final PrepareVulnAnalysisRes preparationResult = prepare(ctx, arg.getProjectUuid());
@@ -138,7 +138,7 @@ public final class VulnAnalysisWorkflow implements Workflow<VulnAnalysisWorkflow
         final var awaitableByAnalyzerName = new LinkedHashMap<String, Awaitable<InvokeVulnAnalyzerRes>>();
 
         for (final String analyzerName : analyzerNames) {
-            try (var ignored = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
+            try (var _ = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
                 ctx.logger().debug("Invoking analyzer");
                 final Awaitable<InvokeVulnAnalyzerRes> awaitable =
                         invokeAnalyzer(ctx, projectUuid, analyzerName, bomFileMetadata);
@@ -176,7 +176,7 @@ public final class VulnAnalysisWorkflow implements Workflow<VulnAnalysisWorkflow
             final String analyzerName = entry.getKey();
             final Awaitable<InvokeVulnAnalyzerRes> awaitable = entry.getValue();
 
-            try (var ignored = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
+            try (var _ = MDC.putCloseable(MDC_VULN_ANALYZER_NAME, analyzerName)) {
                 ctx.logger().debug("Waiting for analyzer to complete");
 
                 final var result = awaitable.await();

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -105,7 +105,7 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
         final var updatePolicy = new VulnerabilityUpdatePolicy(pluginManager);
 
-        try (var ignoredMdc = new MdcScope(Map.of(MDC_VULN_DATA_SOURCE_NAME, arg.getDataSourceName()))) {
+        try (var _ = new MdcScope(Map.of(MDC_VULN_DATA_SOURCE_NAME, arg.getDataSourceName()))) {
             LOGGER.info("Starting mirror");
             final long startTimeNs = System.nanoTime();
             long lastHeartbeatNs = startTimeNs;
@@ -184,7 +184,7 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
 
             final Vulnerability vuln;
             final List<VulnerableSoftware> vsList;
-            try (var ignored = new MdcScope(Map.ofEntries(
+            try (var _ = new MdcScope(Map.ofEntries(
                     Map.entry(MDC_VULN_ID, bov.getVulnerabilities(0).getId()),
                     Map.entry(MDC_VULN_SOURCE, bov.getVulnerabilities(0).getSource().getName())))) {
                 vuln = BovModelConverter.convert(bov, bov.getVulnerabilities(0), true);

--- a/apiserver/src/test/java/org/dependencytrack/TestDatabaseManager.java
+++ b/apiserver/src/test/java/org/dependencytrack/TestDatabaseManager.java
@@ -74,7 +74,7 @@ public final class TestDatabaseManager {
                     System.getProperty("java.io.tmpdir"),
                     "hyades-apiserver-postgres-testcontainer.lock");
             try (final var channel = FileChannel.open(lockFile, CREATE, WRITE);
-                 final var ignored = channel.lock()) {
+                 var _ = channel.lock()) {
                 container.start();
                 dropStaleDatabases(container, pid);
             } catch (IOException e) {
@@ -128,7 +128,7 @@ public final class TestDatabaseManager {
                         if (ProcessHandle.of(existingPid).isEmpty() || existingPid == pid) {
                             staleDatabases.add(existingDb);
                         }
-                    } catch (NumberFormatException ignored) {
+                    } catch (NumberFormatException _) {
                     }
                 }
             }

--- a/apiserver/src/test/java/org/dependencytrack/notification/NotificationOutboxRelayTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/notification/NotificationOutboxRelayTest.java
@@ -72,7 +72,7 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
         relay = new NotificationOutboxRelay(
                 dexEngineMock,
                 fileStorage,
-                ignored -> routerMock,
+                _ -> routerMock,
                 new SimpleMeterRegistry(),
                 /* pollIntervalMillis */ 10,
                 /* batchSize */ 10,
@@ -238,7 +238,7 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
                     .isThrownBy(() -> new NotificationOutboxRelay(
                             null,
                             fileStorage,
-                            ignored -> routerMock,
+                            _ -> routerMock,
                             new SimpleMeterRegistry(),
                             /* pollIntervalMillis */ 100,
                             /* batchSize */ 10,
@@ -251,7 +251,7 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
                     .isThrownBy(() -> new NotificationOutboxRelay(
                             dexEngineMock,
                             null,
-                            ignored -> routerMock,
+                            _ -> routerMock,
                             new SimpleMeterRegistry(),
                             /* pollIntervalMillis */ 100,
                             /* batchSize */ 10,
@@ -277,7 +277,7 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
                     .isThrownBy(() -> new NotificationOutboxRelay(
                             dexEngineMock,
                             fileStorage,
-                            ignored -> routerMock,
+                            _ -> routerMock,
                             null,
                             /* pollIntervalMillis */ 100,
                             /* batchSize */ 10,
@@ -290,7 +290,7 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
                     .isThrownBy(() -> new NotificationOutboxRelay(
                             dexEngineMock,
                             fileStorage,
-                            ignored -> routerMock,
+                            _ -> routerMock,
                             new SimpleMeterRegistry(),
                             /* pollIntervalMillis */ 0,
                             /* batchSize */ 10,
@@ -303,7 +303,7 @@ class NotificationOutboxRelayTest extends PersistenceCapableTest {
                     .isThrownBy(() -> new NotificationOutboxRelay(
                             dexEngineMock,
                             fileStorage,
-                            ignored -> routerMock,
+                            _ -> routerMock,
                             new SimpleMeterRegistry(),
                             /* pollIntervalMillis */ 100,
                             /* batchSize */ 0,

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/TagResourceTest.java
@@ -987,7 +987,7 @@ class TagResourceTest extends ResourceTest {
         qm.createTag("foo");
 
         final List<String> projectUuids = IntStream.range(0, 101)
-                .mapToObj(ignored -> UUID.randomUUID())
+                .mapToObj(_ -> UUID.randomUUID())
                 .map(UUID::toString)
                 .toList();
 
@@ -1470,7 +1470,7 @@ class TagResourceTest extends ResourceTest {
         qm.createTag("foo");
 
         final List<String> policyUuids = IntStream.range(0, 101)
-                .mapToObj(ignored -> UUID.randomUUID())
+                .mapToObj(_ -> UUID.randomUUID())
                 .map(UUID::toString)
                 .toList();
 
@@ -1967,7 +1967,7 @@ class TagResourceTest extends ResourceTest {
         qm.createTag("foo");
 
         final List<String> policyUuids = IntStream.range(0, 101)
-                .mapToObj(ignored -> UUID.randomUUID())
+                .mapToObj(_ -> UUID.randomUUID())
                 .map(UUID::toString)
                 .toList();
 
@@ -2236,7 +2236,7 @@ class TagResourceTest extends ResourceTest {
         qm.createTag("foo");
 
         final List<String> vulnUuids = IntStream.range(0, 101)
-                .mapToObj(ignored -> UUID.randomUUID())
+                .mapToObj(_ -> UUID.randomUUID())
                 .map(UUID::toString)
                 .toList();
 

--- a/cache/api/src/main/java/org/dependencytrack/cache/api/Cache.java
+++ b/cache/api/src/main/java/org/dependencytrack/cache/api/Cache.java
@@ -33,7 +33,7 @@ public interface Cache {
 
     default byte @Nullable [] get(String key) {
         try {
-            return get(key, ignored -> {
+            return get(key, _ -> {
                 throw CacheMissException.INSTANCE;
             });
         } catch (CacheMissException e) {

--- a/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceHealthCheck.java
+++ b/common/datasource/src/main/java/org/dependencytrack/common/datasource/DataSourceHealthCheck.java
@@ -25,7 +25,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Map;
 
@@ -58,7 +57,7 @@ public final class DataSourceHealthCheck implements HealthCheck {
             final DataSource dataSource = entry.getValue();
 
             LOGGER.debug("Checking health of data source {}", name);
-            try (final Connection ignored = dataSource.getConnection()) {
+            try (var _ = dataSource.getConnection()) {
                 responseBuilder.withData(name, HealthCheckResponse.Status.UP.name());
             } catch (SQLException | RuntimeException e) {
                 responseBuilder.withData(name, HealthCheckResponse.Status.DOWN.name());

--- a/dex/api/src/main/java/org/dependencytrack/dex/api/WorkflowContext.java
+++ b/dex/api/src/main/java/org/dependencytrack/dex/api/WorkflowContext.java
@@ -132,11 +132,11 @@ public interface WorkflowContext<A extends @Nullable Object> {
             String name,
             PayloadConverter<SR> resultConverter,
             Supplier<SR> supplier) {
-        return executeSideEffect(name, null, resultConverter, ignored -> supplier.get());
+        return executeSideEffect(name, null, resultConverter, _ -> supplier.get());
     }
 
     default Awaitable<Void> executeSideEffect(String name, Runnable runnable) {
-        return executeSideEffect(name, null, voidConverter(), ignored -> {
+        return executeSideEffect(name, null, voidConverter(), _ -> {
             runnable.run();
             return null;
         });

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskScheduler.java
@@ -204,7 +204,7 @@ final class ActivityTaskScheduler implements Closeable {
         boolean didScheduleTasks = false;
         for (final Queue queue : queues) {
             final Timer.Sample latencySample = Timer.start();
-            try (var ignored = MDC.putCloseable("queueName", queue.name())) {
+            try (var _ = MDC.putCloseable("queueName", queue.name())) {
                 didScheduleTasks |= jdbi.inTransaction(handle -> processQueue(handle, queue));
             } finally {
                 latencySample.stop(

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -84,9 +84,9 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     void process(final ActivityTask task) {
-        try (var ignoredMdcWorkflowRunId = MDC.putCloseable("workflowRunId", task.id().workflowRunId().toString());
-             var ignoredMdcActivityName = MDC.putCloseable("activityName", task.activityName());
-             var ignoredMdcActivityTaskAttempt = MDC.putCloseable("activityTaskAttempt", String.valueOf(task.attempt()))) {
+        try (var _ = MDC.putCloseable("workflowRunId", task.id().workflowRunId().toString());
+             var _ = MDC.putCloseable("activityName", task.activityName());
+             var _ = MDC.putCloseable("activityTaskAttempt", String.valueOf(task.attempt()))) {
             final ActivityMetadata activityMetadata;
             try {
                 activityMetadata = metadataRegistry.getActivityMetadata(task.activityName());

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/AwaitableImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/AwaitableImpl.java
@@ -90,7 +90,7 @@ final class AwaitableImpl<T> implements Awaitable<T> {
             case State.Completed<T> it -> it.result();
             case State.Failed<T> it -> throw it.exception();
             case State.Canceled<T> it -> throw new CancellationFailureException(it.reason());
-            case State.Pending<T> ignored -> throw new AssertionError("unreachable");
+            case State.Pending<T> _ -> throw new AssertionError("unreachable");
         };
     }
 

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowContextImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowContextImpl.java
@@ -339,7 +339,7 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
             return awaitable;
         }
 
-        pendingAwaitablesByExternalEventId.compute(externalEventId, (ignored, awaitables) -> {
+        pendingAwaitablesByExternalEventId.compute(externalEventId, (_, awaitables) -> {
             if (awaitables == null) {
                 return new LinkedList<>(List.of(awaitable));
             }
@@ -348,10 +348,10 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
             return awaitables;
         });
 
-        createTimerInternal("External event %s wait timeout".formatted(externalEventId), timeout).onComplete(ignored -> {
+        createTimerInternal("External event %s wait timeout".formatted(externalEventId), timeout).onComplete(_ -> {
             awaitable.cancel("Timed out while waiting for external event");
 
-            pendingAwaitablesByExternalEventId.computeIfPresent(externalEventId, (ignoredKey, awaitables) -> {
+            pendingAwaitablesByExternalEventId.computeIfPresent(externalEventId, (_, awaitables) -> {
                 awaitables.remove(awaitable);
                 if (awaitables.isEmpty()) {
                     return null;
@@ -824,7 +824,7 @@ final class WorkflowContextImpl<A, R> implements WorkflowContext<A> {
             return;
         }
 
-        bufferedExternalEvents.compute(externalEventId, (ignored, awaitables) -> {
+        bufferedExternalEvents.compute(externalEventId, (_, awaitables) -> {
             if (awaitables == null) {
                 return new LinkedList<>(List.of(event));
             }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskScheduler.java
@@ -204,7 +204,7 @@ final class WorkflowTaskScheduler implements Closeable {
         boolean didScheduleTasks = false;
         for (final Queue queue : queues) {
             final Timer.Sample latencySample = Timer.start();
-            try (var ignored = MDC.putCloseable("queueName", queue.name())) {
+            try (var _ = MDC.putCloseable("queueName", queue.name())) {
                 didScheduleTasks |= jdbi.inTransaction(handle -> processQueue(handle, queue));
             } finally {
                 latencySample.stop(

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowTaskWorker.java
@@ -71,9 +71,9 @@ final class WorkflowTaskWorker extends AbstractTaskWorker<WorkflowTask> {
     @Override
     @SuppressWarnings({"rawtypes", "unchecked"})
     void process(final WorkflowTask task) {
-        try (var ignoredMdcWorkflowName = MDC.putCloseable("workflowName", task.workflowName());
-             var ignoredMdcWorkflowInstanceId = MDC.putCloseable("workflowInstanceId", task.workflowInstanceId());
-             var ignoredMdcWorkflowRunId = MDC.putCloseable("workflowRunId", task.workflowRunId().toString())) {
+        try (var _ = MDC.putCloseable("workflowName", task.workflowName());
+             var _ = MDC.putCloseable("workflowInstanceId", task.workflowInstanceId());
+             var _ = MDC.putCloseable("workflowRunId", task.workflowRunId().toString())) {
             final WorkflowMetadata workflowMetadata;
             try {
                 workflowMetadata = metadataRegistry.getWorkflowMetadata(task.workflowName());

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/WorkflowDao.java
@@ -641,22 +641,22 @@ public final class WorkflowDao extends AbstractDao {
             switch (polledEvent.eventType()) {
                 case HISTORY -> {
                     final List<WorkflowEvent> history = historyByRunId.computeIfAbsent(
-                            polledEvent.workflowRunId(), ignored -> new ArrayList<>());
+                            polledEvent.workflowRunId(), _ -> new ArrayList<>());
                     history.add(polledEvent.event());
 
                     maxHistorySequenceNumberByRunId.compute(
                             polledEvent.workflowRunId(),
-                            (ignored, previousMax) -> (previousMax == null || previousMax < polledEvent.historySequenceNumber())
+                            (_, previousMax) -> (previousMax == null || previousMax < polledEvent.historySequenceNumber())
                                     ? polledEvent.historySequenceNumber()
                                     : previousMax);
                 }
                 case INBOX -> {
                     final List<WorkflowEvent> inbox = inboxByRunId.computeIfAbsent(
-                            polledEvent.workflowRunId(), ignored -> new ArrayList<>());
+                            polledEvent.workflowRunId(), _ -> new ArrayList<>());
                     inbox.add(polledEvent.event());
 
                     final List<Long> messageIds = inboxMessageIdsByRunId.computeIfAbsent(
-                            polledEvent.workflowRunId(), ignored -> new ArrayList<>());
+                            polledEvent.workflowRunId(), _ -> new ArrayList<>());
                     messageIds.add(polledEvent.inboxMessageId());
                 }
             }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/support/Buffer.java
@@ -197,7 +197,7 @@ public final class Buffer<T> implements Closeable {
                     LOGGER.warn("{}: Flush thread did not stop in time; Interrupting it", name);
                     flushThread.interrupt();
                 }
-            } catch (InterruptedException ignored) {
+            } catch (InterruptedException _) {
                 LOGGER.warn("{}: Interrupted while waiting for flush thread to stop", name);
                 Thread.currentThread().interrupt();
                 flushThread.interrupt();
@@ -234,7 +234,7 @@ public final class Buffer<T> implements Closeable {
             // Request a flush to be performed, but don't block
             // if the queue already has a pending request.
             LOGGER.debug("{}: Requesting another flush because {} items are still queued", name, itemsQueue.size());
-            boolean ignored = flushRequestQueue.offer(true);
+            boolean _ = flushRequestQueue.offer(true);
         }
 
         return future;
@@ -356,7 +356,7 @@ public final class Buffer<T> implements Closeable {
             if (itemsQueue.size() >= maxBatchSize) {
                 // Request another flush if there's still at least
                 // a full batch worth of items queued.
-                boolean ignored = flushRequestQueue.offer(true);
+                boolean _ = flushRequestQueue.offer(true);
             }
         } finally {
             flushLock.unlock();

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/support/BufferTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/support/BufferTest.java
@@ -65,7 +65,7 @@ class BufferTest {
 
     @Test
     void addShouldThrowWhenNotRunning() {
-        final Consumer<List<String>> batchConsumer = ignored -> {
+        final Consumer<List<String>> batchConsumer = _ -> {
         };
 
         final var buffer = new Buffer<>(

--- a/docs/adr/024-java-25-baseline.md
+++ b/docs/adr/024-java-25-baseline.md
@@ -1,0 +1,23 @@
+| Status   | Date       | Author(s)                            |
+|:---------|:-----------|:-------------------------------------|
+| Accepted | 2026-05-18 | [@nscuro](https://github.com/nscuro) |
+
+## Context
+
+Container images have shipped on [Java 25] since September 2025 ([PR #1446]), and CI moved to Java 25 in
+January 2026 ([PR #1663]). The compiler release level is still 21, so source code cannot use features added
+in 22 through 25. Java 25 is the next LTS after 21 and is stable.
+
+## Decision
+
+Raise the compiler release level to Java 25. Artifacts require Java 25 at runtime.
+
+## Consequences
+
+Operators still on Java 21 must upgrade. Contributor toolchains move to Java 25. Features from 22 through 25
+such as stream gatherers, scoped values, flexible constructor bodies, and unnamed pattern variables become
+available across the codebase.
+
+[Java 25]: https://openjdk.org/projects/jdk/25/
+[PR #1446]: https://github.com/DependencyTrack/hyades-apiserver/pull/1446
+[PR #1663]: https://github.com/DependencyTrack/hyades-apiserver/pull/1663

--- a/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionException.java
+++ b/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/RetryableResolutionException.java
@@ -94,7 +94,7 @@ public class RetryableResolutionException extends RuntimeException {
         try {
             final long seconds = Long.parseLong(trimmed);
             return seconds > 0 ? Duration.ofSeconds(seconds) : null;
-        } catch (NumberFormatException ignored) {
+        } catch (NumberFormatException _) {
             // Fallthrough to date parsing.
         }
 
@@ -104,7 +104,7 @@ public class RetryableResolutionException extends RuntimeException {
                     .toInstant();
             final Duration delta = Duration.between(clock.instant(), deadline);
             return (delta.isZero() || delta.isNegative()) ? null : delta;
-        } catch (DateTimeParseException ignored) {
+        } catch (DateTimeParseException _) {
             return null;
         }
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CacheControl.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CacheControl.java
@@ -88,7 +88,7 @@ record CacheControl(boolean noStore, boolean noCache, @Nullable Long maxAgeSecon
         try {
             final long parsed = Long.parseLong(unquoted);
             return parsed >= 0 ? parsed : null;
-        } catch (NumberFormatException ignored) {
+        } catch (NumberFormatException _) {
             // Treat as absent as per RFC 9111.
             return null;
         }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cache/CachingHttpClient.java
@@ -114,7 +114,7 @@ public final class CachingHttpClient {
         return sendWithStaleFallback(uri, entry, this::staleBody, () -> {
             final HttpResponse<byte[]> response = httpClient.send(
                     requestBuilderCopy.build(),
-                    ignored -> new LimitedBodySubscriber(maxBytes));
+                    _ -> new LimitedBodySubscriber(maxBytes));
             return handleGetResponse(response, entry, cacheKey);
         });
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cargo/CargoPackageMetadataResolver.java
@@ -93,7 +93,7 @@ final class CargoPackageMetadataResolver implements PackageMetadataResolver {
                     if (crateVersion.createdAt() != null) {
                         try {
                             latestVersionPublishedAt = Instant.parse(crateVersion.createdAt());
-                        } catch (DateTimeParseException ignored) {
+                        } catch (DateTimeParseException _) {
                         }
                     }
                 }
@@ -120,7 +120,7 @@ final class CargoPackageMetadataResolver implements PackageMetadataResolver {
         if (crateVersion.createdAt() != null) {
             try {
                 publishedAt = Instant.parse(crateVersion.createdAt());
-            } catch (DateTimeParseException ignored) {
+            } catch (DateTimeParseException _) {
             }
         }
 

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/composer/ComposerPackageMetadataResolver.java
@@ -321,12 +321,12 @@ final class ComposerPackageMetadataResolver implements PackageMetadataResolver {
         if (requestedVersion != null) {
             try {
                 requested = VersionFactory.forScheme(SCHEME_COMPOSER, requestedVersion);
-            } catch (InvalidVersionException ignored) {}
+            } catch (InvalidVersionException _) {}
         }
         if (latestVersion != null) {
             try {
                 requestedLatest = VersionFactory.forScheme(SCHEME_COMPOSER, latestVersion);
-            } catch (InvalidVersionException ignored) {}
+            } catch (InvalidVersionException _) {}
         }
 
         Instant latestVersionPublishedAt = null;
@@ -342,7 +342,7 @@ final class ComposerPackageMetadataResolver implements PackageMetadataResolver {
                 if (requestedLatest != null && requestedLatest.equals(VersionFactory.forScheme(SCHEME_COMPOSER, entryVersion))) {
                     latestVersionPublishedAt = extractPublishedAt(entry);
                 }
-            } catch (InvalidVersionException ignored) {
+            } catch (InvalidVersionException _) {
             }
 
             try {
@@ -352,7 +352,7 @@ final class ComposerPackageMetadataResolver implements PackageMetadataResolver {
                         break;
                     }
                 }
-            } catch (InvalidVersionException ignored) {
+            } catch (InvalidVersionException _) {
             }
         }
 

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/cpan/CpanPackageMetadataResolver.java
@@ -114,7 +114,7 @@ final class CpanPackageMetadataResolver implements PackageMetadataResolver {
             try {
                 // CPAN dates are in ISO local date-time format without timezone (UTC implied).
                 publishedAt = LocalDateTime.parse(date).toInstant(ZoneOffset.UTC);
-            } catch (DateTimeParseException ignored) {
+            } catch (DateTimeParseException _) {
             }
         }
         return publishedAt;

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/hex/HexPackageMetadataResolver.java
@@ -105,7 +105,7 @@ final class HexPackageMetadataResolver implements PackageMetadataResolver {
         if (insertedAt != null) {
             try {
                 return Instant.parse(insertedAt);
-            } catch (DateTimeParseException ignored) {}
+            } catch (DateTimeParseException _) {}
         }
         return null;
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageDocument.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/npm/NpmPackageDocument.java
@@ -123,7 +123,7 @@ record NpmPackageDocument(
             if (version != null && version.contains(".")) {
                 try {
                     timestamps.put(version, Instant.parse(parser.getText()));
-                } catch (DateTimeParseException ignored) {
+                } catch (DateTimeParseException _) {
                 }
             }
         }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/nuget/NugetPackageMetadataResolver.java
@@ -422,13 +422,13 @@ final class NugetPackageMetadataResolver implements PackageMetadataResolver {
 
         try {
             return OffsetDateTime.parse(published).toInstant();
-        } catch (DateTimeParseException ignored) {
+        } catch (DateTimeParseException _) {
             // try next format
         }
 
         try {
             return LocalDateTime.parse(published).toInstant(ZoneOffset.UTC);
-        } catch (DateTimeParseException ignored) {
+        } catch (DateTimeParseException _) {
             return null;
         }
     }

--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolver.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolver.java
@@ -100,7 +100,7 @@ final class PypiPackageMetadataResolver implements PackageMetadataResolver {
                             if (mostRecentUploadTime == null || instant.isAfter(mostRecentUploadTime)) {
                                 mostRecentUploadTime = instant;
                             }
-                        } catch (DateTimeParseException ignored) {}
+                        } catch (DateTimeParseException _) {}
                     }
                 }
                 latestVersionPublishedAt = mostRecentUploadTime;

--- a/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/PluginManager.java
+++ b/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/PluginManager.java
@@ -286,7 +286,7 @@ public class PluginManager implements Closeable {
 
         LOGGER.debug("Loading plugins");
         for (final Plugin plugin : plugins) {
-            try (var ignoredMdcPlugin = MDC.putCloseable(MDC_PLUGIN, plugin.getClass().getName())) {
+            try (var _ = MDC.putCloseable(MDC_PLUGIN, plugin.getClass().getName())) {
                 LOGGER.debug("Loading plugin");
                 loadExtensionsForPlugin(plugin);
 
@@ -338,10 +338,10 @@ public class PluginManager implements Closeable {
             final ExtensionPointMetadata extensionPointMetadata =
                     requireImplementsExtensionPoint(extensionFactory.extensionClass());
 
-            try (var ignoredMdcExtensionPointName = MDC.putCloseable(MDC_EXTENSION_POINT_NAME, extensionPointMetadata.name());
-                 var ignoredMdcExtensionPoint = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointMetadata.clazz().getName());
-                 var ignoredMdcExtensionName = MDC.putCloseable(MDC_EXTENSION_NAME, extensionFactory.extensionName());
-                 var ignoredMdcExtension = MDC.putCloseable(MDC_EXTENSION, extensionFactory.extensionClass().getName())) {
+            try (var _ = MDC.putCloseable(MDC_EXTENSION_POINT_NAME, extensionPointMetadata.name());
+                 var _ = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointMetadata.clazz().getName());
+                 var _ = MDC.putCloseable(MDC_EXTENSION_NAME, extensionFactory.extensionName());
+                 var _ = MDC.putCloseable(MDC_EXTENSION, extensionFactory.extensionClass().getName())) {
                 loadExtension(plugin, extensionFactory, extensionPointMetadata);
             }
         }
@@ -437,11 +437,11 @@ public class PluginManager implements Closeable {
         }
 
         factoriesByPlugin.computeIfAbsent(
-                        plugin, ignored -> new ArrayList<>())
+                        plugin, _ -> new ArrayList<>())
                 .add(extensionFactory);
         extensionNamesByExtensionPointClass.computeIfAbsent(
                         extensionIdentity.extensionPointClass(),
-                        ignored -> new HashSet<>())
+                        _ -> new HashSet<>())
                 .add(extensionFactory.extensionName());
         factoryByExtensionIdentity.put(extensionIdentity, extensionFactory);
         pluginByExtensionIdentity.put(extensionIdentity, plugin);
@@ -457,8 +457,8 @@ public class PluginManager implements Closeable {
                         """.formatted(extensionPointClass.getName()));
             }
 
-            try (var ignoredMdcExtensionPoint = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointClass.getName());
-                 var ignoredMdcExtensionPointName = MDC.putCloseable(MDC_EXTENSION_POINT_NAME, extensionPointMetadata.name())) {
+            try (var _ = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointClass.getName());
+                 var _ = MDC.putCloseable(MDC_EXTENSION_POINT_NAME, extensionPointMetadata.name())) {
                 LOGGER.debug("Determining default extension");
 
                 final SequencedCollection<? extends ExtensionFactory<?>> factories = getFactories(extensionPointClass);
@@ -561,7 +561,7 @@ public class PluginManager implements Closeable {
 
         // Unload plugins in reverse order in which they were loaded.
         for (final Plugin plugin : loadedPluginByClass.sequencedValues().reversed()) {
-            try (var ignoredMdcPlugin = MDC.putCloseable(MDC_PLUGIN, plugin.getClass().getName())) {
+            try (var _ = MDC.putCloseable(MDC_PLUGIN, plugin.getClass().getName())) {
                 LOGGER.debug("Unloading plugin");
                 unloadPlugin(plugin);
 
@@ -584,8 +584,8 @@ public class PluginManager implements Closeable {
             final String extensionPointClassName = extensionPointMetadata.clazz().getName();
             final String extensionClassName = extensionFactory.extensionClass().getName();
 
-            try (var ignoredMdcExtensionPoint = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointClassName);
-                 var ignoredMdcExtension = MDC.putCloseable(MDC_EXTENSION, extensionClassName)) {
+            try (var _ = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointClassName);
+                 var _ = MDC.putCloseable(MDC_EXTENSION, extensionClassName)) {
                 LOGGER.debug("Closing extension");
                 extensionFactory.close();
 

--- a/plugin/testing/src/main/java/org/dependencytrack/plugin/testing/MockKeyValueStore.java
+++ b/plugin/testing/src/main/java/org/dependencytrack/plugin/testing/MockKeyValueStore.java
@@ -102,7 +102,7 @@ public final class MockKeyValueStore implements KeyValueStore {
         // the entry having been modified.
         final var versionMatched = new AtomicBoolean(false);
 
-        final Entry entry = kvMap.computeIfPresent(key, (ignored, existingEntry) -> {
+        final Entry entry = kvMap.computeIfPresent(key, (_, existingEntry) -> {
             if (existingEntry.version() != expectedVersion) {
                 return existingEntry;
             }
@@ -133,7 +133,7 @@ public final class MockKeyValueStore implements KeyValueStore {
         // In both scenarios computeIfPresent returns null.
         final var versionMatched = new AtomicBoolean(false);
 
-        kvMap.computeIfPresent(key, (ignored, entry) -> {
+        kvMap.computeIfPresent(key, (_, entry) -> {
             if (entry.version() == expectedVersion) {
                 versionMatched.set(true);
                 return null;

--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.15.0</version>
                     <configuration>
-                        <release>21</release>
+                        <release>25</release>
                         <compilerArgs>
                             <arg>-Xlint:all</arg>
                             <arg>-Xlint:-processing</arg>

--- a/secret-management/src/main/java/org/dependencytrack/secret/management/database/Crypto.java
+++ b/secret-management/src/main/java/org/dependencytrack/secret/management/database/Crypto.java
@@ -318,7 +318,7 @@ final class Crypto {
             } finally {
                 try {
                     connection.setAutoCommit(originalAutoCommit);
-                } catch (SQLException ignored) {
+                } catch (SQLException _) {
                 }
             }
         } catch (SQLException e) {

--- a/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
+++ b/vuln-analysis/internal/src/main/java/org/dependencytrack/vulnanalysis/internal/InternalVulnAnalyzer.java
@@ -54,6 +54,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Gatherers;
 
 import static io.github.nscuro.versatile.version.KnownVersioningSchemes.SCHEME_GENERIC;
 import static java.util.Objects.requireNonNull;
@@ -66,6 +67,7 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
     private static final Logger LOGGER = LoggerFactory.getLogger(InternalVulnAnalyzer.class);
     private static final Pattern EPOCH_PREFIX_PATTERN = Pattern.compile("^\\d+:");
     private static final String INTERNAL_VULN_ID_PROPERTY = "dependencytrack:internal:vulnerability-id";
+    private static final int QUERY_BATCH_SIZE = 25;
 
     private final Jdbi jdbi;
 
@@ -102,7 +104,9 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
         final var findingsByVuln = new HashMap<Long, Set<Long>>();
         final var vulnMetadata = new HashMap<Long, VulnMetadata>();
 
-        for (final List<CpeCoordinate> batch : partition(cpeCoordinates)) {
+        for (final var batch : (Iterable<List<CpeCoordinate>>) () -> cpeCoordinates.stream()
+                .gather(Gatherers.windowFixed(QUERY_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all components could be analyzed");
             }
@@ -115,7 +119,9 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
                     vulnMetadata);
         }
 
-        for (final List<PurlCoordinate> batch : partition(purlCoordinates)) {
+        for (final var batch : (Iterable<List<PurlCoordinate>>) () -> purlCoordinates.stream()
+                .gather(Gatherers.windowFixed(QUERY_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all components could be analyzed");
             }
@@ -294,8 +300,8 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
                     }
 
                     final boolean affected = switch (coordinate) {
-                        case CpeCoordinate ignored -> isAffectedByCpe(candidate, criteria);
-                        case PurlCoordinate ignored -> isAffectedByPurl(candidate, criteria);
+                        case CpeCoordinate _ -> isAffectedByCpe(candidate, criteria);
+                        case PurlCoordinate _ -> isAffectedByPurl(candidate, criteria);
                     };
                     if (affected) {
                         findingsByVuln
@@ -614,15 +620,6 @@ final class InternalVulnAnalyzer implements VulnAnalyzer {
     }
 
     private record VulnMetadata(String vulnId, String source) {
-    }
-
-    private static <T> List<List<T>> partition(List<T> list) {
-        final var partitions = new ArrayList<List<T>>();
-        for (int i = 0; i < list.size(); i += 25) {
-            partitions.add(list.subList(i, Math.min(i + 25, list.size())));
-        }
-
-        return partitions;
     }
 
 }

--- a/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzer.java
+++ b/vuln-analysis/oss-index/src/main/java/org/dependencytrack/vulnanalysis/ossindex/OssIndexVulnAnalyzer.java
@@ -45,7 +45,6 @@ import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
@@ -55,6 +54,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Gatherers;
 
 /**
  * @since 5.0.0
@@ -115,7 +115,9 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
 
         // Try to populate results from cache.
         // Do so in batches as to not overwhelm cache providers.
-        for (final var purlBatch : partition(List.copyOf(bomRefsByPurl.keySet()), CACHE_BATCH_SIZE)) {
+        for (final var purlBatch : (Iterable<List<String>>) () -> bomRefsByPurl.keySet().stream()
+                .gather(Gatherers.windowFixed(CACHE_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all cache lookups could complete");
             }
@@ -186,7 +188,9 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
 
         final var reportedVulnsByPurl = new HashMap<String, List<ComponentReportVulnerability>>(purls.size());
 
-        for (final var purlBatch : partition(List.copyOf(purls), REQUEST_BATCH_SIZE)) {
+        for (final var purlBatch : (Iterable<List<String>>) () -> purls.stream()
+                .gather(Gatherers.windowFixed(REQUEST_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all components could be analyzed");
             }
@@ -285,7 +289,7 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
                 final Vulnerability.Builder vulnBuilder =
                         vulnBuilderByVulnId.computeIfAbsent(
                                 reportedVuln.id(),
-                                ignored -> OssIndexModelConverter.convert(reportedVuln, aliasSyncEnabled));
+                                _ -> OssIndexModelConverter.convert(reportedVuln, aliasSyncEnabled));
 
                 for (final String bomRef : bomRefs) {
                     vulnBuilder.addAffects(
@@ -303,15 +307,6 @@ final class OssIndexVulnAnalyzer implements VulnAnalyzer {
                                 .map(Vulnerability.Builder::build)
                                 .toList())
                 .build();
-    }
-
-    private static <T> List<List<T>> partition(List<T> list, int batchSize) {
-        final var partitions = new ArrayList<List<T>>();
-        for (int i = 0; i < list.size(); i += batchSize) {
-            partitions.add(list.subList(i, Math.min(i + batchSize, list.size())));
-        }
-
-        return partitions;
     }
 
 }

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykModelConverter.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykModelConverter.java
@@ -259,10 +259,10 @@ final class SnykModelConverter {
             return SCORE_METHOD_OTHER;
         }
         return switch (cvss) {
-            case Cvss4P0 ignored -> SCORE_METHOD_CVSSV4;
-            case Cvss3P1 ignored -> SCORE_METHOD_CVSSV31;
-            case Cvss3P0 ignored -> SCORE_METHOD_CVSSV3;
-            case Cvss2 ignored -> SCORE_METHOD_CVSSV2;
+            case Cvss4P0 _ -> SCORE_METHOD_CVSSV4;
+            case Cvss3P1 _ -> SCORE_METHOD_CVSSV31;
+            case Cvss3P0 _ -> SCORE_METHOD_CVSSV3;
+            case Cvss2 _ -> SCORE_METHOD_CVSSV2;
             default -> SCORE_METHOD_OTHER;
         };
     }

--- a/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
+++ b/vuln-analysis/snyk/src/main/java/org/dependencytrack/vulnanalysis/snyk/SnykVulnAnalyzer.java
@@ -51,6 +51,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Gatherers;
 
 /**
  * @since 5.0.0
@@ -103,7 +104,9 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
         final var issuesByPurl = new HashMap<String, List<SnykIssue>>(bomRefsByPurl.size());
         final var purlsToAnalyze = new LinkedHashSet<>(bomRefsByPurl.keySet());
 
-        for (final var purlBatch : partition(List.copyOf(bomRefsByPurl.keySet()), CACHE_BATCH_SIZE)) {
+        for (final var purlBatch : (Iterable<List<String>>) () -> bomRefsByPurl.keySet().stream()
+                .gather(Gatherers.windowFixed(CACHE_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all cache lookups could complete");
             }
@@ -178,7 +181,9 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
 
         final var issuesByPurl = new HashMap<String, List<SnykIssue>>(purls.size());
 
-        for (final var purlBatch : partition(List.copyOf(purls), REQUEST_BATCH_SIZE)) {
+        for (final var purlBatch : (Iterable<List<String>>) () -> purls.stream()
+                .gather(Gatherers.windowFixed(REQUEST_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all components could be analyzed");
             }
@@ -295,7 +300,7 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
                 final Vulnerability.Builder vulnBuilder =
                         vulnBuilderByVulnId.computeIfAbsent(
                                 issue.id(),
-                                ignored -> SnykModelConverter.convert(issue, aliasSyncEnabled));
+                                _ -> SnykModelConverter.convert(issue, aliasSyncEnabled));
 
                 for (final String bomRef : bomRefs) {
                     vulnBuilder.addAffects(
@@ -312,14 +317,6 @@ final class SnykVulnAnalyzer implements VulnAnalyzer {
                                 .map(Vulnerability.Builder::build)
                                 .toList())
                 .build();
-    }
-
-    private static <T> List<List<T>> partition(List<T> list, int batchSize) {
-        final var partitions = new ArrayList<List<T>>();
-        for (int i = 0; i < list.size(); i += batchSize) {
-            partitions.add(list.subList(i, Math.min(i + batchSize, list.size())));
-        }
-        return partitions;
     }
 
 }

--- a/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzer.java
+++ b/vuln-analysis/trivy/src/main/java/org/dependencytrack/vulnanalysis/trivy/TrivyVulnAnalyzer.java
@@ -182,7 +182,7 @@ final class TrivyVulnAnalyzer implements VulnAnalyzer {
         }
 
         bomRefsByPurl
-                .computeIfAbsent(purl.toString(), ignored -> new HashSet<>())
+                .computeIfAbsent(purl.toString(), _ -> new HashSet<>())
                 .add(component.getBomRef());
 
         if (!PurlType.APP_TYPE_PACKAGES.equals(appType)) {
@@ -250,7 +250,7 @@ final class TrivyVulnAnalyzer implements VulnAnalyzer {
             }
         }
 
-        final PackageInfo.Builder pkg = pkgs.computeIfAbsent(pkgType, ignored -> PackageInfo.newBuilder());
+        final PackageInfo.Builder pkg = pkgs.computeIfAbsent(pkgType, _ -> PackageInfo.newBuilder());
 
         final trivy.proto.common.Package.Builder packageBuilder = trivy.proto.common.Package.newBuilder()
                 .setName(purl.getName())
@@ -379,7 +379,7 @@ final class TrivyVulnAnalyzer implements VulnAnalyzer {
                 final Vulnerability.Builder vulnBuilder =
                         vulnBuilderByVulnId.computeIfAbsent(
                                 trivyVuln.getVulnerabilityId(),
-                                ignored -> TrivyModelConverter.convert(trivyVuln));
+                                _ -> TrivyModelConverter.convert(trivyVuln));
 
                 for (final String bomRef : bomRefs) {
                     vulnBuilder.addAffects(

--- a/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzer.java
+++ b/vuln-analysis/vuln-db/src/main/java/org/dependencytrack/vulnanalysis/vulndb/VulnDbVulnAnalyzer.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,6 +42,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Gatherers;
 
 /**
  * @since 5.0.0
@@ -81,7 +81,9 @@ final class VulnDbVulnAnalyzer implements VulnAnalyzer {
         final var vulnsByCpe = new HashMap<String, List<VulnDbApiResponse.Vulnerability>>(bomRefsByCpe.size());
         final var cpesToAnalyze = new LinkedHashSet<>(bomRefsByCpe.keySet());
 
-        for (final var cpeBatch : partition(List.copyOf(bomRefsByCpe.keySet()), CACHE_BATCH_SIZE)) {
+        for (final var cpeBatch : (Iterable<List<String>>) () -> bomRefsByCpe.keySet().stream()
+                .gather(Gatherers.windowFixed(CACHE_BATCH_SIZE))
+                .iterator()) {
             if (Thread.interrupted()) {
                 throw new InterruptedException("Interrupted before all cache lookups could complete");
             }
@@ -196,7 +198,7 @@ final class VulnDbVulnAnalyzer implements VulnAnalyzer {
                 final Vulnerability.Builder vulnBuilder =
                         vulnBuilderByVulnId.computeIfAbsent(
                                 vulnId,
-                                ignored -> VulnDbModelConverter.convert(vulnDbVuln, aliasSyncEnabled));
+                                _ -> VulnDbModelConverter.convert(vulnDbVuln, aliasSyncEnabled));
 
                 for (final String bomRef : bomRefs) {
                     vulnBuilder.addAffects(
@@ -213,14 +215,6 @@ final class VulnDbVulnAnalyzer implements VulnAnalyzer {
                                 .map(Vulnerability.Builder::build)
                                 .toList())
                 .build();
-    }
-
-    private static <T> List<List<T>> partition(List<T> list, int batchSize) {
-        final var partitions = new ArrayList<List<T>>();
-        for (int i = 0; i < list.size(); i += batchSize) {
-            partitions.add(list.subList(i, Math.min(i + batchSize, list.size())));
-        }
-        return partitions;
     }
 
 }

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/NvdVulnDataSourceFactory.java
@@ -135,7 +135,7 @@ final class NvdVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
         feeds.add(new NvdDataFeed.ModifiedDataFeed());
 
         final List<String> feedNames = feeds.stream().map(NvdDataFeed::name).toList();
-        final var watermarkManager = WatermarkManager.create(kvStore, feedNames);
+        final var watermarkManager = new WatermarkManager(kvStore, feedNames);
 
         return new NvdVulnDataSource(watermarkManager, objectMapper, httpClient, config.getCveFeedsUrl().toString(), feeds);
     }
@@ -201,7 +201,7 @@ final class NvdVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
         testResult.pass("connection");
 
         try {
-            final var ignored = NvdDataFeedMetadata.of(response.body());
+            var _ = NvdDataFeedMetadata.of(response.body());
             testResult.pass("feed_format");
         } catch (RuntimeException e) {
             LOGGER.warn("Failed to parse feed metadata from {}", metadataUri, e);

--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/WatermarkManager.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/WatermarkManager.java
@@ -46,22 +46,7 @@ final class WatermarkManager {
     private final Map<String, Long> committedFeedDigestVersions;
     private final Map<String, String> pendingFeedDigests;
 
-    private WatermarkManager(
-            final KeyValueStore kvStore,
-            final Instant committedWatermark,
-            final Long committedWatermarkVersion,
-            final Map<String, String> committedFeedDigests,
-            final Map<String, Long> committedFeedDigestVersions) {
-        this.kvStore = kvStore;
-        this.committedWatermark = committedWatermark;
-        this.committedWatermarkVersion = committedWatermarkVersion;
-        this.committedFeedDigests = committedFeedDigests;
-        this.committedFeedDigestVersions = committedFeedDigestVersions;
-        this.pendingFeedDigests = new HashMap<>();
-    }
-
-    // TODO: Just use constructor after upgrading to Java 25: https://openjdk.org/jeps/513
-    static WatermarkManager create(final KeyValueStore kvStore, final Collection<String> feedNames) {
+    WatermarkManager(final KeyValueStore kvStore, final Collection<String> feedNames) {
         Instant committedWatermark = null;
         Long committedWatermarkVersion = null;
 
@@ -93,9 +78,12 @@ final class WatermarkManager {
             }
         }
 
-        return new WatermarkManager(
-                kvStore, committedWatermark, committedWatermarkVersion,
-                committedFeedDigests, committedFeedDigestVersions);
+        this.kvStore = kvStore;
+        this.committedWatermark = committedWatermark;
+        this.committedWatermarkVersion = committedWatermarkVersion;
+        this.committedFeedDigests = committedFeedDigests;
+        this.committedFeedDigestVersions = committedFeedDigestVersions;
+        this.pendingFeedDigests = new HashMap<>();
     }
 
     Instant getWatermark() {

--- a/vuln-data-source/nvd/src/test/java/org/dependencytrack/vulndatasource/nvd/WatermarkManagerTest.java
+++ b/vuln-data-source/nvd/src/test/java/org/dependencytrack/vulndatasource/nvd/WatermarkManagerTest.java
@@ -33,7 +33,7 @@ class WatermarkManagerTest {
         final var kvStore = new MockKeyValueStore();
         kvStore.put("watermark", "1700000000000");
 
-        final var manager = WatermarkManager.create(kvStore, List.of());
+        final var manager = new WatermarkManager(kvStore, List.of());
 
         assertThat(manager.getWatermark()).isEqualTo(Instant.ofEpochMilli(1700000000000L));
     }
@@ -42,7 +42,7 @@ class WatermarkManagerTest {
     void shouldReturnNullWatermarkWhenNoneExists() {
         final var kvStore = new MockKeyValueStore();
 
-        final var manager = WatermarkManager.create(kvStore, List.of());
+        final var manager = new WatermarkManager(kvStore, List.of());
 
         assertThat(manager.getWatermark()).isNull();
     }
@@ -50,7 +50,7 @@ class WatermarkManagerTest {
     @Test
     void shouldAdvanceAndCommitWatermark() {
         final var kvStore = new MockKeyValueStore();
-        final var manager = WatermarkManager.create(kvStore, List.of());
+        final var manager = new WatermarkManager(kvStore, List.of());
 
         final var watermark = Instant.ofEpochMilli(1700000000000L);
         manager.maybeAdvance(watermark);
@@ -63,7 +63,7 @@ class WatermarkManagerTest {
     @Test
     void shouldNotAdvanceToEarlierWatermark() {
         final var kvStore = new MockKeyValueStore();
-        final var manager = WatermarkManager.create(kvStore, List.of());
+        final var manager = new WatermarkManager(kvStore, List.of());
 
         final var later = Instant.ofEpochMilli(1700000000000L);
         final var earlier = Instant.ofEpochMilli(1600000000000L);
@@ -80,7 +80,7 @@ class WatermarkManagerTest {
         kvStore.put("feed-digest:2024", "abc123");
         kvStore.put("feed-digest:modified", "def456");
 
-        final var manager = WatermarkManager.create(kvStore, List.of("2024", "2023", "modified"));
+        final var manager = new WatermarkManager(kvStore, List.of("2024", "2023", "modified"));
 
         assertThat(manager.getFeedDigest("2024")).isEqualTo("abc123");
         assertThat(manager.getFeedDigest("modified")).isEqualTo("def456");
@@ -90,7 +90,7 @@ class WatermarkManagerTest {
     @Test
     void shouldReturnNullForUnknownFeedDigest() {
         final var kvStore = new MockKeyValueStore();
-        final var manager = WatermarkManager.create(kvStore, List.of("2024"));
+        final var manager = new WatermarkManager(kvStore, List.of("2024"));
 
         assertThat(manager.getFeedDigest("1999")).isNull();
     }
@@ -98,7 +98,7 @@ class WatermarkManagerTest {
     @Test
     void shouldCommitPendingFeedDigests() {
         final var kvStore = new MockKeyValueStore();
-        final var manager = WatermarkManager.create(kvStore, List.of("2024", "2023"));
+        final var manager = new WatermarkManager(kvStore, List.of("2024", "2023"));
 
         manager.recordFeedDigest("2024", "abc123");
         manager.recordFeedDigest("2023", "def456");
@@ -116,7 +116,7 @@ class WatermarkManagerTest {
         final var kvStore = new MockKeyValueStore();
         kvStore.put("feed-digest:2024", "abc123");
 
-        final var manager = WatermarkManager.create(kvStore, List.of("2024"));
+        final var manager = new WatermarkManager(kvStore, List.of("2024"));
 
         manager.recordFeedDigest("2024", "abc123");
         manager.commitFeedDigests();
@@ -129,7 +129,7 @@ class WatermarkManagerTest {
         final var kvStore = new MockKeyValueStore();
         kvStore.put("feed-digest:2024", "old_digest");
 
-        final var manager = WatermarkManager.create(kvStore, List.of("2024"));
+        final var manager = new WatermarkManager(kvStore, List.of("2024"));
 
         manager.recordFeedDigest("2024", "new_digest");
         manager.commitFeedDigests();
@@ -141,7 +141,7 @@ class WatermarkManagerTest {
     @Test
     void shouldHandleEmptyFeedNameList() {
         final var kvStore = new MockKeyValueStore();
-        final var manager = WatermarkManager.create(kvStore, List.of());
+        final var manager = new WatermarkManager(kvStore, List.of());
 
         assertThat(manager.getFeedDigest("2024")).isNull();
     }
@@ -149,7 +149,7 @@ class WatermarkManagerTest {
     @Test
     void shouldCommitFeedDigestsIndependentlyOfWatermark() {
         final var kvStore = new MockKeyValueStore();
-        final var manager = WatermarkManager.create(kvStore, List.of("2024"));
+        final var manager = new WatermarkManager(kvStore, List.of("2024"));
 
         manager.maybeAdvance(Instant.ofEpochMilli(1700000000000L));
         manager.recordFeedDigest("2024", "abc123");

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/ModelConverter.java
@@ -234,10 +234,10 @@ final class ModelConverter {
                 ? "(" + cvss + ")"
                 : cvss.toString();
         return switch (cvss) {
-            case Cvss4P0 ignored -> new DerivedCvss(SCORE_METHOD_CVSSV4, score, scoreToSeverityCvssV4(score), stored);
-            case Cvss3P1 ignored -> new DerivedCvss(SCORE_METHOD_CVSSV31, score, scoreToSeverityCvssV3(score), stored);
-            case Cvss3P0 ignored -> new DerivedCvss(SCORE_METHOD_CVSSV3, score, scoreToSeverityCvssV3(score), stored);
-            case Cvss2 ignored -> new DerivedCvss(SCORE_METHOD_CVSSV2, score, scoreToSeverityCvssV2(score), stored);
+            case Cvss4P0 _ -> new DerivedCvss(SCORE_METHOD_CVSSV4, score, scoreToSeverityCvssV4(score), stored);
+            case Cvss3P1 _ -> new DerivedCvss(SCORE_METHOD_CVSSV31, score, scoreToSeverityCvssV3(score), stored);
+            case Cvss3P0 _ -> new DerivedCvss(SCORE_METHOD_CVSSV3, score, scoreToSeverityCvssV3(score), stored);
+            case Cvss2 _ -> new DerivedCvss(SCORE_METHOD_CVSSV2, score, scoreToSeverityCvssV2(score), stored);
             default -> null;
         };
     }

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceFactory.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceFactory.java
@@ -103,7 +103,7 @@ final class OsvVulnDataSourceFactory implements VulnDataSourceFactory, RuntimeCo
         }
 
         final @Nullable WatermarkManager watermarkManager = config.isIncrementalMirroringEnabled()
-                ? WatermarkManager.create(config.getEcosystems(), kvStore)
+                ? new WatermarkManager(config.getEcosystems(), kvStore)
                 : null;
 
         return new OsvVulnDataSource(

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/WatermarkManager.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/WatermarkManager.java
@@ -37,23 +37,16 @@ final class WatermarkManager {
     private final Map<String, WatermarkRecord> pendingRecordByEcosystem;
     private final Map<String, WatermarkRecord> committedRecordByEcosystem;
 
-    private WatermarkManager(
-            final WatermarkStore store,
-            final Map<String, WatermarkRecord> committedRecordByEcosystem) {
-        this.store = store;
-        this.pendingRecordByEcosystem = new HashMap<>(committedRecordByEcosystem);
-        this.committedRecordByEcosystem = new HashMap<>(committedRecordByEcosystem);
-    }
-
-    // TODO: Just use constructor after upgrading to Java 25 (https://openjdk.org/jeps/513)
-    static WatermarkManager create(
+    WatermarkManager(
             final Collection<String> ecosystems,
             final KeyValueStore kvStore) {
         final var watermarkStore = new WatermarkStore(kvStore);
         final Map<String, WatermarkRecord> recordByEcosystem =
                 watermarkStore.getForEcosystems(ecosystems);
 
-        return new WatermarkManager(watermarkStore, recordByEcosystem);
+        this.store = watermarkStore;
+        this.pendingRecordByEcosystem = new HashMap<>(recordByEcosystem);
+        this.committedRecordByEcosystem = new HashMap<>(recordByEcosystem);
     }
 
     Instant getWatermark(final String ecosystem) {
@@ -62,7 +55,7 @@ final class WatermarkManager {
     }
 
     void maybeAdvance(final String ecosystem, final Instant watermark) {
-        pendingRecordByEcosystem.compute(ecosystem, (ignored, existingRecord) -> {
+        pendingRecordByEcosystem.compute(ecosystem, (_, existingRecord) -> {
             if (existingRecord == null) {
                 return new WatermarkRecord(ecosystem, watermark);
             } else if (existingRecord.value().isAfter(watermark)) {

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/WatermarkManagerTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/WatermarkManagerTest.java
@@ -39,7 +39,7 @@ class WatermarkManagerTest {
                 Map.entry("watermark/npm", String.valueOf(Instant.ofEpochSecond(555).toEpochMilli()))
         ));
 
-        final var watermarkManager = WatermarkManager.create(List.of("maven", "npm"), kvStore);
+        final var watermarkManager = new WatermarkManager(List.of("maven", "npm"), kvStore);
         assertThat(watermarkManager).isNotNull();
         assertThat(watermarkManager.getWatermark("maven")).isEqualTo(Instant.ofEpochSecond(666));
         assertThat(watermarkManager.getWatermark("npm")).isEqualTo(Instant.ofEpochSecond(555));
@@ -47,14 +47,14 @@ class WatermarkManagerTest {
 
     @Test
     void createShouldNotInitializeWatermarkWhenNotAvailable() {
-        final var watermarkManager = WatermarkManager.create(List.of("maven"), kvStore);
+        final var watermarkManager = new WatermarkManager(List.of("maven"), kvStore);
         assertThat(watermarkManager).isNotNull();
         assertThat(watermarkManager.getWatermark("maven")).isNull();
     }
 
     @Test
     void shouldAdvanceWatermarkWhenInitialWatermarkIsNull() {
-        final var watermarkManager = WatermarkManager.create(List.of("maven"), kvStore);
+        final var watermarkManager = new WatermarkManager(List.of("maven"), kvStore);
 
         watermarkManager.maybeAdvance("maven", Instant.ofEpochSecond(666));
         assertThat(watermarkManager.getWatermark("maven")).isNull();
@@ -67,7 +67,7 @@ class WatermarkManagerTest {
     void shouldAdvanceWatermarkWhenInitialWatermarkIsEarlier() {
         kvStore.put("watermark/maven", String.valueOf(Instant.ofEpochSecond(666).toEpochMilli()));
 
-        final var watermarkManager = WatermarkManager.create(List.of("maven"), kvStore);
+        final var watermarkManager = new WatermarkManager(List.of("maven"), kvStore);
 
         watermarkManager.maybeAdvance("maven", Instant.ofEpochSecond(667));
         assertThat(watermarkManager.getWatermark("maven")).isEqualTo(Instant.ofEpochSecond(666));


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Raises the Java baseline from 21 to 25, and leverages new language features:

* Replaces the various "ignored" and "ignoredMdc" variables with `_`.
* Replaces hand-rolled batching / partitioning logic with `windowFixed(n)` stream gatherers.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Closes https://github.com/DependencyTrack/hyades/issues/2017

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Note that we already shipped with a Java 25 base image for a long while, so there are no runtime-related changes.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
