### PR TITLE
Fix NVD vuln data source dropping CPEs with NA version

### DIFF
--- a/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/ModelConverter.java
+++ b/vuln-data-source/nvd/src/main/java/org/dependencytrack/vulndatasource/nvd/ModelConverter.java
@@ -242,6 +242,25 @@ final class ModelConverter {
                     component.getBomRef(),
                     bomRef -> VulnerabilityAffects.newBuilder()
                             .setRef(bomRef));
+
+            // NB: CPEs use "-" (NA) where the concept of versions does not apply
+            // (e.g. some firmware or hardware). The entire product is considered
+            // affected. vers has no representation for this, so we emit "-" as an exact
+            // version and let downstream handle it verbatim.
+            if (versForCpeMatch == null && "-".equals(cpe.getVersion())) {
+                final boolean shouldAddVersion = affectsBuilder.getVersionsList().stream()
+                        .filter(VulnerabilityAffectedVersions::hasVersion)
+                        .map(VulnerabilityAffectedVersions::getVersion)
+                        .noneMatch("-"::equals);
+                if (shouldAddVersion) {
+                    affectsBuilder.addVersions(
+                            VulnerabilityAffectedVersions.newBuilder()
+                                    .setVersion("-"));
+                }
+
+                continue;
+            }
+
             if (versForCpeMatch != null && versForCpeMatch.constraints().size() == 1
                 && versForCpeMatch.constraints().getFirst().comparator().equals(Comparator.EQUAL)) {
                 var versConstraint = versForCpeMatch.constraints().getFirst();

--- a/vuln-data-source/nvd/src/test/java/org/dependencytrack/vulndatasource/nvd/ModelConverterTest.java
+++ b/vuln-data-source/nvd/src/test/java/org/dependencytrack/vulndatasource/nvd/ModelConverterTest.java
@@ -81,7 +81,12 @@ class ModelConverterTest {
                             {
                               "affects": [
                                 {
-                                  "ref": "7876921d-3df8-3c87-bcdf-66579b0c4860"
+                                  "ref": "7876921d-3df8-3c87-bcdf-66579b0c4860",
+                                  "versions": [
+                                    {
+                                      "version": "-"
+                                    }
+                                  ]
                                 },
                                 {
                                   "ref": "e3e3aa1a-542e-3dee-a577-d4dbe0314003",


### PR DESCRIPTION
### Description

<!-- REQUIRED
    Provide a concise description of your change. What does it do? Why is it necessary?
    As a guideline, think about how you would describe your change if you were to write a changelog entry for it.
-->

Fixes NVD vuln data source dropping CPEs with NA version.

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords like `closes` or `fixes` to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

Fixes https://github.com/DependencyTrack/hyades/issues/2163

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?
-->

versatile's `versFromNvdRange` (correctly) ignores `-` / NA versions because they don't belong in version ranges: https://github.com/nscuro/versatile/blob/3c6a8976ccdc3e9373f04706fa060c510a980fa6/versatile-core/src/main/java/io/github/nscuro/versatile/VersUtils.java#L211-L214

However, that caused us to drop such CPEs entirely. Now handling this with a special case.

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [x] I have read and understand the [contributing guidelines]
- [x] This PR fixes a defect, and I have provided tests to verify that the fix is effective
- ~This PR implements an enhancement, and I have provided tests to verify that it works as intended~
- ~This PR introduces changes to the database model, and I have updated the [migration changelog] accordingly~
- ~This PR introduces new or alters existing behavior, and I have updated the [documentation] accordingly~
- ~This PR is a substantial change (per the [ADR criteria]), and I have added an [ADR] under `docs/adr/`~

[ADR]: ../docs/adr/
[ADR criteria]: ../CONTRIBUTING.md#architecture-decision-records
[contributing guidelines]: ../CONTRIBUTING.md#pull-requests
[documentation]: https://github.com/DependencyTrack/docs
[migration changelog]: ../DEVELOPING.md#database-migrations
