### PR TITLE
dex: Improve handling of activity interrupts

### DIFF
--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/ActivityTaskWorker.java
@@ -138,8 +138,8 @@ final class ActivityTaskWorker extends AbstractTaskWorker<ActivityTask> {
                 engine.onTaskEvent(new ActivityTaskCompletedEvent(task, result));
             } catch (ExecutionException e) {
                 final Throwable cause = e.getCause();
-                if (cause instanceof InterruptedException) {
-                    logger.debug("Activity was interrupted; Abandoning task");
+                if (cause instanceof InterruptedException || executionExecutor.isShutdown()) {
+                    logger.debug("Activity was interrupted or worker is shutting down; abandoning task");
                     abandon(task);
                 } else if (cause instanceof TaskLockLostException) {
                     logger.warn("""

--- a/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
+++ b/dex/engine/src/test/java/org/dependencytrack/dex/engine/DexEngineImplTest.java
@@ -56,6 +56,7 @@ import org.dependencytrack.dex.engine.api.response.CreateWorkflowRunResponse;
 import org.dependencytrack.dex.proto.event.v1.WorkflowEvent;
 import org.dependencytrack.dex.proto.payload.v1.Payload;
 import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.jdbi.v3.core.Jdbi;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -1274,6 +1275,44 @@ class DexEngineImplTest {
         engine.close();
 
         assertThat(activityInterrupted).isTrue();
+    }
+
+    @Test
+    void shouldAbandonActivityInterruptedDuringShutdownInsteadOfFailingIt() throws Exception {
+        final var activityStarted = new AtomicBoolean(false);
+        final var activityBlockedLatch = new CountDownLatch(1);
+
+        registerWorkflow("test", (ctx, _) -> {
+            ctx.callActivity("test", ACTIVITY_TASK_QUEUE, null, voidConverter(), voidConverter(), RetryPolicy.ofDefault()).await();
+            return null;
+        });
+        registerActivity("test", (_, _) -> {
+            activityStarted.set(true);
+            try {
+                activityBlockedLatch.await(1, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                throw new IllegalStateException("Interrupted", e);
+            }
+            return null;
+        });
+        registerWorkflowWorker("workflow-worker", 1);
+        registerTaskWorker("activity-worker", 1);
+        engine.start();
+
+        final UUID runId = engine.createRun(new CreateWorkflowRunRequest<>("test", 1));
+
+        await("Activity start")
+                .atMost(Duration.ofSeconds(3))
+                .until(activityStarted::get);
+
+        engine.close();
+        
+        final Integer attempt = Jdbi.create(dataSource).withHandle(handle -> handle
+                .createQuery("SELECT attempt FROM dex_activity_task WHERE workflow_run_id = :runId")
+                .bind("runId", runId)
+                .mapTo(Integer.class)
+                .one());
+        assertThat(attempt).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves handling of dex activity interrupts.

Library code outside of our control will not surface InterruptExceptions as-is, but may suppress them. That leads to us registering it as failure, when in reality we should cleanly abandon the task instead.

This change adds another more reliable signal, namely whether the task executor is shut down at time of exception handling.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
