### PR TITLE
Cap download of individual modified OSV advisories to 50

### DIFF
--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
@@ -63,6 +63,7 @@ import static org.dependencytrack.vulndatasource.osv.CycloneDxPropertyNames.OSV_
 final class OsvVulnDataSource implements VulnDataSource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OsvVulnDataSource.class);
+    private static final int MAX_INCREMENTAL_ADVISORY_DOWNLOADS = 50;
 
     private final WatermarkManager watermarkManager;
     private final ObjectMapper objectMapper;
@@ -322,6 +323,15 @@ final class OsvVulnDataSource implements VulnDataSource {
             return;
         }
 
+        if (modifiedIds.size() > MAX_INCREMENTAL_ADVISORY_DOWNLOADS) {
+            LOGGER.info("""
+                            {} new or updated advisories for ecosystem {} exceeds the incremental \
+                            download threshold of {}; downloading the full advisory archive instead""",
+                    modifiedIds.size(), ecosystem, MAX_INCREMENTAL_ADVISORY_DOWNLOADS);
+            downloadEcosystemFilesAll(ecosystem, destDirPath);
+            return;
+        }
+
         // TODO: Use structured concurrency after Java 25 upgrade (https://openjdk.org/jeps/505).
         LOGGER.info("Downloading {} new or updated advisories for ecosystem {}", modifiedIds.size(), ecosystem);
         for (final String modifiedId : modifiedIds) {
@@ -402,6 +412,11 @@ final class OsvVulnDataSource implements VulnDataSource {
                 final Instant timestamp = Instant.parse(parts[0]);
                 if (timestamp.isAfter(watermark)) {
                     modifiedIds.add(parts[1]);
+                    if (modifiedIds.size() > MAX_INCREMENTAL_ADVISORY_DOWNLOADS) {
+                        // NB: We already know there are too many modified IDs,
+                        // no point in scanning further.
+                        break;
+                    }
                 } else {
                     break;
                 }

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
@@ -20,8 +20,9 @@ package org.dependencytrack.vulndatasource.osv;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.google.protobuf.util.JsonFormat;
 import com.google.protobuf.util.Timestamps;
 import net.javacrumbs.jsonunit.core.Option;
@@ -45,7 +46,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@WireMockTest
 class OsvVulnDataSourceTest {
 
     private WatermarkManager watermarkManagerMock;
@@ -154,11 +155,7 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
-    void testDownloadAndExtractEcosystemFiles() throws Exception {
-
-        var wireMockServer = new WireMockServer(options().dynamicPort());
-        wireMockServer.start();
-        WireMock.configureFor("localhost", wireMockServer.port());
+    void testDownloadAndExtractEcosystemFiles(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         final String ecosystem = "maven";
 
         // Create in-memory ZIP with one advisory JSON
@@ -166,14 +163,14 @@ class OsvVulnDataSourceTest {
         try (ZipOutputStream zos = new ZipOutputStream(zipBytes)) {
             ZipEntry entry = new ZipEntry("osv-advisory.json");
             zos.putNextEntry(entry);
-            String advisoryJson = """
-                {
-                    "id": "OSV-789",
-                    "summary": "Test vulnerability",
-                    "affected": [],
-                    "modified": "2022-06-09T07:01:32.587Z"
-                }
-                """;
+            String advisoryJson = /* language=JSON */ """
+                    {
+                        "id": "OSV-789",
+                        "summary": "Test vulnerability",
+                        "affected": [],
+                        "modified": "2022-06-09T07:01:32.587Z"
+                    }
+                    """;
             zos.write(advisoryJson.getBytes());
             zos.closeEntry();
         }
@@ -187,7 +184,7 @@ class OsvVulnDataSourceTest {
         OsvVulnDataSource dataSource = new OsvVulnDataSource(
                 watermarkManagerMock,
                 objectMapper,
-                "http://localhost:" + wireMockServer.port(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 List.of(ecosystem),
                 HttpClient.newHttpClient(),
                 false
@@ -197,32 +194,34 @@ class OsvVulnDataSourceTest {
         var bom = dataSource.next();
         assertThatJson(JsonFormat.printer().print(bom))
                 .when(Option.IGNORING_ARRAY_ORDER)
-                .isEqualTo("""
+                .isEqualTo(/* language=JSON */ """
                         {
-                           "vulnerabilities" : [
+                          "vulnerabilities": [
+                            {
+                              "id":"OSV-789",
+                              "source":{
+                                "name":"OSV"
+                              },
+                              "ratings": [
                                 {
-                                     "id" : "OSV-789",
-                                     "source" : {
-                                       "name" : "OSV"
-                                     },
-                                     "ratings" : [ {
-                                       "severity" : "SEVERITY_UNKNOWN"
-                                     } ],
-                                     "updated": "2022-06-09T07:01:32.587Z",
-                                     "properties" : [
-                                         {
-                                           "name" : "dependency-track:vuln:title",
-                                           "value" : "Test vulnerability"
-                                         },
-                                         {
-                                            "name": "internal:osv:ecosystem",
-                                            "value": "maven"
-                                         }
-                                     ]
+                                  "severity":"SEVERITY_UNKNOWN"
                                 }
-                           ]
+                              ],
+                              "updated":"2022-06-09T07:01:32.587Z",
+                              "properties": [
+                                {
+                                  "name":"dependency-track:vuln:title",
+                                  "value":"Test vulnerability"
+                                },
+                                {
+                                  "name":"internal:osv:ecosystem",
+                                  "value":"maven"
+                                }
+                              ]
+                            }
+                          ]
                         }
-        """);
+                        """);
 
         dataSource.markProcessed(bom);
         verify(watermarkManagerMock).maybeAdvance(eq(ecosystem), any());
@@ -232,22 +231,19 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
-    void nullWatermarkManagerPerformsFullDownload() throws Exception {
-        var wireMockServer = new WireMockServer(options().dynamicPort());
-        wireMockServer.start();
-        WireMock.configureFor("localhost", wireMockServer.port());
+    void nullWatermarkManagerPerformsFullDownload(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         ByteArrayOutputStream zipBytes = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(zipBytes)) {
             ZipEntry entry = new ZipEntry("osv-advisory.json");
             zos.putNextEntry(entry);
-            String advisoryJson = """
-                {
-                    "id": "OSV-2024-001",
-                    "summary": "Test",
-                    "affected": [],
-                    "modified": "2024-01-01T00:00:00Z"
-                }
-                """;
+            String advisoryJson = /* language=JSON */ """
+                    {
+                      "id": "OSV-2024-001",
+                      "summary": "Test",
+                      "affected": [],
+                      "modified": "2024-01-01T00:00:00Z"
+                    }
+                    """;
             zos.write(advisoryJson.getBytes());
             zos.closeEntry();
         }
@@ -260,7 +256,7 @@ class OsvVulnDataSourceTest {
         try (var dataSource = new OsvVulnDataSource(
                 null,
                 objectMapper,
-                "http://localhost:" + wireMockServer.port(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 List.of("maven"),
                 HttpClient.newHttpClient(),
                 false)) {
@@ -276,23 +272,20 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
-    void watermarkManagerReturnsNullPerformsFullDownload() throws Exception {
+    void watermarkManagerReturnsNullPerformsFullDownload(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         when(watermarkManagerMock.getWatermark("maven")).thenReturn(null);
-        var wireMockServer = new WireMockServer(options().dynamicPort());
-        wireMockServer.start();
-        WireMock.configureFor("localhost", wireMockServer.port());
         ByteArrayOutputStream zipBytes = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(zipBytes)) {
             ZipEntry entry = new ZipEntry("osv-advisory.json");
             zos.putNextEntry(entry);
-            String advisoryJson = """
-                {
-                    "id": "OSV-2024-002",
-                    "summary": "Test",
-                    "affected": [],
-                    "modified": "2024-01-02T00:00:00Z"
-                }
-                """;
+            String advisoryJson = /* language=JSON */ """
+                    {
+                      "id": "OSV-2024-002",
+                      "summary": "Test",
+                      "affected": [],
+                      "modified": "2024-01-02T00:00:00Z"
+                    }
+                    """;
             zos.write(advisoryJson.getBytes());
             zos.closeEntry();
         }
@@ -305,7 +298,7 @@ class OsvVulnDataSourceTest {
         try (var dataSource = new OsvVulnDataSource(
                 watermarkManagerMock,
                 objectMapper,
-                "http://localhost:" + wireMockServer.port(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 List.of("maven"),
                 HttpClient.newHttpClient(),
                 false)) {
@@ -321,25 +314,22 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
-    void watermarkManagerReturnsInstantPerformsIncrementalDownload() throws Exception {
+    void watermarkManagerReturnsInstantPerformsIncrementalDownload(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         when(watermarkManagerMock.getWatermark("maven")).thenReturn(Instant.parse("2024-01-01T00:00:00Z"));
-        var wireMockServer = new WireMockServer(options().dynamicPort());
-        wireMockServer.start();
-        WireMock.configureFor("localhost", wireMockServer.port());
         String csvBody = "2025-01-01T00:00:00Z,OSV-123\n";
         stubFor(get(urlEqualTo("/maven/modified_id.csv"))
                 .willReturn(aResponse()
                         .withStatus(200)
                         .withHeader("Content-Type", "text/csv")
                         .withBody(csvBody)));
-        String advisoryJson = """
-            {
-                "id": "OSV-123",
-                "summary": "Incremental advisory",
-                "affected": [],
-                "modified": "2025-01-01T00:00:00Z"
-            }
-            """;
+        String advisoryJson = /* language=JSON */ """
+                {
+                  "id": "OSV-123",
+                  "summary": "Incremental advisory",
+                  "affected": [],
+                  "modified": "2025-01-01T00:00:00Z"
+                }
+                """;
         stubFor(get(urlEqualTo("/maven/OSV-123.json"))
                 .willReturn(aResponse()
                         .withStatus(200)
@@ -349,7 +339,7 @@ class OsvVulnDataSourceTest {
         try (var dataSource = new OsvVulnDataSource(
                 watermarkManagerMock,
                 objectMapper,
-                "http://localhost:" + wireMockServer.port(),
+                wmRuntimeInfo.getHttpBaseUrl(),
                 List.of("maven"),
                 HttpClient.newHttpClient(),
                 false)) {
@@ -364,6 +354,57 @@ class OsvVulnDataSourceTest {
         WireMock.verify(getRequestedFor(urlEqualTo("/maven/modified_id.csv")));
         WireMock.verify(getRequestedFor(urlEqualTo("/maven/OSV-123.json")));
         WireMock.verify(0, getRequestedFor(urlEqualTo("/maven/all.zip")));
+    }
+
+    @Test
+    void shouldFallBackToFullDownloadWhenIncrementalThresholdExceeded(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        when(watermarkManagerMock.getWatermark("maven")).thenReturn(Instant.parse("2024-01-01T00:00:00Z"));
+
+        final var csvBody = new StringBuilder();
+        for (int i = 0; i < 51; i++) {
+            csvBody.append("2025-01-01T00:00:00Z,OSV-%d\n".formatted(i));
+        }
+        stubFor(get(urlEqualTo("/maven/modified_id.csv"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/csv")
+                        .withBody(csvBody.toString())));
+
+        var zipBytes = new ByteArrayOutputStream();
+        try (var zos = new ZipOutputStream(zipBytes)) {
+            zos.putNextEntry(new ZipEntry("osv-advisory.json"));
+            zos.write(/* language=JSON */ """
+                    {
+                      "id": "OSV-789",
+                      "summary": "Test vulnerability",
+                      "affected": [],
+                      "modified": "2025-01-01T00:00:00Z"
+                    }
+                    """.getBytes());
+            zos.closeEntry();
+        }
+        stubFor(get(urlEqualTo("/maven/all.zip"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/zip")
+                        .withBody(zipBytes.toByteArray())));
+
+        try (var dataSource = new OsvVulnDataSource(
+                watermarkManagerMock,
+                objectMapper,
+                wmRuntimeInfo.getHttpBaseUrl(),
+                List.of("maven"),
+                HttpClient.newHttpClient(),
+                false)) {
+            assertTrue(dataSource.hasNext());
+            Bom first = dataSource.next();
+            assertThat(first.getVulnerabilitiesList().getFirst().getId()).isEqualTo("OSV-789");
+            assertThat(dataSource.hasNext()).isFalse();
+        }
+
+        WireMock.verify(getRequestedFor(urlEqualTo("/maven/modified_id.csv")));
+        WireMock.verify(getRequestedFor(urlEqualTo("/maven/all.zip")));
+        WireMock.verify(0, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
     }
 
 }


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Caps download of individual modified OSV advisories to 50.

This prevents the OSV vuln data source from trying to download 1000s of modified advisories, which can happen when upstream sources like Ubuntu bulk-publish advisories.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
