### PR TITLE
Add support for UNKNOWN vuln source

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/model/Vulnerability.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/Vulnerability.java
@@ -35,6 +35,7 @@ import org.dependencytrack.resources.v1.serializers.CweDeserializer;
 import org.dependencytrack.resources.v1.serializers.CweSerializer;
 import org.dependencytrack.resources.v1.serializers.Iso8601DateSerializer;
 import org.dependencytrack.resources.v1.vo.AffectedComponent;
+import org.jspecify.annotations.Nullable;
 
 import javax.jdo.annotations.Column;
 import javax.jdo.annotations.Convert;
@@ -58,6 +59,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
@@ -124,18 +126,56 @@ public class Vulnerability implements Serializable {
      */
     public enum Source {
         NVD,      // National Vulnerability Database
-        NPM,      // NPM Public Advisories - NEED TO KEEP FOR LEGACY PURPOSES
         GITHUB,   // GitHub Security Advisories
         VULNDB,   // VulnDB from Risk Based Security
         OSSINDEX, // Sonatype OSS Index
-        RETIREJS, // Retire.js
-        INTERNAL,  // Internally-managed (and manually entered) vulnerability
-        OSV, // Google OSV Advisories
-        SNYK;    // Snyk Purl Vulnerability
+        INTERNAL, // Internally-managed (and manually entered) vulnerability
+        OSV,      // Google OSV Advisories
+        SNYK,     // Snyk Purl Vulnerability
+        UNKNOWN;  // Unknown vulnerability sources
 
         public static boolean isKnownSource(String source) {
-            return Arrays.stream(values()).anyMatch(enumSource -> enumSource.name().equalsIgnoreCase(source));
+            return ofName(source) != null;
         }
+
+        public static @Nullable Source ofName(String name) {
+            if (name == null) {
+                return null;
+            }
+
+            return Arrays.stream(values())
+                    .filter(source -> source.name().equalsIgnoreCase(name))
+                    .findAny()
+                    .orElse(null);
+        }
+
+        private static final java.util.regex.Pattern CVE_ID_PATTERN =
+                java.util.regex.Pattern.compile(
+                        "^CVE-\\d{4}-\\d{4,}$", java.util.regex.Pattern.CASE_INSENSITIVE);
+
+        public static @Nullable Source ofVulnId(String id) {
+            if (id == null) {
+                return null;
+            }
+
+            if (CVE_ID_PATTERN.matcher(id).matches()) {
+                return NVD;
+            }
+
+            final String lowerId = id.toLowerCase(Locale.ROOT);
+            if (lowerId.startsWith("ghsa-")) {
+                return GITHUB;
+            } else if (lowerId.startsWith("internal-")) {
+                return INTERNAL;
+            } else if (lowerId.startsWith("osv-")) {
+                return OSV;
+            } else if (lowerId.startsWith("snyk-")) {
+                return SNYK;
+            }
+
+            return null;
+        }
+
     }
 
     @PrimaryKey

--- a/apiserver/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
+++ b/apiserver/src/main/java/org/dependencytrack/model/VulnerabilityAlias.java
@@ -130,18 +130,6 @@ public class VulnerabilityAlias implements Serializable {
         this.vulnDbId = vulnDbId;
     }
 
-    public void setBySource(Vulnerability.Source source, String id) {
-        switch (source) {
-            case GITHUB -> setGhsaId(id);
-            case INTERNAL -> setInternalId(id);
-            case NVD -> setCveId(id);
-            case OSSINDEX -> setSonatypeId(id);
-            case OSV -> setOsvId(id);
-            case SNYK -> setSnykId(id);
-            case VULNDB -> setVulnDbId(id);
-        }
-    }
-
     private String getBySource(final Vulnerability.Source source) {
         return switch (source) {
             case GITHUB -> getGhsaId();

--- a/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/cyclonedx/util/ModelConverter.java
@@ -1135,24 +1135,12 @@ public class ModelConverter {
         org.cyclonedx.model.vulnerability.Vulnerability.Source cdxSource = new org.cyclonedx.model.vulnerability.Vulnerability.Source();
         cdxSource.setName(vulnSource.name());
         switch (vulnSource) {
-            case NVD:
-                cdxSource.setUrl("https://nvd.nist.gov/");
-                break;
-            case NPM:
-                cdxSource.setUrl("https://www.npmjs.com/");
-                break;
-            case GITHUB:
-                cdxSource.setUrl("https://github.com/advisories");
-                break;
-            case VULNDB:
-                cdxSource.setUrl("https://vulndb.cyberriskanalytics.com/");
-                break;
-            case OSSINDEX:
-                cdxSource.setUrl("https://ossindex.sonatype.org/");
-                break;
-            case RETIREJS:
-                cdxSource.setUrl("https://github.com/RetireJS/retire.js");
-                break;
+            case GITHUB -> cdxSource.setUrl("https://github.com/advisories");
+            case NVD -> cdxSource.setUrl("https://nvd.nist.gov/");
+            case OSSINDEX -> cdxSource.setUrl("https://ossindex.sonatype.org/");
+            case OSV -> cdxSource.setUrl("https://osv.dev/");
+            case SNYK -> cdxSource.setUrl("https://security.snyk.io/");
+            case VULNDB -> cdxSource.setUrl("https://vulndb.cyberriskanalytics.com/");
         }
         return cdxSource;
     }

--- a/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/dependencytrack/BovModelConverter.java
@@ -42,6 +42,7 @@ import org.dependencytrack.model.VulnerableSoftware;
 import org.dependencytrack.parser.common.resolver.CweResolver;
 import org.dependencytrack.util.PurlUtil;
 import org.dependencytrack.util.VulnerabilityUtil;
+import org.jspecify.annotations.Nullable;
 import org.metaeffekt.core.security.cvss.CvssVector;
 import org.metaeffekt.core.security.cvss.processor.BakedCvssVectorScores;
 import org.slf4j.Logger;
@@ -254,7 +255,9 @@ public final class BovModelConverter {
 
         if (isAliasSyncEnabled && !cdxVuln.getReferencesList().isEmpty()) {
             vuln.setAliases(cdxVuln.getReferencesList().stream()
-                    .map(alias -> convert(cdxVuln, alias)).toList());
+                    .map(alias -> convert(cdxVuln, alias))
+                    .filter(Objects::nonNull)
+                    .toList());
         }
 
         // EPSS is an additional enrichment that no scanner currently provides.
@@ -301,44 +304,62 @@ public final class BovModelConverter {
                 .toList();
     }
 
-    private static VulnerabilityAlias convert(final org.cyclonedx.proto.v1_7.Vulnerability cycloneVuln,
-                                              final VulnerabilityReference cycloneAlias) {
+    private static @Nullable VulnerabilityAlias convert(
+            org.cyclonedx.proto.v1_7.Vulnerability cycloneVuln,
+            VulnerabilityReference cycloneAlias) {
+        final var vulnSource = Vulnerability.Source.ofName(cycloneVuln.getSource().getName());
+        if (vulnSource == null || vulnSource == Vulnerability.Source.UNKNOWN) {
+            return null;
+        }
+
+        final var aliasSource = Vulnerability.Source.ofName(cycloneAlias.getSource().getName());
+        if (aliasSource == null || aliasSource == Vulnerability.Source.UNKNOWN) {
+            return null;
+        }
+
         final var alias = new VulnerabilityAlias();
-        switch (cycloneVuln.getSource().getName()) {
-            case "GITHUB" -> alias.setGhsaId(cycloneVuln.getId());
-            case "INTERNAL" -> alias.setInternalId(cycloneVuln.getId());
-            case "NVD" -> alias.setCveId(cycloneVuln.getId());
-            case "OSSINDEX" -> alias.setSonatypeId(cycloneVuln.getId());
-            case "OSV" -> alias.setOsvId(cycloneVuln.getId());
-            case "SNYK" -> alias.setSnykId(cycloneVuln.getId());
-            case "VULNDB" -> alias.setVulnDbId(cycloneVuln.getId());
+        switch (vulnSource) {
+            case GITHUB -> alias.setGhsaId(cycloneVuln.getId());
+            case INTERNAL -> alias.setInternalId(cycloneVuln.getId());
+            case NVD -> alias.setCveId(cycloneVuln.getId());
+            case OSSINDEX -> alias.setSonatypeId(cycloneVuln.getId());
+            case OSV -> alias.setOsvId(cycloneVuln.getId());
+            case SNYK -> alias.setSnykId(cycloneVuln.getId());
+            case VULNDB -> alias.setVulnDbId(cycloneVuln.getId());
             // Source of the vulnerability itself has been validated before,
             // so this scenario is highly unlikely to ever happen. Including
             // it here to make linters happy.
-            default ->
-                    throw new IllegalArgumentException("Invalid vulnerability source %s".formatted(cycloneVuln.getSource().getName()));
+            default -> throw new IllegalArgumentException(
+                    "Invalid vulnerability source %s".formatted(vulnSource));
         }
-        switch (cycloneAlias.getSource().getName()) {
-            case "GITHUB" -> alias.setGhsaId(cycloneAlias.getId());
-            case "INTERNAL" -> alias.setInternalId(cycloneAlias.getId());
-            case "NVD" -> alias.setCveId(cycloneAlias.getId());
-            case "OSSINDEX" -> alias.setSonatypeId(cycloneAlias.getId());
-            case "OSV" -> alias.setOsvId(cycloneAlias.getId());
-            case "SNYK" -> alias.setSnykId(cycloneAlias.getId());
-            case "VULNDB" -> alias.setVulnDbId(cycloneAlias.getId());
-            default -> throw new IllegalArgumentException("Invalid source %s for alias %s"
-                    .formatted(cycloneAlias.getSource().getName(), cycloneAlias.getId()));
+
+        switch (aliasSource) {
+            case GITHUB -> alias.setGhsaId(cycloneAlias.getId());
+            case INTERNAL -> alias.setInternalId(cycloneAlias.getId());
+            case NVD -> alias.setCveId(cycloneAlias.getId());
+            case OSSINDEX -> alias.setSonatypeId(cycloneAlias.getId());
+            case OSV -> alias.setOsvId(cycloneAlias.getId());
+            case SNYK -> alias.setSnykId(cycloneAlias.getId());
+            case VULNDB -> alias.setVulnDbId(cycloneAlias.getId());
+            default -> throw new IllegalArgumentException(
+                    "Invalid source %s for alias %s".formatted(aliasSource, cycloneAlias.getId()));
         }
+
         return alias;
     }
 
-    public static Vulnerability.Source extractSource(String vulnId, Source source) {
-        final String sourceId = vulnId.split("-")[0];
-        return switch (sourceId) {
-            case "GHSA" -> Vulnerability.Source.GITHUB;
-            case "CVE" -> Vulnerability.Source.NVD;
-            default -> source != null ? Vulnerability.Source.valueOf(source.getName()) : Vulnerability.Source.INTERNAL;
-        };
+    static Vulnerability.Source extractSource(String vulnId, Source source) {
+        var resolvedSource = Vulnerability.Source.ofName(source.getName());
+        if (resolvedSource != null) {
+            return resolvedSource;
+        }
+
+        resolvedSource = Vulnerability.Source.ofVulnId(vulnId);
+        if (resolvedSource != null) {
+            return resolvedSource;
+        }
+
+        return Vulnerability.Source.UNKNOWN;
     }
 
     /**

--- a/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulnanalysis/ReconcileVulnAnalysisResultsActivity.java
@@ -73,6 +73,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Gatherers;
 import java.util.stream.Stream;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.dependencytrack.common.MdcKeys.MDC_PROJECT_UUID;
 import static org.dependencytrack.common.MdcKeys.MDC_VULN_ANALYZER_NAME;
 import static org.dependencytrack.notification.api.NotificationFactory.createAnalyzerErrorNotification;
@@ -219,14 +220,18 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
             Map<VulnerabilityKey, ReportedVulnerability> reportedVulnByVulnKey,
             Map<String, Map<VulnerabilityKey, Set<VulnerabilityKey>>> aliasAssertionsByAnalyzer) {
         for (final org.cyclonedx.proto.v1_7.Vulnerability vdrVuln : vdr.getVulnerabilitiesList()) {
-            final Vulnerability.Source source =
-                    BovModelConverter.extractSource(vdrVuln.getId(), vdrVuln.getSource());
+            var source = Vulnerability.Source.ofName(vdrVuln.getSource().getName());
+            if (source == null) {
+                source = requireNonNullElse(
+                        Vulnerability.Source.ofVulnId(vdrVuln.getId()),
+                        Vulnerability.Source.UNKNOWN);
+            }
             final var vulnKey = new VulnerabilityKey(vdrVuln.getId(), source);
 
             final Long internalVulnId = extractInternalVulnId(vdrVuln);
             final String referenceUrl = extractReferenceUrl(vdrVuln);
 
-            if (internalVulnId == null) {
+            if (internalVulnId == null && source != Vulnerability.Source.UNKNOWN) {
                 // Ensure that each vulnerability reported by an analyzer has alias assertions,
                 // even if the assertions set is empty. This is the only way we can detect whether
                 // a previously reported alias has been removed.
@@ -234,19 +239,22 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
                 // Note that this does not apply to the internal analyzer, since it can't report
                 // aliases we don't already have in the database.
                 final Map<VulnerabilityKey, Set<VulnerabilityKey>> analyzerAssertions =
-                        aliasAssertionsByAnalyzer.computeIfAbsent(analyzerName, k -> new HashMap<>());
-                analyzerAssertions.computeIfAbsent(vulnKey, k -> new HashSet<>());
+                        aliasAssertionsByAnalyzer.computeIfAbsent(analyzerName, _ -> new HashMap<>());
+                analyzerAssertions.computeIfAbsent(vulnKey, _ -> new HashSet<>());
 
                 for (final VulnerabilityReference vdrVulnRef : vdrVuln.getReferencesList()) {
-                    try {
-                        final Vulnerability.Source refSource =
-                                BovModelConverter.extractSource(vdrVulnRef.getId(), vdrVulnRef.getSource());
-                        final var aliasKey = new VulnerabilityKey(vdrVulnRef.getId(), refSource);
-                        if (!aliasKey.equals(vulnKey)) {
-                            analyzerAssertions.get(vulnKey).add(aliasKey);
-                        }
-                    } catch (IllegalArgumentException e) {
+                    var refSource = Vulnerability.Source.ofName(vdrVulnRef.getSource().getName());
+                    if (refSource == null) {
+                        refSource = Vulnerability.Source.ofVulnId(vdrVulnRef.getId());
+                    }
+                    if (refSource == null || refSource == Vulnerability.Source.UNKNOWN) {
                         LOGGER.debug("Skipping alias reference with unknown source for vulnerability '{}'", vulnKey);
+                        continue;
+                    }
+
+                    final var aliasKey = new VulnerabilityKey(vdrVulnRef.getId(), refSource);
+                    if (!aliasKey.equals(vulnKey)) {
+                        analyzerAssertions.get(vulnKey).add(aliasKey);
                     }
                 }
             }
@@ -858,10 +866,14 @@ public final class ReconcileVulnAnalysisResultsActivity implements Activity<Reco
 
     private static org.dependencytrack.notification.proto.v1.AnalysisTrigger convertAnalysisTrigger(AnalysisTrigger trigger) {
         return switch (trigger) {
-            case ANALYSIS_TRIGGER_BOM_UPLOAD -> org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD;
-            case ANALYSIS_TRIGGER_SCHEDULE -> org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_SCHEDULE;
-            case ANALYSIS_TRIGGER_MANUAL -> org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_MANUAL;
-            case ANALYSIS_TRIGGER_UNSPECIFIED -> org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_UNSPECIFIED;
+            case ANALYSIS_TRIGGER_BOM_UPLOAD ->
+                    org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_BOM_UPLOAD;
+            case ANALYSIS_TRIGGER_SCHEDULE ->
+                    org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_SCHEDULE;
+            case ANALYSIS_TRIGGER_MANUAL ->
+                    org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_MANUAL;
+            case ANALYSIS_TRIGGER_UNSPECIFIED ->
+                    org.dependencytrack.notification.proto.v1.AnalysisTrigger.ANALYSIS_TRIGGER_UNSPECIFIED;
             case UNRECOGNIZED -> org.dependencytrack.notification.proto.v1.AnalysisTrigger.UNRECOGNIZED;
         };
     }

--- a/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
+++ b/apiserver/src/main/java/org/dependencytrack/vulndatasource/MirrorVulnDataSourceActivity.java
@@ -82,10 +82,8 @@ public final class MirrorVulnDataSourceActivity implements Activity<MirrorVulnDa
             throw new TerminalApplicationFailureException("No argument or data source name provided");
         }
 
-        final Vulnerability.Source source;
-        try {
-            source = Vulnerability.Source.valueOf(arg.getSourceName());
-        } catch (IllegalArgumentException e) {
+        final var source = Vulnerability.Source.ofName(arg.getSourceName());
+        if (source == null) {
             throw new TerminalApplicationFailureException(
                     "Invalid source name: %s".formatted(arg.getSourceName()));
         }

--- a/apiserver/src/test/java/org/dependencytrack/model/VulnerabilityTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/model/VulnerabilityTest.java
@@ -18,14 +18,24 @@
  */
 package org.dependencytrack.model;
 
+import org.dependencytrack.model.Vulnerability.Source;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class VulnerabilityTest { 
 
@@ -143,8 +153,8 @@ public class VulnerabilityTest {
         Vulnerability vuln = new Vulnerability();
         vuln.setSource("My source");
         Assertions.assertEquals("My source", vuln.getSource());
-        vuln.setSource(Vulnerability.Source.NPM);
-        Assertions.assertEquals("NPM", vuln.getSource());
+        vuln.setSource(Vulnerability.Source.INTERNAL);
+        Assertions.assertEquals("INTERNAL", vuln.getSource());
     } 
 
     @Test
@@ -243,4 +253,99 @@ public class VulnerabilityTest {
         vuln.setUuid(uuid);
         Assertions.assertEquals(uuid.toString(), vuln.getUuid().toString());
     }
-} 
+
+    @Nested
+    class SourceTest {
+
+        @ParameterizedTest
+        @CsvSource({
+                "NVD,      NVD",
+                "nvd,      NVD",
+                "Nvd,      NVD",
+                "GITHUB,   GITHUB",
+                "VULNDB,   VULNDB",
+                "OSSINDEX, OSSINDEX",
+                "INTERNAL, INTERNAL",
+                "OSV,      OSV",
+                "SNYK,     SNYK",
+                "UNKNOWN,  UNKNOWN"
+        })
+        void ofNameShouldReturnEnumForKnownNamesCaseInsensitive(String input, Source expected) {
+            assertThat(Source.ofName(input)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {" ", "NPM", "RETIREJS", "FOO", "nvd ", "NVD-EXTRA"})
+        void ofNameShouldReturnNullForUnknownOrBlankInput(String input) {
+            assertThat(Source.ofName(input)).isNull();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "CVE-1999-0001,   NVD",
+                "CVE-2024-12345,  NVD",
+                "cve-2024-12345,  NVD",
+                "Cve-2024-12345,  NVD",
+                "GHSA-xxxx-yyyy-zzzz, GITHUB",
+                "ghsa-anything,   GITHUB",
+                "INTERNAL-foo,    INTERNAL",
+                "internal-bar,    INTERNAL",
+                "OSV-2024-1,      OSV",
+                "osv-2024-1,      OSV",
+                "SNYK-JS-FOO-123, SNYK",
+                "snyk-anything,   SNYK"
+        })
+        void ofVulnIdShouldReturnEnumForRecognizedPrefixes(String input, Source expected) {
+            assertThat(Source.ofVulnId(input)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "CVE-2024",
+                "CVE-2024-",
+                "CVE-2024-123",
+                "CVE-abcd-1234",
+                "CVE-2024-1234-5",
+                "XCVE-2024-1234",
+                "CVE2024-1234",
+                "cveidsomething",
+        })
+        void ofVulnIdShouldNotMatchMalformedCveIds(String input) {
+            assertThat(Source.ofVulnId(input)).isNotEqualTo(Source.NVD);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {
+                "PYSEC-2024-1",
+                "RUSTSEC-2024-0001",
+                "GO-2024-0001",
+                "RHSA-2024:1234",
+                "USN-1234-1",
+                "DSA-1234-1",
+                "MAL-2024-1",
+                "unknown",
+                "1234"
+        })
+        void ofVulnIdShouldReturnNullForUnrecognizedOrBlankIds(String input) {
+            assertThat(Source.ofVulnId(input)).isNull();
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"NVD", "GITHUB", "OSV", "SNYK", "INTERNAL", "UNKNOWN", "nvd"})
+        void isKnownSourceShouldReturnTrueForEnumNames(String input) {
+            assertThat(Source.isKnownSource(input)).isTrue();
+        }
+
+        @ParameterizedTest
+        @NullSource
+        @EmptySource
+        @ValueSource(strings = {"NPM", "RETIREJS", "FOO"})
+        void isKnownSourceShouldReturnFalseForUnknownInput(String input) {
+            assertThat(Source.isKnownSource(input)).isFalse();
+        }
+
+    }
+
+}

--- a/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/parser/dependencytrack/BovModelConverterTest.java
@@ -30,6 +30,9 @@ import org.dependencytrack.model.Vulnerability;
 import org.dependencytrack.model.VulnerableSoftware;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.math.BigDecimal;
 import java.util.List;
@@ -583,6 +586,73 @@ class BovModelConverterTest {
                     .addComponents(component)
                     .addVulnerabilities(vuln)
                     .build();
+        }
+
+    }
+
+    @Nested
+    class ExtractSourceTest {
+
+        @ParameterizedTest
+        @CsvSource({
+                "NVD,      NVD",
+                "nvd,      NVD",
+                "GITHUB,   GITHUB",
+                "OSV,      OSV",
+                "SNYK,     SNYK",
+                "OSSINDEX, OSSINDEX",
+                "VULNDB,   VULNDB",
+                "INTERNAL, INTERNAL",
+                "UNKNOWN,  UNKNOWN"
+        })
+        void shouldPreferKnownSourceNameOverVulnId(String sourceName, Vulnerability.Source expected) {
+            final var source = Source.newBuilder().setName(sourceName).build();
+            assertThat(BovModelConverter.extractSource("CVE-2024-1234", source)).isEqualTo(expected);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "CVE-2024-12345,   NVD",
+                "cve-2024-12345,   NVD",
+                "GHSA-xxxx-yyyy-zzzz, GITHUB",
+                "INTERNAL-foo,     INTERNAL",
+                "OSV-2024-1,       OSV",
+                "SNYK-JS-FOO-123,  SNYK"
+        })
+        void shouldInferSourceFromVulnIdWhenSourceNameIsUnrecognized(String vulnId, Vulnerability.Source expected) {
+            final var source = Source.newBuilder().setName("NOT_A_REAL_SOURCE").build();
+            assertThat(BovModelConverter.extractSource(vulnId, source)).isEqualTo(expected);
+        }
+
+        @Test
+        void shouldInferSourceFromVulnIdWhenSourceNameIsAbsent() {
+            final var source = Source.newBuilder().build();
+            assertThat(BovModelConverter.extractSource("CVE-2024-1234", source))
+                    .isEqualTo(Vulnerability.Source.NVD);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "PYSEC-2024-1",
+                "RUSTSEC-2024-0001",
+                "GO-2024-0001",
+                "MAL-2024-1",
+                "RHSA-2024:1234",
+                "no-recognizable-prefix",
+                "CVE-2024-123",
+                ""
+        })
+        void shouldFallBackToUnknownWhenNeitherSourceNameNorVulnIdMatch(String vulnId) {
+            final var source = Source.newBuilder().setName("NOT_A_REAL_SOURCE").build();
+            assertThat(BovModelConverter.extractSource(vulnId, source))
+                    .isEqualTo(Vulnerability.Source.UNKNOWN);
+        }
+
+        @Test
+        void shouldFallBackToUnknownWhenBothSourceNameAndVulnIdAreAbsent() {
+            final var source = Source.newBuilder().build();
+            assertThat(BovModelConverter.extractSource("", source))
+                    .isEqualTo(Vulnerability.Source.UNKNOWN);
         }
 
     }

--- a/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/vulnanalysis/VulnAnalysisWorkflowTest.java
@@ -92,6 +92,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.dependencytrack.dex.api.payload.PayloadConverters.protoConverter;
 import static org.dependencytrack.dex.api.payload.PayloadConverters.voidConverter;
 import static org.dependencytrack.notification.NotificationTestUtil.createCatchAllNotificationRule;
@@ -1265,6 +1266,61 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
         assertThat(getAllAliasGroups()).isEmpty();
     }
 
+    @Test
+    void shouldHandleUnknownVulnSourceAndSkipAliasAssertions() {
+        var project = new Project();
+        project.setName("acme-app");
+        project = qm.persist(project);
+
+        final var component = new Component();
+        component.setProject(project);
+        component.setGroup("com.fasterxml.jackson.core");
+        component.setName("jackson-databind");
+        component.setVersion("2.9.8");
+        component.setPurl("pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.8");
+        qm.persist(component);
+
+        mockAnalyzerFunction.set(bom -> Bom.newBuilder()
+                .addVulnerabilities(
+                        org.cyclonedx.proto.v1_7.Vulnerability.newBuilder()
+                                .setId("FOO-1")
+                                .setSource(Source.newBuilder().setName("FOO"))
+                                .addAffects(VulnerabilityAffects.newBuilder().setRef(bom.getComponents(0).getBomRef()))
+                                .addReferences(VulnerabilityReference.newBuilder()
+                                        .setId("GHSA-aaaa-aaaa-aaaa")
+                                        .setSource(Source.newBuilder().setName("GITHUB"))))
+                .addVulnerabilities(
+                        org.cyclonedx.proto.v1_7.Vulnerability.newBuilder()
+                                .setId("CVE-2024-9999")
+                                .setSource(Source.newBuilder().setName("NVD"))
+                                .addAffects(VulnerabilityAffects.newBuilder().setRef(bom.getComponents(0).getBomRef()))
+                                .addReferences(VulnerabilityReference.newBuilder()
+                                        .setId("FOO-9")
+                                        .setSource(Source.newBuilder().setName("FOO")))
+                                .addReferences(VulnerabilityReference.newBuilder()
+                                        .setId("GHSA-bbbb-bbbb-bbbb")
+                                        .setSource(Source.newBuilder().setName("GITHUB"))))
+                .build());
+
+        final UUID runId = workflowTest.getEngine().createRun(
+                new CreateWorkflowRunRequest<>(VulnAnalysisWorkflow.class)
+                        .withArgument(VulnAnalysisWorkflowArg.newBuilder()
+                                .setProjectUuid(project.getUuid().toString())
+                                .build()));
+        workflowTest.awaitRunStatus(runId, WorkflowRunStatus.COMPLETED);
+
+        assertThat(qm.getVulnerabilities(project, true))
+                .extracting(Vulnerability::getVulnId, Vulnerability::getSource)
+                .containsExactlyInAnyOrder(
+                        tuple("FOO-1", Vulnerability.Source.UNKNOWN.name()),
+                        tuple("CVE-2024-9999", Vulnerability.Source.NVD.name()));
+
+        assertThat(getAllAliasGroups()).satisfiesExactly(group ->
+                assertThat(group).containsExactlyInAnyOrder(
+                        new VulnerabilityKey("CVE-2024-9999", "NVD"),
+                        new VulnerabilityKey("GHSA-bbbb-bbbb-bbbb", "GITHUB")));
+    }
+
     private record AliasRow(UUID groupId, String source, String vulnId) {
     }
 
@@ -1276,7 +1332,7 @@ class VulnAnalysisWorkflowTest extends PersistenceCapableTest {
                              , "VULN_ID"
                           FROM "VULNERABILITY_ALIAS"
                         """)
-                .map((rs, ctx) -> new AliasRow(
+                .map((rs, _) -> new AliasRow(
                         rs.getObject("group_id", UUID.class),
                         rs.getString("source"),
                         rs.getString("vuln_id")))


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Adds support for `UNKNOWN` vuln source.

It was initially introduced via https://github.com/DependencyTrack/dependency-track/pull/3259

While at it, also removes the `NPM` and `RETIREJS` vuln sources, which have been dragged along since v3. They were not used by any v4 instance.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

Supersedes https://github.com/DependencyTrack/hyades-apiserver/pull/1948

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- [x] This PR implements an enhancement, and I have provided tests to verify that it works as intended
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
