### PR TITLE
Allow filtering project findings by epss score

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
+++ b/apiserver/src/main/java/org/dependencytrack/persistence/jdbi/FindingDao.java
@@ -110,8 +110,11 @@ public interface FindingDao {
     @SqlQuery(/* language=InjectedFreeMarker */ """
             <#-- @ftlvariable name="apiOrderByClause" type="String" -->
             <#-- @ftlvariable name="apiOffsetLimitClause" type="String" -->
+            <#-- @ftlvariable name="epssFrom" type="boolean" -->
+            <#-- @ftlvariable name="epssTo" type="boolean" -->
             <#-- @ftlvariable name="includeInactive" type="boolean" -->
             <#-- @ftlvariable name="includeSuppressed" type="boolean" -->
+            <#-- @ftlvariable name="source" type="boolean" -->
             SELECT p."UUID" AS "projectUuid"
                  , p."NAME" AS "projectName"
                  , p."VERSION" AS "projectVersion"
@@ -257,6 +260,12 @@ public interface FindingDao {
                AND a."SUPPRESSED" IS DISTINCT FROM TRUE
             </#if>
                AND (:hasAnalysis IS NULL OR (a."ID" IS NOT NULL) = :hasAnalysis)
+            <#if epssFrom>
+               AND e."SCORE" >= :epssFrom
+            </#if>
+            <#if epssTo>
+               AND e."SCORE" <= :epssTo
+            </#if>
             <#if apiOrderByClause??>
               ${apiOrderByClause}
             <#else>
@@ -267,6 +276,11 @@ public interface FindingDao {
     @AllowApiOrdering(alwaysBy = "attribution.id", by = {
             @AllowApiOrdering.Column(name = "vulnerability.vulnId", queryName = "v.\"VULNID\""),
             @AllowApiOrdering.Column(name = "vulnerability.severity", queryName = "\"vulnSeverity\""),
+            @AllowApiOrdering.Column(name = "vulnerability.cvssV2BaseScore", queryName = "\"cvssV2BaseScore\""),
+            @AllowApiOrdering.Column(name = "vulnerability.cvssV3BaseScore", queryName = "\"cvssV3BaseScore\""),
+            @AllowApiOrdering.Column(name = "vulnerability.cvssV4Score", queryName = "\"cvssV4Score\""),
+            @AllowApiOrdering.Column(name = "vulnerability.epssScore", queryName = "\"epssScore\""),
+            @AllowApiOrdering.Column(name = "vulnerability.epssPercentile", queryName = "\"epssPercentile\""),
             @AllowApiOrdering.Column(name = "attribution.analyzerIdentity", queryName = "fa.\"ANALYZERIDENTITY\""),
             @AllowApiOrdering.Column(name = "component.group", queryName = "c.\"GROUP\""),
             @AllowApiOrdering.Column(name = "component.name", queryName = "c.\"NAME\""),
@@ -283,10 +297,19 @@ public interface FindingDao {
             @Define boolean includeInactive,
             @Define boolean includeSuppressed,
             @Bind Boolean hasAnalysis,
-            @Bind String source);
+            @Bind String source,
+            @Bind BigDecimal epssFrom,
+            @Bind BigDecimal epssTo);
 
     default List<Finding> getFindings(final long projectId, final boolean includeSuppressed) {
-        List<FindingRow> findingRows = getFindingsByProject(projectId, /* includeInactive */ false, includeSuppressed, null, null);
+        List<FindingRow> findingRows = getFindingsByProject(
+                projectId,
+                /* includeInactive */ false,
+                includeSuppressed,
+                /* hasAnalysis */ null,
+                /* source */ null,
+                /* epssFrom */ null,
+                /* epssTo */ null);
         List<Finding> findings = findingRows.stream().map(Finding::new).toList();
         return mapComponentLatestVersion(findings);
     }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/FindingResource.java
@@ -72,6 +72,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,14 +144,24 @@ public class FindingResource extends AbstractApiResource {
                                          @QueryParam("source") Vulnerability.Source source,
                                          @HeaderParam("accept") String acceptHeader,
                                          @Parameter(description = "Whether to include only projects with existing analysis.")
-                                         @QueryParam("hasAnalysis") final Boolean hasAnalysis) {
+                                         @QueryParam("hasAnalysis") final Boolean hasAnalysis,
+                                         @Parameter(description = "Filter EPSS score from this value (inclusive)")
+                                         @QueryParam("epssFrom") final BigDecimal epssFrom,
+                                         @Parameter(description = "Filter EPSS score to this value (inclusive)")
+                                         @QueryParam("epssTo") final BigDecimal epssTo) {
         try (QueryManager qm = new QueryManager(getAlpineRequest())) {
             final Project project = qm.getObjectByUuid(Project.class, uuid);
             if (project != null) {
                 requireAccess(qm, project);
                 List<FindingDao.FindingRow> findingRows = withJdbiHandle(getAlpineRequest(), handle ->
                         handle.attach(FindingDao.class).getFindingsByProject(
-                                project.getId(), false, suppressed, hasAnalysis, source != null ? source.name() : null));
+                                project.getId(),
+                                /* includeInactive */ false,
+                                suppressed,
+                                hasAnalysis,
+                                source != null ? source.name() : null,
+                                epssFrom,
+                                epssTo));
                 final long totalCount = findingRows.isEmpty() ? 0 : findingRows.getFirst().totalCount();
                 List<Finding> findings = findingRows.stream().map(Finding::new).toList();
                 findings = mapComponentLatestVersion(findings);

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/FindingResourceTest.java
@@ -307,6 +307,34 @@ public class FindingResourceTest extends ResourceTest {
     }
 
     @Test
+    void shouldFilterFindingsByProjectByEpssScore() {
+        initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
+
+        final Project project = qm.createProject("Acme Example", null, "1.0", null, null, null, null, false);
+        final Component cLow = createComponent(project, "Component Low", "1.0");
+        final Component cHigh = createComponent(project, "Component High", "1.0");
+        final Component cNoEpss = createComponent(project, "Component NoEpss", "1.0");
+
+        qm.addVulnerability(createVulnerabilityWithEpss("Vuln-Low", Severity.LOW, new BigDecimal("0.10")), cLow, "none");
+        qm.addVulnerability(createVulnerabilityWithEpss("Vuln-High", Severity.CRITICAL, new BigDecimal("0.85")), cHigh, "none");
+        qm.addVulnerability(createVulnerability("Vuln-NoEpss", Severity.MEDIUM), cNoEpss, "none");
+
+        final Response response = jersey
+                .target(V1_FINDING + "/project/" + project.getUuid())
+                .queryParam("epssFrom", "0.05")
+                .queryParam("epssTo", "0.5")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get(Response.class);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].vulnerability.vulnId")
+                .isArray()
+                .containsExactly("Vuln-Low");
+    }
+
+    @Test
     public void exportFindingsByProjectTest() {
         initializeWithPermissions(Permissions.VIEW_VULNERABILITY);
 

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
@@ -322,8 +322,10 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
                                 projectId,
                                 /* includeInactive */ false,
                                 /* includeSuppressed */ false,
-                                null,
-                                null));
+                                /* hasAnalysis */ null,
+                                /* source */ null,
+                                /* epssFrom */ null,
+                                /* epssTo */ null));
 
         List<FindingRow> findings = findingsSupplier.get();
         assertThat(findings).hasSize(1);
@@ -1193,7 +1195,14 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
         final long projectId = project.getId();
         final List<FindingDao.FindingRow> findings = withJdbiHandle(
                 handle -> handle.attach(FindingDao.class)
-                        .getFindingsByProject(projectId, false, false, null, null));
+                        .getFindingsByProject(
+                                projectId,
+                                /* includeInactive */ false,
+                                /* includeSuppressed */ false,
+                                /* hasAnalysis */ null,
+                                /* source */ null,
+                                /* epssFrom */ null,
+                                /* epssTo */ null));
         assertThat(findings).hasSize(1);
 
         assertThat(getAllAliasGroups()).satisfiesExactly(group ->


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows filtering project findings by epss score.

This is required for the "Exploit Predictions" tab in the UI. It previously filtered findings on source=NVD, because before ADR 022, only NVD vulns could have EPSS values. Since ADR 022, potentially all vulns can have EPSS values. Adding epss filters allows the UI to filter on epssFrom=0 to only list findings that have EPSS values.

Also added epss columns to the list of allowed sorting columns.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/hyades-frontend/pull/528

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
