### PR TITLE
Align vuln policy bundle sync API with vuln data source mirror API

### DIFF
--- a/api/src/main/openapi/openapi.yaml
+++ b/api/src/main/openapi/openapi.yaml
@@ -231,8 +231,10 @@ paths:
     $ref: "./resources/vuln-policies/vuln-policy-bundles.yaml"
   /vuln-policy-bundles/{uuid}:
     $ref: "./resources/vuln-policies/vuln-policy-bundle.yaml"
-  /vuln-policy-bundles/{uuid}/sync:
-    $ref: "./resources/vuln-policies/vuln-policy-bundle-sync.yaml"
+  /vuln-policy-bundles/{uuid}/sync-runs:
+    $ref: "./resources/vuln-policies/vuln-policy-bundle-sync-runs.yaml"
+  /vuln-policy-bundles/{uuid}/sync-runs/latest:
+    $ref: "./resources/vuln-policies/vuln-policy-bundle-sync-run-latest.yaml"
   /vuln-data-sources/{name}/mirror-runs:
     $ref: "./resources/vuln-data-sources/vuln-data-source-mirror-runs.yaml"
   /vuln-data-sources/{name}/mirror-runs/latest:

--- a/api/src/main/openapi/resources/vuln-policies/vuln-policy-bundle-sync-run-latest.yaml
+++ b/api/src/main/openapi/resources/vuln-policies/vuln-policy-bundle-sync-run-latest.yaml
@@ -1,0 +1,53 @@
+# This file is part of Dependency-Track.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+get:
+  operationId: getLatestVulnPolicyBundleSyncRun
+  summary: Get the latest vulnerability policy bundle sync run
+  description: |-
+    Returns the status of the most recent synchronization run for a given
+    vulnerability policy bundle.
+
+    Returns 404 if no sync run is available
+    (e.g. none has been triggered yet, or the most recent run
+    is no longer retained), or if the bundle is unknown.
+
+    Requires permission `POLICY_MANAGEMENT` or `POLICY_MANAGEMENT_READ`.
+  tags:
+    - Vuln Policies
+  parameters:
+    - name: uuid
+      in: path
+      description: UUID of the vulnerability policy bundle
+      required: true
+      schema:
+        type: string
+        format: uuid
+  responses:
+    "200":
+      description: Sync run status
+      content:
+        application/json:
+          schema:
+            $ref: "./schemas/vuln-policy-bundle-sync-status.yaml"
+    "401":
+      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
+    "403":
+      $ref: "../../shared/responses/generic-forbidden-error.yaml"
+    "404":
+      $ref: "../../shared/responses/generic-not-found-error.yaml"
+    default:
+      $ref: "../../shared/responses/generic-error.yaml"

--- a/api/src/main/openapi/resources/vuln-policies/vuln-policy-bundle-sync-runs.yaml
+++ b/api/src/main/openapi/resources/vuln-policies/vuln-policy-bundle-sync-runs.yaml
@@ -14,47 +14,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
-get:
-  operationId: getVulnPolicyBundleSyncStatus
-  summary: Get bundle synchronization status
-  description: |-
-    Returns the status of the most recent synchronization for a given
-    vulnerability policy bundle.
-
-    Returns 404 if no synchronization has been triggered yet.
-
-    Requires permission `POLICY_MANAGEMENT` or `POLICY_MANAGEMENT_READ`.
-  tags:
-    - Vuln Policies
-  parameters:
-    - name: uuid
-      in: path
-      description: UUID of the vulnerability policy bundle
-      required: true
-      schema:
-        type: string
-        format: uuid
-  responses:
-    "200":
-      description: Synchronization status
-      content:
-        application/json:
-          schema:
-            $ref: "./schemas/vuln-policy-bundle-sync-status.yaml"
-    "401":
-      $ref: "../../shared/responses/generic-unauthorized-error.yaml"
-    "403":
-      $ref: "../../shared/responses/generic-forbidden-error.yaml"
-    "404":
-      $ref: "../../shared/responses/generic-not-found-error.yaml"
-    default:
-      $ref: "../../shared/responses/generic-error.yaml"
-
 post:
-  operationId: triggerVulnPolicyBundleSync
-  summary: Trigger bundle synchronization
+  operationId: triggerVulnPolicyBundleSyncRun
+  summary: Trigger a vulnerability policy bundle sync run
   description: |-
-    Triggers synchronization of the vulnerability policy bundle.
+    Triggers a synchronization run for the given vulnerability policy bundle.
 
     Requires permission `POLICY_MANAGEMENT` or `POLICY_MANAGEMENT_UPDATE`.
   tags:
@@ -69,15 +33,15 @@ post:
         format: uuid
   responses:
     "202":
-      description: Synchronization triggered
+      description: Sync run triggered
       headers:
         Location:
-          description: URL of the synchronization status endpoint
+          description: URL of the latest sync run resource.
           schema:
             type: string
             format: uri
     "400":
-      description: Bad Request
+      description: Sync run cannot be started
       content:
         application/problem+json:
           schema:
@@ -89,7 +53,7 @@ post:
     "404":
       $ref: "../../shared/responses/generic-not-found-error.yaml"
     "409":
-      description: Synchronization already in progress
+      description: A sync run is already in progress
       content:
         application/problem+json:
           schema:

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnPoliciesResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/VulnPoliciesResource.java
@@ -305,7 +305,7 @@ public final class VulnPoliciesResource extends AbstractApiResource implements V
             Permissions.Constants.POLICY_MANAGEMENT,
             Permissions.Constants.POLICY_MANAGEMENT_READ
     })
-    public Response getVulnPolicyBundleSyncStatus(UUID uuid) {
+    public Response getLatestVulnPolicyBundleSyncRun(UUID uuid) {
         if (!VulnerabilityPolicyDao.DEFAULT_BUNDLE_UUID.equals(uuid)) {
             final VulnPolicyBundleRow bundle = withJdbiHandle(
                     handle -> handle.attach(VulnerabilityPolicyDao.class).getBundleByUuid(uuid));
@@ -368,7 +368,7 @@ public final class VulnPoliciesResource extends AbstractApiResource implements V
             Permissions.Constants.POLICY_MANAGEMENT,
             Permissions.Constants.POLICY_MANAGEMENT_UPDATE
     })
-    public Response triggerVulnPolicyBundleSync(UUID uuid) {
+    public Response triggerVulnPolicyBundleSyncRun(UUID uuid) {
         if (!VulnerabilityPolicyDao.DEFAULT_BUNDLE_UUID.equals(uuid)) {
             final VulnPolicyBundleRow bundle = withJdbiHandle(
                     handle -> handle.attach(VulnerabilityPolicyDao.class).getBundleByUuid(uuid));
@@ -396,7 +396,7 @@ public final class VulnPoliciesResource extends AbstractApiResource implements V
                 .accepted()
                 .header("Location", getUriInfo()
                         .getBaseUriBuilder()
-                        .path("/vuln-policy-bundles/{uuid}/sync")
+                        .path("/vuln-policy-bundles/{uuid}/sync-runs/latest")
                         .resolveTemplate("uuid", uuid)
                         .build())
                 .build();

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnPoliciesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnPoliciesResourceTest.java
@@ -497,7 +497,7 @@ class VulnPoliciesResourceTest extends ResourceTest {
                 .thenReturn(runId);
 
         Response response = jersey
-                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync")
+                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync-runs")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -505,14 +505,14 @@ class VulnPoliciesResourceTest extends ResourceTest {
         assertThat(getPlainTextBody(response)).isEmpty();
 
         response = jersey
-                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync")
+                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync-runs")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
         assertThat(response.getStatus()).isEqualTo(409);
 
         response = jersey
-                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync")
+                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync-runs")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -528,14 +528,14 @@ class VulnPoliciesResourceTest extends ResourceTest {
                 .thenReturn(null);
 
         final Response firstResponse = jersey
-                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync")
+                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync-runs")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
         assertThat(firstResponse.getStatus()).isEqualTo(202);
 
         final Response secondResponse = jersey
-                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync")
+                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync-runs")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .post(null);
@@ -657,7 +657,7 @@ class VulnPoliciesResourceTest extends ResourceTest {
         when(DEX_ENGINE_MOCK.getRunById(runId)).thenReturn(run);
 
         final Response response = jersey
-                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync")
+                .target("/vuln-policy-bundles/bc106cf4-3993-4e38-952d-d2f5f11412ed/sync-runs/latest")
                 .request()
                 .header(X_API_KEY, apiKey)
                 .get();


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Aligns vuln policy bundle sync API with vuln data source mirror API.

Use a more "REST-like" structure that treats runs as resources instead of the RPC-like current structure. This leaves room for us to trivially provide a list of historic executions later if needed.

But most importantly, makes the API as a whole more consistent.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Frontend PR: https://github.com/DependencyTrack/hyades-apiserver/pull/2206

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
