### PR TITLE
Raise max response body size for PyPI

### DIFF
--- a/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverFactory.java
+++ b/package-metadata/resolution/src/main/java/org/dependencytrack/pkgmetadata/resolution/pypi/PypiPackageMetadataResolverFactory.java
@@ -38,7 +38,7 @@ import static com.github.packageurl.PackageURLBuilder.aPackageURL;
 public final class PypiPackageMetadataResolverFactory implements PackageMetadataResolverFactory {
 
     private static final Duration FRESH_FOR = Duration.ofHours(12);
-    private static final long MAX_BYTES = 4L * 1024 * 1024;
+    private static final long MAX_BYTES = 8L * 1024 * 1024;
 
     private @Nullable ObjectMapper objectMapper;
     private @Nullable CachingHttpClient cachingHttpClient;


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Raises max response body size for PyPI.

Some packages such as `coverage` and `sqlalchemy` have so many versions that their PyPI `/json` responses exceed the current limit of 4MiB.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
