### PR TITLE
Remove "default extension" concept

### DIFF
--- a/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v2/ExtensionsResourceTest.java
@@ -581,7 +581,7 @@ class ExtensionsResourceTest extends ResourceTest {
                 """);
     }
 
-    @ExtensionPointSpec(name = "dummy", required = false)
+    @ExtensionPointSpec(name = "dummy")
     private interface DummyExtensionPoint extends ExtensionPoint {
     }
 

--- a/notification/api/src/main/java/org/dependencytrack/notification/api/publishing/NotificationPublisher.java
+++ b/notification/api/src/main/java/org/dependencytrack/notification/api/publishing/NotificationPublisher.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * @since 5.0.0
  */
-@ExtensionPointSpec(name = "notification-publisher", required = false)
+@ExtensionPointSpec(name = "notification-publisher")
 public interface NotificationPublisher extends ExtensionPoint {
 
     /**

--- a/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/PackageMetadataResolver.java
+++ b/package-metadata/api/src/main/java/org/dependencytrack/pkgmetadata/resolution/api/PackageMetadataResolver.java
@@ -28,7 +28,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @since 5.0.0
  */
-@ExtensionPointSpec(name = "package-metadata-resolver", required = false)
+@ExtensionPointSpec(name = "package-metadata-resolver")
 public interface PackageMetadataResolver extends ExtensionPoint {
 
     /**

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionFactory.java
@@ -29,7 +29,7 @@ public interface ExtensionFactory<T extends ExtensionPoint> extends Closeable {
     int PRIORITY_LOWEST = Integer.MAX_VALUE;
 
     /**
-     * @return Name of the extension. Can contain lowercase letters, numbers, and periods.
+     * @return Name of the extension. Can contain lowercase letters, numbers, and hyphens.
      */
     String extensionName();
 

--- a/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionPointSpec.java
+++ b/plugin/api/src/main/java/org/dependencytrack/plugin/api/ExtensionPointSpec.java
@@ -36,14 +36,8 @@ public @interface ExtensionPointSpec {
 
     /**
      * @return The name of the extension point.
-     * Can contain lowercase letters, numbers, and periods.
+     * Can contain lowercase letters, numbers, and hyphens.
      */
     String name();
-
-    /**
-     * @return Whether the extension point is required.
-     * Required extension points must have at least one active extension.
-     */
-    boolean required();
 
 }

--- a/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/ExtensionPointMetadata.java
+++ b/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/ExtensionPointMetadata.java
@@ -25,6 +25,5 @@ import org.dependencytrack.plugin.api.ExtensionPoint;
  */
 public record ExtensionPointMetadata(
         String name,
-        Class<? extends ExtensionPoint> clazz,
-        boolean required) {
+        Class<? extends ExtensionPoint> clazz) {
 }

--- a/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/PluginManager.java
+++ b/plugin/runtime/src/main/java/org/dependencytrack/plugin/runtime/PluginManager.java
@@ -91,7 +91,6 @@ public class PluginManager implements Closeable {
     private final Map<Class<? extends ExtensionPoint>, Set<String>> extensionNamesByExtensionPointClass;
     private final Map<ExtensionIdentity, ExtensionFactory<?>> factoryByExtensionIdentity;
     private final Map<ExtensionIdentity, ConfigRegistry> configRegistryByExtensionIdentity;
-    private final Map<Class<? extends ExtensionPoint>, ExtensionFactory<?>> defaultFactoryByExtensionPointClass;
     private final Comparator<ExtensionFactory<?>> factoryComparator;
     private final AtomicBoolean closed = new AtomicBoolean();
     private final ReentrantLock lock;
@@ -116,7 +115,6 @@ public class PluginManager implements Closeable {
         this.extensionNamesByExtensionPointClass = new HashMap<>();
         this.factoryByExtensionIdentity = new HashMap<>();
         this.configRegistryByExtensionIdentity = new HashMap<>();
-        this.defaultFactoryByExtensionPointClass = new HashMap<>();
         this.factoryComparator = Comparator
                 .<ExtensionFactory<?>>comparingInt(ExtensionFactory::priority)
                 .thenComparing(ExtensionFactory::extensionName);
@@ -144,8 +142,7 @@ public class PluginManager implements Closeable {
                     extensionPointClass,
                     new ExtensionPointMetadata(
                             specAnnotation.name(),
-                            extensionPointClass,
-                            specAnnotation.required()));
+                            extensionPointClass));
         }
     }
 
@@ -155,18 +152,6 @@ public class PluginManager implements Closeable {
 
     public SequencedCollection<Plugin> getLoadedPlugins() {
         return List.copyOf(loadedPluginByClass.sequencedValues());
-    }
-
-    @SuppressWarnings("unchecked")
-    public <T extends ExtensionPoint> T getExtension(Class<T> extensionPointClass) {
-        final ExtensionPointMetadata extensionPointMetadata = requireKnownExtensionPoint(extensionPointClass);
-
-        final ExtensionFactory<?> factory = defaultFactoryByExtensionPointClass.get(extensionPointClass);
-        if (factory == null) {
-            throw new NoSuchExtensionException(extensionPointMetadata.name());
-        }
-
-        return (T) requireNonNull(factory.create(), "extension must not be null");
     }
 
     @SuppressWarnings("unchecked")
@@ -180,18 +165,6 @@ public class PluginManager implements Closeable {
         }
 
         return (T) requireNonNull(factory.create(), "extension must not be null");
-    }
-
-    @SuppressWarnings("unchecked")
-    public <T extends ExtensionPoint, U extends ExtensionFactory<T>> U getFactory(Class<T> extensionPointClass) {
-        final ExtensionPointMetadata extensionPointMetadata = requireKnownExtensionPoint(extensionPointClass);
-
-        final ExtensionFactory<?> factory = defaultFactoryByExtensionPointClass.get(extensionPointClass);
-        if (factory == null) {
-            throw new NoSuchExtensionException(extensionPointMetadata.name());
-        }
-
-        return (U) factory;
     }
 
     @SuppressWarnings("unchecked")
@@ -294,10 +267,6 @@ public class PluginManager implements Closeable {
                 loadedPluginByClass.put(plugin.getClass(), plugin);
             }
         }
-
-        determineDefaultExtensions();
-
-        assertRequiredExtensionPoints();
     }
 
     private void loadExtensionsForPlugin(Plugin plugin) {
@@ -447,52 +416,6 @@ public class PluginManager implements Closeable {
         pluginByExtensionIdentity.put(extensionIdentity, plugin);
     }
 
-    private void determineDefaultExtensions() {
-        for (final Class<? extends ExtensionPoint> extensionPointClass : extensionNamesByExtensionPointClass.keySet()) {
-            final ExtensionPointMetadata extensionPointMetadata = metadataByExtensionPointClass.get(extensionPointClass);
-            if (extensionPointMetadata == null) {
-                throw new IllegalStateException("""
-                        No specification exists for extension point %s; \
-                        This is likely a logic error in the plugin loading procedure\
-                        """.formatted(extensionPointClass.getName()));
-            }
-
-            try (var _ = MDC.putCloseable(MDC_EXTENSION_POINT, extensionPointClass.getName());
-                 var _ = MDC.putCloseable(MDC_EXTENSION_POINT_NAME, extensionPointMetadata.name())) {
-                LOGGER.debug("Determining default extension");
-
-                final SequencedCollection<? extends ExtensionFactory<?>> factories = getFactories(extensionPointClass);
-                if (factories == null || factories.isEmpty()) {
-                    LOGGER.warn("No extension available; Skipping");
-                    continue;
-                }
-
-                final String defaultExtensionName = config
-                        .getOptionalValue("dt.%s.default-extension".formatted(extensionPointMetadata.name()), String.class)
-                        .orElse(null);
-
-                final ExtensionFactory<?> extensionFactory;
-                if (defaultExtensionName == null) {
-                    LOGGER.debug("No default extension configured; Choosing based on priority");
-                    extensionFactory = factories.getFirst();
-                    LOGGER.debug("Chose extension %s (%s) with priority %d as default".formatted(
-                            extensionFactory.extensionName(),
-                            extensionFactory.extensionClass().getName(),
-                            extensionFactory.priority()));
-                } else {
-                    extensionFactory = factories.stream()
-                            .filter(factory -> factory.extensionName().equals(defaultExtensionName))
-                            .findFirst()
-                            .orElseThrow(() -> new NoSuchExtensionException(extensionPointMetadata.name(), defaultExtensionName));
-                    LOGGER.debug("Using extension %s (%s) as default".formatted(
-                            extensionFactory.extensionName(), extensionFactory.extensionClass().getName()));
-                }
-
-                defaultFactoryByExtensionPointClass.put(extensionPointClass, extensionFactory);
-            }
-        }
-    }
-
     private ExtensionPointMetadata requireKnownExtensionPoint(Class<? extends ExtensionPoint> extensionPointClass) {
         final ExtensionPointMetadata metadata = metadataByExtensionPointClass.get(extensionPointClass);
         if (metadata == null) {
@@ -514,22 +437,6 @@ public class PluginManager implements Closeable {
                         concreteExtensionClass.getName()));
     }
 
-    private void assertRequiredExtensionPoints() {
-        for (final ExtensionPointMetadata metadata : metadataByExtensionPointClass.values()) {
-            if (!metadata.required()) {
-                continue;
-            }
-
-            try {
-                getFactory(metadata.clazz());
-            } catch (NoSuchExtensionException e) {
-                throw new IllegalStateException(
-                        "Extension point %s (%s) is required, but no extension is enabled".formatted(
-                                metadata.name(), metadata.clazz().getName()));
-            }
-        }
-    }
-
     @Override
     public void close() {
         if (!closed.compareAndSet(false, true)) {
@@ -539,7 +446,6 @@ public class PluginManager implements Closeable {
         lock.lock();
         try {
             unloadPluginsLocked();
-            defaultFactoryByExtensionPointClass.clear();
             configRegistryByExtensionIdentity.clear();
             factoryByExtensionIdentity.clear();
             extensionNamesByExtensionPointClass.clear();

--- a/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/PluginManagerTest.java
+++ b/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/PluginManagerTest.java
@@ -18,7 +18,6 @@
  */
 package org.dependencytrack.plugin.runtime;
 
-import io.smallrye.config.SmallRyeConfigBuilder;
 import org.dependencytrack.cache.api.NoopCacheManager;
 import org.dependencytrack.plugin.api.ExtensionFactory;
 import org.dependencytrack.plugin.api.ExtensionPoint;
@@ -71,32 +70,6 @@ class PluginManagerTest extends AbstractDatabaseTest {
     }
 
     @Test
-    void testGetExtensionWithConfig() {
-        final var config = new SmallRyeConfigBuilder()
-                .withDefaultValue("dt.test.dummy.bar", "qux")
-                .build();
-
-        try (final var pluginManager = new PluginManager(
-                config, new NoopCacheManager(), secretName -> null,
-                jdbi, HttpClient.newHttpClient(),
-                List.of(TestExtensionPoint.class))) {
-            pluginManager.loadPlugins(List.of(new DummyPlugin()));
-
-            final TestExtensionPoint extension =
-                    pluginManager.getExtension(TestExtensionPoint.class);
-            assertThat(extension).isNotNull();
-            assertThat(extension.test()).isEqualTo("qux");
-        }
-    }
-
-    @Test
-    void testGetExtensionWithImplementationClass() {
-        assertThatExceptionOfType(NoSuchExtensionPointException.class)
-                .isThrownBy(() -> pluginManager.getExtension(DummyTestExtension.class))
-                .withMessage("org.dependencytrack.plugin.runtime.DummyTestExtension is not a known extension point");
-    }
-
-    @Test
     void testGetExtensionByName() {
         final TestExtensionPoint extension =
                 pluginManager.getExtension(TestExtensionPoint.class, "dummy");
@@ -108,20 +81,6 @@ class PluginManagerTest extends AbstractDatabaseTest {
         assertThatExceptionOfType(NoSuchExtensionException.class)
                 .isThrownBy(() -> pluginManager.getExtension(TestExtensionPoint.class, "doesNotExist"))
                 .withMessage("No extension named 'doesNotExist' exists for the extension point 'test'");
-    }
-
-    @Test
-    void testGetFactory() {
-        final ExtensionFactory<TestExtensionPoint> factory =
-                pluginManager.getFactory(TestExtensionPoint.class);
-        assertThat(factory).isExactlyInstanceOf(DummyTestExtensionFactory.class);
-    }
-
-    @Test
-    void testGetFactoryForUnknownExtensionPoint() {
-        assertThatExceptionOfType(NoSuchExtensionPointException.class)
-                .isThrownBy(() -> pluginManager.getFactory(UnknownExtensionPoint.class))
-                .withMessage("org.dependencytrack.plugin.runtime.PluginManagerTest$UnknownExtensionPoint is not a known extension point");
     }
 
     @Test
@@ -162,22 +121,6 @@ class PluginManagerTest extends AbstractDatabaseTest {
         assertThatExceptionOfType(IllegalStateException.class)
                 .isThrownBy(() -> pluginManager.loadPlugins(List.of(new DummyPlugin())))
                 .withMessage("Plugins were already loaded; Unload them first");
-    }
-
-    @Test
-    void testDefaultExtensionNotLoaded() {
-        final var config = new SmallRyeConfigBuilder()
-                .withDefaultValue("dt.test.default-extension", "does.not.exist")
-                .build();
-
-        try (final var pluginManager = new PluginManager(
-                config, new NoopCacheManager(), secretName -> null,
-                jdbi, HttpClient.newHttpClient(),
-                List.of(TestExtensionPoint.class))) {
-            assertThatExceptionOfType(NoSuchExtensionException.class)
-                    .isThrownBy(() -> pluginManager.loadPlugins(List.of(new DummyPlugin())))
-                    .withMessage("No extension named 'does.not.exist' exists for the extension point 'test'");
-        }
     }
 
 }

--- a/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/TestExtensionPoint.java
+++ b/plugin/runtime/src/test/java/org/dependencytrack/plugin/runtime/TestExtensionPoint.java
@@ -21,7 +21,7 @@ package org.dependencytrack.plugin.runtime;
 import org.dependencytrack.plugin.api.ExtensionPoint;
 import org.dependencytrack.plugin.api.ExtensionPointSpec;
 
-@ExtensionPointSpec(name = "test", required = false)
+@ExtensionPointSpec(name = "test")
 public interface TestExtensionPoint extends ExtensionPoint {
 
     String test();

--- a/vuln-analysis/api/src/main/java/org/dependencytrack/vulnanalysis/api/VulnAnalyzer.java
+++ b/vuln-analysis/api/src/main/java/org/dependencytrack/vulnanalysis/api/VulnAnalyzer.java
@@ -31,7 +31,7 @@ import org.dependencytrack.plugin.api.ExtensionPointSpec;
  *
  * @since 5.0.0
  */
-@ExtensionPointSpec(name = "vuln-analyzer", required = false)
+@ExtensionPointSpec(name = "vuln-analyzer")
 public interface VulnAnalyzer extends ExtensionPoint {
 
     /**

--- a/vuln-data-source/api/src/main/java/org/dependencytrack/vulndatasource/api/VulnDataSource.java
+++ b/vuln-data-source/api/src/main/java/org/dependencytrack/vulndatasource/api/VulnDataSource.java
@@ -86,7 +86,7 @@ import java.util.Iterator;
  * @see <a href="https://cyclonedx.org/capabilities/bov/">CycloneDX BOV</a>
  * @since 5.0.0
  */
-@ExtensionPointSpec(name = "vuln-data-source", required = false)
+@ExtensionPointSpec(name = "vuln-data-source")
 public interface VulnDataSource extends ExtensionPoint, Iterator<Bom> {
 
     /**


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Removes the "default extension" concept.

We no longer have a case where only a single extension of a given extension point is requested, so the concept of default extensions is no longer useful.

Similarly, required extensions are no longer a thing. All extension points we have can handle 0..N extensions.

This simplifies the plugin API by dropping baggage we don't need.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

N/A

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- ~This PR fixes a defect, and I have provided tests to verify that the fix is effective~
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
