### PR TITLE
dex: Explicitly handle lost task locks

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityContextImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityContextImpl.java
@@ -23,6 +23,8 @@ import org.dependencytrack.dex.api.ActivityContext;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
 final class ActivityContextImpl implements ActivityContext {
 
@@ -55,7 +57,24 @@ final class ActivityContextImpl implements ActivityContext {
             return false;
         }
 
-        task.setLock(engine.heartbeatActivityTask(task.id(), task.lock(), lockTimeout).join());
+        final CompletableFuture<TaskLock> newLockFuture =
+                engine.heartbeatActivityTask(task.id(), task.lock(), lockTimeout);
+
+        final TaskLock newLock;
+        try {
+            newLock = newLockFuture.join();
+        } catch (CompletionException e) {
+            // The completion exception has no meaning to callers of this method.
+            // Unwrap its cause if possible.
+            switch (e.getCause()) {
+                case RuntimeException re -> throw re;
+                case Error err -> throw err;
+                case null -> throw e;
+                default -> throw new IllegalStateException(e.getCause());
+            }
+        }
+
+        task.setLock(newLock);
         return true;
     }
 

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -141,6 +141,11 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 if (cause instanceof InterruptedException) {
                     logger.debug("Activity was interrupted; Abandoning task");
                     abandon(task);
+                } else if (cause instanceof TaskLockLostException) {
+                    logger.warn("""
+                            Activity task lock was lost, likely because execution took longer than \
+                            the lock timeout without a heartbeat; discarding this execution as \
+                            another worker has taken over the task""");
                 } else {
                     final Instant retryAt = computeRetryAt(task, cause);
                     if (retryAt == null) {

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -1608,7 +1608,7 @@ final class DexEngineImpl implements DexEngine {
             if (lock != null) {
                 future.complete(lock);
             } else {
-                future.completeExceptionally(new IllegalStateException());
+                future.completeExceptionally(new TaskLockLostException());
             }
         }
     }

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskLockLostException.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/TaskLockLostException.java
@@ -1,0 +1,27 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.dex.engine;
+
+final class TaskLockLostException extends RuntimeException {
+
+    TaskLockLostException() {
+        super("Task lock was lost");
+    }
+
+}

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -74,6 +74,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -1197,6 +1198,48 @@ class DexEngineImplTest {
         awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
 
         assertThat(heartbeatsPerformed).containsExactly(false, true, false);
+    }
+
+    @Test
+    void shouldDiscardActivityExecutionWhenLockIsLost() {
+        final var invocations = new AtomicInteger();
+        final var lockLostObserved = new AtomicBoolean();
+        final var successorStarted = new CountDownLatch(1);
+
+        registerWorkflow("test", (ctx, _) -> {
+            ctx.callActivity("test", ACTIVITY_TASK_QUEUE, null, voidConverter(), voidConverter(), RetryPolicy.ofDefault()).await();
+            return null;
+        });
+
+        engine.registerActivityInternal(
+                "test", voidConverter(), voidConverter(), ACTIVITY_TASK_QUEUE, Duration.ofSeconds(1),
+                (ctx, _) -> {
+                    if (invocations.incrementAndGet() > 1) {
+                        successorStarted.countDown();
+                        return null;
+                    }
+
+                    assertThat(successorStarted.await(30, TimeUnit.SECONDS)).isTrue();
+
+                    try {
+                        ctx.maybeHeartbeat();
+                    } catch (TaskLockLostException e) {
+                        lockLostObserved.set(true);
+                        throw e;
+                    }
+
+                    return null;
+                });
+        registerWorkflowWorker("workflow-worker", 1);
+        registerTaskWorker("activity-worker", 2);
+        engine.start();
+
+        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+        awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+
+        await("Displaced execution to observe the lost lock")
+                .untilAsserted(() -> assertThat(lockLostObserved).isTrue());
+        assertThat(invocations.get()).isGreaterThanOrEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Explicitly handles lost task locks for activity heartbeats.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
