### PR TITLE
Allow vuln data sources to close gracefully even after interrupt

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.jdo.Query;
+import java.io.Closeable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -112,7 +113,12 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             int vulnsProcessed = 0;
             int vulnsSkipped = 0;
 
-            try (final VulnDataSource dataSource = dataSourceFactory.create()) {
+            final VulnDataSource dataSource = dataSourceFactory.create();
+
+            // NB: Give the data source the chance to persist its pending state
+            // when the activity got interrupted. That requires temporarily popping
+            // the interrupt flag from the thread before invoking close() on it.
+            try (var _ = (Closeable) () -> closeUninterruptibly(dataSource)) {
                 final var bovBatch = new ArrayList<Bom>(25);
                 while (dataSource.hasNext()) {
                     if (Thread.interrupted()) {
@@ -256,6 +262,17 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             return query.executeUnique();
         } finally {
             query.closeAll();
+        }
+    }
+
+    private static void closeUninterruptibly(VulnDataSource dataSource) {
+        final boolean interrupted = Thread.interrupted();
+        try {
+            dataSource.close();
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Allows vuln data sources to close gracefully even after interrupt.

All VulnDataSource implementations persist watermarks on close(), and they explicitly wait for close to be called to avoid excessive DB writes.

Interrupting their thread, as we do during shutdown, prevents them from persisting their state.

This change handles that case explicitly.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
