### PR TITLE
dex: Expose parent ID of workflow runs via API

### DIFF
--- a/api/src/main/openapi/resources/internal/workflows/schemas/workflow-run-metadata.yaml
+++ b/api/src/main/openapi/resources/internal/workflows/schemas/workflow-run-metadata.yaml
@@ -19,6 +19,9 @@ properties:
   id:
     type: string
     format: uuid
+  parent_id:
+    type: string
+    format: uuid
   workflow_name:
     type: string
   workflow_version:

--- a/apiserver/src/main/java/org/dependencytrack/resources/v2/WorkflowsResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v2/WorkflowsResource.java
@@ -264,6 +264,7 @@ public class WorkflowsResource extends AbstractApiResource implements WorkflowsA
     private static org.dependencytrack.api.v2.model.WorkflowRunMetadata convert(WorkflowRunMetadata runMetadata) {
         return org.dependencytrack.api.v2.model.WorkflowRunMetadata.builder()
                 .id(runMetadata.id())
+                .parentId(runMetadata.parentId())
                 .workflowName(runMetadata.workflowName())
                 .workflowVersion(runMetadata.workflowVersion())
                 .workflowInstanceId(runMetadata.workflowInstanceId())

--- a/apiserver/src/test/java/org/dependencytrack/dex/listener/DelayedBomProcessedNotificationEmitterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/dex/listener/DelayedBomProcessedNotificationEmitterTest.java
@@ -222,6 +222,7 @@ class DelayedBomProcessedNotificationEmitterTest extends PersistenceCapableTest 
             Map<String, String> labels) {
         return new WorkflowRunMetadata(
                 UUID.randomUUID(),
+                null,
                 workflowName,
                 1,
                 null,

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/BomResourceTest.java
@@ -2259,7 +2259,7 @@ class BomResourceTest extends ResourceTest {
 
         final var runId = UUID.fromString("6214c0c2-660c-4615-8b3a-174a64e4abe4");
         final var runMetadata = new WorkflowRunMetadata(
-                runId, "import-bom", 1, null, "default",
+                runId, null, "import-bom", 1, null, "default",
                 WorkflowRunStatus.RUNNING, null, 0, null, null,
                 java.time.Instant.now(), java.time.Instant.now(), null, null);
         doReturn(false).when(DEX_ENGINE_MOCK).existsRun(any(ExistsWorkflowRunRequest.class));

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/EventResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/EventResourceTest.java
@@ -72,6 +72,7 @@ class EventResourceTest extends ResourceTest {
         final var runId = UUID.fromString("6214c0c2-660c-4615-8b3a-174a64e4abe4");
         final var runMetadata = new WorkflowRunMetadata(
                 runId,
+                null,
                 "analyze-project",
                 1,
                 null,

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnDataSourcesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnDataSourcesResourceTest.java
@@ -236,7 +236,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
 
         when(DEX_ENGINE_MOCK.listRuns(any(ListWorkflowRunsRequest.class)))
                 .thenReturn(new Page<>(List.of(new WorkflowRunMetadata(
-                        runId, "MirrorVulnDataSourceWorkflow", 1,
+                        runId, null, "MirrorVulnDataSourceWorkflow", 1,
                         "mirror-vuln-data-source:osv",
                         "default", WorkflowRunStatus.RUNNING, null, 0, null, null,
                         startedAt, startedAt, startedAt, null)), null, null));
@@ -266,7 +266,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
         final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
 
         final var runMetadata = new WorkflowRunMetadata(
-                runId, "MirrorVulnDataSourceWorkflow", 1,
+                runId, null, "MirrorVulnDataSourceWorkflow", 1,
                 "mirror-vuln-data-source:osv",
                 "default", WorkflowRunStatus.FAILED, null, 0, null, null,
                 startedAt, completedAt, startedAt, completedAt);
@@ -282,7 +282,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
                 .build();
 
         final var run = new WorkflowRun(
-                runId, "MirrorVulnDataSourceWorkflow", 1,
+                runId, null, "MirrorVulnDataSourceWorkflow", 1,
                 "mirror-vuln-data-source:osv",
                 WorkflowRunStatus.FAILED, null, 0, null, null,
                 startedAt, completedAt, startedAt, completedAt,
@@ -319,7 +319,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
         final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
 
         final var runMetadata = new WorkflowRunMetadata(
-                runId, "MirrorVulnDataSourceWorkflow", 1,
+                runId, null, "MirrorVulnDataSourceWorkflow", 1,
                 "mirror-vuln-data-source:osv",
                 "default", WorkflowRunStatus.FAILED, null, 0, null, null,
                 startedAt, completedAt, startedAt, completedAt);
@@ -332,7 +332,7 @@ class VulnDataSourcesResourceTest extends ResourceTest {
                 .build();
 
         final var run = new WorkflowRun(
-                runId, "MirrorVulnDataSourceWorkflow", 1,
+                runId, null, "MirrorVulnDataSourceWorkflow", 1,
                 "mirror-vuln-data-source:osv",
                 WorkflowRunStatus.FAILED, null, 0, null, null,
                 startedAt, completedAt, startedAt, completedAt,

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnPoliciesResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/VulnPoliciesResourceTest.java
@@ -629,7 +629,7 @@ class VulnPoliciesResourceTest extends ResourceTest {
         final var completedAt = Instant.parse("2026-04-15T10:01:00Z");
 
         final var runMetadata = new WorkflowRunMetadata(
-                runId, "SyncVulnPolicyBundleWorkflow", 1,
+                runId, null, "SyncVulnPolicyBundleWorkflow", 1,
                 "sync-vuln-policy-bundle:bc106cf4-3993-4e38-952d-d2f5f11412ed",
                 "default", WorkflowRunStatus.FAILED, null, 0, null, null,
                 startedAt, completedAt, startedAt, completedAt);
@@ -648,7 +648,7 @@ class VulnPoliciesResourceTest extends ResourceTest {
                 .build();
 
         final var run = new WorkflowRun(
-                runId, "SyncVulnPolicyBundleWorkflow", 1,
+                runId, null, "SyncVulnPolicyBundleWorkflow", 1,
                 "sync-vuln-policy-bundle:bc106cf4-3993-4e38-952d-d2f5f11412ed",
                 WorkflowRunStatus.FAILED, null, 0, null, null,
                 startedAt, completedAt, startedAt, completedAt,

--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/WorkflowsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/WorkflowsResourceTest.java
@@ -81,6 +81,7 @@ class WorkflowsResourceTest extends ResourceTest {
 
         final var workflowRunMetadata = new WorkflowRunMetadata(
                 UUID.fromString("724c0700-4eeb-45f0-8ff4-8bba369c0174"),
+                null,
                 "workflowName",
                 66,
                 "workflowInstanceId",
@@ -154,6 +155,7 @@ class WorkflowsResourceTest extends ResourceTest {
         final var runId = UUID.fromString("724c0700-4eeb-45f0-8ff4-8bba369c0174");
         final var workflowRunMetadata = new WorkflowRunMetadata(
                 runId,
+                null,
                 "workflowName",
                 66,
                 "workflowInstanceId",
@@ -228,6 +230,7 @@ class WorkflowsResourceTest extends ResourceTest {
 
         final var workflowRunMetadata = new WorkflowRunMetadata(
                 UUID.fromString("724c0700-4eeb-45f0-8ff4-8bba369c0174"),
+                null,
                 "workflowName",
                 66,
                 "workflowInstanceId",

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/WorkflowRun.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/WorkflowRun.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 public record WorkflowRun(
         UUID id,
+        @Nullable UUID parentId,
         String workflowName,
         int workflowVersion,
         String workflowInstanceId,

--- a/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/WorkflowRunMetadata.java
+++ b/dex/engine-api/src/main/java/org/dependencytrack/dex/engine/api/WorkflowRunMetadata.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 
 public record WorkflowRunMetadata(
         UUID id,
+        @Nullable UUID parentId,
         String workflowName,
         int workflowVersion,
         @Nullable String workflowInstanceId,

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/DexEngineImpl.java
@@ -740,6 +740,7 @@ final class DexEngineImpl implements DexEngine {
 
         return new WorkflowRun(
                 runState.id(),
+                runState.parentId(),
                 runState.workflowName(),
                 runState.workflowVersion(),
                 runState.workflowInstanceId(),
@@ -1144,6 +1145,7 @@ final class DexEngineImpl implements DexEngine {
             if (!runsCompletedEventListeners.isEmpty() && run.status().isTerminal()) {
                 completedRuns.add(new WorkflowRunMetadata(
                         run.id(),
+                        run.parentId(),
                         run.workflowName(),
                         run.workflowVersion(),
                         run.workflowInstanceId(),

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowRunState.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/WorkflowRunState.java
@@ -69,6 +69,7 @@ import static org.dependencytrack.dex.engine.support.ProtobufUtil.toProtoTimesta
 final class WorkflowRunState {
 
     private final UUID id;
+    private @Nullable UUID parentId;
     private @Nullable String workflowName;
     private @Nullable Integer workflowVersion;
     private @Nullable String workflowInstanceId;
@@ -116,6 +117,11 @@ final class WorkflowRunState {
 
     UUID id() {
         return id;
+    }
+
+    @Nullable
+    UUID parentId() {
+        return parentId;
     }
 
     @Nullable
@@ -261,6 +267,9 @@ final class WorkflowRunState {
                             "%s/%s: Duplicate RunCreated event; Previous event is: %s; New event is: %s".formatted(
                                     this.workflowName, this.id, previousEventStr, nextEventStr));
                 }
+                parentId = event.getRunCreated().hasParentRun()
+                        ? UUID.fromString(event.getRunCreated().getParentRun().getId())
+                        : null;
                 workflowName = event.getRunCreated().getWorkflowName();
                 workflowVersion = event.getRunCreated().getWorkflowVersion();
                 workflowInstanceId = event.getRunCreated().hasWorkflowInstanceId()

--- a/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/jdbi/WorkflowRunMetadataRowMapper.java
+++ b/dex/engine/src/main/java/org/dependencytrack/dex/engine/persistence/jdbi/WorkflowRunMetadataRowMapper.java
@@ -58,6 +58,7 @@ final class WorkflowRunMetadataRowMapper implements RowMapper<WorkflowRunMetadat
 
         return new WorkflowRunMetadata(
                 rs.getObject("id", UUID.class),
+                rs.getObject("parent_id", UUID.class),
                 rs.getString("workflow_name"),
                 rs.getInt("workflow_version"),
                 rs.getString("workflow_instance_id"),


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Exposes parent ID of workflow runs via API.

To be used by the UI to link from child to parent run.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
