### PR TITLE
Allow filtering workflow runs by label(s)

### DIFF
--- a/api/src/main/openapi/resources/internal/workflows/workflow-runs.yaml
+++ b/api/src/main/openapi/resources/internal/workflows/workflow-runs.yaml
@@ -55,6 +55,19 @@ get:
       in: query
       schema:
         $ref: "./schemas/workflow-run-status.yaml"
+    - name: label
+      description: |-
+        Filter by label in `key=value` form. Repeat to require multiple labels.
+        A run matches only if it carries every supplied label.
+        On duplicate keys the last occurrence wins.
+      in: query
+      style: form
+      explode: true
+      schema:
+        type: array
+        items:
+          type: string
+          pattern: "^[^=]+=.*$"
     - name: created_at_from
       description: Filter runs created on or after this timestamp.
       in: query

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/WorkflowsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/WorkflowsResource.java
@@ -61,6 +61,8 @@ import org.jspecify.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -127,6 +129,7 @@ public class WorkflowsResource extends AbstractApiResource implements WorkflowsA
             @Nullable Integer workflowVersion,
             @Nullable String workflowInstanceId,
             @Nullable WorkflowRunStatus status,
+            @Nullable List<String> label,
             @Nullable Long createdAtFrom,
             @Nullable Long createdAtTo,
             @Nullable Long completedAtFrom,
@@ -141,6 +144,7 @@ public class WorkflowsResource extends AbstractApiResource implements WorkflowsA
                         .withWorkflowVersion(workflowVersion)
                         .withWorkflowInstanceId(workflowInstanceId)
                         .withStatuses(status != null ? Set.of(convert(status)) : null)
+                        .withLabels(convertLabelFilters(label))
                         .withCreatedAtFrom(createdAtFrom != null
                                 ? Instant.ofEpochMilli(createdAtFrom)
                                 : null)
@@ -241,6 +245,22 @@ public class WorkflowsResource extends AbstractApiResource implements WorkflowsA
         };
     }
 
+    private static @Nullable Map<String, String> convertLabelFilters(@Nullable List<String> labelFilters) {
+        if (labelFilters == null || labelFilters.isEmpty()) {
+            return null;
+        }
+
+        final var labels = new HashMap<String, String>(labelFilters.size());
+        for (final String entry : labelFilters) {
+            // NB: format is already validated via @Pattern annotation in
+            // the WorkflowsApi interface.
+            final int eq = entry.indexOf('=');
+            labels.put(entry.substring(0, eq), entry.substring(eq + 1));
+        }
+
+        return labels;
+    }
+
     private static org.dependencytrack.api.v2.model.WorkflowRunMetadata convert(WorkflowRunMetadata runMetadata) {
         return org.dependencytrack.api.v2.model.WorkflowRunMetadata.builder()
                 .id(runMetadata.id())
@@ -283,4 +303,5 @@ public class WorkflowsResource extends AbstractApiResource implements WorkflowsA
                 .event(eventJsonMap)
                 .build();
     }
+    
 }

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/WorkflowsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/WorkflowsResourceTest.java
@@ -293,6 +293,7 @@ class WorkflowsResourceTest extends ResourceTest {
                 .queryParam("workflow_version", 42)
                 .queryParam("workflow_instance_id", "instance-123")
                 .queryParam("status", "CANCELLED")
+                .queryParam("label", "env=prod", "team=api")
                 .queryParam("created_at_from", 1000000)
                 .queryParam("created_at_to", 2000000)
                 .queryParam("completed_at_from", 3000000)
@@ -314,6 +315,7 @@ class WorkflowsResourceTest extends ResourceTest {
         assertThat(capturedRequest.workflowVersion()).isEqualTo(42);
         assertThat(capturedRequest.workflowInstanceId()).isEqualTo("instance-123");
         assertThat(capturedRequest.statuses()).containsOnly(WorkflowRunStatus.CANCELLED);
+        assertThat(capturedRequest.labels()).containsExactlyInAnyOrderEntriesOf(Map.of("env", "prod", "team", "api"));
         assertThat(capturedRequest.createdAtFrom()).isEqualTo(Instant.ofEpochMilli(1000000));
         assertThat(capturedRequest.createdAtTo()).isEqualTo(Instant.ofEpochMilli(2000000));
         assertThat(capturedRequest.completedAtFrom()).isEqualTo(Instant.ofEpochMilli(3000000));
@@ -322,6 +324,57 @@ class WorkflowsResourceTest extends ResourceTest {
         assertThat(capturedRequest.pageToken()).isEqualTo("nextPageToken");
         assertThat(capturedRequest.sortDirection()).isEqualTo(SortDirection.DESC);
         assertThat(capturedRequest.sortBy()).isEqualTo(ListWorkflowRunsRequest.SortBy.CREATED_AT);
+    }
+
+    @Test
+    public void listWorkflowRunsShouldReturn400WhenLabelFilterIsMalformed() {
+        initializeWithPermissions(Permissions.SYSTEM_CONFIGURATION_READ);
+
+        final Response missingEquals = jersey
+                .target("/internal/workflow-runs")
+                .queryParam("label", "noEqualsSign")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(missingEquals.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(missingEquals)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "about:blank",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "detail": "The request could not be processed because it failed validation.",
+                  "errors": [
+                    {
+                      "path": "listWorkflowRuns.label[0].<list element>",
+                      "value": "noEqualsSign",
+                      "message": "must match \\"^[^=]+=.*$\\""
+                    }
+                  ]
+                }
+                """);
+
+        final Response emptyKey = jersey
+                .target("/internal/workflow-runs")
+                .queryParam("label", "=value")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(emptyKey.getStatus()).isEqualTo(400);
+        assertThatJson(getPlainTextBody(emptyKey)).isEqualTo(/* language=JSON */ """
+                {
+                  "type": "about:blank",
+                  "status": 400,
+                  "title": "Bad Request",
+                  "detail": "The request could not be processed because it failed validation.",
+                  "errors": [
+                    {
+                      "path": "listWorkflowRuns.label[0].<list element>",
+                      "value": "=value",
+                      "message": "must match \\"^[^=]+=.*$\\""
+                    }
+                  ]
+                }
+                """);
     }
 
     @Test

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -1678,6 +1678,34 @@ class DexEngineImplTest {
         assertThat(runsPage.nextPageToken()).isNull();
     }
 
+    @Test
+    void shouldListRunsFilteredByLabels() {
+        registerWorkflow("test", (_, _) -> null);
+
+        engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                .withLabels(Map.of("env", "prod", "team", "api")));
+        engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                .withLabels(Map.of("env", "prod", "team", "web")));
+        engine.createRun(new CreateWorkflowRunRequest<>("test", 1)
+                .withLabels(Map.of("env", "dev", "team", "api")));
+        engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+        assertThat(engine.listRuns(
+                new ListWorkflowRunsRequest()
+                        .withLabels(Map.of("env", "prod"))).items())
+                .hasSize(2);
+
+        assertThat(engine.listRuns(
+                new ListWorkflowRunsRequest()
+                        .withLabels(Map.of("env", "prod", "team", "api"))).items())
+                .hasSize(1);
+
+        assertThat(engine.listRuns(
+                new ListWorkflowRunsRequest()
+                        .withLabels(Map.of("env", "staging"))).items())
+                .isEmpty();
+    }
+
     @Nested
     class ExistsRunTest {
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Enables clients to filter runs by e.g. `triggered_by=<username>` or `project_uuid=<uuid>`.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
