### PR TITLE
Fix /api/v1/cwe not supporting filtering and sorting

### DIFF
--- a/apiserver/src/main/java/org/dependencytrack/parser/common/resolver/CweResolver.java
+++ b/apiserver/src/main/java/org/dependencytrack/parser/common/resolver/CweResolver.java
@@ -18,14 +18,18 @@
  */
 package org.dependencytrack.parser.common.resolver;
 
+import alpine.persistence.OrderDirection;
 import alpine.persistence.PaginatedResult;
 import alpine.persistence.Pagination;
 import org.apache.commons.lang3.StringUtils;
 import org.dependencytrack.model.Cwe;
+import org.jspecify.annotations.Nullable;
 
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Attempts to resolve an internal CWE object from a string
@@ -49,6 +53,7 @@ public class CweResolver {
      * Lookups a CWE from the internal CWE dictionary. This method
      * does not query the database, but will return a Cwe object useful
      * for JSON serialization, but not for persistence.
+     *
      * @param cweString the string to lookup
      * @return a Cwe object
      * @since 4.5.0
@@ -61,6 +66,7 @@ public class CweResolver {
      * Lookups a CWE from the internal CWE dictionary. This method
      * does not query the database, but will return a Cwe object useful
      * for JSON serialization, but not for persistence.
+     *
      * @param cweId the cwe id to lookup
      * @return a Cwe object
      * @since 4.5.0
@@ -80,6 +86,7 @@ public class CweResolver {
 
     /**
      * Parses a CWE string returning the CWE ID, or null.
+     *
      * @param cweString the string to parse
      * @return a Cwe object
      */
@@ -120,30 +127,50 @@ public class CweResolver {
                 .toList();
     }
 
-    public PaginatedResult all(final Pagination pagination) {
+    public PaginatedResult all(
+            @Nullable String searchText,
+            @Nullable String orderBy,
+            @Nullable OrderDirection orderDirection,
+            @Nullable Pagination pagination) {
+        final String needle = (searchText != null && !searchText.isBlank())
+                ? searchText.trim().toLowerCase(Locale.ROOT)
+                : null;
+
+        Stream<Map.Entry<Integer, String>> dictEntryStream =
+                CweDictionary.DICTIONARY.entrySet().stream()
+                        .filter(entry -> needle == null
+                                || entry.getValue().toLowerCase(Locale.ROOT).contains(needle)
+                                || ("cwe-" + entry.getKey()).contains(needle));
+
+        if ("cweId".equals(orderBy)) {
+            final Comparator<Map.Entry<Integer, String>> comparator =
+                    orderDirection == OrderDirection.DESCENDING
+                            ? Map.Entry.<Integer, String>comparingByKey().reversed()
+                            : Map.Entry.comparingByKey();
+            dictEntryStream = dictEntryStream.sorted(comparator);
+        }
+
+        final List<Map.Entry<Integer, String>> dictEntries = dictEntryStream.toList();
+        final int total = dictEntries.size();
+
+        final List<Map.Entry<Integer, String>> dictEntriesPage;
         if (pagination == null || !pagination.isPaginated()) {
-            final List<Cwe> cwes = all();
-            return new PaginatedResult().objects(cwes).total(CweDictionary.DICTIONARY.size());
+            dictEntriesPage = dictEntries;
+        } else {
+            final int offset = Math.min(pagination.getOffset(), total);
+            final int end = Math.min(offset + pagination.getLimit(), total);
+            dictEntriesPage = dictEntries.subList(offset, end);
         }
 
-        int pos = 0, count = 0;
-        final var cwes = new ArrayList<Cwe>();
-        for (final Map.Entry<Integer, String> dictEntry : CweDictionary.DICTIONARY.entrySet()) {
-            if (pos >= pagination.getOffset() && count < pagination.getLimit()) {
-                final var cwe = new Cwe();
-                cwe.setCweId(dictEntry.getKey());
-                cwe.setName(dictEntry.getValue());
-                cwes.add(cwe);
-                count++;
-            }
-
-            pos++;
-            if (count >= pagination.getLimit()) {
-                break;
-            }
-        }
-
-        return new PaginatedResult().objects(cwes).total(CweDictionary.DICTIONARY.size());
+        final List<Cwe> cwes = dictEntriesPage.stream()
+                .map(entry -> {
+                    final var cwe = new Cwe();
+                    cwe.setCweId(entry.getKey());
+                    cwe.setName(entry.getValue());
+                    return cwe;
+                })
+                .toList();
+        return new PaginatedResult().objects(cwes).total(total);
     }
 
 }

--- a/apiserver/src/main/java/org/dependencytrack/resources/v1/CweResource.java
+++ b/apiserver/src/main/java/org/dependencytrack/resources/v1/CweResource.java
@@ -21,6 +21,7 @@ package org.dependencytrack.resources.v1;
 import alpine.persistence.PaginatedResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -59,6 +60,11 @@ public class CweResource extends AbstractApiResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Returns a list of all CWEs")
     @PaginatedApi
+    @Parameter(
+            name = "searchText",
+            in = ParameterIn.QUERY,
+            description = "Case-insensitive substring filter matched against CWE name and CWE-ID."
+    )
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "200",
@@ -69,7 +75,11 @@ public class CweResource extends AbstractApiResource {
             @ApiResponse(responseCode = "401", description = "Unauthorized")
     })
     public Response getCwes() {
-        final PaginatedResult cwes = CweResolver.getInstance().all(getAlpineRequest().getPagination());
+        final PaginatedResult cwes = CweResolver.getInstance().all(
+                getAlpineRequest().getFilter(),
+                getAlpineRequest().getOrderBy(),
+                getAlpineRequest().getOrderDirection(),
+                getAlpineRequest().getPagination());
         return Response.ok(cwes.getObjects()).header(TOTAL_COUNT_HEADER, cwes.getTotal()).build();
     }
 

--- a/apiserver/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
+++ b/apiserver/src/test/java/org/dependencytrack/resources/v1/CweResourceTest.java
@@ -32,8 +32,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.util.Comparator;
 import java.util.HashSet;
 
+import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CweResourceTest extends ResourceTest {
@@ -82,6 +84,180 @@ public class CweResourceTest extends ResourceTest {
                 cwesSeen.add(cweId);
             }
         }
+    }
+
+    @Test
+    public void shouldFilterByNameSubstringCaseInsensitive() {
+        final Response response = jersey.target(V1_CWE)
+                .queryParam("searchText", "doubled character")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("1");
+        assertThatJson(getPlainTextBody(response)).isEqualTo(/* language=JSON */ """
+                [
+                  {
+                    "cweId": 85,
+                    "name": "Doubled Character XSS Manipulations"
+                  }
+                ]
+                """);
+    }
+
+    @Test
+    public void shouldFilterByCweIdStringRegardlessOfCase() {
+        final String upperBody = getPlainTextBody(jersey.target(V1_CWE)
+                .queryParam("searchText", "CWE-79")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get());
+        final String lowerBody = getPlainTextBody(jersey.target(V1_CWE)
+                .queryParam("searchText", "cwe-79")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get());
+
+        assertThatJson(upperBody).isEqualTo(lowerBody);
+        assertThatJson(upperBody)
+                .isArray()
+                .isNotEmpty();
+        assertThatJson(upperBody)
+                .inPath("$[?(@.cweId == 79)].name")
+                .isArray()
+                .containsExactly("Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')");
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenSearchTextHasNoMatches() {
+        final Response response = jersey.target(V1_CWE)
+                .queryParam("searchText", "no-such-cwe-xyzzy")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(response.getHeaderString(TOTAL_COUNT_HEADER)).isEqualTo("0");
+        assertThatJson(getPlainTextBody(response)).isEqualTo("[]");
+    }
+
+    @Test
+    public void shouldApplyPaginationAfterFilter() {
+        final Response response = jersey.target(V1_CWE)
+                .queryParam("searchText", "injection")
+                .queryParam("pageSize", "5")
+                .queryParam("pageNumber", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        final int totalCount = Integer.parseInt(response.getHeaderString(TOTAL_COUNT_HEADER));
+        assertThat(totalCount).isLessThan(CweDictionary.DICTIONARY.size());
+
+        final String body = getPlainTextBody(response);
+        assertThatJson(body).isArray().hasSizeLessThanOrEqualTo(5);
+        assertThatJson(body).inPath("$[*].name")
+                .isArray()
+                .allSatisfy(name -> assertThat(((String) name).toLowerCase()).contains("injection"));
+    }
+
+    @Test
+    public void shouldSortByCweIdAscending() {
+        final Response response = jersey
+                .target(V1_CWE)
+                .queryParam("sortName", "cweId")
+                .queryParam("sortOrder", "asc")
+                .queryParam("pageSize", "3")
+                .queryParam("pageNumber", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].cweId")
+                .isArray()
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void shouldSortByCweIdDescending() {
+        final Response response = jersey
+                .target(V1_CWE)
+                .queryParam("sortName", "cweId")
+                .queryParam("sortOrder", "desc")
+                .queryParam("pageSize", "3")
+                .queryParam("pageNumber", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].cweId")
+                .isArray()
+                .isSortedAccordingTo(Comparator.comparingInt((Object cweId) -> ((Number) cweId).intValue()).reversed());
+    }
+
+    @Test
+    public void shouldDefaultToAscendingWhenSortOrderOmitted() {
+        final Response response = jersey
+                .target(V1_CWE)
+                .queryParam("sortName", "cweId")
+                .queryParam("pageSize", "3")
+                .queryParam("pageNumber", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThatJson(getPlainTextBody(response))
+                .inPath("$[*].cweId")
+                .isArray()
+                .containsExactly(1, 2, 3);
+    }
+
+    @Test
+    public void shouldIgnoreUnsupportedSortField() {
+        final String sortedBody = getPlainTextBody(
+                jersey.target(V1_CWE)
+                        .queryParam("sortName", "name")
+                        .queryParam("sortOrder", "asc")
+                        .queryParam("pageSize", "5")
+                        .queryParam("pageNumber", "1")
+                        .request()
+                        .header(X_API_KEY, apiKey)
+                        .get());
+        final String defaultBody = getPlainTextBody(
+                jersey.target(V1_CWE)
+                        .queryParam("pageSize", "5")
+                        .queryParam("pageNumber", "1")
+                        .request()
+                        .header(X_API_KEY, apiKey)
+                        .get());
+        assertThatJson(sortedBody).isEqualTo(defaultBody);
+    }
+
+    @Test
+    public void shouldCombineFilterSortAndPagination() {
+        final Response response = jersey
+                .target(V1_CWE)
+                .queryParam("searchText", "injection")
+                .queryParam("sortName", "cweId")
+                .queryParam("sortOrder", "asc")
+                .queryParam("pageSize", "5")
+                .queryParam("pageNumber", "1")
+                .request()
+                .header(X_API_KEY, apiKey)
+                .get();
+        assertThat(response.getStatus()).isEqualTo(200);
+        final int totalCount = Integer.parseInt(response.getHeaderString(TOTAL_COUNT_HEADER));
+        assertThat(totalCount).isLessThan(CweDictionary.DICTIONARY.size());
+
+        final String body = getPlainTextBody(response);
+        assertThatJson(body).isArray().hasSizeLessThanOrEqualTo(5);
+        assertThatJson(body).inPath("$[*].name")
+                .isArray()
+                .allSatisfy(name -> assertThat(((String) name).toLowerCase()).contains("injection"));
+        assertThatJson(body).inPath("$[*].cweId")
+                .isArray()
+                .isSortedAccordingTo(Comparator.comparingInt((Object cweId) -> ((Number) cweId).intValue()));
     }
 
     @Test


### PR DESCRIPTION


### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes `/api/v1/cwe` not supporting filtering and sorting.

The data is served from an in-memory map so these features need to be hand-rolled.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/2161

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

N/A

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
