### PR TITLE
dex: allow engine to transition from STARTING to STOPPING

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -129,11 +129,11 @@ final class DexEngineImpl implements DexEngine {
 
     enum Status {
 
-        CREATED(1, 3), // 0
-        STARTING(2),   // 1
-        RUNNING(3),    // 2
-        STOPPING(4),   // 3
-        STOPPED(1);    // 4
+        CREATED(1, 3),  // 0
+        STARTING(2, 3), // 1
+        RUNNING(3),     // 2
+        STOPPING(4),    // 3
+        STOPPED(1);     // 4
 
         private final Set<Integer> allowedTransitions;
 
@@ -1598,16 +1598,13 @@ final class DexEngineImpl implements DexEngine {
             throw e;
         }
 
-        final Map<ActivityTaskId, CompletableFuture<TaskLock>> futureByTaskId = heartbeats.stream()
-                .collect(Collectors.toMap(
-                        ActivityTaskHeartbeat::taskId,
-                        ActivityTaskHeartbeat::future));
+        for (final ActivityTaskHeartbeat heartbeat : heartbeats) {
+            final CompletableFuture<TaskLock> future = heartbeat.future();
+            if (future.isDone()) {
+                continue;
+            }
 
-        for (final var entry : futureByTaskId.entrySet()) {
-            final ActivityTaskId taskId = entry.getKey();
-            final CompletableFuture<TaskLock> future = entry.getValue();
-
-            final TaskLock lock = lockByTaskId.get(taskId);
+            final TaskLock lock = lockByTaskId.get(heartbeat.taskId());
             if (lock != null) {
                 future.complete(lock);
             } else {


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows the dex engine to transition from STARTING to STOPPING.

Enables the engine to cleanly stop when starting failed halfway through.

Also handle the rare case where duplicate heartbeats for a task ID are sent. Resolve them all instead of de-duplicating them via temporary map.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
