### PR TITLE
Improve efficiency of OSV vuln data source

### DIFF
--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvAdvisorySource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvAdvisorySource.java
@@ -1,0 +1,159 @@
+/*
+ * This file is part of Dependency-Track.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.dependencytrack.vulndatasource.osv;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.dependencytrack.vulndatasource.osv.schema.Osv;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static java.util.function.Predicate.not;
+
+/**
+ * @since 5.0.0
+ */
+sealed interface OsvAdvisorySource extends Iterator<Osv>, Closeable {
+
+    final class ZipOsvAdvisorySource implements OsvAdvisorySource {
+
+        private final Path zipFilePath;
+        private final ObjectMapper objectMapper;
+        private final ZipFile zipFile;
+        private final Iterator<? extends ZipEntry> entryIterator;
+
+        ZipOsvAdvisorySource(Path zipFilePath, ObjectMapper objectMapper) throws IOException {
+            this.zipFilePath = zipFilePath;
+            this.objectMapper = objectMapper;
+            this.zipFile = new ZipFile(zipFilePath.toFile());
+            this.entryIterator = zipFile.stream()
+                    .filter(not(ZipEntry::isDirectory))
+                    .filter(entry -> entry.getName().endsWith(".json"))
+                    .iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return entryIterator.hasNext();
+        }
+
+        @Override
+        public Osv next() {
+            final ZipEntry entry = entryIterator.next();
+            try (final InputStream inputStream = zipFile.getInputStream(entry)) {
+                return objectMapper.readValue(inputStream, Osv.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read OSV advisory " + entry.getName(), e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                zipFile.close();
+            } finally {
+                Files.deleteIfExists(zipFilePath);
+            }
+        }
+
+    }
+
+    final class IncrementalOsvAdvisorySource implements OsvAdvisorySource {
+
+        private static final Logger LOGGER = LoggerFactory.getLogger(IncrementalOsvAdvisorySource.class);
+
+        private final HttpClient httpClient;
+        private final ObjectMapper objectMapper;
+        private final String dataUrl;
+        private final String ecosystem;
+        private final Iterator<String> advisoryIdIterator;
+
+        IncrementalOsvAdvisorySource(
+                HttpClient httpClient,
+                ObjectMapper objectMapper,
+                String dataUrl,
+                String ecosystem,
+                Set<String> advisoryIds) {
+            this.httpClient = httpClient;
+            this.objectMapper = objectMapper;
+            this.dataUrl = dataUrl;
+            this.ecosystem = ecosystem;
+            this.advisoryIdIterator = Set.copyOf(advisoryIds).iterator();
+        }
+
+        @Override
+        public boolean hasNext() {
+            return advisoryIdIterator.hasNext();
+        }
+
+        @Override
+        public Osv next() {
+            final String advisoryId = advisoryIdIterator.next();
+            LOGGER.debug("Downloading advisory {}", advisoryId);
+
+            final var request = HttpRequest.newBuilder()
+                    .uri(URI.create("%s/%s/%s.json".formatted(dataUrl, ecosystem, advisoryId)))
+                    .GET()
+                    .build();
+
+            final HttpResponse<byte[]> response;
+            try {
+                response = httpClient.send(request, BodyHandlers.ofByteArray());
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to download OSV advisory " + advisoryId, e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while downloading OSV advisory " + advisoryId, e);
+            }
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException(
+                        "Unexpected response code %d while downloading OSV advisory %s".formatted(
+                                response.statusCode(), advisoryId));
+            }
+
+            try {
+                return objectMapper.readValue(response.body(), Osv.class);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to read OSV advisory " + advisoryId, e);
+            }
+        }
+
+        @Override
+        public void close() {
+            // Nothing to do
+        }
+
+    }
+
+}

--- a/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
+++ b/vuln-data-source/osv/src/main/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSource.java
@@ -24,12 +24,14 @@ import org.cyclonedx.proto.v1_7.Bom;
 import org.cyclonedx.proto.v1_7.Property;
 import org.cyclonedx.proto.v1_7.Vulnerability;
 import org.dependencytrack.vulndatasource.api.VulnDataSource;
+import org.dependencytrack.vulndatasource.osv.OsvAdvisorySource.IncrementalOsvAdvisorySource;
+import org.dependencytrack.vulndatasource.osv.OsvAdvisorySource.ZipOsvAdvisorySource;
 import org.dependencytrack.vulndatasource.osv.schema.Osv;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -43,18 +45,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Predicate.not;
 import static org.dependencytrack.vulndatasource.osv.CycloneDxPropertyNames.OSV_ECOSYSTEM;
 
 /**
@@ -63,7 +59,7 @@ import static org.dependencytrack.vulndatasource.osv.CycloneDxPropertyNames.OSV_
 final class OsvVulnDataSource implements VulnDataSource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OsvVulnDataSource.class);
-    private static final int MAX_INCREMENTAL_ADVISORY_DOWNLOADS = 50;
+    private static final int MAX_INCREMENTAL_ADVISORY_DOWNLOADS = 250;
 
     private final WatermarkManager watermarkManager;
     private final ObjectMapper objectMapper;
@@ -75,9 +71,7 @@ final class OsvVulnDataSource implements VulnDataSource {
     private String currentEcosystem;
     private int currentEcosystemIndex;
     private int currentEcosystemAdvisoriesProcessed;
-    private Path currentEcosystemDirPath;
-    private Stream<Path> currentEcosystemFileStream;
-    private Iterator<Path> currentEcosystemFileIterator;
+    private @Nullable OsvAdvisorySource currentAdvisorySource;
     private boolean hasNextCalled;
     private Bom nextItem;
     private final boolean isAliasSyncEnabled;
@@ -107,7 +101,7 @@ final class OsvVulnDataSource implements VulnDataSource {
 
         hasNextCalled = true;
 
-        if (currentEcosystemFileIterator != null) {
+        if (currentEcosystem != null) {
             final Bom item = readNextItem();
             if (item != null) {
                 nextItem = item;
@@ -158,7 +152,7 @@ final class OsvVulnDataSource implements VulnDataSource {
     }
 
     @Override
-    public void markProcessed(final Bom bov) {
+    public void markProcessed(Bom bov) {
         requireNonNull(bov, "bov must not be null");
 
         if (bov.getVulnerabilitiesCount() != 1) {
@@ -196,19 +190,11 @@ final class OsvVulnDataSource implements VulnDataSource {
     }
 
     private Bom readNextItem() {
-        if (currentEcosystemFileIterator == null || !currentEcosystemFileIterator.hasNext()) {
+        if (currentAdvisorySource == null || !currentAdvisorySource.hasNext()) {
             return null;
         }
 
-        final Path filePath = currentEcosystemFileIterator.next();
-
-        final Osv osv;
-        try {
-            osv = objectMapper.readValue(filePath.toFile(), Osv.class);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to read OSV advisory " + filePath.getFileName(), e);
-        }
-
+        final Osv osv = currentAdvisorySource.next();
         currentEcosystemAdvisoriesProcessed++;
         return modelConverter.convert(osv, isAliasSyncEnabled, currentEcosystem);
     }
@@ -231,154 +217,102 @@ final class OsvVulnDataSource implements VulnDataSource {
 
         currentEcosystem = ecosystems.get(currentEcosystemIndex);
         currentEcosystemAdvisoriesProcessed = 0;
-
-        currentEcosystemDirPath = downloadEcosystemFiles(currentEcosystem);
-        try {
-            currentEcosystemFileStream = Files.walk(currentEcosystemDirPath)
-                    .filter(not(Files::isDirectory))
-                    .filter(file -> file.getFileName().toString().endsWith(".json"));
-            currentEcosystemFileIterator = currentEcosystemFileStream.iterator();
-        } catch (IOException e) {
-            closeCurrentEcosystem();
-            throw new UncheckedIOException("Failed to walk " + currentEcosystemDirPath, e);
-        }
+        currentAdvisorySource = openAdvisorySource(currentEcosystem);
 
         LOGGER.info("Processing ecosystem {}", currentEcosystem);
         return true;
     }
 
-    private Path downloadEcosystemFiles(final String ecosystem) {
-        final Path tempDirPath;
-        try {
-            tempDirPath = Files.createTempDirectory(null);
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to create temp directory", e);
-        }
-
+    private @Nullable OsvAdvisorySource openAdvisorySource(String ecosystem) {
         if (watermarkManager == null) {
-            LOGGER.debug("Incremental mirroring disabled; Downloading all advisories");
-            downloadEcosystemFilesAll(ecosystem, tempDirPath);
-        } else {
-            final Instant watermark = watermarkManager.getWatermark(ecosystem);
-            if (watermark == null) {
-                LOGGER.debug("No watermark found; Downloading all advisories");
-                downloadEcosystemFilesAll(ecosystem, tempDirPath);
-            } else {
-                LOGGER.debug("Downloading advisories changed since {}", watermark);
-                downloadEcosystemFilesIncremental(ecosystem, watermark, tempDirPath);
-            }
+            LOGGER.debug("Incremental mirroring disabled; downloading all advisories");
+            return downloadFullArchive(ecosystem);
         }
 
-        return tempDirPath;
-    }
-
-    private void downloadEcosystemFilesAll(final String ecosystem, final Path destDirPath) {
-        LOGGER.info("Downloading all advisories for ecosystem {} from upstream", ecosystem);
-        final var request = HttpRequest.newBuilder()
-                .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, ecosystem)))
-                .build();
-
-        final HttpResponse<InputStream> response;
-        try {
-            response = httpClient.send(request, BodyHandlers.buffering(BodyHandlers.ofInputStream(), 1024));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to download advisory archive", e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while downloading advisory archive", e);
+        final Instant watermark = watermarkManager.getWatermark(ecosystem);
+        if (watermark == null) {
+            LOGGER.debug("No watermark found; Downloading all advisories");
+            return downloadFullArchive(ecosystem);
         }
 
-        LOGGER.info("Extracting advisories for ecosystem {}", ecosystem);
-        LOGGER.debug("Extraction destination: {}", destDirPath);
-        try (final InputStream responseBodyInputStream = response.body();
-             final var zipInputStream = new ZipInputStream(responseBodyInputStream)) {
-            ZipEntry zipEntry;
-            while ((zipEntry = zipInputStream.getNextEntry()) != null) {
-                if (zipEntry.isDirectory()) {
-                    LOGGER.debug("Skipping directory {}", zipEntry.getName());
-                    continue;
-                }
-
-                final Path filePath = destDirPath.resolve(zipEntry.getName());
-                if (!filePath.normalize().startsWith(destDirPath.normalize())) {
-                    LOGGER.warn("Entry path {} resolves to a location outside of the destination directory; Skipping", filePath);
-                    continue;
-                }
-
-                LOGGER.debug("Extracting {} to {}", zipEntry.getName(), filePath);
-                Files.copy(zipInputStream, filePath);
-            }
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to read advisory archive", e);
-        }
-    }
-
-    private void downloadEcosystemFilesIncremental(
-            final String ecosystem,
-            final Instant watermark,
-            final Path destDirPath) {
+        LOGGER.debug("Downloading advisories changed since {}", watermark);
         final Set<String> modifiedIds = getModifiedIds(ecosystem, watermark);
         if (modifiedIds.isEmpty()) {
             LOGGER.info("No new or updated advisories since {}", watermark);
-            return;
+            return null;
         }
 
         if (modifiedIds.size() > MAX_INCREMENTAL_ADVISORY_DOWNLOADS) {
             LOGGER.info("""
-                            {} new or updated advisories for ecosystem {} exceeds the incremental \
+                            Number of new or updated advisories for ecosystem {} exceeds the incremental \
                             download threshold of {}; downloading the full advisory archive instead""",
-                    modifiedIds.size(), ecosystem, MAX_INCREMENTAL_ADVISORY_DOWNLOADS);
-            downloadEcosystemFilesAll(ecosystem, destDirPath);
-            return;
+                    ecosystem, MAX_INCREMENTAL_ADVISORY_DOWNLOADS);
+            return downloadFullArchive(ecosystem);
         }
 
-        // TODO: Use structured concurrency after Java 25 upgrade (https://openjdk.org/jeps/505).
-        LOGGER.info("Downloading {} new or updated advisories for ecosystem {}", modifiedIds.size(), ecosystem);
-        for (final String modifiedId : modifiedIds) {
-            LOGGER.debug("Downloading advisory {}", modifiedId);
-            downloadAdvisoryFile(ecosystem, modifiedId, destDirPath);
-        }
+        LOGGER.info("Incrementally mirroring {} new or updated advisories for ecosystem {}",
+                modifiedIds.size(), ecosystem);
+        return new IncrementalOsvAdvisorySource(httpClient, objectMapper, dataUrl, ecosystem, modifiedIds);
     }
 
-    private void downloadAdvisoryFile(final String ecosystem, final String advisoryId, final Path destDirPath) {
+    private ZipOsvAdvisorySource downloadFullArchive(String ecosystem) {
+        LOGGER.info("Downloading all advisories for ecosystem {} from upstream", ecosystem);
+
+        final Path tempZipPath;
+        try {
+            tempZipPath = Files.createTempFile(null, ".zip");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create temp file", e);
+        }
+
         final var request = HttpRequest.newBuilder()
-                .uri(URI.create("%s/%s/%s.json".formatted(dataUrl, ecosystem, advisoryId)))
+                .uri(URI.create("%s/%s/all.zip".formatted(dataUrl, ecosystem)))
                 .GET()
                 .build();
 
-        final HttpResponse<?> response;
         try {
-            response = httpClient.send(request, BodyHandlers.ofFile(destDirPath.resolve("%s.json".formatted(advisoryId))));
-        } catch (IOException e) {
-            throw new UncheckedIOException("Failed to download advisory", e);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException("Interrupted while downloading advisory", e);
-        }
-        if (response.statusCode() != 200) {
-            throw new IllegalStateException("Unexpected response code: " + response.statusCode());
+            final HttpResponse<Path> response;
+            try {
+                response = httpClient.send(request, BodyHandlers.ofFile(tempZipPath));
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to download advisory archive", e);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException("Interrupted while downloading advisory archive", e);
+            }
+            if (response.statusCode() != 200) {
+                throw new IllegalStateException("Unexpected response code: " + response.statusCode());
+            }
+
+            try {
+                return new ZipOsvAdvisorySource(tempZipPath, objectMapper);
+            } catch (IOException e) {
+                throw new UncheckedIOException("Failed to open advisory archive " + tempZipPath, e);
+            }
+        } catch (RuntimeException e) {
+            try {
+                Files.deleteIfExists(tempZipPath);
+            } catch (IOException suppressed) {
+                e.addSuppressed(suppressed);
+            }
+            throw e;
         }
     }
 
     private void closeCurrentEcosystem() {
-        if (currentEcosystemFileStream != null) {
-            currentEcosystemFileStream.close();
-            currentEcosystemFileIterator = null;
-        }
-
-        if (currentEcosystemDirPath != null) {
+        if (currentAdvisorySource != null) {
             try {
-                deleteRecursively(currentEcosystemDirPath);
+                currentAdvisorySource.close();
             } catch (IOException e) {
-                LOGGER.warn("Failed to delete directory {}", currentEcosystemDirPath, e);
+                LOGGER.warn("Failed to close advisory source for ecosystem {}", currentEcosystem, e);
             }
-            currentEcosystemDirPath = null;
+            currentAdvisorySource = null;
         }
 
         currentEcosystem = null;
     }
 
-    private Set<String> getModifiedIds(final String ecosystem, final Instant watermark) {
+    private Set<String> getModifiedIds(String ecosystem, Instant watermark) {
         final var request = HttpRequest.newBuilder()
                 .uri(URI.create("%s/%s/modified_id.csv".formatted(dataUrl, ecosystem)))
                 .GET()
@@ -428,7 +362,7 @@ final class OsvVulnDataSource implements VulnDataSource {
         return modifiedIds;
     }
 
-    private static String extractEcosystem(final Vulnerability vuln) {
+    private static String extractEcosystem(Vulnerability vuln) {
         for (final Property property : vuln.getPropertiesList()) {
             if (OSV_ECOSYSTEM.equals(property.getName())) {
                 return property.getValue();
@@ -436,15 +370,6 @@ final class OsvVulnDataSource implements VulnDataSource {
         }
 
         return null;
-    }
-
-    private static void deleteRecursively(final Path path) throws IOException {
-        try (final Stream<Path> filePaths = Files.walk(path)) {
-            filePaths
-                    .sorted(Comparator.reverseOrder())
-                    .map(Path::toFile)
-                    .forEach(File::delete);
-        }
     }
 
     WatermarkManager getWatermarkManager() {

--- a/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
+++ b/vuln-data-source/osv/src/test/java/org/dependencytrack/vulndatasource/osv/OsvVulnDataSourceTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.net.http.HttpClient;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.zip.ZipEntry;
@@ -155,7 +156,7 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
-    void testDownloadAndExtractEcosystemFiles(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+    void shouldIterateAdvisoriesFromFullArchive(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         final String ecosystem = "maven";
 
         // Create in-memory ZIP with one advisory JSON
@@ -228,6 +229,48 @@ class OsvVulnDataSourceTest {
 
         dataSource.close();
         verify(watermarkManagerMock).maybeCommit(any());
+    }
+
+    @Test
+    void shouldSkipDirectoryAndNonJsonEntriesInFullArchive(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        ByteArrayOutputStream zipBytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(zipBytes)) {
+            zos.putNextEntry(new ZipEntry("nested/"));
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("README.txt"));
+            zos.write("not an advisory".getBytes());
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("nested/OSV-1.json"));
+            zos.write(/* language=JSON */ """
+                    {"id":"OSV-1","summary":"first","affected":[],"modified":"2024-01-01T00:00:00Z"}
+                    """.getBytes());
+            zos.closeEntry();
+            zos.putNextEntry(new ZipEntry("OSV-2.json"));
+            zos.write(/* language=JSON */ """
+                    {"id":"OSV-2","summary":"second","affected":[],"modified":"2024-01-02T00:00:00Z"}
+                    """.getBytes());
+            zos.closeEntry();
+        }
+        stubFor(get(urlEqualTo("/maven/all.zip"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/zip")
+                        .withBody(zipBytes.toByteArray())));
+
+        final var ids = new ArrayList<String>();
+        try (var dataSource = new OsvVulnDataSource(
+                null,
+                objectMapper,
+                wmRuntimeInfo.getHttpBaseUrl(),
+                List.of("maven"),
+                HttpClient.newHttpClient(),
+                false)) {
+            while (dataSource.hasNext()) {
+                ids.add(dataSource.next().getVulnerabilitiesList().getFirst().getId());
+            }
+        }
+
+        assertThat(ids).containsExactlyInAnyOrder("OSV-1", "OSV-2");
     }
 
     @Test
@@ -357,11 +400,54 @@ class OsvVulnDataSourceTest {
     }
 
     @Test
+    void shouldDownloadIncrementalAdvisoriesLazily(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        when(watermarkManagerMock.getWatermark("maven")).thenReturn(Instant.parse("2024-01-01T00:00:00Z"));
+        String csvBody = """
+                2025-01-02T00:00:00Z,OSV-2
+                2025-01-01T00:00:00Z,OSV-1
+                """;
+        stubFor(get(urlEqualTo("/maven/modified_id.csv"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "text/csv")
+                        .withBody(csvBody)));
+        for (final String id : List.of("OSV-1", "OSV-2")) {
+            stubFor(get(urlEqualTo("/maven/" + id + ".json"))
+                    .willReturn(aResponse()
+                            .withStatus(200)
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(/* language=JSON */ """
+                                    {"id":"%s","summary":"s","affected":[],"modified":"2025-01-01T00:00:00Z"}
+                                    """.formatted(id))));
+        }
+
+        try (var dataSource = new OsvVulnDataSource(
+                watermarkManagerMock,
+                objectMapper,
+                wmRuntimeInfo.getHttpBaseUrl(),
+                List.of("maven"),
+                HttpClient.newHttpClient(),
+                false)) {
+            assertThat(dataSource.hasNext()).isTrue();
+            WireMock.verify(1, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+
+            dataSource.next();
+            WireMock.verify(1, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+
+            assertThat(dataSource.hasNext()).isTrue();
+            WireMock.verify(2, getRequestedFor(urlPathMatching("/maven/OSV-.*\\.json")));
+
+            dataSource.next();
+            assertThat(dataSource.hasNext()).isFalse();
+        }
+    }
+
+    @Test
     void shouldFallBackToFullDownloadWhenIncrementalThresholdExceeded(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         when(watermarkManagerMock.getWatermark("maven")).thenReturn(Instant.parse("2024-01-01T00:00:00Z"));
 
         final var csvBody = new StringBuilder();
-        for (int i = 0; i < 51; i++) {
+        for (int i = 0; i < 251; i++) {
             csvBody.append("2025-01-01T00:00:00Z,OSV-%d\n".formatted(i));
         }
         stubFor(get(urlEqualTo("/maven/modified_id.csv"))


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Improves efficiency of OSV vuln data source:

* Iterates over entries in ZIP archives directly, instead of extracting all files to disk first. Makes a big difference for large archives like Ubuntu's.
* For incremental mirroring, lazily fetches advisories when hasNext() is called, not all at once sequentially. Enables hasNext() to block for a shorter duration, which also allows us to raise the threshold after which we just download the full archive instead.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
